### PR TITLE
Refactor RxNullabilityPropagator.

### DIFF
--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
@@ -26,8 +26,11 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.ObservableSource;
+import io.reactivex.functions.BiPredicate;
 import io.reactivex.functions.Predicate;
 import io.reactivex.functions.Function;
 
@@ -153,6 +156,25 @@ public class NullAwayRxSupportNegativeCases {
                 });
     }
 
+    private Observable<NullableContainer<String>> filterThenDistinctUntilChanged(Observable<NullableContainer<String>>
+            observable) {
+        return observable
+                .filter(new Predicate<NullableContainer<String>>() {
+                    @Override
+                    public boolean test(NullableContainer<String> container) throws Exception {
+                        return container.get() != null;
+                    }
+                })
+                .distinctUntilChanged(new BiPredicate<NullableContainer<String>,NullableContainer<String>>() {
+                    @Override
+                    public boolean test(NullableContainer<String> nc1, NullableContainer<String> nc2) {
+                        return nc1.get().length() == nc2.get().length()
+                                && nc1.get().contains(nc2.get())
+                                && nc2.get().contains(nc1.get());
+                    }
+                });
+    }
+
     static private class NoOpFilterClass<T> implements Predicate<T> {
         public NoOpFilterClass() { }
 
@@ -170,5 +192,37 @@ public class NullAwayRxSupportNegativeCases {
                 return s.length();
             }
         });
+    }
+
+    private Maybe<Integer> testMaybe(Maybe<NullableContainer<String>>
+            maybe) {
+        return maybe
+                .filter(new Predicate<NullableContainer<String>>() {
+                    @Override
+                    public boolean test(NullableContainer<String> container) throws Exception {
+                        return container.get() != null;
+                    }
+                }).map(new Function<NullableContainer<String>, Integer>() {
+                    @Override
+                    public Integer apply(NullableContainer<String> c) throws Exception {
+                        return c.get().length();
+                    }
+                });
+    }
+
+    private Maybe<Integer> testSingle(Single<NullableContainer<String>>
+            single) {
+        return single
+                .filter(new Predicate<NullableContainer<String>>() {
+                    @Override
+                    public boolean test(NullableContainer<String> container) throws Exception {
+                        return container.get() != null;
+                    }
+                }).map(new Function<NullableContainer<String>, Integer>() {
+                    @Override
+                    public Integer apply(NullableContainer<String> c) throws Exception {
+                        return c.get().length();
+                    }
+                });
     }
 }


### PR DESCRIPTION
This adds models for: distinctUntilChanged, Maybe, and Single. It also makes it easier to add further models in the future by using the `RxNullabilityPropagator.StreamModelBuilder` class (internal to `RxNullabilityPropagator`).

Tests included.
