### PR TITLE
Add lambda support to the RxNullabilityPropagator handler.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,8 +15,9 @@
  */
 
 def versions = [
-    checkerFramework : "2.1.14",
-    errorProne       : "2.1.1",
+    checkerFramework       : "2.1.14",
+    checkerFrameworkNAFork : "2.1.14.1-nullaway",
+    errorProne             : "2.1.1",
 ]
 
 def apt = [
@@ -29,7 +30,7 @@ def build = [
     errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProne}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
-    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}-nullaway",
+    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFrameworkNAFork}",
                                "org.checkerframework:javacutil:${versions.checkerFramework}"],
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -415,6 +415,7 @@ public class NullAway extends BugChecker
   public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
     Symbol.MethodSymbol methodSymbol =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
+    handler.onMatchLambdaExpression(this, tree, state, methodSymbol);
     Description description = checkParamOverriding(tree, tree.getParameters(), methodSymbol, true);
     if (description != Description.NO_MATCH) {
       return description;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -121,9 +121,21 @@ public final class AccessPathNullnessAnalysis {
     return result;
   }
 
-  /** ToDo: Document or implement in a better way */
-  public void forceRunOnMethod(TreePath methodPath, Context context) {
-    dataFlow.finalResultForMethod(methodPath, context, nullnessPropagation);
+  /**
+   * Forces a run of the access path nullness analysis on the method (or lambda) at the given
+   * TreePath.
+   *
+   * <p>Because of caching, if the analysis has run in the past for this particular path, it might
+   * not be re-run. The intended usage of this method is to force an analysis pass and thus the
+   * execution of any Handler hooks into the dataflow analysis (such as `onDataflowInitialStore` or
+   * `onDataflowVisitX`).
+   *
+   * @param methodPath tree path of the method (or lambda) to analyze.
+   * @param context Javac context
+   * @return the final NullnessStore on exit from the method.
+   */
+  public NullnessStore<Nullness> forceRunOnMethod(TreePath methodPath, Context context) {
+    return dataFlow.finalResultForMethod(methodPath, context, nullnessPropagation);
   }
 
   /** invalidate all caches */

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -78,6 +78,7 @@ import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
 import org.checkerframework.dataflow.cfg.node.IntegerDivisionNode;
 import org.checkerframework.dataflow.cfg.node.IntegerLiteralNode;
 import org.checkerframework.dataflow.cfg.node.IntegerRemainderNode;
+import org.checkerframework.dataflow.cfg.node.LambdaResultExpressionNode;
 import org.checkerframework.dataflow.cfg.node.LeftShiftNode;
 import org.checkerframework.dataflow.cfg.node.LessThanNode;
 import org.checkerframework.dataflow.cfg.node.LessThanOrEqualNode;
@@ -204,6 +205,7 @@ public class AccessPathNullnessPropagation
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }
+    result = handler.onDataflowInitialStore(underlyingAST, parameters, result);
     return result.build();
   }
 
@@ -221,7 +223,7 @@ public class AccessPathNullnessPropagation
       Nullness assumed = Nullness.hasNullableAnnotation(element) ? NULLABLE : NONNULL;
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }
-    result = handler.onDataflowMethodInitialStore(underlyingAST, parameters, result);
+    result = handler.onDataflowInitialStore(underlyingAST, parameters, result);
     return result.build();
   }
 
@@ -736,6 +738,15 @@ public class AccessPathNullnessPropagation
   public TransferResult<Nullness, NullnessStore<Nullness>> visitReturn(
       ReturnNode returnNode, TransferInput<Nullness, NullnessStore<Nullness>> input) {
     handler.onDataflowVisitReturn(returnNode.getTree(), input.getThenStore(), input.getElseStore());
+    return noStoreChanges(NULLABLE, input);
+  }
+
+  @Override
+  public TransferResult<Nullness, NullnessStore<Nullness>> visitLambdaResultExpression(
+      LambdaResultExpressionNode resultNode,
+      TransferInput<Nullness, NullnessStore<Nullness>> input) {
+    handler.onDataflowVisitLambdaResultExpression(
+        resultNode.getTree(), input.getThenStore(), input.getElseStore());
     return noStoreChanges(NULLABLE, input);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -180,7 +180,7 @@ public final class DataFlow {
   }
 
   /**
-   * @param methodPath path to method
+   * @param methodPath path to method (or lambda)
    * @param context Javac context
    * @param transfer transfer functions
    * @param <A> values in abstraction
@@ -192,8 +192,8 @@ public final class DataFlow {
       S finalResultForMethod(TreePath methodPath, Context context, T transfer) {
     final Tree leaf = methodPath.getLeaf();
     Preconditions.checkArgument(
-        leaf instanceof MethodTree,
-        "Leaf of exprPath must be of type ExpressionTree, but was %s",
+        leaf instanceof MethodTree || leaf instanceof LambdaExpressionTree,
+        "Leaf of methodPath must be of type MethodTree or LambdaExpressionTree, but was %s",
         leaf.getClass().getName());
 
     return methodDataflow(methodPath, context, transfer).getAnalysis().getRegularExitStore();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
@@ -48,7 +49,7 @@ import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
  * interface. Additionally, we can add extensibility points without breaking existing handlers, as
  * long as we define the corresponding No-Op behavior here.
  */
-class BaseNoOpHandler implements Handler {
+abstract class BaseNoOpHandler implements Handler {
 
   protected BaseNoOpHandler() {
     // We don't allow creating useless handlers, subclass to add real behavior.
@@ -70,6 +71,15 @@ class BaseNoOpHandler implements Handler {
   public void onMatchMethodInvocation(
       NullAway analysis,
       MethodInvocationTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol) {
+    // NoOp
+  }
+
+  @Override
+  public void onMatchLambdaExpression(
+      NullAway analysis,
+      LambdaExpressionTree tree,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol) {
     // NoOp
@@ -98,7 +108,7 @@ class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public NullnessStore.Builder<Nullness> onDataflowMethodInitialStore(
+  public NullnessStore.Builder<Nullness> onDataflowInitialStore(
       UnderlyingAST underlyingAST,
       List<LocalVariableNode> parameters,
       NullnessStore.Builder<Nullness> result) {
@@ -119,6 +129,12 @@ class BaseNoOpHandler implements Handler {
   @Override
   public void onDataflowVisitReturn(
       ReturnTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
+    // NoOp
+  }
+
+  @Override
+  public void onDataflowVisitLambdaResultExpression(
+      ExpressionTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
     // NoOp
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
@@ -73,6 +74,17 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public void onMatchLambdaExpression(
+      NullAway analysis,
+      LambdaExpressionTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol) {
+    for (Handler h : handlers) {
+      h.onMatchLambdaExpression(analysis, tree, state, methodSymbol);
+    }
+  }
+
+  @Override
   public void onMatchMethodInvocation(
       NullAway analysis,
       MethodInvocationTree tree,
@@ -115,12 +127,12 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public NullnessStore.Builder<Nullness> onDataflowMethodInitialStore(
+  public NullnessStore.Builder<Nullness> onDataflowInitialStore(
       UnderlyingAST underlyingAST,
       List<LocalVariableNode> parameters,
       NullnessStore.Builder<Nullness> result) {
     for (Handler h : handlers) {
-      result = h.onDataflowMethodInitialStore(underlyingAST, parameters, result);
+      result = h.onDataflowInitialStore(underlyingAST, parameters, result);
     }
     return result;
   }
@@ -149,6 +161,14 @@ class CompositeHandler implements Handler {
       ReturnTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
     for (Handler h : handlers) {
       h.onDataflowVisitReturn(tree, thenStore, elseStore);
+    }
+  }
+
+  @Override
+  public void onDataflowVisitLambdaResultExpression(
+      ExpressionTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
+    for (Handler h : handlers) {
+      h.onDataflowVisitLambdaResultExpression(tree, thenStore, elseStore);
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -30,9 +30,9 @@ import com.google.errorprone.predicates.TypePredicate;
 import com.google.errorprone.predicates.type.DescendantOf;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -148,22 +148,23 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    */
 
   // Set of filter methods found thus far (e.g. A.filter, see above)
-  private final Set<MethodTree> filterMethodsSet = new LinkedHashSet<>();
+  private Set<Tree> filterMethodOrLambdaSet = new LinkedHashSet<Tree>();
 
   // Maps each call in the observable call chain to its outer call (see above).
-  private final Map<MethodInvocationTree, MethodInvocationTree> observableOuterCallInChain =
-      new LinkedHashMap<>();
+  private Map<MethodInvocationTree, MethodInvocationTree> observableOuterCallInChain =
+      new LinkedHashMap<MethodInvocationTree, MethodInvocationTree>();
 
-  // Maps the call in the observable call chain to the relevant functor method.
+  // Maps the call in the observable call chain to the relevant inner method or lambda.
   // e.g. In the example above:
   //   observable.filter() => A.filter
   //   observable.filter().map() => B.apply
-  private final Map<MethodInvocationTree, MethodTree> observableCallToActualFunctorMethod =
-      new LinkedHashMap<>();
+  private Map<MethodInvocationTree, Tree> observableCallToInnerMethodOrLambda =
+      new LinkedHashMap<MethodInvocationTree, Tree>();
 
-  // Map from map method to corresponding previous filter method (e.g. B.apply => A.filter)
-  private final Map<MethodTree, MaplikeToFilterInstanceRecord> mapToFilterMap =
-      new LinkedHashMap<>();
+  // Map from map method (or lambda) to corresponding previous filter method (e.g. B.apply =>
+  // A.filter)
+  private Map<Tree, MaplikeToFilterInstanceRecord> mapToFilterMap =
+      new LinkedHashMap<Tree, MaplikeToFilterInstanceRecord>();
 
   /*
    * Note that the above methods imply a diagram like the following:
@@ -179,20 +180,28 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    *                                   }
    */
 
-  // Map from filter method to corresponding nullability info after the method returns true.
+
+  // Map from filter method (or lambda) to corresponding nullability info after the function returns
+  // true.
   // Specifically, this is the least upper bound of the "then" store on the branch of every return
   // statement in
   // which the expression after the return can be true.
-  private final Map<MethodTree, NullnessStore<Nullness>> filterToNSMap = new LinkedHashMap<>();
+  private Map<Tree, NullnessStore<Nullness>> filterToNSMap =
+      new LinkedHashMap<Tree, NullnessStore<Nullness>>();
 
-  // Maps the method body to the corresponding method tree, used because the dataflow analysis loses
-  // the pointer
-  // to the MethodTree by the time we hook into it.
-  private final Map<BlockTree, MethodTree> blockToMethod = new LinkedHashMap<>();
+  // Maps the body of a method or lambda to the corresponding enclosing tree, used because the
+  // dataflow analysis
+  // loses the pointer to the tree by the time we hook into its body.
+  private Map<Tree, Tree> bodyToMethodOrLambda = new LinkedHashMap<Tree, Tree>();
 
   // Maps the return statements of the filter method to the filter tree itself, similar issue as
   // above.
-  private final Map<ReturnTree, MethodTree> returnToMethod = new LinkedHashMap<>();
+  private Map<ReturnTree, Tree> returnToEnclosingMethodOrLambda =
+      new LinkedHashMap<ReturnTree, Tree>();
+
+  // Similar to above, but mapping espression-bodies to their enclosing lambdas
+  private Map<ExpressionTree, LambdaExpressionTree> expressionBodyToFilterLambda =
+      new LinkedHashMap<ExpressionTree, LambdaExpressionTree>();
 
   RxNullabilityPropagator() {
     super();
@@ -202,13 +211,13 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     // Clear compilation unit specific state
-    this.filterMethodsSet.clear();
+    this.filterMethodOrLambdaSet.clear();
     this.observableOuterCallInChain.clear();
-    this.observableCallToActualFunctorMethod.clear();
+    this.observableCallToInnerMethodOrLambda.clear();
     this.mapToFilterMap.clear();
     this.filterToNSMap.clear();
-    this.blockToMethod.clear();
-    this.returnToMethod.clear();
+    this.bodyToMethodOrLambda.clear();
+    this.returnToEnclosingMethodOrLambda.clear();
   }
 
   @Override
@@ -220,6 +229,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
     Type receiverType = ASTHelpers.getReceiverType(tree);
     for (StreamTypeRecord streamType : RX_MODELS) {
       if (streamType.matchesType(receiverType, state)) {
+        String methodName = methodSymbol.toString();
         // Build observable call chain
         buildObservableCallChain(tree);
 
@@ -235,10 +245,10 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
             if (annonClassBody != null) {
               handleFilterAnonClass(streamType, tree, annonClassBody, state);
             }
+          } else if (argTree instanceof LambdaExpressionTree) {
+            LambdaExpressionTree lambdaTree = (LambdaExpressionTree) argTree;
+            handleFilterLambda(streamType, tree, lambdaTree, state);
           }
-          // This can also be a lambda, which currently cannot be used in the code we look at, but
-          // might be
-          // needed by others. Add support soon.
         } else if (streamType.isMapMethod(methodSymbol)
             && methodSymbol.getParameters().length() == 1) {
           ExpressionTree argTree = tree.getArguments().get(0);
@@ -247,12 +257,12 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
             // Ensure that this `new B() ...` has a custom class body, otherwise, we skip for now.
             if (annonClassBody != null) {
               MaplikeMethodRecord methodRecord = streamType.getMaplikeMethodRecord(methodSymbol);
-              handleMapAnonClass(methodRecord, tree, annonClassBody);
+              handleMapAnonClass(methodRecord, tree, annonClassBody, state);
             }
+          } else if (argTree instanceof LambdaExpressionTree) {
+            LambdaExpressionTree lambdaTree = (LambdaExpressionTree) argTree;
+            handleMapLambda(streamType, tree, lambdaTree, state);
           }
-          // This can also be a lambda, which currently cannot be used in the code we look at, but
-          // might be
-          // needed by others. Add support soon.
         }
       }
     }
@@ -265,10 +275,34 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       if (receiverExpression instanceof MethodInvocationTree) {
         observableOuterCallInChain.put((MethodInvocationTree) receiverExpression, tree);
       }
-      // ToDo: Eventually we want to handle more complex observer chains, but filter(...).map(...)
-      // is the
-      // common case.
     } // ToDo: What else can be here? If there are other cases than MemberSelectTree, handle them.
+  }
+
+  private void handleChainFromFilter(
+      StreamTypeRecord streamType,
+      MethodInvocationTree observableDotFilter,
+      Tree filterMethodOrLambda,
+      VisitorState state) {
+    // Traverse the observable call chain out through any pass-through methods
+    MethodInvocationTree outerCallInChain = observableOuterCallInChain.get(observableDotFilter);
+    while (outerCallInChain != null
+        && streamType.matchesType(ASTHelpers.getReceiverType(outerCallInChain), state)
+        && streamType.isPassthroughMethod(ASTHelpers.getSymbol(outerCallInChain))) {
+      outerCallInChain = observableOuterCallInChain.get(outerCallInChain);
+    }
+    // Check for a map method
+    MethodInvocationTree mapCallsite = observableOuterCallInChain.get(observableDotFilter);
+    if (outerCallInChain != null
+        && observableCallToInnerMethodOrLambda.containsKey(outerCallInChain)) {
+      // Update mapToFilterMap
+      Symbol.MethodSymbol mapMethod = ASTHelpers.getSymbol(outerCallInChain);
+      if (streamType.isMapMethod(mapMethod)) {
+        MaplikeToFilterInstanceRecord record =
+            new MaplikeToFilterInstanceRecord(
+                streamType.getMaplikeMethodRecord(mapMethod), filterMethodOrLambda);
+        mapToFilterMap.put(observableCallToInnerMethodOrLambda.get(outerCallInChain), record);
+      }
+    }
   }
 
   private void handleFilterAnonClass(
@@ -278,48 +312,68 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       VisitorState state) {
     for (Tree t : annonClassBody.getMembers()) {
       if (t instanceof MethodTree && ((MethodTree) t).getName().toString().equals("test")) {
-        filterMethodsSet.add((MethodTree) t);
-        observableCallToActualFunctorMethod.put(observableDotFilter, (MethodTree) t);
-        // Traverse the observable call chain out through any pass-through methods
-        MethodInvocationTree outerCallInChain = observableOuterCallInChain.get(observableDotFilter);
-        while (outerCallInChain != null
-            && streamType.matchesType(ASTHelpers.getReceiverType(outerCallInChain), state)
-            && streamType.isPassthroughMethod(ASTHelpers.getSymbol(outerCallInChain))) {
-          outerCallInChain = observableOuterCallInChain.get(outerCallInChain);
-        }
-        // Check for a map method
-        if (outerCallInChain != null
-            && observableCallToActualFunctorMethod.containsKey(outerCallInChain)) {
-          // Update mapToFilterMap
-          Symbol.MethodSymbol mapMethod = ASTHelpers.getSymbol(outerCallInChain);
-          if (streamType.isMapMethod(mapMethod)) {
-            MaplikeToFilterInstanceRecord record =
-                new MaplikeToFilterInstanceRecord(
-                    streamType.getMaplikeMethodRecord(mapMethod), (MethodTree) t);
-            mapToFilterMap.put(observableCallToActualFunctorMethod.get(outerCallInChain), record);
-          }
-        }
+        filterMethodOrLambdaSet.add(t);
+        observableCallToInnerMethodOrLambda.put(observableDotFilter, (MethodTree) t);
+        handleChainFromFilter(streamType, observableDotFilter, t, state);
       }
     }
+  }
+
+  private void handleFilterLambda(
+      StreamTypeRecord streamType,
+      MethodInvocationTree observableDotFilter,
+      LambdaExpressionTree lambdaTree,
+      VisitorState state) {
+    filterMethodOrLambdaSet.add(lambdaTree);
+    observableCallToInnerMethodOrLambda.put(observableDotFilter, lambdaTree);
+    handleChainFromFilter(streamType, observableDotFilter, lambdaTree, state);
   }
 
   private void handleMapAnonClass(
       MaplikeMethodRecord methodRecord,
       MethodInvocationTree observableDotMap,
-      ClassTree annonClassBody) {
+      ClassTree annonClassBody,
+      VisitorState state) {
     for (Tree t : annonClassBody.getMembers()) {
       if (t instanceof MethodTree
           && ((MethodTree) t).getName().toString().equals(methodRecord.getInnerMethodName())) {
-        observableCallToActualFunctorMethod.put(observableDotMap, (MethodTree) t);
+        observableCallToInnerMethodOrLambda.put(observableDotMap, (MethodTree) t);
       }
     }
+  }
+
+  private void handleMapLambda(
+      StreamTypeRecord streamType,
+      MethodInvocationTree observableDotMap,
+      LambdaExpressionTree lambdaTree,
+      VisitorState state) {
+    observableCallToInnerMethodOrLambda.put(observableDotMap, lambdaTree);
   }
 
   @Override
   public void onMatchMethod(
       NullAway analysis, MethodTree tree, VisitorState state, Symbol.MethodSymbol methodSymbol) {
     if (mapToFilterMap.containsKey(tree)) {
-      blockToMethod.put(tree.getBody(), tree);
+      bodyToMethodOrLambda.put(tree.getBody(), tree);
+    }
+  }
+
+  @Override
+  public void onMatchLambdaExpression(
+      NullAway analysis,
+      LambdaExpressionTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol) {
+    if (filterMethodOrLambdaSet.contains(tree)
+        && tree.getBodyKind().equals(LambdaExpressionTree.BodyKind.EXPRESSION)) {
+      expressionBodyToFilterLambda.put((ExpressionTree) tree.getBody(), tree);
+      // Single expression lambda, onMatchReturn will not be triggered, force the dataflow analysis
+      // here
+      AccessPathNullnessAnalysis nullnessAnalysis = analysis.getNullnessAnalysis(state);
+      nullnessAnalysis.forceRunOnMethod(state.getPath(), state.context);
+    }
+    if (mapToFilterMap.containsKey(tree)) {
+      bodyToMethodOrLambda.put(tree.getBody(), tree);
     }
   }
 
@@ -343,47 +397,54 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
     // Figure out the enclosing method node
     TreePath enclosingMethodOrLambda = NullabilityUtil.findEnclosingMethodOrLambda(state.getPath());
     if (enclosingMethodOrLambda == null) {
-      throw new RuntimeException("no enclosing method!");
+      throw new RuntimeException("no enclosing method or lambda!");
     }
     Tree leaf = enclosingMethodOrLambda.getLeaf();
-    if (leaf instanceof MethodTree) {
-      MethodTree enclosingMethod = (MethodTree) leaf;
-      if (filterMethodsSet.contains(enclosingMethod)) {
-        returnToMethod.put(tree, enclosingMethod);
-        // We need to manually trigger the dataflow analysis to run on the filter method,
-        // this ensures onDataflowVisitReturn(...) gets called for all return statements in this
-        // method before
-        // onDataflowMethodInitialStore(...) is called for all successor methods in the observable
-        // chain.
-        // Caching should prevent us from re-analyzing any given method.
-        AccessPathNullnessAnalysis nullnessAnalysis = analysis.getNullnessAnalysis(state);
-        nullnessAnalysis.forceRunOnMethod(
-            new TreePath(state.getPath(), enclosingMethod), state.context);
-      }
+    if (filterMethodOrLambdaSet.contains(leaf)) {
+      returnToEnclosingMethodOrLambda.put(tree, leaf);
+      // We need to manually trigger the dataflow analysis to run on the filter method,
+      // this ensures onDataflowVisitReturn(...) gets called for all return statements in this
+      // method before
+      // onDataflowInitialStore(...) is called for all successor methods in the observable chain.
+      // Caching should prevent us from re-analyzing any given method.
+      AccessPathNullnessAnalysis nullnessAnalysis = analysis.getNullnessAnalysis(state);
+      nullnessAnalysis.forceRunOnMethod(new TreePath(state.getPath(), leaf), state.context);
     }
-    // This can also be a lambda, which currently cannot be used in the code we look at, but might
-    // be needed by
-    // others. Add support soon.
-
   }
 
   @Override
-  public NullnessStore.Builder<Nullness> onDataflowMethodInitialStore(
+  public NullnessStore.Builder<Nullness> onDataflowInitialStore(
       UnderlyingAST underlyingAST,
       List<LocalVariableNode> parameters,
       NullnessStore.Builder<Nullness> nullnessBuilder) {
-    // noinspection RedundantCast
-    MethodTree tree = blockToMethod.get((BlockTree) underlyingAST.getCode());
+    Tree tree = bodyToMethodOrLambda.get(underlyingAST.getCode());
+    if (tree == null) {
+      return nullnessBuilder;
+    }
+    assert (tree instanceof MethodTree || tree instanceof LambdaExpressionTree);
     if (mapToFilterMap.containsKey(tree)) {
       // Plug Nullness info from filter method into entry to map method.
       MaplikeToFilterInstanceRecord callInstanceRecord = mapToFilterMap.get(tree);
-      MethodTree filterMethodTree = callInstanceRecord.getFilter();
+      Tree filterTree = callInstanceRecord.getFilter();
+      assert (filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree);
       MaplikeMethodRecord mapMR = callInstanceRecord.getMaplikeMethodRecord();
       for (int argIdx : mapMR.getArgsFromStream()) {
-        LocalVariableNode filterLocalName =
-            new LocalVariableNode(filterMethodTree.getParameters().get(0));
-        LocalVariableNode mapLocalName = new LocalVariableNode(tree.getParameters().get(argIdx));
-        NullnessStore<Nullness> filterNullnessStore = filterToNSMap.get(filterMethodTree);
+        LocalVariableNode filterLocalName = null;
+        LocalVariableNode mapLocalName = null;
+        if (filterTree instanceof MethodTree) {
+          filterLocalName = new LocalVariableNode(((MethodTree) filterTree).getParameters().get(0));
+        } else {
+          filterLocalName =
+              new LocalVariableNode(((LambdaExpressionTree) filterTree).getParameters().get(0));
+        }
+        if (tree instanceof MethodTree) {
+          mapLocalName = new LocalVariableNode(((MethodTree) tree).getParameters().get(argIdx));
+        } else {
+          mapLocalName =
+              new LocalVariableNode(((LambdaExpressionTree) tree).getParameters().get(argIdx));
+        }
+        NullnessStore<Nullness> filterNullnessStore = filterToNSMap.get(filterTree);
+        assert filterNullnessStore != null;
         NullnessStore<Nullness> renamedRootsNullnessStore =
             filterNullnessStore.uprootAccessPaths(ImmutableMap.of(filterLocalName, mapLocalName));
         for (AccessPath ap : renamedRootsNullnessStore.getAccessPathsWithValue(Nullness.NONNULL)) {
@@ -397,16 +458,27 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
   @Override
   public void onDataflowVisitReturn(
       ReturnTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
-    if (returnToMethod.containsKey(tree)) {
-      MethodTree filterMethod = returnToMethod.get(tree);
+    if (returnToEnclosingMethodOrLambda.containsKey(tree)) {
+      Tree filterTree = returnToEnclosingMethodOrLambda.get(tree);
+      assert (filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree);
       ExpressionTree retExpression = tree.getExpression();
       if (canBooleanExpressionEvalToTrue(retExpression)) {
-        if (filterToNSMap.containsKey(filterMethod)) {
-          filterToNSMap.put(
-              filterMethod, filterToNSMap.get(filterMethod).leastUpperBound(thenStore));
+        if (filterToNSMap.containsKey(filterTree)) {
+          filterToNSMap.put(filterTree, filterToNSMap.get(filterTree).leastUpperBound(thenStore));
         } else {
-          filterToNSMap.put(filterMethod, thenStore);
+          filterToNSMap.put(filterTree, thenStore);
         }
+      }
+    }
+  }
+
+  @Override
+  public void onDataflowVisitLambdaResultExpression(
+      ExpressionTree tree, NullnessStore<Nullness> thenStore, NullnessStore<Nullness> elseStore) {
+    if (expressionBodyToFilterLambda.containsKey(tree)) {
+      LambdaExpressionTree filterTree = expressionBodyToFilterLambda.get(tree);
+      if (canBooleanExpressionEvalToTrue(tree)) {
+        filterToNSMap.put(filterTree, thenStore);
       }
     }
   }
@@ -422,7 +494,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    */
   private static class StreamModelBuilder {
 
-    private final List<StreamTypeRecord> typeRecords = new LinkedList<>();
+    private final List<StreamTypeRecord> typeRecords = new LinkedList<StreamTypeRecord>();
     private TypePredicate tp = null;
     private Set<String> filterMethodSigs;
     private Set<String> filterMethodSimpleNames;
@@ -438,7 +510,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *
      * @return An empty StreamModelBuilder.
      */
-    static StreamModelBuilder start() {
+    public static StreamModelBuilder start() {
       return new StreamModelBuilder();
     }
 
@@ -462,15 +534,15 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      * @param tp A type predicate matching the class/interface of the type in our stream-based API.
      * @return This builder (for chaining).
      */
-    StreamModelBuilder addStreamType(TypePredicate tp) {
+    public StreamModelBuilder addStreamType(TypePredicate tp) {
       finalizeOpenStreamTypeRecord();
       this.tp = tp;
-      this.filterMethodSigs = new HashSet<>();
-      this.filterMethodSimpleNames = new HashSet<>();
-      this.mapMethodSigToRecord = new HashMap<>();
-      this.mapMethodSimpleNameToRecord = new HashMap<>();
-      this.passthroughMethodSigs = new HashSet<>();
-      this.passthroughMethodSimpleNames = new HashSet<>();
+      this.filterMethodSigs = new HashSet<String>();
+      this.filterMethodSimpleNames = new HashSet<String>();
+      this.mapMethodSigToRecord = new HashMap<String, MaplikeMethodRecord>();
+      this.mapMethodSimpleNameToRecord = new HashMap<String, MaplikeMethodRecord>();
+      this.passthroughMethodSigs = new HashSet<String>();
+      this.passthroughMethodSimpleNames = new HashSet<String>();
       return this;
     }
 
@@ -481,7 +553,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *     filter method.
      * @return This builder (for chaining).
      */
-    StreamModelBuilder withFilterMethodFromSignature(String filterMethodSig) {
+    public StreamModelBuilder withFilterMethodFromSignature(String filterMethodSig) {
       this.filterMethodSigs.add(filterMethodSig);
       return this;
     }
@@ -507,7 +579,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *     arguments to this method that receive objects from the stream.
      * @return This builder (for chaining).
      */
-    StreamModelBuilder withMapMethodFromSignature(
+    public StreamModelBuilder withMapMethodFromSignature(
         String methodSig, String innerMethodName, ImmutableSet<Integer> argsFromStream) {
       this.mapMethodSigToRecord.put(
           methodSig, new MaplikeMethodRecord(innerMethodName, argsFromStream));
@@ -525,7 +597,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *     methods with this name (else use withMapMethodFromSignature).
      * @return This builder (for chaining).
      */
-    StreamModelBuilder withMapMethodAllFromName(
+    public StreamModelBuilder withMapMethodAllFromName(
         String methodSimpleName, String innerMethodName, ImmutableSet<Integer> argsFromStream) {
       this.mapMethodSimpleNameToRecord.put(
           methodSimpleName, new MaplikeMethodRecord(innerMethodName, argsFromStream));
@@ -544,7 +616,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *     the method.
      * @return This builder (for chaining).
      */
-    StreamModelBuilder withPassthroughMethodFromSignature(String passthroughMethodSig) {
+    public StreamModelBuilder withPassthroughMethodFromSignature(String passthroughMethodSig) {
       this.passthroughMethodSigs.add(passthroughMethodSig);
       return this;
     }
@@ -555,7 +627,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      * @param methodSimpleName The method's simple name.
      * @return This builder (for chaining).
      */
-    StreamModelBuilder withPassthroughMethodAllFromName(String methodSimpleName) {
+    public StreamModelBuilder withPassthroughMethodAllFromName(String methodSimpleName) {
       this.passthroughMethodSimpleNames.add(methodSimpleName);
       return this;
     }
@@ -565,7 +637,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
      *
      * @return The finalized (immutable) models.
      */
-    ImmutableList<StreamTypeRecord> end() {
+    public ImmutableList<StreamTypeRecord> end() {
       finalizeOpenStreamTypeRecord();
       return ImmutableList.copyOf(typeRecords);
     }
@@ -600,7 +672,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
     private final Set<String> passthroughMethodSigs;
     private final Set<String> passthroughMethodSimpleNames;
 
-    StreamTypeRecord(
+    public StreamTypeRecord(
         TypePredicate typePredicate,
         Set<String> filterMethodSigs,
         Set<String> filterMethodSimpleNames,
@@ -617,21 +689,21 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       this.passthroughMethodSimpleNames = passthroughMethodSimpleNames;
     }
 
-    boolean matchesType(Type type, VisitorState state) {
+    public boolean matchesType(Type type, VisitorState state) {
       return typePredicate.apply(type, state);
     }
 
-    boolean isFilterMethod(Symbol.MethodSymbol methodSymbol) {
+    public boolean isFilterMethod(Symbol.MethodSymbol methodSymbol) {
       return filterMethodSigs.contains(methodSymbol.toString())
           || filterMethodSimpleNames.contains(methodSymbol.getQualifiedName().toString());
     }
 
-    boolean isMapMethod(Symbol.MethodSymbol methodSymbol) {
+    public boolean isMapMethod(Symbol.MethodSymbol methodSymbol) {
       return mapMethodSigToRecord.containsKey(methodSymbol.toString())
           || mapMethodSimpleNameToRecord.containsKey(methodSymbol.getQualifiedName().toString());
     }
 
-    MaplikeMethodRecord getMaplikeMethodRecord(Symbol.MethodSymbol methodSymbol) {
+    public MaplikeMethodRecord getMaplikeMethodRecord(Symbol.MethodSymbol methodSymbol) {
       MaplikeMethodRecord record = mapMethodSigToRecord.get(methodSymbol.toString());
       if (record == null) {
         record = mapMethodSimpleNameToRecord.get(methodSymbol.getQualifiedName().toString());
@@ -639,7 +711,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       return record;
     }
 
-    boolean isPassthroughMethod(Symbol.MethodSymbol methodSymbol) {
+    public boolean isPassthroughMethod(Symbol.MethodSymbol methodSymbol) {
       return passthroughMethodSigs.contains(methodSymbol.toString())
           || passthroughMethodSimpleNames.contains(methodSymbol.getQualifiedName().toString());
     }
@@ -650,17 +722,17 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
 
     private final String innerMethodName;
 
-    String getInnerMethodName() {
+    public String getInnerMethodName() {
       return innerMethodName;
     }
 
     private final Set<Integer> argsFromStream;
 
-    Set<Integer> getArgsFromStream() {
+    public Set<Integer> getArgsFromStream() {
       return argsFromStream;
     }
 
-    MaplikeMethodRecord(String innerMethodName, Set<Integer> argsFromStream) {
+    public MaplikeMethodRecord(String innerMethodName, Set<Integer> argsFromStream) {
       this.innerMethodName = innerMethodName;
       this.argsFromStream = argsFromStream;
     }
@@ -674,17 +746,18 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
 
     private final MaplikeMethodRecord mapMR;
 
-    MaplikeMethodRecord getMaplikeMethodRecord() {
+    public MaplikeMethodRecord getMaplikeMethodRecord() {
       return mapMR;
     }
 
-    private final MethodTree filter;
+    private final Tree filter;
 
-    MethodTree getFilter() {
+    public Tree getFilter() {
       return filter;
     }
 
-    MaplikeToFilterInstanceRecord(MaplikeMethodRecord mapMR, MethodTree filter) {
+    public MaplikeToFilterInstanceRecord(MaplikeMethodRecord mapMR, Tree filter) {
+      assert (filter instanceof MethodTree || filter instanceof LambdaExpressionTree);
       this.mapMR = mapMR;
       this.filter = filter;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -148,22 +148,22 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    */
 
   // Set of filter methods found thus far (e.g. A.filter, see above)
-  private Set<Tree> filterMethodOrLambdaSet = new LinkedHashSet<Tree>();
+  private final Set<Tree> filterMethodOrLambdaSet = new LinkedHashSet<Tree>();
 
   // Maps each call in the observable call chain to its outer call (see above).
-  private Map<MethodInvocationTree, MethodInvocationTree> observableOuterCallInChain =
+  private final Map<MethodInvocationTree, MethodInvocationTree> observableOuterCallInChain =
       new LinkedHashMap<MethodInvocationTree, MethodInvocationTree>();
 
   // Maps the call in the observable call chain to the relevant inner method or lambda.
   // e.g. In the example above:
   //   observable.filter() => A.filter
   //   observable.filter().map() => B.apply
-  private Map<MethodInvocationTree, Tree> observableCallToInnerMethodOrLambda =
+  private final Map<MethodInvocationTree, Tree> observableCallToInnerMethodOrLambda =
       new LinkedHashMap<MethodInvocationTree, Tree>();
 
   // Map from map method (or lambda) to corresponding previous filter method (e.g. B.apply =>
   // A.filter)
-  private Map<Tree, MaplikeToFilterInstanceRecord> mapToFilterMap =
+  private final Map<Tree, MaplikeToFilterInstanceRecord> mapToFilterMap =
       new LinkedHashMap<Tree, MaplikeToFilterInstanceRecord>();
 
   /*
@@ -185,21 +185,21 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
   // Specifically, this is the least upper bound of the "then" store on the branch of every return
   // statement in
   // which the expression after the return can be true.
-  private Map<Tree, NullnessStore<Nullness>> filterToNSMap =
+  private final Map<Tree, NullnessStore<Nullness>> filterToNSMap =
       new LinkedHashMap<Tree, NullnessStore<Nullness>>();
 
   // Maps the body of a method or lambda to the corresponding enclosing tree, used because the
   // dataflow analysis
   // loses the pointer to the tree by the time we hook into its body.
-  private Map<Tree, Tree> bodyToMethodOrLambda = new LinkedHashMap<Tree, Tree>();
+  private final Map<Tree, Tree> bodyToMethodOrLambda = new LinkedHashMap<Tree, Tree>();
 
   // Maps the return statements of the filter method to the filter tree itself, similar issue as
   // above.
-  private Map<ReturnTree, Tree> returnToEnclosingMethodOrLambda =
+  private final Map<ReturnTree, Tree> returnToEnclosingMethodOrLambda =
       new LinkedHashMap<ReturnTree, Tree>();
 
   // Similar to above, but mapping espression-bodies to their enclosing lambdas
-  private Map<ExpressionTree, LambdaExpressionTree> expressionBodyToFilterLambda =
+  private final Map<ExpressionTree, LambdaExpressionTree> expressionBodyToFilterLambda =
       new LinkedHashMap<ExpressionTree, LambdaExpressionTree>();
 
   RxNullabilityPropagator() {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -180,7 +180,6 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    *                                   }
    */
 
-
   // Map from filter method (or lambda) to corresponding nullability info after the function returns
   // true.
   // Specifically, this is the least upper bound of the "then" store on the branch of every return

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
@@ -261,4 +261,60 @@ public class NullAwayRxSupportNegativeCases {
               }
             });
   }
+
+  private Observable<Integer> filterThenMapLambdas(Observable<String> observable) {
+    return observable.filter(s -> s != null).map(s -> s.length());
+  }
+
+  private Observable<Integer> filterThenMapNullableContainerLambdas(
+      Observable<NullableContainer<String>> observable) {
+    return observable.filter(c -> c.get() != null).map(c -> c.get().length());
+  }
+
+  private Observable<Integer> filterThenMapNullableContainerLambdas2(
+      Observable<NullableContainer<String>> observable) {
+    return observable
+        .filter(
+            c -> {
+              if (c.get() == null) {
+                return false;
+              } else {
+                return true;
+              }
+            })
+        .map(c -> c.get().length());
+  }
+
+  private Observable<Integer> filterThenMapNullableContainerLambdas3(
+      Observable<NullableContainer<String>> observable) {
+    return observable
+        .filter(c -> c.get() != null)
+        .map(
+            c -> {
+              String s = c.get();
+              return s.length();
+            });
+  }
+
+  private Observable<Integer> filterThenMapLambdas4(Observable<String> observable) {
+    return observable.filter(s -> s != null && perhaps()).map(s -> s.length());
+  }
+
+  private static <T> boolean predtest(Predicate<T> f, T val) {
+    try {
+      return f.test(val);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static <T, R> R funcapply(Function<T, R> f, T val) throws Exception {
+    return f.apply(val);
+  }
+
+  private Observable<Integer> filterThenMapLambdas5(Observable<String> observable) {
+    return observable
+        .filter(s -> predtest(r -> r != null, s))
+        .map(s -> funcapply(r -> r.length(), s));
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
@@ -119,9 +119,9 @@ public class NullAwayRxSupportPositiveCases {
   }
 
   private Observable<Integer> filterWithLambdaNullExpressionBody(Observable<String> observable) {
-      // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return
-      // type
-      return observable.map(o -> perhaps() ? o : null).map(o -> o.length());
+    // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return
+    // type
+    return observable.map(o -> perhaps() ? o : null).map(o -> o.length());
   }
 
   private Observable<Integer> filterThenMapNullableContainerLambdas(

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
@@ -119,8 +119,14 @@ public class NullAwayRxSupportPositiveCases {
   }
 
   private Observable<Integer> filterWithLambdaNullExpressionBody(Observable<String> observable) {
-    // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return
-    // type
-    return observable.map(o -> perhaps() ? o : null).map(o -> o.length());
+      // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return
+      // type
+      return observable.map(o -> perhaps() ? o : null).map(o -> o.length());
+  }
+
+  private Observable<Integer> filterThenMapNullableContainerLambdas(
+      Observable<NullableContainer<String>> observable) {
+    // BUG: Diagnostic contains: dereferenced expression
+    return observable.filter(c -> c.get() != null || perhaps()).map(c -> c.get().length());
   }
 }


### PR DESCRIPTION
We should support lambdas passed to stream operations wherever we support anonymous classes, this method ensures that our nullability propagator handler works with lambdas. We also add the relevant test cases and a few general-purpose handler hooks to look for lambda expressions or the dataflow at their result expression.
