### PR TITLE
Check the return value of lambdas with a EXPRESSION body

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -96,8 +96,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-import sun.security.krb5.internal.crypto.Des;
-
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.sun.source.tree.Tree.Kind.EXPRESSION_STATEMENT;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -411,7 +411,7 @@ public class NullAway extends BugChecker implements
         if (mayBeNullExpr(state, retExpr)) {
             return createErrorDescription(
                     tree,
-                    "returning @Nullable expression from method with @NonNull return type" + methodSymbol,
+                    "returning @Nullable expression from method with @NonNull return type",
                     state.getPath());
         }
         return Description.NO_MATCH;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -245,7 +245,8 @@ public class NullAway extends BugChecker implements
         if (returnType.toString().equals("java.lang.Void")) {
             return Description.NO_MATCH;
         }
-        if (TrustingNullnessAnalysis.hasNullableAnnotation(methodSymbol)) {
+        if (fromUnannotatedPackage(methodSymbol)
+            || TrustingNullnessAnalysis.hasNullableAnnotation(methodSymbol)) {
             return Description.NO_MATCH;
         }
         if (mayBeNullExpr(state, retExpr)) {
@@ -428,7 +429,11 @@ public class NullAway extends BugChecker implements
             if (returnType.toString().equals("java.lang.Void")) {
                 return Description.NO_MATCH;
             }
-            if (!TrustingNullnessAnalysis.hasNullableAnnotation(methodSymbol) && mayBeNullExpr(state, resExpr)) {
+            if (fromUnannotatedPackage(methodSymbol)
+                    || TrustingNullnessAnalysis.hasNullableAnnotation(methodSymbol)) {
+                return Description.NO_MATCH;
+            }
+            if (mayBeNullExpr(state, resExpr)) {
                 return createErrorDescription(
                         tree,
                         "returning @Nullable expression from method with @NonNull return type" + methodSymbol,

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -55,7 +55,7 @@ public class NullAwayTest {
                         + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases.Super.doInit,"
                         + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"
                         + ".SuperInterface.doInit2",
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab",
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
                 "-XepOpt:NullAway:UnannotatedSubPackages="
                         + "com.uber.nullaway.testdata.unannotated",
                 "-XepOpt:NullAway:ExcludedClasses="

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
@@ -66,7 +66,7 @@ public class NullAwayJava8NegativeCases {
     static void testBuiltIn() {
         java.util.function.Function<String, String> foo = (x) -> x.toString();
         BiFunction<String, Object, String> bar = (x,y) -> x.toString() + y.toString();
-        Function<String,Object> foo2 = (x) -> null;   // Function is unnanotated
+        Function<String,Object> foo2 = (x) -> null;   // java.util.Function is unnanotated
         Function<String,Object> foo3 = (x) -> { return null; };
     }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
@@ -66,8 +66,8 @@ public class NullAwayJava8NegativeCases {
     static void testBuiltIn() {
         java.util.function.Function<String, String> foo = (x) -> x.toString();
         BiFunction<String, Object, String> bar = (x,y) -> x.toString() + y.toString();
-        Function<String,Object> foo2 = (x) -> x;
-        Function<String,Object> foo3 = (x) -> { return x; };
+        Function<String,Object> foo2 = (x) -> null;   // Function is unnanotated
+        Function<String,Object> foo3 = (x) -> { return null; };
     }
 
     static class Size {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
@@ -66,7 +66,8 @@ public class NullAwayJava8NegativeCases {
     static void testBuiltIn() {
         java.util.function.Function<String, String> foo = (x) -> x.toString();
         BiFunction<String, Object, String> bar = (x,y) -> x.toString() + y.toString();
-        Function<String,Object> foo2 = (x) -> null;
+        Function<String,Object> foo2 = (x) -> x;
+        Function<String,Object> foo3 = (x) -> { return x; };
     }
 
     static class Size {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -62,11 +62,4 @@ public class NullAwayJava8PositiveCases {
         NonNullParamFunction n3 = (@Nullable Object x) -> x.toString();
     }
 
-    static void testBuiltIn() {
-        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
-        Function<String,Object> foo2 = (x) -> null;
-        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
-        Function<String,Object> foo3 = (x) -> { return null; };
-    }
-
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -22,8 +22,8 @@
 
 package com.uber.nullaway.testdata;
 
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import io.reactivex.functions.Function;
+import io.reactivex.functions.BiFunction;
 
 import javax.annotation.Nullable;
 
@@ -60,6 +60,15 @@ public class NullAwayJava8PositiveCases {
         NullableParamFunction n2 = (Object x) -> x.toString();
         // BUG: Diagnostic contains: dereferenced expression x is @Nullable
         NonNullParamFunction n3 = (@Nullable Object x) -> x.toString();
+    }
+
+    static void testAnnoatedThirdParty() {
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        Function<String,Object> f1 = (x) -> null;   // io.reactivex.(Bi)Function is anotated
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        Function<String,Object> f2 = (x) -> { return null; };
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        BiFunction<String,String,Object>  f3 = (x, y) -> null;
     }
 
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -22,6 +22,9 @@
 
 package com.uber.nullaway.testdata;
 
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import javax.annotation.Nullable;
 
 public class NullAwayJava8PositiveCases {
@@ -59,6 +62,11 @@ public class NullAwayJava8PositiveCases {
         NonNullParamFunction n3 = (@Nullable Object x) -> x.toString();
     }
 
-
+    static void testBuiltIn() {
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        Function<String,Object> foo2 = (x) -> null;
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        Function<String,Object> foo3 = (x) -> { return null; };
+    }
 
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
@@ -105,4 +105,10 @@ public class NullAwayRxSupportPositiveCases {
             }
         });
     }
+
+    private Observable<Integer> filterWithLambdaNullExpressionBody
+            (Observable<String> observable) {
+        // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+        return observable.map(o -> perhaps() ? o : null).map(o -> o.length());
+    }
 }


### PR DESCRIPTION
Before we were only checking nullability in the return of lambdas with a block body, since those explicitly call `return _;`. This patch extends that behavior to lambdas with expression bodies, and adds corresponding test cases.