### PR TITLE
Better error message for field initialization (#14)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1252,6 +1252,7 @@ public class NullAway extends BugChecker implements
         } else {
             message += "fields " + Joiner.on(", ").join(uninitFields) + " are initialized";
         }
+        message += " along all control-flow paths (remember to check for exceptions or early returns).";
         return message;
     }
 


### PR DESCRIPTION
The error message now:

- Specifies that initializer methods must initialize all `@Nullable` fields along all possible control-flow paths.
- Explicitly reminds the developer to check for early `return;` statements or potential exceptions.

This addresses Issue #14 