### PR TITLE
Add the option to provide custom initializer annotations.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -74,6 +74,8 @@ public abstract class AbstractConfig implements Config {
 
     protected Set<String> excludedClassAnnotations;
 
+    protected Set<String> initializerAnnotations;
+
     protected static Pattern getPackagePattern(Set<String> packagePrefixes) {
         String choiceRegexp = Joiner.on("|").join(
                 Iterables.transform(packagePrefixes, new Function<String, String>() {
@@ -99,6 +101,11 @@ public abstract class AbstractConfig implements Config {
     @Override
     public boolean isExcludedClassAnnotation(String annotationName) {
         return excludedClassAnnotations.contains(annotationName);
+    }
+
+    @Override
+    public boolean isInitializerMethodAnnotation(String annotationName) {
+        return initializerAnnotations.contains(annotationName);
     }
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -57,6 +57,14 @@ public interface Config {
     /**
      *
      * @param annotationName fully-qualified annotation name
+     * @return true if a method with this annotation should be considered an initializer method,
+     * false otherwise.
+     */
+    boolean isInitializerMethodAnnotation(String annotationName);
+
+    /**
+     *
+     * @param annotationName fully-qualified annotation name
      * @return true if a field with this annotation should not be
      * checked for proper initialization, false otherwise
      */

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -76,6 +76,11 @@ public class DummyOptionsConfig implements Config {
     }
 
     @Override
+    public boolean isInitializerMethodAnnotation(String annotationName) {
+        throw new IllegalStateException(error_msg);
+    }
+
+    @Override
     public boolean suggestSuppressions() {
         throw new IllegalStateException(error_msg);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -24,7 +24,10 @@ package com.uber.nullaway;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.ErrorProneFlags;
+
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * provides nullability configuration based on additional flags
@@ -42,7 +45,19 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     static final String FL_CLASS_ANNOTATIONS_TO_EXCLUDE = EP_FL_NAMESPACE + ":ExcludedClassAnnotations";
     static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
     static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
+    static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
     private static final String DELIMITER = ",";
+
+    static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS = ImmutableSet.of(
+            "android.view.View.onFinishInflate",
+            "android.app.Service.onCreate",
+            "android.app.Activity.onCreate",
+            "android.app.Fragment.onCreate",
+            "android.app.Application.onCreate",
+            "javax.annotation.processing.Processor.init");
+    static  final ImmutableSet<String> DEFAULT_INITIALIZER_ANNOT = ImmutableSet.of(
+            "org.junit.Before",
+            "org.junit.BeforeClass");  // + Anything with @Initializer as its "simple name"
 
     ErrorProneCLIFlagsConfig(ErrorProneFlags flags) {
         if (!flags.get(FL_ANNOTATED_PACKAGES).isPresent()) {
@@ -52,8 +67,10 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
         annotatedPackages = getPackagePattern(getFlagStringSet(flags, FL_ANNOTATED_PACKAGES));
         unannotatedSubPackages = getPackagePattern(getFlagStringSet(flags, FL_UNANNOTATED_SUBPACKAGES));
         sourceClassesToExclude = getFlagStringSet(flags, FL_CLASSES_TO_EXCLUDE);
-        knownInitializers = getKnownInitializers(getFlagStringSet(flags, FL_KNOWN_INITIALIZERS));
+        knownInitializers = getKnownInitializers(
+                getFlagStringSet(flags, FL_KNOWN_INITIALIZERS, DEFAULT_KNOWN_INITIALIZERS));
         excludedClassAnnotations = getFlagStringSet(flags, FL_CLASS_ANNOTATIONS_TO_EXCLUDE);
+        initializerAnnotations = getFlagStringSet(flags, FL_INITIALIZER_ANNOT, DEFAULT_INITIALIZER_ANNOT);
         isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
         isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
         ImmutableSet<String> propStrings = getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT);
@@ -66,6 +83,20 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
             return ImmutableSet.copyOf(flagValue.get().split(DELIMITER));
         }
         return ImmutableSet.of();
+    }
+
+    private static ImmutableSet<String> getFlagStringSet(
+            ErrorProneFlags flags,
+            String flagName,
+            ImmutableSet<String> defaults) {
+        Set<String> combined = new LinkedHashSet<String>(defaults);
+        Optional<String> flagValue = flags.get(flagName);
+        if (flagValue.isPresent()) {
+            for (String s : flagValue.get().split(DELIMITER)) {
+                combined.add(s);
+            }
+        }
+        return ImmutableSet.copyOf(combined);
     }
 
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -891,6 +891,12 @@ public class NullAway extends BugChecker implements
                 || config.isKnownInitializerMethod(symbol)) {
             return true;
         }
+        for (AnnotationMirror anno : symbol.getAnnotationMirrors()) {
+            String annoTypeStr = anno.getAnnotationType().toString();
+            if (config.isInitializerMethodAnnotation(annoTypeStr)) {
+                return true;
+            }
+        }
         Symbol.MethodSymbol closestOverriddenMethod = getClosestOverriddenMethod(symbol, state.getTypes());
         if (closestOverriddenMethod == null) {
             return false;

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -24,6 +24,9 @@ package com.uber.nullaway.testdata;
 
 import com.facebook.infer.annotation.Initializer;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
+
 import javax.inject.Inject;
 
 /**
@@ -120,6 +123,24 @@ public class CheckFieldInitNegativeCases {
         }
 
     }
+
+    class T6 {
+
+        Object f, g;
+
+        T6() {}
+
+        @Before
+        void init1() {
+            this.f = new Object();
+        }
+
+        @BeforeClass
+        void init2() {
+            this.g = new Object();
+        }
+    }
+
     abstract class Super {
 
         // to test known initializer methods


### PR DESCRIPTION
- One can pass the full name of initializer annotations with
  `-XepOpt:NullAway:CustomInitializerAnnotations. These will
  be acknowledged, as well as any annotation with @Initializer
  as its simple name.
- Provide sane defaults for this option and for
  `-XepOpt:NullAway:KnownInitializers=`, to match what we say
  in the wiki.
- Make org.junit.Before and org.junit.BeforeClass default initializer
  annotations.
- This fixes issues #18 and #19.
- Sanity test included, but no tests for the Android initializer methods 
  since we don't want to depend on those clases.