### PR TITLE
Use Junit annotations properly in CheckFieldInitNegativeCases.T6

### DIFF
--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -124,9 +124,10 @@ public class CheckFieldInitNegativeCases {
 
     }
 
-    class T6 {
+    static class T6 {
 
-        Object f, g;
+        Object f;
+        static Object g;
 
         T6() {}
 
@@ -136,8 +137,8 @@ public class CheckFieldInitNegativeCases {
         }
 
         @BeforeClass
-        void init2() {
-            this.g = new Object();
+        static void init2() {
+            T6.g = new Object();
         }
     }
 


### PR DESCRIPTION
The test case is only testing that we recognize those annotations,
but on a proper Junit test, @BeforeClass must be a static method
and initialize static fields, so lets use it that way.