### PR TITLE
Add finer grained suppressions and auto-fixes

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -125,6 +125,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
+  @Nullable
   public String getCastToNonNullMethod() {
     return castToNonNullMethod;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -68,6 +68,8 @@ public abstract class AbstractConfig implements Config {
 
   protected Set<String> initializerAnnotations;
 
+  @Nullable protected String castToNonNullMethod;
+
   protected static Pattern getPackagePattern(Set<String> packagePrefixes) {
     // noinspection ConstantConditions
     String choiceRegexp =
@@ -120,6 +122,11 @@ public abstract class AbstractConfig implements Config {
   @Override
   public boolean suggestSuppressions() {
     return isSuggestSuppressions;
+  }
+
+  @Override
+  public String getCastToNonNullMethod() {
+    return castToNonNullMethod;
   }
 
   protected Set<MethodClassAndName> getKnownInitializers(Set<String> qualifiedNames) {

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -80,4 +80,11 @@ public interface Config {
    *     suppressing all warnings in a large code base.
    */
   boolean suggestSuppressions();
+
+  /**
+   * @return the fully qualified name of a method which will take a @Nullable version of a value and
+   *     return an @NonNull copy (likely through an unsafe downcast, but performing runtime checking
+   *     and logging)
+   */
+  String getCastToNonNullMethod();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway;
 
 import com.sun.tools.javac.code.Symbol;
+import javax.annotation.Nullable;
 
 /** Provides configuration parameters for the nullability checker. */
 public interface Config {
@@ -86,5 +87,6 @@ public interface Config {
    *     return an @NonNull copy (likely through an unsafe downcast, but performing runtime checking
    *     and logging)
    */
+  @Nullable
   String getCastToNonNullMethod();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -26,6 +26,7 @@ import static com.uber.nullaway.ErrorProneCLIFlagsConfig.EP_FL_NAMESPACE;
 import static com.uber.nullaway.ErrorProneCLIFlagsConfig.FL_ANNOTATED_PACKAGES;
 
 import com.sun.tools.javac.code.Symbol;
+import javax.annotation.Nullable;
 
 /**
  * Dummy Config class required for the {@link NullAway} empty constructor.
@@ -91,6 +92,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  @Nullable
   public String getCastToNonNullMethod() {
     throw new IllegalStateException(error_msg);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -89,4 +89,9 @@ public class DummyOptionsConfig implements Config {
   public boolean suggestSuppressions() {
     throw new IllegalStateException(error_msg);
   }
+
+  @Override
+  public String getCastToNonNullMethod() {
+    throw new IllegalStateException(error_msg);
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -46,6 +46,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
+  static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
@@ -82,6 +83,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
     ImmutableSet<String> propStrings = getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT);
     fieldAnnotPattern = propStrings.isEmpty() ? null : getPackagePattern(propStrings);
+    castToNonNullMethod = flags.get(FL_CTNN_METHOD).orElse(null);
   }
 
   private static ImmutableSet<String> getFlagStringSet(ErrorProneFlags flags, String flagName) {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -162,4 +162,20 @@ public class CheckFieldInitNegativeCases {
       yetAnotherField = new Object();
     }
   }
+
+  static class SuppressWarningsA {
+
+    Object f; // Should be an error, but we are suppressing
+
+    @SuppressWarnings("NullAway")
+    SuppressWarningsA() {}
+  }
+
+  static class SuppressWarningsB {
+
+    Object f; // Should be an error, but we are suppressing
+
+    @SuppressWarnings("NullAway.Init")
+    SuppressWarningsB() {}
+  }
 }


### PR DESCRIPTION
- We now support methods to be annotated as `@SuppressWarnings("NullAway.Init")`
   which causes NullAway to ignore initialization issues but not other nullness issues.
- NullAway provides better auto-fix suggestions for each error reported, including 
  using a `castToNonNull` method if configured, and suppressing initialization only, 
  rather than all warnings.
