### PR TITLE
WIP: fix up maven + shadow jar integration

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -62,7 +62,6 @@ shadowJar {
 }
 build.dependsOn shadowJar
 
-
 javadoc {
     failOnError = false
 }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -77,5 +77,21 @@ test {
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
+
+install {
+  repositories.mavenInstaller {
+    pom.scopeMappings.mappings.remove(project.configurations.compile)
+    pom.scopeMappings.mappings.remove(project.configurations.runtime)
+    pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+  }
+}
 install.dependsOn shadowJar
+
+uploadArchives {
+  repositories.mavenDeployer {
+    pom.scopeMappings.mappings.remove(project.configurations.compile)
+    pom.scopeMappings.mappings.remove(project.configurations.runtime)
+    pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+  }
+}
 uploadArchives.dependsOn shadowJar

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -62,6 +62,7 @@ shadowJar {
 }
 build.dependsOn shadowJar
 
+
 javadoc {
     failOnError = false
 }
@@ -76,3 +77,5 @@ test {
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
+install.dependsOn shadowJar
+uploadArchives.dependsOn shadowJar

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -77,20 +77,21 @@ test {
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
 
+def configurePomForShadow(pom) {
+  pom.scopeMappings.mappings.remove(project.configurations.compile)
+  pom.scopeMappings.mappings.remove(project.configurations.runtime)
+  pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+}
 install {
   repositories.mavenInstaller {
-    pom.scopeMappings.mappings.remove(project.configurations.compile)
-    pom.scopeMappings.mappings.remove(project.configurations.runtime)
-    pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+    configurePomForShadow(pom)
   }
 }
 install.dependsOn shadowJar
 
 uploadArchives {
   repositories.mavenDeployer {
-    pom.scopeMappings.mappings.remove(project.configurations.compile)
-    pom.scopeMappings.mappings.remove(project.configurations.runtime)
-    pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+    configurePomForShadow(pom)
   }
 }
 uploadArchives.dependsOn shadowJar

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -82,6 +82,7 @@ def configurePomForShadow(pom) {
   pom.scopeMappings.mappings.remove(project.configurations.runtime)
   pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
 }
+
 install {
   repositories.mavenInstaller {
     configurePomForShadow(pom)

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -95,3 +95,4 @@ uploadArchives {
   }
 }
 uploadArchives.dependsOn shadowJar
+


### PR DESCRIPTION
The maven integration with our new shadow jar setup needs some fixing.  Thus far I've made the `install` and `uploadArchives` tasks depend on `shadowJar` so the right jar gets installed / uploaded.  But, there's a problem with the generated POM file; it still includes:
```xml
    <dependency>
      <groupId>org.checkerframework</groupId>
      <artifactId>dataflow</artifactId>
      <version>2.1.14.1-nullaway</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.checkerframework</groupId>
      <artifactId>javacutil</artifactId>
      <version>2.1.14</version>
      <scope>compile</scope>
    </dependency>
```
These need to be excluded from the generated POM since the classes are in the shadow jar.  When using shadow jar, we want to exclude all `compile` dependencies from the generated POM.  Not sure where to fix this.  @kageiit any ideas?