### PR TITLE
-XepOpt:NullAway:ExcludedClasses accepts package prefixes.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -86,7 +86,15 @@ public abstract class AbstractConfig implements Config {
 
   @Override
   public boolean isExcludedClass(String className) {
-    return sourceClassesToExclude != null && sourceClassesToExclude.contains(className);
+    if (sourceClassesToExclude == null) {
+      return false;
+    }
+    for (String classPrefix : sourceClassesToExclude) {
+      if (className.startsWith(classPrefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -53,7 +53,9 @@ public class NullAwayTest {
                 + ".SuperInterface.doInit2",
             "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
             "-XepOpt:NullAway:UnannotatedSubPackages=" + "com.uber.nullaway.testdata.unannotated",
-            "-XepOpt:NullAway:ExcludedClasses=" + "com.uber.nullaway.testdata.Shape_Stuff",
+            "-XepOpt:NullAway:ExcludedClasses="
+                + "com.uber.nullaway.testdata.Shape_Stuff,"
+                + "com.uber.nullaway.testdata.excluded",
             "-XepOpt:NullAway:ExcludedClassAnnotations="
                 + "com.uber.nullaway.testdata"
                 + ".TestAnnot",
@@ -82,6 +84,7 @@ public class NullAwayTest {
   @Test
   public void coreNullabilitySkipClass() {
     compilationHelper.addSourceFile("Shape_Stuff.java").doTest();
+    compilationHelper.addSourceFile("excluded/Shape_Stuff2.java").doTest();
     compilationHelper.addSourceFile("AnnotatedClass.java").addSourceFile("TestAnnot.java").doTest();
   }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/excluded/Shape_Stuff2.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/excluded/Shape_Stuff2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.testdata.excluded;
+
+/** to test exclusions functionality */
+public class Shape_Stuff2 {
+
+  static class C {
+    Object f = new Object();
+  }
+
+  private static void callee(Object x) {
+    x.toString();
+  }
+  // we should report no errors
+  public static Object doBadStuff() {
+    Object x = null;
+    x.toString();
+    (new C()).f = x;
+    callee(x);
+    return x;
+  }
+}


### PR DESCRIPTION
Simple fix, plus tests.
