### PR TITLE
Make Error Prone dependence compileOnly

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     compileOnly deps.apt.autoValue
     compileOnly deps.apt.autoService
 
-    shadow deps.build.errorProneCheckApi
+    compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow
 
     errorprone deps.build.errorProneCore
@@ -53,7 +53,7 @@ dependencies {
     testCompile deps.apt.javaxInject
     testCompile deps.test.rxjava2
 
-    epJavac deps.build.errorProneCore
+    epJavac deps.build.errorProneCheckApi
     epJavac deps.build.checkerDataflow
 }
 


### PR DESCRIPTION
Whenever NullAway runs, it must be loaded via Error Prone.  Hence, I believe that the Error Prone Check APIs should always be available.  Making the `errorProneCheckApi` a compileOnly dependence should reduce the size of the annotation processor classpath in some cases, which could speed up builds and avoid some incompatibilities like in #48.  