### PR TITLE
Handle @Nullable type use annotations

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,6 +40,7 @@ def build = [
 def test = [
     junit             : "junit:junit:4.12",
     inferAnnotations  : "com.facebook.infer.annotation:infer-annotation:0.11.0",
+    cfQual            : "org.checkerframework:checker-qual:2.2.2",
     rxjava2           : "io.reactivex.rxjava2:rxjava:2.1.2",
 ]
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+    testCompile deps.test.cfQual
     testCompile deps.test.inferAnnotations
     testCompile deps.apt.javaxInject
     testCompile deps.test.rxjava2

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -978,7 +978,7 @@ public class NullAway extends BugChecker
   }
 
   private boolean skipDueToFieldAnnotation(Symbol fieldSymbol) {
-    for (AnnotationMirror anno : fieldSymbol.getAnnotationMirrors()) {
+    for (AnnotationMirror anno : NullabilityUtil.getAllAnnotations(fieldSymbol)) {
       // Check for Nullable like ReturnValueIsNonNull
       String annoTypeStr = anno.getAnnotationType().toString();
       if (config.isExcludedFieldAnnotation(annoTypeStr)) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway;
 
+import com.google.common.collect.Iterables;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
@@ -35,6 +36,9 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.JCDiagnostic;
 import javax.annotation.Nullable;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeMirror;
 
 /** Helpful utility methods for nullability analysis. */
 public class NullabilityUtil {
@@ -118,5 +122,18 @@ public class NullabilityUtil {
       path = parent;
     }
     return null;
+  }
+
+  /**
+   * @param element the element
+   * @return all annotations on the element and on the type of the element
+   */
+  public static Iterable<? extends AnnotationMirror> getAllAnnotations(Element element) {
+    // for methods, we care about annotations on the return type, not on the method type itself
+    TypeMirror typeMirror =
+        element instanceof Symbol.MethodSymbol
+            ? ((Symbol.MethodSymbol) element).getReturnType()
+            : element.asType();
+    return Iterables.concat(element.getAnnotationMirrors(), typeMirror.getAnnotationMirrors());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -128,8 +128,7 @@ public enum Nullness implements AbstractValue<Nullness> {
   }
 
   private static Nullness nullnessFromAnnotations(Element element) {
-    for (AnnotationMirror anno : element.getAnnotationMirrors()) {
-      // Check for Nullable like ReturnValueIsNonNull
+    for (AnnotationMirror anno : NullabilityUtil.getAllAnnotations(element)) {
       if (anno.getAnnotationType().toString().endsWith(".Nullable")) {
         return Nullness.NULLABLE;
       }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -646,4 +646,35 @@ public class NullAwayNegativeCases {
       /* NOP */
     }
   }
+
+  static class CFNullable {
+
+    @org.checkerframework.checker.nullness.qual.Nullable String cfNullableString;
+
+    CFNullable() {}
+
+    static int fizz(@org.checkerframework.checker.nullness.qual.Nullable String str) {
+      if (str != null) {
+        return str.hashCode();
+      }
+      return 10;
+    }
+
+    static void bizz() {
+      fizz(null);
+    }
+
+    @org.checkerframework.checker.nullness.qual.Nullable
+    Object retNullMaybe() {
+      return null;
+    }
+  }
+
+  static class CFExtends extends CFNullable {
+
+    @Override
+    Object retNullMaybe() {
+      return new Object();
+    }
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -429,8 +429,8 @@ public class NullAwayPositiveCases {
   static class CFExtends extends CFNullable {
 
     @Override
-    // BUG: Diagnostic contains: method returns @Nullable, but superclass
     @org.checkerframework.checker.nullness.qual.Nullable
+    // BUG: Diagnostic contains: method returns @Nullable, but superclass
     Object retNonNull() {
       return null;
     }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -413,4 +413,26 @@ public class NullAwayPositiveCases {
       nonNullSField = s;
     }
   }
+
+  static class CFNullable {
+
+    static int fizz(@org.checkerframework.checker.nullness.qual.Nullable String str) {
+      // BUG: Diagnostic contains: dereferenced expression
+      return str.hashCode();
+    }
+
+    Object retNonNull() {
+      return new Object();
+    }
+  }
+
+  static class CFExtends extends CFNullable {
+
+    @Override
+    // BUG: Diagnostic contains: method returns @Nullable, but superclass
+    @org.checkerframework.checker.nullness.qual.Nullable
+    Object retNonNull() {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
E.g., the `@Nullable` annotations provided by Checker Framework are type use annotations.  Reported in [this comment](https://www.reddit.com/r/java/comments/77mir7/nullaway_an_open_source_tool_for_detecting/douvhh9/)