### PR TITLE
fix bug with accesses of fields from unannotated packages

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1506,7 +1506,8 @@ public class NullAway extends BugChecker
   }
 
   private boolean mayBeNullFieldAccess(VisitorState state, ExpressionTree expr, Symbol exprSymbol) {
-    if (exprSymbol != null && !Nullness.hasNullableAnnotation(exprSymbol)) {
+    if (exprSymbol != null
+        && (fromUnannotatedPackage(exprSymbol) || !Nullness.hasNullableAnnotation(exprSymbol))) {
       return false;
     }
     return nullnessFromDataflow(state, expr);

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -79,6 +79,7 @@ public class NullAwayTest {
         .addSourceFile("NullAwayNegativeCases.java")
         .addSourceFile("OtherStuff.java")
         .addSourceFile("TestAnnot.java")
+        .addSourceFile("unannotated/UnannotatedClass.java")
         .doTest();
   }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -26,6 +26,7 @@ import static com.uber.nullaway.testdata.OtherStuff.OtherEnum.TOP;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.uber.nullaway.testdata.unannotated.UnannotatedClass;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -675,6 +676,15 @@ public class NullAwayNegativeCases {
     @Override
     Object retNullMaybe() {
       return new Object();
+    }
+  }
+
+  static class ExcNullField {
+
+    void foo() {
+      UnannotatedClass e = new UnannotatedClass();
+      // no error since not annotated
+      e.maybeNull.hashCode();
     }
   }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/UnannotatedClass.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/UnannotatedClass.java
@@ -22,12 +22,16 @@
 
 package com.uber.nullaway.testdata.unannotated;
 
+import javax.annotation.Nullable;
+
 public class UnannotatedClass {
 
   private Object field;
 
+  @Nullable public Object maybeNull;
+
   // should get no initialization error
-  UnannotatedClass() {}
+  public UnannotatedClass() {}
 
   /**
    * This is an identity method, without Nullability annotations.


### PR DESCRIPTION
Previously we would use nullability annotations on fields even if the package was unannotated, which could lead to unexpected warnings.