### PR TITLE
Handle getting class of primitive type properly

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -138,8 +138,13 @@ public class NullabilityUtil {
   }
 
   public static boolean mayBeNullFieldFromType(@Nullable Symbol symbol, Config config) {
-    return symbol == null
-        || (!fromUnannotatedPackage(symbol, config) && Nullness.hasNullableAnnotation(symbol));
+    if (symbol == null) {
+      return true;
+    }
+    return !(symbol.getSimpleName().toString().equals("class")
+        || symbol.isEnum()
+        || fromUnannotatedPackage(symbol, config)
+        || !Nullness.hasNullableAnnotation(symbol));
   }
 
   public static boolean fromUnannotatedPackage(Symbol symbol, Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -142,9 +142,9 @@ public class NullabilityUtil {
       return true;
     }
     return !(symbol.getSimpleName().toString().equals("class")
-        || symbol.isEnum()
-        || fromUnannotatedPackage(symbol, config)
-        || !Nullness.hasNullableAnnotation(symbol));
+            || symbol.isEnum()
+            || fromUnannotatedPackage(symbol, config))
+        && Nullness.hasNullableAnnotation(symbol);
   }
 
   public static boolean fromUnannotatedPackage(Symbol symbol, Config config) {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -690,5 +690,10 @@ public class NullAwayNegativeCases {
       // no error since not annotated
       y.hashCode();
     }
+
+    void weird() {
+      Class klazz = int.class;
+      klazz.hashCode();
+    }
   }
 }


### PR DESCRIPTION
We failed on `int.class` before