### PR TITLE
Recognize JUnit 5's @BeforeAll and @BeforeEach as initializers

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -60,7 +60,9 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final ImmutableSet<String> DEFAULT_INITIALIZER_ANNOT =
       ImmutableSet.of(
           "org.junit.Before",
-          "org.junit.BeforeClass"); // + Anything with @Initializer as its "simple name"
+          "org.junit.BeforeClass",
+          "org.junit.jupiter.api.BeforeAll",
+          "org.junit.jupiter.api.BeforeEach"); // + Anything with @Initializer as its "simple name"
 
   ErrorProneCLIFlagsConfig(ErrorProneFlags flags) {
     if (!flags.get(FL_ANNOTATED_PACKAGES).isPresent()) {


### PR DESCRIPTION
Fixes #73.

FYI the pre-commit hook was failing for me.  It didn't spit out any error message that I could see, so I disabled the hook.