### PR TITLE
[WIP] Build NullAway with ErrorProne 2.1.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@
 def versions = [
     checkerFramework       : "2.1.14",
     checkerFrameworkNAFork : "2.1.14.1-nullaway",
-    errorProne             : "2.1.1",
+    errorProne             : "2.1.3",
     support                : "27.0.2"
 ]
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -49,11 +49,11 @@ import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.NullnessStore;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -499,7 +499,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    */
   private static class StreamModelBuilder {
 
-    private final List<StreamTypeRecord> typeRecords = new LinkedList<StreamTypeRecord>();
+    private final List<StreamTypeRecord> typeRecords = new ArrayList<StreamTypeRecord>();
     private TypePredicate tp = null;
     private Set<String> filterMethodSigs;
     private Set<String> filterMethodSimpleNames;


### PR DESCRIPTION
Currently failing with a weird error:
```
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':nullaway:compileJava'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:100)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:70)
        at org.gradle.api.internal.tasks.execution.OutputDirectoryCreatingTaskExecuter.execute(OutputDirectoryCreatingTaskExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:62)
[...]
Caused by: java.lang.NoClassDefFoundError: org/checkerframework/javacutil/AnnotationUtils
        at com.google.errorprone.BaseErrorProneJavaCompiler$CFCacheClearingListener.finished(BaseErrorProneJavaCompiler.java:269)
        at com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:817)
        at com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:120)
        at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:1002)
        at com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0(JavacTaskImpl.java:100)
        at com.sun.tools.javac.api.JavacTaskImpl.handleExceptions(JavacTaskImpl.java:142)
        ... 56 more
Caused by: java.lang.ClassNotFoundException: org.checkerframework.javacutil.AnnotationUtils
        at net.ltgt.gradle.errorprone.ErrorProneCompiler$SelfFirstClassLoader.loadClass(ErrorProneCompiler.java:104)
        at net.ltgt.gradle.errorprone.ErrorProneCompiler$SelfFirstClassLoader.loadClass(ErrorProneCompiler.java:90)
        ... 62 more
```
@lazaroclapp I wonder if the issue is we need to keep our custom CF version separate from the version used by EP when building the code?