### PR TITLE
support more annotations by default

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -55,7 +55,8 @@ def support = [
 ]
 
 def test = [
-    junit             : "junit:junit:4.12",
+    junit4            : "junit:junit:4.12",
+    junit5Jupiter     : ["org.junit.jupiter:junit-jupiter-api:5.0.2","org.apiguardian:apiguardian-api:1.0.0"],
     inferAnnotations  : "com.facebook.infer.annotation:infer-annotation:0.11.0",
     cfQual            : "org.checkerframework:checker-qual:2.2.2",
     rxjava2           : "io.reactivex.rxjava2:rxjava:2.1.2",

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -45,10 +45,11 @@ dependencies {
 
     errorprone deps.build.errorProneCore
 
-    testCompile deps.test.junit
+    testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+    testCompile deps.test.junit5Jupiter
     testCompile deps.test.cfQual
     testCompile deps.test.inferAnnotations
     testCompile deps.apt.javaxInject

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -56,7 +56,7 @@ public abstract class AbstractConfig implements Config {
   /** Source code in these packages will not be analyzed for nullability issues */
   @Nullable protected ImmutableSet<String> sourceClassesToExclude;
 
-  @Nullable protected Pattern fieldAnnotPattern;
+  protected Pattern fieldAnnotPattern;
 
   protected boolean isExhaustiveOverride;
 

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -57,10 +57,18 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "android.app.Fragment.onCreate",
           "android.app.Application.onCreate",
           "javax.annotation.processing.Processor.init");
+
   static final ImmutableSet<String> DEFAULT_INITIALIZER_ANNOT =
       ImmutableSet.of(
           "org.junit.Before",
-          "org.junit.BeforeClass"); // + Anything with @Initializer as its "simple name"
+          "org.junit.BeforeClass",
+          "org.junit.jupiter.api.BeforeAll",
+          "org.junit.jupiter.api.BeforeEach"); // + Anything with @Initializer as its "simple name"
+
+  static final ImmutableSet<String> DEFAULT_EXCLUDED_FIELD_ANNOT =
+      ImmutableSet.of(
+          "javax.inject.Inject", // no explicit initialization when there is dependency injection
+          "com.google.errorprone.annotations.concurrent.LazyInit");
 
   ErrorProneCLIFlagsConfig(ErrorProneFlags flags) {
     if (!flags.get(FL_ANNOTATED_PACKAGES).isPresent()) {
@@ -81,8 +89,9 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
         getFlagStringSet(flags, FL_INITIALIZER_ANNOT, DEFAULT_INITIALIZER_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
-    ImmutableSet<String> propStrings = getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT);
-    fieldAnnotPattern = propStrings.isEmpty() ? null : getPackagePattern(propStrings);
+    fieldAnnotPattern =
+        getPackagePattern(
+            getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT, DEFAULT_EXCLUDED_FIELD_ANNOT));
     castToNonNullMethod = flags.get(FL_CTNN_METHOD).orElse(null);
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -52,14 +52,11 @@ public class NullAwayTest {
                 + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"
                 + ".SuperInterface.doInit2",
             "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
-            "-XepOpt:NullAway:UnannotatedSubPackages=" + "com.uber.nullaway.testdata.unannotated",
+            "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.testdata.unannotated",
             "-XepOpt:NullAway:ExcludedClasses="
                 + "com.uber.nullaway.testdata.Shape_Stuff,"
                 + "com.uber.nullaway.testdata.excluded",
-            "-XepOpt:NullAway:ExcludedClassAnnotations="
-                + "com.uber.nullaway.testdata"
-                + ".TestAnnot",
-            "-XepOpt:NullAway:ExcludedFieldAnnotations=javax.inject.Inject",
+            "-XepOpt:NullAway:ExcludedClassAnnotations=" + "com.uber.nullaway.testdata.TestAnnot",
             "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull"));
   }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -23,9 +23,12 @@
 package com.uber.nullaway.testdata;
 
 import com.facebook.infer.annotation.Initializer;
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import javax.inject.Inject;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 /** Created by msridhar on 3/8/17. */
 public class CheckFieldInitNegativeCases {
@@ -43,6 +46,8 @@ public class CheckFieldInitNegativeCases {
     Object k;
 
     @Inject Object m;
+
+    @LazyInit Object lazy;
 
     T1(Object h, Object k, boolean b) {
       g = new Object();
@@ -132,6 +137,24 @@ public class CheckFieldInitNegativeCases {
     @BeforeClass
     static void init2() {
       T6.g = new Object();
+    }
+  }
+
+  static class T7 {
+
+    Object f;
+    static Object g;
+
+    T7() {}
+
+    @BeforeEach
+    void init1() {
+      this.f = new Object();
+    }
+
+    @BeforeAll
+    static void init2() {
+      T7.g = new Object();
     }
   }
 

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile deps.support.appcompat
 
-    testCompile deps.test.junit
+    testCompile deps.test.junit4
 
     annotationProcessor project(path: ":nullaway", configuration: "shadow")
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     errorprone deps.build.errorProneCore
 
     compileOnly deps.build.jsr305Annotations
-    testCompile deps.test.junit
+    testCompile deps.test.junit4
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Support `@BeforeEach` and `@BeforeAll` as initializer annotations, and `@Inject` and `@LazyInit` as excluded field annotations.

Fixes #73, #64