### PR TITLE
add WebView.getUrl() model

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -264,6 +264,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .add(methodRef("android.app.ActivityManager", "getRunningAppProcesses()"))
             .add(methodRef("android.view.View", "getHandler()"))
             .add(methodRef("java.lang.Throwable", "getMessage()"))
+            .add(methodRef("android.webkit.WebView", "getUrl()"))
             .build();
 
     @Override

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -94,7 +94,10 @@ public class NullAwayTest {
 
   @Test
   public void coreNullabilityNativeModels() {
-    compilationHelper.addSourceFile("NullAwayNativeModels.java").doTest();
+    compilationHelper
+        .addSourceFile("NullAwayNativeModels.java")
+        .addSourceFile("androidstubs/WebView.java")
+        .doTest();
   }
 
   @Test

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway.testdata;
 
+import android.webkit.WebView;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -281,5 +282,11 @@ public class NullAwayNativeModels {
     ImmutableSortedSet.builder().add(o).build();
     // BUG: Diagnostic contains: passing @Nullable parameter 'c' where @NonNull is required
     Iterables.getFirst(c, "hi");
+  }
+
+  static void androidStuff() {
+    android.webkit.WebView webView = new WebView();
+    // BUG: Diagnostic contains: dereferenced expression
+    webView.getUrl().toString();
   }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/androidstubs/WebView.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/androidstubs/WebView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// STUB CLASS FOR PURPOSES OF REGRESSION TESTING ONLY
+
+package android.webkit;
+
+public class WebView {
+
+  public String getUrl() {
+    return null;
+  }
+}


### PR DESCRIPTION
We create a stub WebView class for testing purposes so we don't need to add an Android testCompile dependence from NullAway.