### PR TITLE
Properly handle invocation of anonymous class constructor with parameters

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1878,9 +1878,8 @@ public class NullAway extends BugChecker
     Scope scope = superType.tsym.members();
     for (Symbol sym : scope.getSymbolsByName(methodSymbol.name)) {
       if (sym != null
-          && !sym.isStatic()
+          && sym.isConstructor()
           && ((sym.flags() & Flags.SYNTHETIC) == 0)
-          && sym.name.contentEquals(methodSymbol.name)
           && hasSameArgTypes((Symbol.MethodSymbol) sym, methodSymbol, types)) {
         return (Symbol.MethodSymbol) sym;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -319,6 +319,9 @@ public class NullAway extends BugChecker
       Type supertype = state.getTypes().supertype(methodSymbol.owner.type);
       Symbol.MethodSymbol superConstructor =
           findSuperConstructorInType(methodSymbol, supertype, state.getTypes());
+      if (superConstructor == null) {
+        throw new RuntimeException("must find constructor in supertype");
+      }
       methodSymbol = superConstructor;
     }
     return handleInvocation(state, methodSymbol, actualParams);

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -738,4 +738,13 @@ public class NullAwayNegativeCases {
       klazz.hashCode();
     }
   }
+
+  static class TestAnon {
+
+    TestAnon(@Nullable Object p) {}
+  }
+
+  static TestAnon testAnon(@Nullable Object q) {
+    return new TestAnon(q) {};
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -435,4 +435,14 @@ public class NullAwayPositiveCases {
       return null;
     }
   }
+
+  static class TestAnon {
+
+    TestAnon(Object p) {}
+  }
+
+  static TestAnon testAnon(@Nullable Object q) {
+    // BUG: Diagnostic contains: passing @Nullable parameter 'q' where
+    return new TestAnon(q) {};
+  }
 }


### PR DESCRIPTION
Fixes #102.  We now treat the invocation as if it were directly invoking the constructor of the superclass, so appropriate nullability annotations are checked.