### PR TITLE
Fix shadow Gradle configuration

### DIFF
--- a/compile-bench/build.gradle
+++ b/compile-bench/build.gradle
@@ -27,12 +27,12 @@ mainClassName = "com.uber.nullaway.benchmark.NullAwayBenchmarkHarness"
 configurations.maybeCreate("epJavac")
 
 dependencies {
-    compile "com.google.errorprone:error_prone_core:2.1.3"
-    compile project(":nullaway")
+    compile deps.build.errorProneCore
+    compile project(path: ":nullaway", configuration: "shadow")
 
-    errorprone "com.google.errorprone:error_prone_core:2.1.3"
+    errorprone deps.build.errorProneCore
 
-    epJavac "com.google.errorprone:error_prone_core:2.1.3"
+    epJavac deps.build.errorProneCore
 
 }
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -59,10 +59,18 @@ dependencies {
     epJavac deps.build.checkerDataflow
 }
 
+// We include and shade the checker framework jars into the NullAway jar, as we may have custom
+// changes.
 shadowJar {
+    // set classifier to null since we want the artifact uploaded to Maven Central to be the
+    // shadow jar.  Without this, the shadow jar is built with a '-all' suffix in the name.
     classifier = null
     relocate "org.checkerframework", "shadow.checkerframework"
 }
+// Since we set classifier to null above, both the normal jar artifact and the shadow jar have
+// the same name, which can cause races if we are not careful.  We force shadowJar to depend on
+// assemble, so we know that the shadow jar will always overwrite the normal one.  We also force
+// test to depend on shadowJar, to avoid races between running tests and building the shadow jar.
 shadowJar.dependsOn assemble
 test.dependsOn shadowJar
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -15,8 +15,7 @@
  */
 plugins {
   id "net.ltgt.errorprone" version "0.0.13"
-  id "com.github.johnrengelman.shadow" version "2.0.1"
-  id "com.github.johnrengelman.plugin-shadow" version "2.0.0"
+  id "com.github.johnrengelman.shadow" version "2.0.2"
   id "java"
 }
 
@@ -62,8 +61,10 @@ dependencies {
 
 shadowJar {
     classifier = null
+    relocate "org.checkerframework", "shadow.checkerframework"
 }
-build.dependsOn shadowJar
+shadowJar.dependsOn assemble
+test.dependsOn shadowJar
 
 javadoc {
     failOnError = false

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -71,6 +71,9 @@ shadowJar {
 // the same name, which can cause races if we are not careful.  We force shadowJar to depend on
 // assemble, so we know that the shadow jar will always overwrite the normal one.  We also force
 // test to depend on shadowJar, to avoid races between running tests and building the shadow jar.
+// We also require that any other sub-projects only depend on the shadow configuration of this
+// project; otherwise weird races can occur.  Eventually, we should fix this by only renaming the
+// shadow jar artifact before the uploadArchives task runs.
 shadowJar.dependsOn assemble
 test.dependsOn shadowJar
 


### PR DESCRIPTION
There were some subtle bugs in the Gradle config for building a shadow jar that were causing race conditions with parallel builds.  Also contains some cleanup.