### PR TITLE
Fix bug with anonymous classes and generics

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1889,18 +1889,9 @@ public class NullAway extends BugChecker
 
   private static boolean hasSameArgTypes(
       Symbol.MethodSymbol method1, Symbol.MethodSymbol method2, Types types) {
-    com.sun.tools.javac.util.List<VarSymbol> method1params = method1.getParameters();
-    com.sun.tools.javac.util.List<VarSymbol> method2params = method2.getParameters();
-    if (method1params.size() != method2params.size()) {
-      return false;
-    }
-    for (int i = 0; i < method1params.size(); i++) {
-      if (!types.isSameType(
-          types.erasure(method1params.get(i).type), types.erasure(method2params.get(i).type))) {
-        return false;
-      }
-    }
-    return true;
+    com.sun.tools.javac.util.List<Type> method1ArgTypes = method1.type.asMethodType().argtypes;
+    com.sun.tools.javac.util.List<Type> method2ArgTypes = method2.type.asMethodType().argtypes;
+    return types.isSameTypes(types.erasure(method1ArgTypes), types.erasure(method2ArgTypes));
   }
 
   public enum MessageTypes {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1895,7 +1895,8 @@ public class NullAway extends BugChecker
       return false;
     }
     for (int i = 0; i < method1params.size(); i++) {
-      if (!types.isSameType(method1params.get(i).type, method2params.get(i).type)) {
+      if (!types.isSameType(
+          types.erasure(method1params.get(i).type), types.erasure(method2params.get(i).type))) {
         return false;
       }
     }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -749,6 +749,15 @@ public class NullAwayNegativeCases {
     return new TestAnon(q) {};
   }
 
+  static class TestAnon2<T> {
+
+    TestAnon2(@Nullable List<? extends T> q) {}
+  }
+
+  static <Q> TestAnon2<Q> testAnon2(@Nullable List<Q> q) {
+    return new TestAnon2<Q>(q) {};
+  }
+
   // https://github.com/uber/NullAway/issues/104
 
   static class TwoParamIterator<T, R> implements Iterator<T> {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -758,6 +758,17 @@ public class NullAwayNegativeCases {
     return new TestAnon2<Q>(q) {};
   }
 
+  static class TestAnon3 {
+
+    TestAnon3(@Nullable Integer p) {}
+
+    TestAnon3(String p) {}
+  }
+
+  static TestAnon3 testAnon3(@Nullable Integer q) {
+    return new TestAnon3(q) {};
+  }
+
   // https://github.com/uber/NullAway/issues/104
 
   static class TwoParamIterator<T, R> implements Iterator<T> {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -456,4 +456,16 @@ public class NullAwayPositiveCases {
     // BUG: Diagnostic contains: passing @Nullable parameter 'q' where
     return new TestAnon2<Q>(q) {};
   }
+
+  static class TestAnon3 {
+
+    TestAnon3(@Nullable Integer p) {}
+
+    TestAnon3(String p) {}
+  }
+
+  static TestAnon3 testAnon3(@Nullable String q) {
+    // BUG: Diagnostic contains: passing @Nullable parameter 'q' where
+    return new TestAnon3(q) {};
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway.testdata;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class NullAwayPositiveCases {
@@ -444,5 +445,15 @@ public class NullAwayPositiveCases {
   static TestAnon testAnon(@Nullable Object q) {
     // BUG: Diagnostic contains: passing @Nullable parameter 'q' where
     return new TestAnon(q) {};
+  }
+
+  static class TestAnon2<T> {
+
+    TestAnon2(List<? extends T> q) {}
+  }
+
+  static <Q> TestAnon2<Q> testAnon2(@Nullable List<Q> q) {
+    // BUG: Diagnostic contains: passing @Nullable parameter 'q' where
+    return new TestAnon2<Q>(q) {};
   }
 }


### PR DESCRIPTION
Our previous fix for anonymous class constructors with parameters didn't handle generics properly.  We need to use erasure when comparing signatures.