### PR TITLE
Make Guava dependence explicit

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ def build = [
     checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
                                "org.checkerframework:javacutil:${versions.checkerFrameworkNAFork}"],
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
-    guava                   : "com.google.guava:guava:21.0",
+    guava                   : "com.google.guava:guava:22.0",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
 
     // android stuff

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow
+    shadow deps.build.guava
 
     errorprone deps.build.errorProneCore
 


### PR DESCRIPTION
See #119.  Error Prone does not expose its packaged Guava on Bazel.  NullAway does indeed rely on Guava, and this will make it work better out of the box on Bazel.  Eventually, we can think about shading or getting rid of this dependence, but this is a first step.