### PR TITLE
Greatly improve Try/Finally handing, particularly initialization checks.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,8 +15,8 @@
  */
 
 def versions = [
-    checkerFramework       : "2.3.1",
-    checkerFrameworkNAFork : "2.3.1.1-nullaway",
+    checkerFramework       : "2.3.2",
+    checkerFrameworkNAFork : "2.3.2.1-nullaway",
     errorProne             : "2.1.1",
     support                : "27.0.2"
 ]
@@ -31,7 +31,7 @@ def build = [
     errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProne}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
-    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
+    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFrameworkNAFork}",
                                "org.checkerframework:javacutil:${versions.checkerFrameworkNAFork}"],
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
     guava                   : "com.google.guava:guava:22.0",

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -720,7 +720,9 @@ public class AccessPathNullnessPropagation
       TransferInput<Nullness, NullnessStore<Nullness>> input) {
     handler.onDataflowVisitLambdaResultExpression(
         resultNode.getTree(), input.getThenStore(), input.getElseStore());
-    return noStoreChanges(NULLABLE, input);
+    SubNodeValues values = values(input);
+    Nullness nullness = values.valueOfSubNode(resultNode.getResult());
+    return noStoreChanges(nullness, input);
   }
 
   @Override

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -40,7 +40,7 @@ public class NullAwayTryFinallyCases {
     try {
       return;
     } finally {
-      /// ToDo: This should be an error, but isn't.
+      // BUG: Diagnostic contains: dereferenced expression
       System.out.println(o.toString());
     }
   }
@@ -221,9 +221,6 @@ public class NullAwayTryFinallyCases {
     Object f;
     Object g;
 
-    /// ToDo: Fix or work-around for this one.
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g is
-    // initialized
     Initializers() {
       f = new Object();
       try {
@@ -291,9 +288,6 @@ public class NullAwayTryFinallyCases {
       // method... mmh
     }
 
-    /// ToDo: This should be safe, but requires matching the Exception type.
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g is
-    // initialized
     Initializers(Object o1, Object o2, Object o3, Object o4, Object o5) {
       f = new Object();
       try {
@@ -320,9 +314,6 @@ public class NullAwayTryFinallyCases {
       }
     }
 
-    /// ToDo: This should be safe. But return doesn't seem to be flowing into finally.
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g is
-    // initialized
     Initializers(
         Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7, Object o8) {
       f = new Object();
@@ -356,6 +347,92 @@ public class NullAwayTryFinallyCases {
       } finally {
         g = new Object();
       }
+    }
+  }
+
+  private boolean nestedCFGConstructionTest(Object o) {
+    boolean result = true;
+    java.io.BufferedWriter out = null;
+    try {
+      try {
+      } finally {
+        out = new java.io.BufferedWriter(new java.io.OutputStreamWriter(System.err));
+      }
+      if (o != null) {
+        out.write(' ');
+      }
+    } catch (Exception e) {
+    } finally {
+    }
+    return result;
+  }
+
+  private boolean nestedCFGConstructionTest2() throws IOException {
+    java.io.BufferedWriter out =
+        new java.io.BufferedWriter(new java.io.OutputStreamWriter(System.err));
+    try {
+      try {
+        return true;
+      } finally {
+      }
+    } finally {
+      out.write(' ');
+      out.close();
+    }
+  }
+
+  class IndirectInitialization {
+    Object f;
+
+    IndirectInitialization(Object o1) {
+      // Do or do not...
+      init();
+    }
+
+    IndirectInitialization(Object o1, Object o2) {
+      // ... but here there is try
+      try {
+        init();
+      } finally {
+      }
+    }
+
+    private void init() {
+      this.f = new Object();
+    }
+  }
+
+  class IndirectInitialization2 {
+    Object f;
+
+    //// Fixme: This should work recursivelly
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field
+    IndirectInitialization2(Object o1) {
+      wrappedInitNoTry();
+    }
+
+    //// Fixme: This should work recursivelly
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field
+    IndirectInitialization2(Object o1, Object o2) {
+      try {
+        wrappedInitTry();
+      } finally {
+      }
+    }
+
+    private void wrappedInitNoTry() {
+      init();
+    }
+
+    private void wrappedInitTry() {
+      try {
+        init();
+      } finally {
+      }
+    }
+
+    private void init() {
+      this.f = new Object();
     }
   }
 }


### PR DESCRIPTION
This pulls in the changes of Checker Framework PR 1826, and makes a few
fixes of our own in how we handle `try{...}finally{...}` statements
without catch blocks.