### PR TITLE
Add support for classes that get initialized externally

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -67,6 +67,8 @@ public abstract class AbstractConfig implements Config {
 
   protected Set<String> initializerAnnotations;
 
+  protected Set<String> externalInitAnnotations;
+
   @Nullable protected String castToNonNullMethod;
 
   protected static Pattern getPackagePattern(Set<String> packagePrefixes) {
@@ -135,6 +137,11 @@ public abstract class AbstractConfig implements Config {
   @Nullable
   public String getCastToNonNullMethod() {
     return castToNonNullMethod;
+  }
+
+  @Override
+  public boolean isExternalInitClassAnnotation(String annotationName) {
+    return externalInitAnnotations.contains(annotationName);
   }
 
   protected Set<MethodClassAndName> getKnownInitializers(Set<String> qualifiedNames) {

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -77,6 +77,15 @@ public interface Config {
   boolean isKnownInitializerMethod(Symbol.MethodSymbol methodSymbol);
 
   /**
+   * Checks if annotation marks an "external-init class," i.e., a class where some external
+   * framework initializes object fields after invoking the zero-argument constructor.
+   *
+   * @param annotationName fully-qualified annotation name
+   * @return true if classes with the annotation are external-init
+   */
+  boolean isExternalInitClassAnnotation(String annotationName);
+
+  /**
    * @return true if the null checker should suggest adding warning suppressions. Only useful for
    *     suppressing all warnings in a large code base.
    */

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -77,6 +77,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public boolean isExternalInitClassAnnotation(String annotationName) {
+    throw new IllegalStateException(error_msg);
+  }
+
+  @Override
   public boolean isExcludedFieldAnnotation(String annotationName) {
     throw new IllegalStateException(error_msg);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -47,6 +47,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
+  static final String FL_EXTERNAL_INIT_ANNOT = EP_FL_NAMESPACE + ":ExternalInitAnnotations";
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
@@ -87,6 +88,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     excludedClassAnnotations = getFlagStringSet(flags, FL_CLASS_ANNOTATIONS_TO_EXCLUDE);
     initializerAnnotations =
         getFlagStringSet(flags, FL_INITIALIZER_ANNOT, DEFAULT_INITIALIZER_ANNOT);
+    externalInitAnnotations = getFlagStringSet(flags, FL_EXTERNAL_INIT_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
     fieldAnnotPattern =

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -99,6 +99,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -1183,13 +1184,9 @@ public class NullAway extends BugChecker
   }
 
   private boolean isExternalInit(Symbol.ClassSymbol classSymbol) {
-    for (AnnotationMirror anno : NullabilityUtil.getAllAnnotations(classSymbol)) {
-      String annotStr = anno.getAnnotationType().toString();
-      if (config.isExternalInitClassAnnotation(annotStr)) {
-        return true;
-      }
-    }
-    return false;
+    return StreamSupport.stream(NullabilityUtil.getAllAnnotations(classSymbol).spliterator(), false)
+        .map((anno) -> anno.getAnnotationType().toString())
+        .anyMatch(config::isExternalInitClassAnnotation);
   }
 
   private Set<Element> guaranteedNonNullForConstructor(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -56,8 +56,9 @@ public class NullAwayTest {
             "-XepOpt:NullAway:ExcludedClasses="
                 + "com.uber.nullaway.testdata.Shape_Stuff,"
                 + "com.uber.nullaway.testdata.excluded",
-            "-XepOpt:NullAway:ExcludedClassAnnotations=" + "com.uber.nullaway.testdata.TestAnnot",
-            "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull"));
+            "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.nullaway.testdata.TestAnnot",
+            "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
+            "-XepOpt:NullAway:ExternalInitAnnotations=com.uber.ExternalInit"));
   }
 
   @Test
@@ -160,5 +161,27 @@ public class NullAwayTest {
   @Test
   public void tryFinallySupport() {
     compilationHelper.addSourceFile("NullAwayTryFinallyCases.java").doTest();
+  }
+
+  @Test
+  public void externalInitSupport() {
+    compilationHelper
+        .addSourceLines(
+            "ExternalInit.java",
+            "package com.uber;",
+            "@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS)",
+            "public @interface ExternalInit {}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "@ExternalInit",
+            "class Test {",
+            "  Object f;",
+            // no error here due to external init
+            "  public Test() {}",
+            "  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field",
+            "  public Test(int x) {}",
+            "}")
+        .doTest();
   }
 }


### PR DESCRIPTION
Tools like the [Cassandra Object Mapper](https://docs.datastax.com/en/developer/java-driver/3.3/manual/object_mapper/) do their own field initialization of objects with a certain annotation ([`@Table` in this case](https://docs.datastax.com/en/developer/java-driver/3.3/manual/object_mapper/creating/)).  We add support for such cases via a new `-XepOpt:NullAway:ExternalInitAnnotations` option.  For any class annotated with an external-init annotation, we don't check that the zero-arg constructor initializes all `@NonNull` fields.