### PR TITLE
Add TreatGeneratedAsUnannotated option

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -61,6 +61,12 @@ public abstract class AbstractConfig implements Config {
 
   protected boolean isSuggestSuppressions;
 
+  /**
+   * if true, {@link #fromAnnotatedPackage(Symbol.ClassSymbol)} will return false for any class
+   * annotated with {@link javax.annotation.Generated}
+   */
+  protected boolean treatGeneratedAsUnannotated;
+
   protected Set<MethodClassAndName> knownInitializers;
 
   protected Set<String> excludedClassAnnotations;
@@ -80,9 +86,12 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
-  public boolean fromAnnotatedPackage(String className) {
+  public boolean fromAnnotatedPackage(Symbol.ClassSymbol symbol) {
+    String className = symbol.getQualifiedName().toString();
     return annotatedPackages.matcher(className).matches()
-        && !unannotatedSubPackages.matcher(className).matches();
+        && !unannotatedSubPackages.matcher(className).matches()
+        && (!treatGeneratedAsUnannotated
+            || !ASTHelpers.hasDirectAnnotationWithSimpleName(symbol, "Generated"));
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -34,7 +34,7 @@ public interface Config {
    *     according to our convention (every possibly null parameter / return / field
    *     annotated @Nullable), false otherwise
    */
-  boolean fromAnnotatedPackage(String className);
+  boolean fromAnnotatedPackage(Symbol.ClassSymbol symbol);
 
   /**
    * @param className fully-qualified class name

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -52,7 +52,7 @@ public class DummyOptionsConfig implements Config {
   public DummyOptionsConfig() {}
 
   @Override
-  public boolean fromAnnotatedPackage(String className) {
+  public boolean fromAnnotatedPackage(Symbol.ClassSymbol symbol) {
     throw new IllegalStateException(error_msg);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -44,6 +44,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_CLASS_ANNOTATIONS_TO_EXCLUDE =
       EP_FL_NAMESPACE + ":ExcludedClassAnnotations";
   static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
+  static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
@@ -91,6 +92,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     externalInitAnnotations = getFlagStringSet(flags, FL_EXTERNAL_INIT_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
+    treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(
             getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT, DEFAULT_EXCLUDED_FIELD_ANNOT));

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1448,7 +1448,7 @@ public class NullAway extends BugChecker
     if (config.isExcludedClass(className)) {
       return true;
     }
-    if (!config.fromAnnotatedPackage(className)) {
+    if (!config.fromAnnotatedPackage(classSymbol)) {
       return true;
     }
     // check annotations

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -161,6 +161,6 @@ public class NullabilityUtil {
    */
   public static boolean fromUnannotatedPackage(Symbol symbol, Config config) {
     Symbol.ClassSymbol outermostClassSymbol = getOutermostClassSymbol(symbol);
-    return !config.fromAnnotatedPackage(outermostClassSymbol.toString());
+    return !config.fromAnnotatedPackage(outermostClassSymbol);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -211,7 +211,7 @@ public class AccessPathNullnessPropagation
         // treat as non-null
         assumed = NONNULL;
       } else {
-        if (fromUnannotatedPackage(fiMethodSymbol)) {
+        if (NullabilityUtil.fromUnannotatedPackage(fiMethodSymbol, config)) {
           // optimistically assume parameter is non-null
           assumed = NONNULL;
         } else {
@@ -222,12 +222,6 @@ public class AccessPathNullnessPropagation
     }
     result = handler.onDataflowInitialStore(underlyingAST, parameters, result);
     return result.build();
-  }
-
-  private boolean fromUnannotatedPackage(Symbol symbol) {
-    Symbol.ClassSymbol outermostClassSymbol = NullabilityUtil.getOutermostClassSymbol(symbol);
-
-    return !config.fromAnnotatedPackage(outermostClassSymbol.toString());
   }
 
   private NullnessStore<Nullness> methodInitialStore(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -184,4 +184,27 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void generatedAsUnannotated() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+        .addSourceLines(
+            "Generated.java",
+            "package com.uber;",
+            "@javax.annotation.Generated(\"foo\")",
+            "public class Generated { public void takeObj(Object o) {} }")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "class Test {",
+            "  void foo() { (new Generated()).takeObj(null); }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #125.  To enable treatment of `@Generated` code as unannotated, pass `-XepOpt:NullAway:TreatGeneratedAsUnannotated=true`.  Note that this reduces safety; the better solution is to modify the code generator to generate `@Nullable` annotations wherever appropriate.