### PR TITLE
Add support for (a subset of) org.jetbrains.annotations.Contract

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ def versions = [
     checkerFramework       : "2.3.2",
     checkerFrameworkNAFork : "2.3.2.1-nullaway",
     errorProne             : "2.1.1",
-    support                : "27.0.2"
+    support                : "27.0.2",
 ]
 
 def apt = [
@@ -36,6 +36,7 @@ def build = [
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
     guava                   : "com.google.guava:guava:22.0",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
+    jetbrainAnnotations     : "org.jetbrains:annotations:13.0",
 
     // android stuff
     buildToolsVersion: "27.0.2",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,7 +36,6 @@ def build = [
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
     guava                   : "com.google.guava:guava:22.0",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
-    jetbrainAnnotations     : "org.jetbrains:annotations:13.0",
 
     // android stuff
     buildToolsVersion: "27.0.2",
@@ -56,12 +55,13 @@ def support = [
 ]
 
 def test = [
-    junit4            : "junit:junit:4.12",
-    junit5Jupiter     : ["org.junit.jupiter:junit-jupiter-api:5.0.2","org.apiguardian:apiguardian-api:1.0.0"],
-    inferAnnotations  : "com.facebook.infer.annotation:infer-annotation:0.11.0",
-    cfQual            : "org.checkerframework:checker-qual:2.3.0",
-    cfCompatQual      : "org.checkerframework:checker-compat-qual:2.3.0",
-    rxjava2           : "io.reactivex.rxjava2:rxjava:2.1.2",
+    junit4                  : "junit:junit:4.12",
+    junit5Jupiter           : ["org.junit.jupiter:junit-jupiter-api:5.0.2","org.apiguardian:apiguardian-api:1.0.0"],
+    jetbrainAnnotations     : "org.jetbrains:annotations:13.0",
+    inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
+    cfQual                  : "org.checkerframework:checker-qual:2.3.0",
+    cfCompatQual            : "org.checkerframework:checker-compat-qual:2.3.0",
+    rxjava2                  : "io.reactivex.rxjava2:rxjava:2.1.2",
 ]
 
 ext.deps = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -57,7 +57,7 @@ def support = [
 def test = [
     junit4                  : "junit:junit:4.12",
     junit5Jupiter           : ["org.junit.jupiter:junit-jupiter-api:5.0.2","org.apiguardian:apiguardian-api:1.0.0"],
-    jetbrainAnnotations     : "org.jetbrains:annotations:13.0",
+    jetbrainsAnnotations    : "org.jetbrains:annotations:13.0",
     inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
     cfQual                  : "org.checkerframework:checker-qual:2.3.0",
     cfCompatQual            : "org.checkerframework:checker-compat-qual:2.3.0",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ def test = [
     inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
     cfQual                  : "org.checkerframework:checker-qual:2.3.0",
     cfCompatQual            : "org.checkerframework:checker-compat-qual:2.3.0",
-    rxjava2                  : "io.reactivex.rxjava2:rxjava:2.1.2",
+    rxjava2                 : "io.reactivex.rxjava2:rxjava:2.1.2",
 ]
 
 ext.deps = [

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -43,14 +43,13 @@ dependencies {
     compile deps.build.checkerDataflow
     shadow deps.build.guava
 
-    compile deps.build.jetbrainAnnotations
-
     errorprone deps.build.errorProneCore
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+    testCompile deps.test.jetbrainAnnotations
     testCompile deps.test.junit5Jupiter
     testCompile deps.test.cfQual
     testCompile deps.test.cfCompatQual

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     compile deps.build.checkerDataflow
     shadow deps.build.guava
 
+    compile deps.build.jetbrainAnnotations
+
     errorprone deps.build.errorProneCore
 
     testCompile deps.test.junit4

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
-    testCompile deps.test.jetbrainAnnotations
+    testCompile deps.test.jetbrainsAnnotations
     testCompile deps.test.junit5Jupiter
     testCompile deps.test.cfQual
     testCompile deps.test.cfCompatQual

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1637,7 +1637,7 @@ public class NullAway extends BugChecker
    * @param suggestTree the location at which a fix suggestion should be made
    * @return the error description
    */
-  private Description createErrorDescription(
+  public Description createErrorDescription(
       MessageTypes errorType, Tree errorLocTree, String message, @Nullable Tree suggestTree) {
     Description.Builder builder = buildDescription(errorLocTree).setMessage(message);
     if (config.suggestSuppressions() && suggestTree != null) {
@@ -1661,6 +1661,8 @@ public class NullAway extends BugChecker
         case METHOD_NO_INIT:
         case FIELD_NO_INIT:
           builder = addSuppressWarningsFix(suggestTree, builder, INITIALIZATION_CHECK_NAME);
+          break;
+        case ANNOTATION_VALUE_INVALID:
           break;
         default:
           builder = addSuppressWarningsFix(suggestTree, builder, canonicalName());
@@ -1946,7 +1948,8 @@ public class NullAway extends BugChecker
     METHOD_NO_INIT,
     FIELD_NO_INIT,
     UNBOX_NULLABLE,
-    NONNULL_FIELD_READ_BEFORE_INIT;
+    NONNULL_FIELD_READ_BEFORE_INIT,
+    ANNOTATION_VALUE_INVALID;
   }
 
   @AutoValue

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -116,14 +116,15 @@ abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public Nullness onDataflowVisitMethodInvocation(
+  public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
     // NoOp
-    return Nullness.NONNULL;
+    return NullnessHint.UNKNOWN;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -138,22 +138,21 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public Nullness onDataflowVisitMethodInvocation(
+  public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
-    Nullness nullness = Nullness.NONNULL;
+    NullnessHint nullnessHint = NullnessHint.UNKNOWN;
     for (Handler h : handlers) {
-      Nullness n =
-          h.onDataflowVisitMethodInvocation(node, types, thenUpdates, elseUpdates, bothUpdates);
-      // If any handler says this is @Nullable, then it is @Nullable
-      if (n == Nullness.NULLABLE) {
-        nullness = Nullness.NULLABLE;
-      }
+      NullnessHint n =
+          h.onDataflowVisitMethodInvocation(
+              node, types, inputs, thenUpdates, elseUpdates, bothUpdates);
+      nullnessHint = nullnessHint.merge(n);
     }
-    return nullness;
+    return nullnessHint;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.handlers;
+
+import com.google.common.base.Preconditions;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Types;
+import com.uber.nullaway.Nullness;
+import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.jetbrains.annotations.Contract;
+
+/**
+ * This Handler parses the jetbrains @Contract annotation and honors the nullness spec defined there
+ * on a best effort basis.
+ *
+ * <p>Currently, we can only reason about cases where the contract specifies that the return value
+ * of the method depends on the nullness value of a single argument. This means we can reason about
+ * rules like the following:
+ *
+ * <ul>
+ *   <li>@Contract("null -> true")
+ *   <li>@Contract("_, null, _ -> false")
+ *   <li>@Contract("!null, _ -> false; null, _ -> true")
+ *   <li>@Contract("!null -> !null")
+ * </ul>
+ *
+ * In the last case, nullness will be propagated iff the nullness of the argument is already known
+ * at invocation.
+ *
+ * <p>However, when the return depends on multiple arguments, this handler usually ignores the rule,
+ * since it is not clear which of the values in question are null or not. For example,
+ * for @Contract("null, null -> true") we know nothing when the method returns true (because truth
+ * of the consequent doesn't imply truth of the antecedent), and we only know that at least one of
+ * the two arguments was non-null, but can't know for sure which one. NullAway doesn't reason about
+ * multiple value conditional nullness constraints in any general way.
+ *
+ * <p>In some cases, this handler can determine that some arguments are already known to be non-null
+ * and reason in terms of the remaining (under-constrained) arguments, to see if the final value of
+ * this method depends on the nullness of a single argument for this callsite, even if the @Contract
+ * clause is given in terms of many. This is not behavior that should be counted on, but it is
+ * sound.
+ */
+public class ContractHandler extends BaseNoOpHandler {
+
+  @Override
+  public NullnessHint onDataflowVisitMethodInvocation(
+      MethodInvocationNode node,
+      Types types,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
+      AccessPathNullnessPropagation.Updates thenUpdates,
+      AccessPathNullnessPropagation.Updates elseUpdates,
+      AccessPathNullnessPropagation.Updates bothUpdates) {
+    Symbol.MethodSymbol callee = ASTHelpers.getSymbol(node.getTree());
+    Preconditions.checkNotNull(callee);
+    // Check to see if this method has an @Contract annotation
+    if (ASTHelpers.hasDirectAnnotationWithSimpleName(callee, "Contract")) {
+      // Found a contract, lets parse it.
+      Contract contract = ASTHelpers.getAnnotation(callee, Contract.class);
+      String[] clauses = contract.value().split(";");
+      for (String clause : clauses) {
+        String[] parts = clause.split("->");
+        assert parts.length == 2;
+        String[] antecedent = parts[0].split(",");
+        String consequent = parts[1].trim();
+        // Find a single value constraint that is not already known. If more than one arguments with
+        // unknown
+        // nullness affect the method's result, then ignore this clause.
+        int argIdx = -1;
+        Nullness argAntecedentNullness = null;
+        boolean supported =
+            true; // Set to false if the rule is detected to be one we don't yet support
+        // Fixme: Proper error reporting for malformed clauses:
+        assert antecedent.length == node.getArguments().size();
+        for (int i = 0; i < antecedent.length; ++i) {
+          String valueConstraint = antecedent[i].trim();
+          if (valueConstraint.equals("_")) {
+            continue;
+          } else if (valueConstraint.equals("false") || valueConstraint.equals("true")) {
+            supported = false;
+            break;
+          } else if (valueConstraint.equals("!null")
+              && inputs.valueOfSubNode(node.getArgument(i)).equals(Nullness.NONNULL)) {
+            // We already know this argument can't be null, so we can treat it as not part of the
+            // clause
+            // for the purpose of deciding the non-nullness of the other arguments.
+            continue;
+          } else if (valueConstraint.equals("null") || valueConstraint.equals("!null")) {
+            if (argIdx != -1) {
+              // More than one argument involved in the antecedent, ignore this rule
+              supported = false;
+              break;
+            }
+            argIdx = i;
+            argAntecedentNullness =
+                valueConstraint.equals("null") ? Nullness.NULLABLE : Nullness.NONNULL;
+          } else {
+            assert false;
+            supported = false;
+            break;
+          }
+        }
+        if (!supported) {
+          // Too many arguments involved, or unsupported @Contract features. On to next clause in
+          // the
+          // contract expression
+          continue;
+        }
+        if (argIdx == -1) {
+          // The antecedent is unconditionally true. Check for the ... -> !null case and set the
+          // return nullness accordingly
+          if (consequent.equals("!null")) {
+            return NullnessHint.FORCE_NONNULL;
+          }
+          continue;
+        }
+        assert argAntecedentNullness != null;
+        // The nullness of one argument is all that matters for the antecedent, let's negate the
+        // consequent to
+        // fix the nullness of this argument.
+        AccessPath accessPath = AccessPath.getAccessPathForNodeNoMapGet(node.getArgument(argIdx));
+        if (consequent.equals("false") && argAntecedentNullness.equals(Nullness.NULLABLE)) {
+          // If argIdx being null implies the return of the method being false, then the return
+          // being true
+          // implies argIdx is not null and we must mark it as such in the then update.
+          thenUpdates.set(accessPath, Nullness.NONNULL);
+        } else if (consequent.equals("true") && argAntecedentNullness.equals(Nullness.NULLABLE)) {
+          // If argIdx being null implies the return of the method being true, then the return being
+          // false
+          // implies argIdx is not null and we must mark it as such in the else update.
+          elseUpdates.set(accessPath, Nullness.NONNULL);
+        } else if (consequent.equals("fail") && argAntecedentNullness.equals(Nullness.NULLABLE)) {
+          // If argIdx being null implies the method throws an exception, then we can mark it as
+          // non-null on
+          // both non-exceptional exits from the method
+          bothUpdates.set(accessPath, Nullness.NONNULL);
+        }
+      }
+    }
+    return NullnessHint.UNKNOWN;
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -37,6 +37,7 @@ public class Handlers {
   public static Handler buildDefault() {
     // In the future we can add LibraryModels functionality here, and even plug-in handlers.
     return new CompositeHandler(
-        ImmutableList.of(new LibraryModelsHandler(), new RxNullabilityPropagator()));
+        ImmutableList.of(
+            new LibraryModelsHandler(), new RxNullabilityPropagator(), new ContractHandler()));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -38,7 +38,6 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.LibraryModels;
 import com.uber.nullaway.NullAway;
-import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import java.util.ArrayList;
@@ -90,9 +89,10 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public Nullness onDataflowVisitMethodInvocation(
+  public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
@@ -101,8 +101,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     setUnconditionalArgumentNullness(bothUpdates, node.getArguments(), callee);
     setConditionalArgumentNullness(thenUpdates, elseUpdates, node.getArguments(), callee);
     return LibraryModels.LibraryModelUtil.hasNullableReturn(libraryModels, callee, types)
-        ? Nullness.NULLABLE
-        : Nullness.NONNULL;
+        ? NullnessHint.HINT_NULLABLE
+        : NullnessHint.UNKNOWN;
   }
 
   private void setConditionalArgumentNullness(


### PR DESCRIPTION
Fix #96 by introducing support for a number of cases of the `@Contract` annotation mentioned by @hzsweers.

Currently, we can only reason about cases where the contract specifies that the return value of the method depends on the nullness value of a single argument. This means we can reason about rules like the following:

* `@Contract("null -> true")`
* `@Contract("_, null, _ -> false")`
* `@Contract("!null, _ -> false; null, _ -> true")`
* `@Contract("!null -> !null")`

In the last case, nullness will be propagated iff the nullness of the argument is already known at invocation.

We don't support cases where the antecedent of the clause involves multiple arguments, except in limited cases. 

For example for `@Contract("null, null -> true")` we know nothing when the method returns `true` (because truth of the consequent doesn't imply truth of the antecedent), and if it returns `false`, we only know that at least one of the two arguments was non-null, but can't know for sure which one.