### PR TITLE
Add support for Objects#requireNonNull(T)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -157,6 +157,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     private static final ImmutableSetMultimap<MethodRef, Integer> FAIL_IF_NULL_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
             .put(methodRef(Preconditions.class, "<T>checkNotNull(T)"), 0)
+            .put(methodRef("java.util.Objects", "<T>requireNonNull(T)"), 0)
             .put(methodRef("org.junit.Assert", "assertNotNull(java.lang.Object)"), 0)
             .put(
                 methodRef("org.junit.Assert", "assertNotNull(java.lang.String,java.lang.Object)"),

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNegativeCases.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -520,6 +521,11 @@ public class NullAwayNegativeCases {
 
   static void checkNotNull(@Nullable Object o) {
     Preconditions.checkNotNull(o);
+    o.toString();
+  }
+
+  static void requireNonNull(@Nullable Object o) {
+    Objects.requireNonNull(o);
     o.toString();
   }
 


### PR DESCRIPTION
This change set adds support for [`Objects#requireNonNull(T)`](https://docs.oracle.com/javase/7/docs/api/java/util/Objects.html#requireNonNull(T)) which has been introduced in Java 7.

Until now, NullAway only supported the similar `Preconditions#checkNotNull(T)` method from Google Guava.