### PR TITLE
Add support for JUnit 5 Assertions#assertNotNull()

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -161,6 +161,18 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(
                 methodRef("org.junit.Assert", "assertNotNull(java.lang.String,java.lang.Object)"),
                 1)
+            .put(
+                methodRef("org.junit.jupiter.api.Assertions", "assertNotNull(java.lang.Object)"), 0)
+            .put(
+                methodRef(
+                    "org.junit.jupiter.api.Assertions",
+                    "assertNotNull(java.lang.Object,java.lang.String)"),
+                1)
+            .put(
+                methodRef(
+                    "org.junit.jupiter.api.Assertions",
+                    "assertNotNull(java.lang.Object,java.util.function.Supplier<String>)"),
+                1)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NON_NULL_PARAMETERS =

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -206,6 +206,12 @@ public class NullAwayNativeModels {
     o1.toString();
     org.junit.Assert.assertNotNull("Null!", o2);
     o2.toString();
+    org.junit.jupiter.api.Assertions.assertNotNull(o1);
+    o1.toString();
+    org.junit.jupiter.api.Assertions.assertNotNull(o2, "Null!");
+    o2.toString();
+    org.junit.jupiter.api.Assertions.assertNotNull(o2, () -> "Null!");
+    o2.toString();
   }
 
   static void nonNullParameters() {


### PR DESCRIPTION
This change set adds support for JUnit 5 assertions checking for non-null values, such as [`Assertions#assertNotNull(Object)`](https://junit.org/junit5/docs/5.1.0/api/org/junit/jupiter/api/Assertions.html#assertNotNull-java.lang.Object-), similar to the respective JUnit 4 assertions.