### PR TITLE
Update link to Uber CLA in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-Thank you for contributing to NullAway.  Note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform).
+Thank you for contributing to NullAway!
+
+Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).
 
 Before pressing the "Create Pull Request" button, please provide the following:
 


### PR DESCRIPTION
The pull request template linked to a Google Doc instead of CLA assistant which is being used for collecting CLAs in this repository.