### PR TITLE
Fix crash when using try-with-resource with an empty try block.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1278,8 +1278,12 @@ public class NullAway extends BugChecker
       if (stmt.getKind().equals(Tree.Kind.TRY)) {
         TryTree tryTree = (TryTree) stmt;
         if (tryTree.getCatches().size() == 0) {
-          result.addAll(getSafeInitMethods(tryTree.getBlock(), classSymbol, state));
-          result.addAll(getSafeInitMethods(tryTree.getFinallyBlock(), classSymbol, state));
+          if (tryTree.getBlock() != null) {
+            result.addAll(getSafeInitMethods(tryTree.getBlock(), classSymbol, state));
+          }
+          if (tryTree.getFinallyBlock() != null) {
+            result.addAll(getSafeInitMethods(tryTree.getFinallyBlock(), classSymbol, state));
+          }
         }
       }
     }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.testdata;
 
 import java.io.IOException;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 // This code tests our, admitedly quite unsound, handling of try{ ... }finally{ ... } blocks.
@@ -214,6 +215,11 @@ public class NullAwayTryFinallyCases {
       // BUG: Diagnostic contains: dereferenced expression
       System.out.println(o.toString());
     }
+  }
+
+  public void tryWithResourcesNoBlock() {
+    // Just check that this doesn't blow up
+    try (Stream<Integer> stream = Stream.of(1, 2, 3)) {}
   }
 
   class Initializers {
@@ -433,6 +439,13 @@ public class NullAwayTryFinallyCases {
 
     private void init() {
       this.f = new Object();
+    }
+  }
+
+  class TryWithResourceInitializer {
+    TryWithResourceInitializer() {
+      // Just check that this doesn't blow up
+      try (Stream<Integer> stream = Stream.of(1, 2, 3)) {}
     }
   }
 }


### PR DESCRIPTION
Should fix #133 
