### PR TITLE
Fix crash when access path doesn't exist for an actual argument in ContractHandler

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
@@ -190,6 +190,9 @@ public class ContractHandler extends BaseNoOpHandler {
         // consequent to
         // fix the nullness of this argument.
         AccessPath accessPath = AccessPath.getAccessPathForNodeNoMapGet(node.getArgument(argIdx));
+        if (accessPath == null) {
+          continue;
+        }
         if (consequent.equals("false") && argAntecedentNullness.equals(Nullness.NULLABLE)) {
           // If argIdx being null implies the return of the method being false, then the return
           // being true

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -319,4 +319,33 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void contractNonVarArg() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "NullnessChecker.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.jetbrains.annotations.Contract;",
+            "public class NullnessChecker {",
+            "  @Contract(\"null -> fail\")",
+            "  static void assertNonNull(@Nullable Object o) { if (o != null) throw new Error(); }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  void test(java.util.function.Function<Object, Object> fun) {",
+            "    NullnessChecker.assertNonNull(fun.apply(new Object()));",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Not everything that can be passed to a function has an access path in the caller (e.g. the return of a function doesn't), make sure we skip that case when setting up the updated Nullness info.