### PR TITLE
Handle method references

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -536,8 +536,6 @@ public class NullAway extends BugChecker
   @Override
   public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
     // TODO XXX make sure we've tested:
-    //            /** super # instMethod */
-    //             SUPER(ReferenceMode.INVOKE, false),
     //             /** Inner # new */
     //            IMPLICIT_INNER(ReferenceMode.NEW, false),
     //            /** Toplevel # new */

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -419,15 +419,8 @@ public class NullAway extends BugChecker
   }
 
   /**
-   * checks that an overriding method does not override a
-   *
-   * <pre>@Nullable</pre>
-   *
-   * parameter with a
-   *
-   * <pre>@NonNull</pre>
-   *
-   * parameter
+   * checks that an overriding method does not override a {@code @Nullable} parameter with a
+   * {@code @NonNull} parameter
    *
    * @param methodParams parameters of overriding method. If memberReferenceTree is non-null, these
    *     are the parameters of the referenced method

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -535,13 +535,6 @@ public class NullAway extends BugChecker
 
   @Override
   public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-    // TODO XXX make sure we've tested:
-    //             /** Inner # new */
-    //            IMPLICIT_INNER(ReferenceMode.NEW, false),
-    //            /** Toplevel # new */
-    //            TOPLEVEL(ReferenceMode.NEW, false),
-    //            /** ArrayType # new */
-    //            ARRAY_CTOR(ReferenceMode.NEW, false);
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
     Symbol.MethodSymbol funcInterfaceSymbol =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -62,18 +62,18 @@ public class NullabilityUtil {
   }
 
   /**
-   * determines whether a lambda parameter has an explicit type declaration
+   * determines whether a lambda parameter is missing an explicit type declaration
    *
    * @param lambdaParameter the parameter
-   * @return true if there is a type declaration, false otherwise
+   * @return true if there is no type declaration, false otherwise
    */
-  public static boolean lambdaParamIsExplicitlyTyped(VariableTree lambdaParameter) {
+  public static boolean lambdaParamIsImplicitlyTyped(VariableTree lambdaParameter) {
     // kind of a hack; the "preferred position" seems to be the position
     // of the variable name.  if this differs from the start position, it
     // means there is an explicit type declaration
     JCDiagnostic.DiagnosticPosition diagnosticPosition =
         (JCDiagnostic.DiagnosticPosition) lambdaParameter;
-    return diagnosticPosition.getStartPosition() != diagnosticPosition.getPreferredPosition();
+    return diagnosticPosition.getStartPosition() == diagnosticPosition.getPreferredPosition();
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -22,11 +22,14 @@
 
 package com.uber.nullaway;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
@@ -46,14 +49,15 @@ public class NullabilityUtil {
   private NullabilityUtil() {}
 
   /**
-   * finds the corresponding functional interface method for a lambda expression
+   * finds the corresponding functional interface method for a lambda expression or method reference
    *
-   * @param tree the lambda expression
+   * @param tree the lambda expression or method reference
    * @return the functional interface method
    */
-  public static Symbol.MethodSymbol getFunctionalInterfaceMethod(
-      LambdaExpressionTree tree, Types types) {
-    Type funcInterfaceType = ((JCTree.JCLambda) tree).type;
+  public static Symbol.MethodSymbol getFunctionalInterfaceMethod(ExpressionTree tree, Types types) {
+    Preconditions.checkArgument(
+        (tree instanceof LambdaExpressionTree) || (tree instanceof MemberReferenceTree));
+    Type funcInterfaceType = ((JCTree.JCFunctionalExpression) tree).type;
     return (Symbol.MethodSymbol) types.findDescriptorSymbol(funcInterfaceType.tsym);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -207,7 +207,7 @@ public class AccessPathNullnessPropagation
       // corresponding functional interface parameter, unless they are explicitly annotated
       if (Nullness.hasNullableAnnotation(element)) {
         assumed = NULLABLE;
-      } else if (NullabilityUtil.lambdaParamIsExplicitlyTyped(variableTree)) {
+      } else if (!NullabilityUtil.lambdaParamIsImplicitlyTyped(variableTree)) {
         // the parameter has a declared type with no @Nullable annotation
         // treat as non-null
         assumed = NONNULL;

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
@@ -52,9 +52,9 @@ public class NullAwayJava8NegativeCases {
   }
 
   @FunctionalInterface
-  interface NullableParamFunction<T> {
+  interface NullableParamFunction<T, U> {
 
-    String takeVal(@Nullable T x);
+    U takeVal(@Nullable T x);
   }
 
   static void testNonNullParam() {
@@ -141,7 +141,7 @@ public class NullAwayJava8NegativeCases {
     return fun.apply(t);
   }
 
-  static <T> String applyTakeVal(NullableParamFunction<T> nn) {
+  static <T, U> U applyTakeVal(NullableParamFunction<T, U> nn) {
     return nn.takeVal(null);
   }
 
@@ -214,6 +214,21 @@ public class NullAwayJava8NegativeCases {
 
     void testSuperRef() {
       applyDoubleTakeVal(this::derefSecondParam2, new Object());
+    }
+  }
+
+  static class ConstructorRefs {
+
+    public ConstructorRefs(@Nullable Object p) {}
+
+    class Inner {
+
+      public Inner(@Nullable Object q) {}
+    }
+
+    void testConstRefs() {
+      applyTakeVal(ConstructorRefs::new);
+      applyTakeVal(Inner::new);
     }
   }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8NegativeCases.java
@@ -212,7 +212,7 @@ public class NullAwayJava8NegativeCases {
       return "" + ((z != null) ? z.hashCode() : 10);
     }
 
-    void testSuperRef() {
+    void testOverrideWithMethodRef() {
       applyDoubleTakeVal(this::derefSecondParam2, new Object());
     }
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -44,9 +44,9 @@ public class NullAwayJava8PositiveCases {
   }
 
   @FunctionalInterface
-  interface NullableParamFunction {
+  interface NullableParamFunction<T> {
 
-    String takeVal(@Nullable Object x);
+    String takeVal(@Nullable T x);
   }
 
   @FunctionalInterface
@@ -88,7 +88,7 @@ public class NullAwayJava8PositiveCases {
     return fun.apply(t);
   }
 
-  static String applyTakeVal(Object o, NullableParamFunction nn) {
+  static <T> String applyTakeVal(NullableParamFunction<T> nn) {
     return nn.takeVal(null);
   }
 
@@ -106,7 +106,7 @@ public class NullAwayJava8PositiveCases {
     // BUG: Diagnostic contains: referenced method returns @Nullable, but functional
     map(ex, NullAwayJava8PositiveCases::returnNull);
     // BUG: Diagnostic contains: parameter o of referenced method is @NonNull, but
-    applyTakeVal(ex, NullAwayJava8PositiveCases::derefParam);
+    applyTakeVal(NullAwayJava8PositiveCases::derefParam);
   }
 
   @FunctionalInterface
@@ -139,6 +139,10 @@ public class NullAwayJava8PositiveCases {
       return p.toString();
     }
 
+    String makeStr() {
+      return "buzz";
+    }
+
     void testRefsToInstanceMethods() {
       String ex = "bye";
       MethodContainer m = new MethodContainer();
@@ -150,6 +154,8 @@ public class NullAwayJava8PositiveCases {
       applyDoubleTakeVal(MethodContainer::derefParam, m);
       // BUG: Diagnostic contains: referenced method returns @Nullable, but functional interface
       applyDoubleTakeVal(MethodContainer::returnNullWithNullableParam, m);
+      // BUG: Diagnostic contains: hello
+      applyTakeVal(MethodContainer::makeStr);
     }
   }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -44,9 +44,9 @@ public class NullAwayJava8PositiveCases {
   }
 
   @FunctionalInterface
-  interface NullableParamFunction<T> {
+  interface NullableParamFunction<T, U> {
 
-    String takeVal(@Nullable T x);
+    U takeVal(@Nullable T x);
   }
 
   @FunctionalInterface
@@ -88,7 +88,7 @@ public class NullAwayJava8PositiveCases {
     return fun.apply(t);
   }
 
-  static <T> String applyTakeVal(NullableParamFunction<T> nn) {
+  static <T, U> U applyTakeVal(NullableParamFunction<T, U> nn) {
     return nn.takeVal(null);
   }
 
@@ -168,6 +168,23 @@ public class NullAwayJava8PositiveCases {
     void testSuperRef() {
       // BUG: Diagnostic contains: parameter z of referenced method is @NonNull, but parameter
       applyDoubleTakeVal(super::derefSecondParam, new Object());
+    }
+  }
+
+  static class ConstructorRefs {
+
+    public ConstructorRefs(Object p) {}
+
+    class Inner {
+
+      public Inner(Object q) {}
+    }
+
+    void testConstRefs() {
+      // BUG: Diagnostic contains: parameter p of referenced method is @NonNull, but parameter
+      applyTakeVal(ConstructorRefs::new);
+      // BUG: Diagnostic contains: parameter q of referenced method is @NonNull, but parameter
+      applyTakeVal(Inner::new);
     }
   }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.testdata;
 
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Function;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class NullAwayJava8PositiveCases {
@@ -62,6 +63,8 @@ public class NullAwayJava8PositiveCases {
     NullableParamFunction n2 = (Object x) -> x.toString();
     // BUG: Diagnostic contains: dereferenced expression x is @Nullable
     NonNullParamFunction n3 = (@Nullable Object x) -> x.toString();
+    // BUG: Diagnostic contains: parameter x is @NonNull, but parameter in functional interface
+    NullableParamFunction n4 = (@Nonnull Object x) -> x.toString();
   }
 
   static void testAnnoatedThirdParty() {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -75,4 +75,81 @@ public class NullAwayJava8PositiveCases {
     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return
     BiFunction<String, String, Object> f3 = (x, y) -> null;
   }
+
+  ////////////////////////
+  // method references  //
+  ////////////////////////
+
+  interface Function<T, R> {
+    R apply(T t);
+  }
+
+  static <R, T> R map(T t, Function<T, R> fun) {
+    return fun.apply(t);
+  }
+
+  static String applyTakeVal(Object o, NullableParamFunction nn) {
+    return nn.takeVal(null);
+  }
+
+  @Nullable
+  static Object returnNull(String t) {
+    return null;
+  }
+
+  static String derefParam(Object o) {
+    return o.toString();
+  }
+
+  static void testRefsToStaticMethods() {
+    String ex = "hi";
+    // BUG: Diagnostic contains: referenced method returns @Nullable, but functional
+    map(ex, NullAwayJava8PositiveCases::returnNull);
+    // BUG: Diagnostic contains: parameter o of referenced method is @NonNull, but
+    applyTakeVal(ex, NullAwayJava8PositiveCases::derefParam);
+  }
+
+  @FunctionalInterface
+  interface NullableSecondParamFunction<T> {
+
+    String takeVal(T x, @Nullable Object y);
+  }
+
+  static <T> String applyDoubleTakeVal(NullableSecondParamFunction<T> ns, T firstParam) {
+    return ns.takeVal(firstParam, null);
+  }
+
+  static class MethodContainer {
+
+    @Nullable
+    Object returnNull(String t) {
+      return null;
+    }
+
+    @Nullable
+    String returnNullWithNullableParam(@Nullable Object t) {
+      return null;
+    }
+
+    String derefSecondParam(Object w, Object z) {
+      return z.toString();
+    }
+
+    String derefParam(Object p) {
+      return p.toString();
+    }
+
+    void testRefsToInstanceMethods() {
+      String ex = "bye";
+      MethodContainer m = new MethodContainer();
+      // BUG: Diagnostic contains: referenced method returns @Nullable, but functional
+      map(ex, m::returnNull);
+      // BUG: Diagnostic contains: parameter z of referenced method is @NonNull, but
+      applyDoubleTakeVal(m::derefSecondParam, new Object());
+      // BUG: Diagnostic contains: parameter p of referenced method is @NonNull, but parameter in
+      applyDoubleTakeVal(MethodContainer::derefParam, m);
+      // BUG: Diagnostic contains: referenced method returns @Nullable, but functional interface
+      applyDoubleTakeVal(MethodContainer::returnNullWithNullableParam, m);
+    }
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -158,4 +158,16 @@ public class NullAwayJava8PositiveCases {
       applyTakeVal(MethodContainer::makeStr);
     }
   }
+
+  static class MethodContainerSub extends MethodContainer {
+    @Override
+    String derefSecondParam(Object w, @Nullable Object z) {
+      return "" + ((z != null) ? z.hashCode() : 10);
+    }
+
+    void testSuperRef() {
+      // BUG: Diagnostic contains: parameter z of referenced method is @NonNull, but parameter
+      applyDoubleTakeVal(super::derefSecondParam, new Object());
+    }
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayJava8PositiveCases.java
@@ -154,7 +154,7 @@ public class NullAwayJava8PositiveCases {
       applyDoubleTakeVal(MethodContainer::derefParam, m);
       // BUG: Diagnostic contains: referenced method returns @Nullable, but functional interface
       applyDoubleTakeVal(MethodContainer::returnNullWithNullableParam, m);
-      // BUG: Diagnostic contains: hello
+      // BUG: Diagnostic contains: unbound instance method reference cannot be used
       applyTakeVal(MethodContainer::makeStr);
     }
   }


### PR DESCRIPTION
Fixes #138.  Due to an oversight we were not doing any checking of method references beforehand.