### PR TITLE
Initial RxNullabilityPropagator support for method references.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1011,6 +1011,7 @@ public class NullAway extends BugChecker
       initTree2PrevFieldInit.clear();
       class2Entities.clear();
       class2ConstructorUninit.clear();
+      computedNullnessMap.clear();
     }
     if (matchWithinClass) {
       checkFieldInitialization(tree, state);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -220,6 +220,13 @@ public class NullAway extends BugChecker
       new LinkedHashMap<>();
 
   /**
+   * dynamically computer/overriden nullness facts for certain expressions, such as specific method
+   * calls where we can infer a more precise set of facts than those given by the method's
+   * annotations.
+   */
+  private final Map<ExpressionTree, Nullness> computedNullnessMap = new LinkedHashMap<>();
+
+  /**
    * Error Prone requires us to have an empty constructor for each Plugin, in addition to the
    * constructor taking an ErrorProneFlags object. This constructor should not be used anywhere
    * else. Checker objects constructed with this constructor will fail with IllegalStateException if
@@ -565,6 +572,7 @@ public class NullAway extends BugChecker
     Symbol.MethodSymbol referencedMethod = ASTHelpers.getSymbol(tree);
     Symbol.MethodSymbol funcInterfaceSymbol =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
+    handler.onMatchMethodReference(this, tree, state, referencedMethod);
     return checkOverriding(funcInterfaceSymbol, referencedMethod, tree, state);
   }
 
@@ -591,7 +599,8 @@ public class NullAway extends BugChecker
     // if the super method returns nonnull,
     // overriding method better not return nullable
     if (!Nullness.hasNullableAnnotation(overriddenMethod)
-        && Nullness.hasNullableAnnotation(overridingMethod)) {
+        && Nullness.hasNullableAnnotation(overridingMethod)
+        && getComputedNullness(memberReferenceTree).equals(Nullness.NULLABLE)) {
       String message;
       if (memberReferenceTree != null) {
         message =
@@ -2024,6 +2033,41 @@ public class NullAway extends BugChecker
     }
     message += " along all control-flow paths (remember to check for exceptions or early returns).";
     return message;
+  }
+
+  /**
+   * Returns the computed nullness information from an expression. If none is available, it returns
+   * Nullable.
+   *
+   * <p>Computed information can be added by handlers or by the core, and should supersede that
+   * comming from annotations.
+   *
+   * <p>The default value of an expression without additional computed nullness information is
+   * always Nullable, since this method should only be called when the fact that the expression is
+   * NonNull is not clear from looking at annotations.
+   *
+   * @param e an expression
+   * @return computed nullness for e, if any, else Nullable
+   */
+  public Nullness getComputedNullness(ExpressionTree e) {
+    if (computedNullnessMap.containsKey(e)) {
+      return computedNullnessMap.get(e);
+    } else {
+      return Nullness.NULLABLE;
+    }
+  }
+
+  /**
+   * Add computed nullness informat to an expression.
+   *
+   * <p>Used by handlers to communicate that an expression should has a more precise nullness than
+   * what is known from source annotations.
+   *
+   * @param e
+   * @param nullness
+   */
+  public void setComputedNullness(ExpressionTree e, Nullness nullness) {
+    computedNullnessMap.put(e, nullness);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -27,6 +27,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
@@ -80,6 +81,15 @@ abstract class BaseNoOpHandler implements Handler {
   public void onMatchLambdaExpression(
       NullAway analysis,
       LambdaExpressionTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol) {
+    // NoOp
+  }
+
+  @Override
+  public void onMatchMethodReference(
+      NullAway analysis,
+      MemberReferenceTree tree,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol) {
     // NoOp

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -28,6 +28,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
@@ -81,6 +82,17 @@ class CompositeHandler implements Handler {
       Symbol.MethodSymbol methodSymbol) {
     for (Handler h : handlers) {
       h.onMatchLambdaExpression(analysis, tree, state, methodSymbol);
+    }
+  }
+
+  @Override
+  public void onMatchMethodReference(
+      NullAway analysis,
+      MemberReferenceTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol) {
+    for (Handler h : handlers) {
+      h.onMatchMethodReference(analysis, tree, state, methodSymbol);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -27,6 +27,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
@@ -89,7 +90,7 @@ public interface Handler {
       Symbol.MethodSymbol methodSymbol);
 
   /**
-   * Called when NullAway first matches a particular method call-site.
+   * Called when NullAway first matches a particular lambda expression.
    *
    * @param analysis A reference to the running NullAway analysis.
    * @param tree The AST node for the lambda expression being matched.
@@ -99,6 +100,20 @@ public interface Handler {
   void onMatchLambdaExpression(
       NullAway analysis,
       LambdaExpressionTree tree,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol);
+
+  /**
+   * Called when NullAway first matches a particular method reference expression
+   *
+   * @param analysis A reference to the running NullAway analysis.
+   * @param tree The AST node for the method reference expression being matched.
+   * @param state The current visitor state.
+   * @param methodSymbol The method symbol for the reference being matched.
+   */
+  void onMatchMethodReference(
+      NullAway analysis,
+      MemberReferenceTree tree,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol);
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
@@ -351,4 +351,12 @@ public class NullAwayRxSupportNegativeCases {
         .filter(s -> predtest(r -> r != null, s))
         .map(s -> funcapply(r -> r.length(), s));
   }
+
+  private Observable<Integer> filterThenMapMethodRefs1(
+      Observable<NullableContainer<String>> observable) {
+    return observable
+        .filter(c -> c.get() != null && perhaps())
+        .map(NullableContainer::get)
+        .map(String::length);
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportPositiveCases.java
@@ -129,4 +129,13 @@ public class NullAwayRxSupportPositiveCases {
     // BUG: Diagnostic contains: dereferenced expression
     return observable.filter(c -> c.get() != null || perhaps()).map(c -> c.get().length());
   }
+
+  private Observable<Integer> filterThenMapMethodRefs1(
+      Observable<NullableContainer<String>> observable) {
+    return observable
+        .filter(c -> c.get() != null || perhaps())
+        // BUG: Diagnostic contains: referenced method returns @Nullable
+        .map(NullableContainer::get)
+        .map(String::length);
+  }
 }


### PR DESCRIPTION
Only supports:
* Method refs in map-like methods
* Unbound
* Taking zero args

This is potentially WIP, pending testing this branch with our internal code to look for missed cases before merging.