### PR TITLE
Use `@SuppressWarnings` as autofix in a couple more places

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1793,10 +1793,10 @@ public class NullAway extends BugChecker
           }
           break;
         case WRONG_OVERRIDE_RETURN:
-          builder = changeReturnNullabilityFix(suggestTree, builder);
+          builder = addSuppressWarningsFix(suggestTree, builder, canonicalName());
           break;
         case WRONG_OVERRIDE_PARAM:
-          builder = changeParamNullabilityFix(suggestTree, builder);
+          builder = addSuppressWarningsFix(suggestTree, builder, canonicalName());
           break;
         case METHOD_NO_INIT:
         case FIELD_NO_INIT:
@@ -1882,6 +1882,7 @@ public class NullAway extends BugChecker
     return builder.addFix(fix);
   }
 
+  @SuppressWarnings("unused")
   private Description.Builder changeReturnNullabilityFix(
       Tree suggestTree, Description.Builder builder) {
     if (suggestTree.getKind() != Tree.Kind.METHOD) {
@@ -1900,6 +1901,7 @@ public class NullAway extends BugChecker
     return builder.addFix(fixBuilder.build());
   }
 
+  @SuppressWarnings("unused")
   private Description.Builder changeParamNullabilityFix(
       Tree suggestTree, Description.Builder builder) {
     return builder.addFix(SuggestedFix.prefixWith(suggestTree, "@Nullable "));


### PR DESCRIPTION
We need to re-think auto-fixing as a whole, but for now, this makes the auto-fix behavior simpler; it just always suppresses warnings or (optionally) adds `castToNonNull`.