### PR TITLE
Make sure our unit tests break if we drop regexp support.

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -52,7 +52,8 @@ public class NullAwayTest {
                 + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"
                 + ".SuperInterface.doInit2",
             "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
-            "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.testdata.unannotated",
+            // We give the following in Regexp format to test that support
+            "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
             "-XepOpt:NullAway:ExcludedClasses="
                 + "com.uber.nullaway.testdata.Shape_Stuff,"
                 + "com.uber.nullaway.testdata.excluded",


### PR DESCRIPTION
(Hey Manu, this is **not urgent** at all, putting up the PR just so I don't forget)

This is an undocumented feature about how our config options work for matching e.g. package names. I think is it worthwhile to have something warn us if we drop support accidentally, but not sure if we are committing to supporting this non-standard regexp format (The format is just Java regexp but `.` is interpreted as the literal dot character, not "any character" because of how normal package names look like).