### PR TITLE
Add UnannotatedClasses option

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -52,8 +52,13 @@ public abstract class AbstractConfig implements Config {
    */
   protected Pattern unannotatedSubPackages;
 
-  /** Source code in these packages will not be analyzed for nullability issues */
+  /** Source code in these classes will not be analyzed for nullability issues */
   @Nullable protected ImmutableSet<String> sourceClassesToExclude;
+
+  /**
+   * these classes will be treated as unannotated (don't analyze *and* treat methods as unannotated)
+   */
+  @Nullable protected ImmutableSet<String> unannotatedClasses;
 
   protected Pattern fieldAnnotPattern;
 
@@ -100,6 +105,20 @@ public abstract class AbstractConfig implements Config {
       return false;
     }
     for (String classPrefix : sourceClassesToExclude) {
+      if (className.startsWith(classPrefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isUnannotatedClass(Symbol.ClassSymbol symbol) {
+    if (unannotatedClasses == null) {
+      return false;
+    }
+    String className = symbol.getQualifiedName().toString();
+    for (String classPrefix : unannotatedClasses) {
       if (className.startsWith(classPrefix)) {
         return true;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -44,6 +44,13 @@ public interface Config {
   boolean isExcludedClass(String className);
 
   /**
+   * @param className fully-qualified class name
+   * @return true if the class should be treated as unannotated (in spite of being in an annotated
+   *     package)
+   */
+  boolean isUnannotatedClass(Symbol.ClassSymbol symbol);
+
+  /**
    * @param annotationName fully-qualified annotation name
    * @return true if a top-level class with this annotation should be excluded from nullability
    *     analysis, false otherwise

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -62,6 +62,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public boolean isUnannotatedClass(Symbol.ClassSymbol symbol) {
+    throw new IllegalStateException(error_msg);
+  }
+
+  @Override
   public boolean isExcludedClassAnnotation(String annotationName) {
     throw new IllegalStateException(error_msg);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -49,6 +49,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
   static final String FL_EXTERNAL_INIT_ANNOT = EP_FL_NAMESPACE + ":ExternalInitAnnotations";
+  static final String FL_UNANNOTATED_CLASSES = EP_FL_NAMESPACE + ":UnannotatedClasses";
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
@@ -83,6 +84,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     annotatedPackages = getPackagePattern(getFlagStringSet(flags, FL_ANNOTATED_PACKAGES));
     unannotatedSubPackages = getPackagePattern(getFlagStringSet(flags, FL_UNANNOTATED_SUBPACKAGES));
     sourceClassesToExclude = getFlagStringSet(flags, FL_CLASSES_TO_EXCLUDE);
+    unannotatedClasses = getFlagStringSet(flags, FL_UNANNOTATED_CLASSES);
     knownInitializers =
         getKnownInitializers(
             getFlagStringSet(flags, FL_KNOWN_INITIALIZERS, DEFAULT_KNOWN_INITIALIZERS));

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -247,7 +247,7 @@ public class NullAway extends BugChecker
   private Predicate<MethodInvocationNode> nonAnnotatedMethodCheck() {
     return invocationNode ->
         invocationNode == null
-            || NullabilityUtil.fromUnannotatedPackage(
+            || NullabilityUtil.isUnannotated(
                 ASTHelpers.getSymbol(invocationNode.getTree()), config);
   }
 
@@ -553,7 +553,7 @@ public class NullAway extends BugChecker
     if (returnType.toString().equals("java.lang.Void")) {
       return Description.NO_MATCH;
     }
-    if (NullabilityUtil.fromUnannotatedPackage(methodSymbol, config)
+    if (NullabilityUtil.isUnannotated(methodSymbol, config)
         || Nullness.hasNullableAnnotation(methodSymbol)) {
       return Description.NO_MATCH;
     }
@@ -570,7 +570,7 @@ public class NullAway extends BugChecker
     Symbol.MethodSymbol funcInterfaceMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
     handler.onMatchLambdaExpression(this, tree, state, funcInterfaceMethod);
-    if (NullabilityUtil.fromUnannotatedPackage(funcInterfaceMethod, config)) {
+    if (NullabilityUtil.isUnannotated(funcInterfaceMethod, config)) {
       return Description.NO_MATCH;
     }
     Description description =
@@ -623,7 +623,7 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol overridingMethod,
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
-    if (NullabilityUtil.fromUnannotatedPackage(overriddenMethod, config)) {
+    if (NullabilityUtil.isUnannotated(overriddenMethod, config)) {
       return Description.NO_MATCH;
     }
     // if the super method returns nonnull,
@@ -1140,7 +1140,7 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol methodSymbol,
       List<? extends ExpressionTree> actualParams) {
     ImmutableSet<Integer> nonNullPositions = null;
-    if (NullabilityUtil.fromUnannotatedPackage(methodSymbol, config)) {
+    if (NullabilityUtil.isUnannotated(methodSymbol, config)) {
       nonNullPositions =
           handler.onUnannotatedInvocationGetNonNullPositions(
               this, state, methodSymbol, actualParams, ImmutableSet.of());
@@ -1714,7 +1714,7 @@ public class NullAway extends BugChecker
 
   private boolean mayBeNullMethodCall(
       VisitorState state, ExpressionTree expr, Symbol.MethodSymbol exprSymbol) {
-    if (NullabilityUtil.fromUnannotatedPackage(exprSymbol, config)) {
+    if (NullabilityUtil.isUnannotated(exprSymbol, config)) {
       return false;
     }
     if (!Nullness.hasNullableAnnotation(exprSymbol)) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -153,18 +153,18 @@ public class NullabilityUtil {
     }
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()
-            || fromUnannotatedPackage(symbol, config))
+            || isUnannotated(symbol, config))
         && Nullness.hasNullableAnnotation(symbol);
   }
 
   /**
    * @param symbol symbol for entity
    * @param config NullAway config
-   * @return true if symbol represents an entity from a package not marked as annotated in the
-   *     config; false otherwise
+   * @return true if symbol represents an entity from a class that is unannotated; false otherwise
    */
-  public static boolean fromUnannotatedPackage(Symbol symbol, Config config) {
+  public static boolean isUnannotated(Symbol symbol, Config config) {
     Symbol.ClassSymbol outermostClassSymbol = getOutermostClassSymbol(symbol);
-    return !config.fromAnnotatedPackage(outermostClassSymbol);
+    return !config.fromAnnotatedPackage(outermostClassSymbol)
+        || config.isUnannotatedClass(outermostClassSymbol);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -212,7 +212,7 @@ public class AccessPathNullnessPropagation
         // treat as non-null
         assumed = NONNULL;
       } else {
-        if (NullabilityUtil.fromUnannotatedPackage(fiMethodSymbol, config)) {
+        if (NullabilityUtil.isUnannotated(fiMethodSymbol, config)) {
           // optimistically assume parameter is non-null
           assumed = NONNULL;
         } else {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -503,4 +503,37 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void unannotatedClass() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedClasses=com.uber.UnAnnot"))
+        .addSourceLines(
+            "UnAnnot.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class UnAnnot {",
+            "  @Nullable static Object retNull() { return null; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @Nullable static Object nullRetSameClass() { return null; }",
+            "  void test() {",
+            "    UnAnnot.retNull().toString();",
+            // make sure other classes in the package still get analyzed
+            "    Object x = nullRetSameClass();",
+            "    // BUG: Diagnostic contains: dereferenced expression x is @Nullable",
+            "    x.hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Previously, one could use the `UnannotatedSubPackages` to mark entire packages as unannotated, but there was no way to set a particular class within an annotated package to be treated as unannotated.  This is useful, e.g., to deal with a particular library class with a `@Nullable` return annotation that cannot yet be handled in the client code base.