### PR TITLE
fix bug in handling TBase.isSet()

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -116,6 +116,8 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
     // noinspection ConstantConditions
     return tbaseType.isPresent()
         && symbol.getSimpleName().toString().startsWith("isSet")
+        // weeds out the isSet() method in TBase itself
+        && symbol.getParameters().length() == 0
         && types.isSubtype(symbol.owner.type, tbaseType.get());
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -435,6 +435,28 @@ public class NullAwayTest {
   }
 
   @Test
+  public void testThriftIsSetWithArg() {
+    compilationHelper
+        .addSourceLines(
+            "TBase.java",
+            "package org.apache.thrift;",
+            "public interface TBase {",
+            "  boolean isSet(String fieldName);",
+            "}")
+        .addSourceLines(
+            "Client.java",
+            "package com.uber;",
+            "public class Client {",
+            "  public void testNeg(org.apache.thrift.TBase tBase) {",
+            "    if (tBase.isSet(\"Hello\")) {",
+            "      System.out.println(\"set\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void erasedIterator() {
     // just checking for crash
     compilationHelper


### PR DESCRIPTION
Previously NullAway would crash on direct calls to the [`TBase.isSet(field)`](https://github.com/apache/thrift/blob/92d80629ac2a39d432ac5bb29f45951be3465f8f/lib/java/src/org/apache/thrift/TBase.java#L42) method.
