### PR TITLE
Fix a couple of Thrift issues

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -48,7 +48,6 @@ import org.checkerframework.javacutil.Pair;
 public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
 
   private static String TBASE_NAME = "org.apache.thrift.TBase";
-  private static String TUNION_NAME = "org.apache.thrift.TUnion";
 
   @Nullable private Optional<Type> tbaseType;
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -55,7 +55,12 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (tbaseType == null) {
-      tbaseType = Optional.ofNullable(state.getTypeFromString(TBASE_NAME));
+      Type tbaseFromString = state.getTypeFromString(TBASE_NAME);
+      if (tbaseFromString == null) {
+        tbaseType = Optional.empty();
+      } else {
+        tbaseType = Optional.of(state.getTypes().erasure(tbaseFromString));
+      }
     }
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -487,6 +487,44 @@ public class NullAwayTest {
         .doTest();
   }
 
+  /** we do not have proper support for Thrift unions yet; just checks that we don't crash */
+  @Test
+  public void testThriftUnion() {
+    compilationHelper
+        .addSourceLines(
+            "TBase.java", "package org.apache.thrift;", "public interface TBase<T, F> {}")
+        .addSourceLines(
+            "TUnion.java",
+            "package org.apache.thrift;",
+            "public abstract class TUnion<T, F> implements TBase<T, F> {",
+            "  protected Object value_;",
+            "  public Object getFieldValue() {",
+            "    return this.value_;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Generated.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Generated extends org.apache.thrift.TUnion<String, Integer> {",
+            "  public Object getId() { return getFieldValue(); }",
+            "  public boolean isSetId() { return true; }",
+            "}")
+        .addSourceLines(
+            "Client.java",
+            "package com.uber;",
+            "public class Client {",
+            "  public void testNeg(Generated g) {",
+            "    if (!g.isSetId()) {",
+            "      return;",
+            "    }",
+            "    Object x = g.getId();",
+            "    if (x.toString() == null) return;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   @Test
   public void erasedIterator() {
     // just checking for crash

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -435,6 +435,37 @@ public class NullAwayTest {
   }
 
   @Test
+  public void testThriftIsSetWithGenerics() {
+    compilationHelper
+        .addSourceLines(
+            "TBase.java", "package org.apache.thrift;", "public interface TBase<T, F> {}")
+        .addSourceLines(
+            "Generated.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Generated implements org.apache.thrift.TBase<String, Integer> {",
+            "  public @Nullable Object id;",
+            "  @Nullable public Object getId() { return this.id; }",
+            "  public boolean isSetId() { return this.id != null; }",
+            "}")
+        .addSourceLines(
+            "Client.java",
+            "package com.uber;",
+            "public class Client {",
+            "  public void testNeg(Generated g) {",
+            "    if (!g.isSetId()) {",
+            "      return;",
+            "    }",
+            "    Object x = g.getId();",
+            "    if (x.toString() == null) return;",
+            "    g.getId().toString();",
+            "    g.id.hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testThriftIsSetWithArg() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
* Properly handle the `TBase` generic type by erasing it.
* Get rid of strong checking that field is present in generated code.  It is not present in `TUnion`s or for private fields when compiling against ABI jars.