### PR TITLE
Don't report initialization warnings on fields for @ExternalInit classes with no initializer methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1225,8 +1225,11 @@ public class NullAway extends BugChecker
         // report it on the initializer
         errorFieldsForInitializer.put(singleInitializerMethod, uninitField);
       } else if (constructorInitInfo == null) {
-        // report it on the field
-        fieldsWithInitializationErrors.add(uninitField);
+        // report it on the field, except in the case where the class is externalInit and
+        // we have no initializer methods
+        if (!(isExternalInit(classSymbol) && entities.instanceInitializerMethods().isEmpty())) {
+          fieldsWithInitializationErrors.add(uninitField);
+        }
       } else {
         // report it on each constructor that does not initialize it
         for (MethodTree methodTree : constructorInitInfo.keySet()) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -183,6 +183,14 @@ public class NullAwayTest {
             "  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field",
             "  public Test(int x) {}",
             "}")
+        .addSourceLines(
+            "Test2.java",
+            "package com.uber;",
+            "@ExternalInit",
+            "class Test2 {",
+            // no error here due to external init
+            "  Object f;",
+            "}")
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -191,6 +191,15 @@ public class NullAwayTest {
             // no error here due to external init
             "  Object f;",
             "}")
+        .addSourceLines(
+            "Test3.java",
+            "package com.uber;",
+            "@ExternalInit",
+            "class Test3 {",
+            "  Object f;",
+            "  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field",
+            "  public Test3(int x) {}",
+            "}")
         .doTest();
   }
 


### PR DESCRIPTION
Fixes #163 