### PR TITLE
Remove a suppression from a test that doesn't need it.

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -772,7 +772,6 @@ public class NullAwayTest {
             "class Test {",
             "  private String path;",
             "  private String f;",
-            "  @SuppressWarnings(\"NullAway\")",
             "  Test(String p) throws IOException {",
             "    path = p;",
             "    try (BufferedReader br = new BufferedReader(new FileReader(path))) {",


### PR DESCRIPTION
Literally don't know why or how I did this, but a test that passes was not testing anything due to NullAway being suppressed for the entire scope of the test. Removing the suppression gives us a passing test.