### PR TITLE
Add support for LEFT_SHIFT and RIGHT_SHIFT expressions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1663,6 +1663,8 @@ public class NullAway extends BugChecker
       case AND:
       case OR:
       case XOR:
+      case LEFT_SHIFT:
+      case RIGHT_SHIFT:
         // clearly not null
         exprMayBeNull = false;
         break;


### PR DESCRIPTION
Tiny fix. There two cases were missing from `mayBeNullExpr`.