### PR TITLE
Add -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations config flag.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -66,7 +66,7 @@ public abstract class AbstractConfig implements Config {
 
   protected boolean isSuggestSuppressions;
 
-  protected boolean iscknowledgeRestrictive;
+  protected boolean isAcknowledgeRestrictive;
 
   /**
    * if true, {@link #fromAnnotatedPackage(Symbol.ClassSymbol)} will return false for any class
@@ -165,7 +165,7 @@ public abstract class AbstractConfig implements Config {
 
   @Override
   public boolean acknowledgeRestrictiveAnnotations() {
-    return iscknowledgeRestrictive;
+    return isAcknowledgeRestrictive;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -66,6 +66,8 @@ public abstract class AbstractConfig implements Config {
 
   protected boolean isSuggestSuppressions;
 
+  protected boolean iscknowledgeRestrictive;
+
   /**
    * if true, {@link #fromAnnotatedPackage(Symbol.ClassSymbol)} will return false for any class
    * annotated with {@link javax.annotation.Generated}
@@ -159,6 +161,11 @@ public abstract class AbstractConfig implements Config {
   @Override
   public boolean suggestSuppressions() {
     return isSuggestSuppressions;
+  }
+
+  @Override
+  public boolean acknowledgeRestrictiveAnnotations() {
+    return iscknowledgeRestrictive;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -99,6 +99,15 @@ public interface Config {
   boolean suggestSuppressions();
 
   /**
+   * @return true if the null checker should acknowledge stricter nullability annotations whenever
+   *     they are available in unannotated code, defaulting to optimistic defaults only when
+   *     explicit annotations are missing. false if any annotations in code not explicitly marked as
+   *     annotated should be ignored completely and unannotated code should always be treated
+   *     optimistically.
+   */
+  boolean acknowledgeRestrictiveAnnotations();
+
+  /**
    * @return the fully qualified name of a method which will take a @Nullable version of a value and
    *     return an @NonNull copy (likely through an unsafe downcast, but performing runtime checking
    *     and logging)

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -102,6 +102,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public boolean acknowledgeRestrictiveAnnotations() {
+    throw new IllegalStateException(error_msg);
+  }
+
+  @Override
   @Nullable
   public String getCastToNonNullMethod() {
     throw new IllegalStateException(error_msg);

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -50,6 +50,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
   static final String FL_EXTERNAL_INIT_ANNOT = EP_FL_NAMESPACE + ":ExternalInitAnnotations";
   static final String FL_UNANNOTATED_CLASSES = EP_FL_NAMESPACE + ":UnannotatedClasses";
+  static final String FL_ACKNOWLEDGE_RESTRICTIVE =
+      EP_FL_NAMESPACE + ":AcknowledgeRestrictiveAnnotations";
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
@@ -94,6 +96,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     externalInitAnnotations = getFlagStringSet(flags, FL_EXTERNAL_INIT_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
+    iscknowledgeRestrictive = flags.getBoolean(FL_ACKNOWLEDGE_RESTRICTIVE).orElse(false);
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -96,7 +96,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     externalInitAnnotations = getFlagStringSet(flags, FL_EXTERNAL_INIT_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
-    iscknowledgeRestrictive = flags.getBoolean(FL_ACKNOWLEDGE_RESTRICTIVE).orElse(false);
+    isAcknowledgeRestrictive = flags.getBoolean(FL_ACKNOWLEDGE_RESTRICTIVE).orElse(false);
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -182,7 +182,7 @@ public class NullAway extends BugChecker
    * The handler passed to our analysis (usually a {@code CompositeHandler} including handlers for
    * various APIs.
    */
-  private final Handler handler = Handlers.buildDefault();
+  private final Handler handler;
 
   /**
    * entities relevant to field initialization per class. cached for performance. nulled out in
@@ -221,11 +221,13 @@ public class NullAway extends BugChecker
    */
   public NullAway() {
     config = new DummyOptionsConfig();
+    handler = Handlers.buildEmpty();
     nonAnnotatedMethod = nonAnnotatedMethodCheck();
   }
 
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
+    handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = nonAnnotatedMethodCheck();
     // workaround for Checker Framework static state bug;
     // See https://github.com/typetools/checker-framework/issues/1482

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.handlers;
 
 import com.google.common.collect.ImmutableList;
+import com.uber.nullaway.Config;
 
 /** Utility static methods for the handlers package. */
 public class Handlers {
@@ -32,15 +33,27 @@ public class Handlers {
   /**
    * Builds the default handler for the checker.
    *
+   * @param config NullAway config
    * @return A {@code CompositeHandler} including the standard handlers for the nullness checker.
    */
-  public static Handler buildDefault() {
-    // In the future we can add LibraryModels functionality here, and even plug-in handlers.
-    return new CompositeHandler(
-        ImmutableList.of(
-            new LibraryModelsHandler(),
-            new RxNullabilityPropagator(),
-            new ContractHandler(),
-            new ApacheThriftIsSetHandler()));
+  public static Handler buildDefault(Config config) {
+    ImmutableList.Builder<Handler> handlerListBuilder = ImmutableList.builder();
+    handlerListBuilder.add(new LibraryModelsHandler());
+    handlerListBuilder.add(new RxNullabilityPropagator());
+    handlerListBuilder.add(new ContractHandler());
+    handlerListBuilder.add(new ApacheThriftIsSetHandler());
+    if (config.acknowledgeRestrictiveAnnotations()) {
+      handlerListBuilder.add(new RestrictiveAnnotationHandler());
+    }
+    return new CompositeHandler(handlerListBuilder.build());
+  }
+
+  /**
+   * Builds an empty handler chain (used for the NullAway dummy empty constructor).
+   *
+   * @return An empty {@code CompositeHandler}.
+   */
+  public static Handler buildEmpty() {
+    return new CompositeHandler(ImmutableList.of());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.handlers;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.TargetType;
+import com.sun.tools.javac.code.Types;
+import com.uber.nullaway.NullAway;
+import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
+import java.util.HashSet;
+import java.util.List;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+
+public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
+
+  @Override
+  public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      List<? extends ExpressionTree> actualParams,
+      ImmutableSet<Integer> nonNullPositions) {
+    HashSet<Integer> positions = new HashSet<Integer>();
+    positions.addAll(nonNullPositions);
+    for (Attribute.TypeCompound tc : methodSymbol.getRawTypeAttributes()) {
+      if (tc.position.type.equals(TargetType.METHOD_FORMAL_PARAMETER)
+          && tc.getAnnotationType().asElement().getSimpleName().contentEquals("NonNull")) {
+        positions.add(tc.position.parameter_index);
+      }
+    }
+    return ImmutableSet.copyOf(positions);
+  }
+
+  @Override
+  public boolean onOverrideMayBeNullExpr(
+      NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
+    if (expr.getKind().equals(Tree.Kind.METHOD_INVOCATION)) {
+      Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol((MethodInvocationTree) expr);
+      return isMethodSymbolAnnotatedNullable(methodSymbol);
+    }
+    return exprMayBeNull;
+  }
+
+  @Override
+  public NullnessHint onDataflowVisitMethodInvocation(
+      MethodInvocationNode node,
+      Types types,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
+      AccessPathNullnessPropagation.Updates thenUpdates,
+      AccessPathNullnessPropagation.Updates elseUpdates,
+      AccessPathNullnessPropagation.Updates bothUpdates) {
+    Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(node.getTree());
+    return (isMethodSymbolAnnotatedNullable(methodSymbol)
+        ? NullnessHint.HINT_NULLABLE
+        : NullnessHint.UNKNOWN);
+  }
+
+  private boolean isMethodSymbolAnnotatedNullable(Symbol.MethodSymbol methodSymbol) {
+    Preconditions.checkNotNull(methodSymbol);
+    for (Attribute.TypeCompound tc : methodSymbol.getRawTypeAttributes()) {
+      if (tc.position.type.equals(TargetType.METHOD_RETURN)
+          && tc.getAnnotationType().asElement().getSimpleName().contentEquals("Nullable")) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
@@ -1,0 +1,15 @@
+package com.uber.lib.unannotated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class RestrictivelyAnnotatedClass {
+
+  public static @Nullable Object returnsNull() {
+    return null;
+  }
+
+  public static void consumesObjectNonNull(@NonNull Object o) {}
+
+  public static void consumesObjectUnannotated(Object o) {}
+}


### PR DESCRIPTION
- `-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true` means the null checker should acknowledge stricter nullability annotations whenever they are available in unannotated code, defaulting to optimistic defaults only when explicit annotations are missing. Thus if an "unannotated" bytecode library explicitly marks an argument as `@NonNull`, or a return value as `@Nullable`, NullAway should respect this, but otherwise treat the rest of the library optimistically.
- `-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=false` (the **current default**) is NullAway's behavior up to now and means any annotations in code not explicitly marked as annotated should be ignored completely and unannotated code should always be treated optimistically.