### PR TITLE
Check that castToNonNull method is not passed @NonNull

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -298,7 +298,7 @@ public class NullAway extends BugChecker
     handler.onMatchMethodInvocation(this, tree, state, methodSymbol);
     // assuming this list does not include the receiver
     List<? extends ExpressionTree> actualParams = tree.getArguments();
-    return handleInvocation(state, methodSymbol, actualParams);
+    return handleInvocation(tree, state, methodSymbol, actualParams);
   }
 
   @Override
@@ -319,7 +319,7 @@ public class NullAway extends BugChecker
       // see https://github.com/uber/NullAway/issues/102
       methodSymbol = getSymbolOfSuperConstructor(methodSymbol, state);
     }
-    return handleInvocation(state, methodSymbol, actualParams);
+    return handleInvocation(tree, state, methodSymbol, actualParams);
   }
 
   private Symbol.MethodSymbol getSymbolOfSuperConstructor(
@@ -1110,12 +1110,14 @@ public class NullAway extends BugChecker
   /**
    * handle either a method invocation or a 'new' invocation
    *
+   * @param tree the corresponding MethodInvocationTree or NewClassTree
    * @param state visitor state
    * @param methodSymbol symbol for invoked method
    * @param actualParams parameters passed at call
    * @return description of error or NO_MATCH if no error
    */
   private Description handleInvocation(
+      Tree tree,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol,
       List<? extends ExpressionTree> actualParams) {
@@ -1173,9 +1175,22 @@ public class NullAway extends BugChecker
             "Invalid number of parameters passed to configured CastToNonNullMethod.");
       }
       actual = actualParams.get(0);
+      TreePath enclosingMethodOrLambda =
+          NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(state.getPath());
+      boolean isInitializer;
+      if (enclosingMethodOrLambda == null) {
+        throw new RuntimeException("no enclosing method, lambda or initializer!");
+      } else if (enclosingMethodOrLambda.getLeaf() instanceof LambdaExpressionTree) {
+        isInitializer = false;
+      } else if (enclosingMethodOrLambda.getLeaf() instanceof MethodTree) {
+        MethodTree enclosingMethod = (MethodTree) enclosingMethodOrLambda.getLeaf();
+        isInitializer = isInitializerMethod(state, ASTHelpers.getSymbol(enclosingMethod));
+      } else {
+        // Initializer block
+        isInitializer = true;
+      }
       MethodTree enclosingMethod = ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class);
-      if (!isInitializerMethod(state, ASTHelpers.getSymbol(enclosingMethod))
-          && !mayBeNullExpr(state, actual)) {
+      if (!isInitializer && !mayBeNullExpr(state, actual)) {
         String message =
             "passing known @NonNull parameter '"
                 + actual.toString()
@@ -1184,7 +1199,7 @@ public class NullAway extends BugChecker
                 + "). This method should only take arguments that NullAway considers @Nullable "
                 + "at the invocation site, but which are known not to be null at runtime.";
         return createErrorDescription(
-            MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, actual, message, enclosingMethod);
+            MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, actual, message, tree);
       }
     }
     // NOTE: the case of an invocation on a possibly-null reference
@@ -1829,6 +1844,9 @@ public class NullAway extends BugChecker
             builder = addSuppressWarningsFix(suggestTree, builder, canonicalName());
           }
           break;
+        case CAST_TO_NONNULL_ARG_NONNULL:
+          builder = removeCastToNonNullFix(suggestTree, builder);
+          break;
         case WRONG_OVERRIDE_RETURN:
           builder = addSuppressWarningsFix(suggestTree, builder, canonicalName());
           break;
@@ -1915,6 +1933,24 @@ public class NullAway extends BugChecker
         SuggestedFix.builder()
             .replace(suggestTree, replacement)
             .addStaticImport(fullMethodName) // ensure castToNonNull static import
+            .build();
+    return builder.addFix(fix);
+  }
+
+  private Description.Builder removeCastToNonNullFix(
+      Tree suggestTree, Description.Builder builder) {
+    assert suggestTree.getKind() == Tree.Kind.METHOD_INVOCATION;
+    MethodInvocationTree invTree = (MethodInvocationTree) suggestTree;
+    final Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invTree);
+    String qualifiedName =
+        ASTHelpers.enclosingClass(methodSymbol) + "." + methodSymbol.getSimpleName().toString();
+    if (!qualifiedName.equals(config.getCastToNonNullMethod())) {
+      throw new RuntimeException("suggestTree should point to the castToNonNull invocation.");
+    }
+    // Remove the call to castToNonNull:
+    SuggestedFix fix =
+        SuggestedFix.builder()
+            .replace(suggestTree, invTree.getArguments().get(0).toString())
             .build();
     return builder.addFix(fix);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1199,7 +1199,7 @@ public class NullAway extends BugChecker
                 + "). This method should only take arguments that NullAway considers @Nullable "
                 + "at the invocation site, but which are known not to be null at runtime.";
         return createErrorDescription(
-            MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, actual, message, tree);
+            MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, tree, message, tree);
       }
     }
     // NOTE: the case of an invocation on a possibly-null reference

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.ErrorProneFlags;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NullAwayAutoSuggestTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ErrorProneFlags flags;
+
+  @Before
+  public void setup() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("NullAway:AnnotatedPackages", "com.uber,com.ubercab,io.reactivex");
+    b.putFlag("NullAway:CastToNonNullMethod", "com.uber.nullaway.testdata.Util.castToNonNull");
+    b.putFlag("NullAway:SuggestSuppressions", "true");
+    flags = b.build();
+  }
+
+  @Test
+  public void correctCastToNonNull() throws IOException {
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
+
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr.addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  Object test1(@Nullable Object o) {",
+            "    return castToNonNull(o);",
+            "  }",
+            "}")
+        .expectUnchanged();
+    bcr.doTest();
+  }
+
+  @Test
+  public void suggestCastToNonNull() throws IOException {
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
+
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr.addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object test1(@Nullable Object o) {",
+            "    return o;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object test1(@Nullable Object o) {",
+            "    return castToNonNull(o);",
+            "  }",
+            "}");
+    bcr.doTest();
+  }
+
+  @Test
+  public void removeUnnecessaryCastToNonNull() throws IOException {
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
+
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr.addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  Object test1(Object o) {",
+            "    return castToNonNull(o);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  Object test1(Object o) {",
+            "    return o;",
+            "  }",
+            "}");
+    bcr.doTest();
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -879,4 +879,25 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testCastToNonNull() {
+    compilationHelper
+        .addSourceFile("Util.java")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  Object test1(@Nullable Object o) {",
+            "    return castToNonNull(o);",
+            "  }",
+            "  Object test2(Object o) {",
+            "    // BUG: Diagnostic contains: passing known @NonNull parameter 'o' to CastToNonNullMethod",
+            "    return castToNonNull(o);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This adds a NullAway warning whenever all the following conditions apply:

- A `castToNonNull` method is configured with `-XepOpt:NullAway:CastToNonNullMethod=...`
- This method is passed an argument that NullAway knows to be `@NonNull`
- The invocation happens outside an initializer (inside an initializer, an `@NonNull` field might be passed to `castToNonNull` to "initialize it" in some weird cases where the actual reason for initialization is not detected by NullAway)

(See #190)

**Important**: This is a breaking change that adds a new `WARNING` level alert on a case that a) is safe, b) we previously allowed, but which I believe we should disallow for code quality purposes. We could gate this by a config flag, but I tentatively prefer not to proliferate those, and I can't see a good reason to need to pass `@NonNull` to `castToNonNull` other than refactoring issues and code written for earlier less precise versions of NullAway. I tentatively vote for a version bump to 0.5.0 instead of a config flag, but can do either.
