### PR TITLE
Various fixes for AcknowledgeRestrictiveAnnotations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -61,6 +61,9 @@ public interface LibraryModels {
   /** @return set of library methods that may return null */
   ImmutableSet<MethodRef> nullableReturns();
 
+  /** @return set of library methods that are assumed not to return null */
+  ImmutableSet<MethodRef> nonNullReturns();
+
   /**
    * representation of a method as a qualified class name + a signature for the method
    *
@@ -148,6 +151,12 @@ public interface LibraryModels {
         LibraryModels models, Symbol.MethodSymbol symbol, Types types) {
       // need to check if symbol is in the model or if it overrides a method in the model
       return methodInSet(symbol, types, models.nullableReturns()) != null;
+    }
+
+    public static boolean hasNonNullReturn(
+        LibraryModels models, Symbol.MethodSymbol symbol, Types types) {
+      // need to check if symbol is in the model or if it overrides a method in the model
+      return methodInSet(symbol, types, models.nonNullReturns()) != null;
     }
 
     @Nullable

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -38,13 +38,15 @@ public class Handlers {
    */
   public static Handler buildDefault(Config config) {
     ImmutableList.Builder<Handler> handlerListBuilder = ImmutableList.builder();
+    if (config.acknowledgeRestrictiveAnnotations()) {
+      // This runs before LibraryModelsHandler, so that library models can override third-party
+      // bytecode annotations
+      handlerListBuilder.add(new RestrictiveAnnotationHandler(config));
+    }
     handlerListBuilder.add(new LibraryModelsHandler());
     handlerListBuilder.add(new RxNullabilityPropagator());
     handlerListBuilder.add(new ContractHandler());
     handlerListBuilder.add(new ApacheThriftIsSetHandler());
-    if (config.acknowledgeRestrictiveAnnotations()) {
-      handlerListBuilder.add(new RestrictiveAnnotationHandler());
-    }
     return new CompositeHandler(handlerListBuilder.build());
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -297,8 +297,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
     private static final ImmutableSet<MethodRef> NONNULL_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
-            .add(methodRef("android.view.View", "<T>findViewById(int)"))
             .add(methodRef("android.app.Activity", "<T>findViewById(int)"))
+            .add(methodRef("android.view.View", "<T>findViewById(int)"))
+            .add(methodRef("android.view.View", "getResources()"))
             .add(
                 methodRef(
                     "android.content.res.Resources",

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -308,6 +308,10 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .add(methodRef("android.support.v4.app.Fragment", "getContext()"))
             .add(
                 methodRef(
+                    "android.support.v4.app.Fragment",
+                    "onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
+            .add(
+                methodRef(
                     "android.support.v4.content.ContextCompat",
                     "getDrawable(android.content.Context,int)"))
             .add(methodRef("android.support.v7.app.AppCompatDialog", "<T>findViewById(int)"))
@@ -342,15 +346,15 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
   private static class CombinedLibraryModels implements LibraryModels {
 
-    private final ImmutableSetMultimap<MethodRef, Integer> fail_if_null_parameters;
+    private final ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters;
 
-    private final ImmutableSetMultimap<MethodRef, Integer> non_null_parameters;
+    private final ImmutableSetMultimap<MethodRef, Integer> nonNullParameters;
 
-    private final ImmutableSetMultimap<MethodRef, Integer> null_implies_true_parameters;
+    private final ImmutableSetMultimap<MethodRef, Integer> nullImpliesTrueParameters;
 
-    private final ImmutableSet<MethodRef> nullable_returns;
+    private final ImmutableSet<MethodRef> nullableReturns;
 
-    private final ImmutableSet<MethodRef> nonnull_returns;
+    private final ImmutableSet<MethodRef> nonNullReturns;
 
     public CombinedLibraryModels(Iterable<LibraryModels> models) {
       ImmutableSetMultimap.Builder<MethodRef, Integer> failIfNullParametersBuilder =
@@ -379,36 +383,36 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
           nonNullReturnsBuilder.add(name);
         }
       }
-      fail_if_null_parameters = failIfNullParametersBuilder.build();
-      non_null_parameters = nonNullParametersBuilder.build();
-      null_implies_true_parameters = nullImpliesTrueParametersBuilder.build();
-      nullable_returns = nullableReturnsBuilder.build();
-      nonnull_returns = nonNullReturnsBuilder.build();
+      failIfNullParameters = failIfNullParametersBuilder.build();
+      nonNullParameters = nonNullParametersBuilder.build();
+      nullImpliesTrueParameters = nullImpliesTrueParametersBuilder.build();
+      nullableReturns = nullableReturnsBuilder.build();
+      nonNullReturns = nonNullReturnsBuilder.build();
     }
 
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters() {
-      return fail_if_null_parameters;
+      return failIfNullParameters;
     }
 
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> nonNullParameters() {
-      return non_null_parameters;
+      return nonNullParameters;
     }
 
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> nullImpliesTrueParameters() {
-      return null_implies_true_parameters;
+      return nullImpliesTrueParameters;
     }
 
     @Override
     public ImmutableSet<MethodRef> nullableReturns() {
-      return nullable_returns;
+      return nullableReturns;
     }
 
     @Override
     public ImmutableSet<MethodRef> nonNullReturns() {
-      return nonnull_returns;
+      return nonNullReturns;
     }
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -881,6 +881,32 @@ public class NullAwayTest {
   }
 
   @Test
+  public void restrictivelyAnnotatedMethodsWorkWithNullnessFromDataflow() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.uber.lib.unannotated.RestrictivelyAnnotatedClass;",
+            "class Test {",
+            "  Object test(RestrictivelyAnnotatedClass instance) {",
+            "    if (instance.getField() != null) {",
+            "      return instance.getField();",
+            "    }",
+            "    throw new Error();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testCastToNonNull() {
     compilationHelper
         .addSourceFile("Util.java")

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -46,4 +46,9 @@ public class ExampleLibraryModels implements LibraryModels {
   public ImmutableSet<MethodRef> nullableReturns() {
     return ImmutableSet.of();
   }
+
+  @Override
+  public ImmutableSet<MethodRef> nonNullReturns() {
+    return ImmutableSet.of();
+  }
 }

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
@@ -5,6 +5,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class RestrictivelyAnnotatedClass {
 
+  private final Object field;
+
+  public RestrictivelyAnnotatedClass(Object field) {
+    this.field = field;
+  }
+
+  public @Nullable Object getField() {
+    return field;
+  }
+
   public static @Nullable Object returnsNull() {
     return null;
   }


### PR DESCRIPTION
This is a collection of fixes that actually makes the `AcknowledgeRestrictiveAnnotations` option usable.

The version of this flag shipped with NullAway 0.5.0 is pretty much useless in large codebases and will break some parts of our dataflow analysis even for first-party/annotated code.

Additionally, we needed support for library models that override an `@Nullable` return annotation in certain common APIs, trading some soundness for usability. This includes these models and the basic support for them, back-ported from #187  