### PR TITLE
Fix NPE in Thrift handler on complex receiver expressions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -78,10 +78,15 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
       Pair<Element, Element> fieldAndGetter = getFieldAndSetterForProperty(symbol, capPropName);
       Node base = node.getTarget().getReceiver();
       if (fieldAndGetter.first != null) {
-        thenUpdates.set(
-            AccessPath.fromBaseAndElement(base, fieldAndGetter.first), Nullness.NONNULL);
+        AccessPath ap = AccessPath.fromBaseAndElement(base, fieldAndGetter.first);
+        if (ap != null) {
+          thenUpdates.set(ap, Nullness.NONNULL);
+        }
       }
-      thenUpdates.set(AccessPath.fromBaseAndElement(base, fieldAndGetter.second), Nullness.NONNULL);
+      AccessPath ap = AccessPath.fromBaseAndElement(base, fieldAndGetter.second);
+      if (ap != null) {
+        thenUpdates.set(ap, Nullness.NONNULL);
+      }
     }
     return NullnessHint.UNKNOWN;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -446,6 +446,10 @@ public class NullAwayTest {
             "    } else {",
             "      g.id.toString();",
             "    }",
+            "    java.util.List<Generated> l = new java.util.ArrayList<>();",
+            "    if (l.get(0).isSetId()) {",
+            "      l.get(0).getId().hashCode();",
+            "    }",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -448,6 +448,7 @@ public class NullAwayTest {
             "    }",
             "    java.util.List<Generated> l = new java.util.ArrayList<>();",
             "    if (l.get(0).isSetId()) {",
+            "      // BUG: Diagnostic contains: dereferenced expression l.get(0).getId()",
             "      l.get(0).getId().hashCode();",
             "    }",
             "  }",


### PR DESCRIPTION
Before NullAway would crash on code like:
```
if (list.get(0).isSetId()) {
  return list.get(0).getId();
}
```
We still don't create an access path for `list.get(0).getId()` but we no longer crash.