### PR TITLE
Handler for separate Android models jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
 repositories {
   // to get the google-java-format jar and dependencies
   jcenter()
+  mavenLocal()
 }
 
 subprojects {

--- a/jar-infer/scripts/android-jar.conf
+++ b/jar-infer/scripts/android-jar.conf
@@ -1,8 +1,19 @@
 [android-paths]
 aosp-out-dir = /Volumes/AOSP8.1/out/target/common/obj/JAVA_LIBRARIES/framework_intermediates
-android-jar-path = ~/android-sdk/platforms/android-27/android.jar
+android-stubs-jar = ~/android-sdk/platforms/android-27/android.jar
 
 [jar-infer-paths]
-nullaway-dir = ~/src/NullAway
 jar-infer-path = ~/src/NullAway/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-0.5.2-SNAPSHOT.jar
-astubx-path = META-INF/nullaway/jarinfer.astubx
+
+[android-model]
+android-model-jar = ~/src/NullAway/jar-infer/scripts/android-model/android-jarinfer-model-0.5.2-SNAPSHOT.jar
+wrk-dir = ~/src/NullAway/jar-infer/scripts/android-model
+astubx-path = resources/jarinfer.astubx
+package-name = com.uber.nullaway.jarinfer
+class-name = AndroidJarInferModels
+dummy-code: package %(package-name)s;
+    public class %(class-name)s {
+        public %(class-name)s() {
+            System.out.println(\"This dummy class locates the Android RT JarInfer models.\");
+        }
+    }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -56,6 +56,9 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
 
   private static final int VERSION_0_FILE_MAGIC_NUMBER = 691458791;
   private static final String DEFAULT_ASTUBX_LOCATION = "META-INF/nullaway/jarinfer.astubx";
+  private static final String ANDROID_ASTUBX_LOCATION = "resources/jarinfer.astubx";
+  private static final String ANDROID_MODEL_CLASS =
+      "com.uber.nullaway.jarinfer.AndroidJarInferModels";
 
   private static final int RETURN = -1; // '-1' indexes Return type in the Annotation Cache
 
@@ -66,6 +69,19 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
     super();
     argAnnotCache = new LinkedHashMap<>();
     loadedJars = new HashSet<>();
+    // Load Android models
+    try {
+      InputStream androidStubxIS =
+          Class.forName(ANDROID_MODEL_CLASS)
+              .getClassLoader()
+              .getResourceAsStream(ANDROID_ASTUBX_LOCATION);
+      if (androidStubxIS != null) {
+        parseStubStream(androidStubxIS, "android.jar: " + ANDROID_ASTUBX_LOCATION);
+        LOG(DEBUG, "DEBUG", "Loaded Android RT models.");
+      }
+    } catch (Exception e) {
+      LOG(VERBOSE, "Warn", "Cannot load Android RT models.");
+    }
   }
 
   @Override


### PR DESCRIPTION
- Instead of adding JarInfer models to the Android-library-stubs jar, we create a new Android-library-models jar.
- The NullAway handler initially loads the JarInfer models for the Android libraries into the Annotation Cache, and all subsequent invocations of Android class methods hit the Annotation Cache.