### PR TITLE
JarInfer Fix: zip entry size error

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -329,7 +329,7 @@ public class DefinitelyDerefedParamsDriver {
   private static void writeModelToJarStream(ZipInputStream zis, ZipOutputStream zos)
       throws IOException {
     for (ZipEntry ze; (ze = zis.getNextEntry()) != null; ) {
-      zos.putNextEntry(ze);
+      zos.putNextEntry(new ZipEntry(ze.getName()));
       IOUtils.copy(zis, zos);
       zos.closeEntry();
     }

--- a/jar-infer/scripts/android-jar.conf.template
+++ b/jar-infer/scripts/android-jar.conf.template
@@ -1,6 +1,6 @@
 [android-paths]
-aosp-out-dir = /Volumes/AOSP8.1/out/target/common/obj/JAVA_LIBRARIES/framework_intermediates
-android-stubs-jar = ${HOME}/android-sdk/platforms/android-27/android.jar
+aosp-out-dir = /Volumes/AOSP9.0/out/target/common/obj/JAVA_LIBRARIES/framework_intermediates
+android-stubs-jar = ${HOME}/android-sdk/platforms/android-28/android.jar
 
 [jar-infer-paths]
 jar-infer-path = ${HOME}/src/NullAway/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-0.5.2-SNAPSHOT.jar


### PR DESCRIPTION
* Bug: While writing a zip entry, if the compression ratio changes (happens for only one jar among those we process), `DefinitelyDerefedParamsDriver.writeModelToJarStream()` throws `java.util.zip.ZipException: invalid entry compressed size`.

* Fix: Create new zip entry with same name, instead of copying the entry metadata.

Also, updated the config file for Android model generation script to point to Android 9.0