### PR TITLE
[JarInfer] Write to/load from separate astubx model jars

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -38,6 +38,7 @@ configurations.all {
 dependencies {
     compileOnly deps.apt.autoValue
     compileOnly deps.apt.autoService
+    compile deps.build.commonsIO
 
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -38,7 +38,6 @@ configurations.all {
 dependencies {
     compileOnly deps.apt.autoValue
     compileOnly deps.apt.autoService
-    compile deps.build.commonsIO
 
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -86,6 +86,12 @@ public abstract class AbstractConfig implements Config {
 
   protected String autofixSuppressionComment;
 
+  /** --- JarInfer configs --- */
+  protected boolean jarInferUseReturnAnnotations;
+
+  protected String jarInferRegexStripModelJarName;
+  protected String jarInferRegexStripCodeJarName;
+
   protected static Pattern getPackagePattern(Set<String> packagePrefixes) {
     // noinspection ConstantConditions
     String choiceRegexp =
@@ -207,5 +213,21 @@ public abstract class AbstractConfig implements Config {
     abstract String enclosingClass();
 
     abstract String methodName();
+  }
+
+  /** --- JarInfer configs --- */
+  @Override
+  public boolean isJarInferUseReturnAnnotations() {
+    return jarInferUseReturnAnnotations;
+  }
+
+  @Override
+  public String getJarInferRegexStripModelJarName() {
+    return jarInferRegexStripModelJarName;
+  }
+
+  @Override
+  public String getJarInferRegexStripCodeJarName() {
+    return jarInferRegexStripCodeJarName;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -120,4 +120,16 @@ public interface Config {
    *     and/or auto-fix runs.
    */
   String getAutofixSuppressionComment();
+
+  /**
+   * --- JarInfer configs ---
+   *
+   * @return true if NullAway should use the @Nullable return value annotations inferred by
+   *     JarInfer.
+   */
+  boolean isJarInferUseReturnAnnotations();
+  /** @return the regex to extract jar name from the JarInfer model jar's path. */
+  String getJarInferRegexStripModelJarName();
+  /** @return the regex to extract jar name from the classfile jar's path. */
+  String getJarInferRegexStripCodeJarName();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -116,4 +116,20 @@ public class DummyOptionsConfig implements Config {
   public String getAutofixSuppressionComment() {
     throw new IllegalStateException(error_msg);
   }
+
+  /** --- JarInfer configs --- */
+  @Override
+  public boolean isJarInferUseReturnAnnotations() {
+    throw new IllegalStateException(error_msg);
+  }
+
+  @Override
+  public String getJarInferRegexStripModelJarName() {
+    throw new IllegalStateException(error_msg);
+  }
+
+  @Override
+  public String getJarInferRegexStripCodeJarName() {
+    throw new IllegalStateException(error_msg);
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -119,8 +119,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     jarInferUseReturnAnnotations = flags.getBoolean(FL_JI_USE_RETURN).orElse(false);
     // The defaults of these two options translate to: remove .aar/.jar from the file name, and also
     // implicitly mean that NullAway will search for jarinfer models in the same jar which contains
-    // the
-    // analyzed classes.
+    // the analyzed classes.
     jarInferRegexStripModelJarName = flags.get(FL_JI_REGEX_MODEL_PATH).orElse(BASENAME_REGEX);
     jarInferRegexStripCodeJarName = flags.get(FL_JI_REGEX_CODE_PATH).orElse(BASENAME_REGEX);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -117,6 +117,10 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     }
     /** --- JarInfer configs --- */
     jarInferUseReturnAnnotations = flags.getBoolean(FL_JI_USE_RETURN).orElse(false);
+    // The defaults of these two options translate to: remove .aar/.jar from the file name, and also
+    // implicitly mean that NullAway will search for jarinfer models in the same jar which contains
+    // the
+    // analyzed classes.
     jarInferRegexStripModelJarName = flags.get(FL_JI_REGEX_MODEL_PATH).orElse(BASENAME_REGEX);
     jarInferRegexStripCodeJarName = flags.get(FL_JI_REGEX_CODE_PATH).orElse(BASENAME_REGEX);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -35,6 +35,8 @@ import java.util.Set;
  */
 final class ErrorProneCLIFlagsConfig extends AbstractConfig {
 
+  private static final String BASENAME_REGEX = ".*/([^/]+)\\.[ja]ar$";
+
   static final String EP_FL_NAMESPACE = "NullAway";
   static final String FL_ANNOTATED_PACKAGES = EP_FL_NAMESPACE + ":AnnotatedPackages";
   static final String FL_UNANNOTATED_SUBPACKAGES = EP_FL_NAMESPACE + ":UnannotatedSubPackages";
@@ -53,6 +55,11 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_ACKNOWLEDGE_RESTRICTIVE =
       EP_FL_NAMESPACE + ":AcknowledgeRestrictiveAnnotations";
   static final String FL_SUPPRESS_COMMENT = EP_FL_NAMESPACE + ":AutoFixSuppressionComment";
+  /** --- JarInfer configs --- */
+  static final String FL_JI_USE_RETURN = EP_FL_NAMESPACE + ":JarInferUseReturnAnnotations";
+
+  static final String FL_JI_REGEX_MODEL_PATH = EP_FL_NAMESPACE + ":JarInferRegexStripModelJar";
+  static final String FL_JI_REGEX_CODE_PATH = EP_FL_NAMESPACE + ":JarInferRegexStripCodeJar";
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
@@ -108,6 +115,10 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
       throw new IllegalStateException(
           "Invalid -XepOpt" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
     }
+    /** --- JarInfer configs --- */
+    jarInferUseReturnAnnotations = flags.getBoolean(FL_JI_USE_RETURN).orElse(false);
+    jarInferRegexStripModelJarName = flags.get(FL_JI_REGEX_MODEL_PATH).orElse(BASENAME_REGEX);
+    jarInferRegexStripCodeJarName = flags.get(FL_JI_REGEX_CODE_PATH).orElse(BASENAME_REGEX);
   }
 
   private static ImmutableSet<String> getFlagStringSet(ErrorProneFlags flags, String flagName) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -43,7 +43,7 @@ public class Handlers {
       // bytecode annotations
       handlerListBuilder.add(new RestrictiveAnnotationHandler(config));
     }
-    handlerListBuilder.add(new InferredJARModelsHandler());
+    handlerListBuilder.add(new InferredJARModelsHandler(config));
     handlerListBuilder.add(new LibraryModelsHandler());
     handlerListBuilder.add(new RxNullabilityPropagator());
     handlerListBuilder.add(new ContractHandler());

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -66,6 +66,13 @@ public class NullAwayTest {
   @Test
   public void jarinferLoadStubsTest() {
     compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-cp",
+                "../jar-infer/test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",


### PR DESCRIPTION
- Writing JarInfer models to separate `<jar_name>.astubx.jar` instead of re-writing original jar.
- Modified NullAway handler to:
  - upon first invocation, scan the javac classpath and build a map of JarInfer model jar locations.
  - upon visiting a new method, resolve method -> class -> classfile -> jar name, and lookup jar name in above map to find JarInfer model jar location, then load to annotation cache.