### PR TITLE
Update readme and tooling versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.2
-    - android-27    
-    - extra-google-m2repository
-    - extra-android-m2repository
+    - build-tools-28.0.2
+    - android-28
 
 before_install:
-  - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28"
 
 script:
   - ./gradlew verGJF build

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Snapshots of the development version are available in [Sonatype's snapshots repo
 
 #### Android
 
-The configuration for an Android project is very similar to the Java case, with one key difference: The `com.google.code.findbugs:jsr305:3.0.2` dependence can be removed; you can use the `android.support.annotation.Nullable` annotation from the Android Support library.
+The configuration for an Android project is very similar to the Java case, with one key difference: The `com.google.code.findbugs:jsr305:3.0.2` dependency can be removed; you can use the `android.support.annotation.Nullable` annotation from the Android Support library.
 
 ```gradle
 dependencies {

--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ buildscript {
 
 plugins {
   // we assume you are already using the Java plugin
-  id "net.ltgt.apt" version "0.13"
-  id "net.ltgt.errorprone" version "0.0.13"
+  id "net.ltgt.errorprone" version "0.0.16"
 }
 
 dependencies {
-  apt "com.uber.nullaway:nullaway:0.5.3"
+  annotationProcessor "com.uber.nullaway:nullaway:0.5.3"
 
   // Optional, some source of nullability annotations.
   // Not required on Android if you use the support 
@@ -50,7 +49,7 @@ tasks.withType(JavaCompile) {
 }
 ```
 
-Let's walk through this script step by step.  The `buildscript` section of the script adds the Maven repository for Gradle plugins.  The `plugins` section pulls in the [Gradle Error Prone plugin](https://github.com/tbroyer/gradle-errorprone-plugin) for Error Prone integration, and the [Gradle APT plugin](https://github.com/tbroyer/gradle-apt-plugin) to ease specification of annotation processor dependencies for a build.  We need the latter since Error Prone loads plugin checkers from the annotation processor path.  If you are using the older `apply plugin` syntax instead of a `plugins` block, the following is equivalent:
+Let's walk through this script step by step.  The `buildscript` section of the script adds the Maven repository for Gradle plugins.  The `plugins` section pulls in the [Gradle Error Prone plugin](https://github.com/tbroyer/gradle-errorprone-plugin) for Error Prone integration. If you are using the older `apply plugin` syntax instead of a `plugins` block, the following is equivalent:
 ```gradle
 buildscript {
   repositories {
@@ -59,16 +58,14 @@ buildscript {
     }
   }
   dependencies {
-    classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"
+    classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16"
   }
 }
 
 apply plugin: 'net.ltgt.errorprone'
-apply plugin: 'net.ltgt.apt'
 ```
 
-In `dependencies`, the `apt` line loads NullAway, and the `compileOnly` line loads a [JSR 305](https://jcp.org/en/jsr/detail?id=305) library which provides a suitable `@Nullable` annotation (`javax.annotation.Nullable`).  NullAway allows for any `@Nullable` annotation to be used, so, e.g., `@Nullable` from the Android Support Library or JetBrains annotations is also fine. The `errorprone` line ensures that a compatible version of Error Prone is used.
+In `dependencies`, the `annotationProcessor` line loads NullAway, and the `compileOnly` line loads a [JSR 305](https://jcp.org/en/jsr/detail?id=305) library which provides a suitable `@Nullable` annotation (`javax.annotation.Nullable`).  NullAway allows for any `@Nullable` annotation to be used, so, e.g., `@Nullable` from the Android Support Library or JetBrains annotations is also fine. The `errorprone` line ensures that a compatible version of Error Prone is used.
 
 Finally, in the `tasks.withType(JavaCompile)` section, we pass some configuration options to NullAway as compiler arguments.  The first argument `-Xep:NullAway:ERROR` is a standard Error Prone argument that sets NullAway issues to the error level; by default NullAway emits warnings.  The second argument, `-XepOpt:NullAway:AnnotatedPackages=com.uber`, tells NullAway that source code in packages under the `com.uber` namespace should be checked for null dereferences and proper usage of `@Nullable` annotations, and that class files in these packages should be assumed to have correct usage of `@Nullable` (see [the docs](https://github.com/uber/NullAway/wiki/Configuration) for more detail).  NullAway requires at least the `AnnotatedPackages` configuration argument to run, in order to distinguish between annotated and unannotated code.  See [the configuration docs](https://github.com/uber/NullAway/wiki/Configuration) for other useful configuration options.
 
@@ -78,11 +75,7 @@ Snapshots of the development version are available in [Sonatype's snapshots repo
 
 #### Android
 
-The configuration for an Android project is very similar to the Java case, with two key differences:
-
-1. The `net.ltgt.apt` plugin is not required.
-2. The `com.google.code.findbugs:jsr305:3.0.2` dependence can be removed; you can use the `android.support.annotation.Nullable` annotation from the Android Support library.
-3. Rather than declaring NullAway as an `apt` dependence, use the `annotationProcessor` configuration:
+The configuration for an Android project is very similar to the Java case, with one key difference: The `com.google.code.findbugs:jsr305:3.0.2` dependence can be removed; you can use the `android.support.annotation.Nullable` annotation from the Android Support library.
 
 ```gradle
 dependencies {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ def versions = [
     checkerFramework       : "2.5.0",
     checkerFrameworkNAFork : "2.5.0",
     errorProne             : "2.1.1",
-    support                : "27.0.2",
+    support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
     commonscli             : "1.4",
 ]
@@ -35,7 +35,7 @@ def build = [
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
     checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFrameworkNAFork}",
                                "org.checkerframework:javacutil:${versions.checkerFrameworkNAFork}"],
-    gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8",
+    gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16",
     guava                   : "com.google.guava:guava:22.0",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
@@ -46,14 +46,14 @@ def build = [
     commonscli              : "commons-cli:commons-cli:${versions.commonscli}",
 
     // android stuff
-    buildToolsVersion: "27.0.2",
-    compileSdkVersion: 27,
+    buildToolsVersion: "28.0.2",
+    compileSdkVersion: 28,
     ci: "true" == System.getenv("CI"),
     minSdkVersion: 16,
-    targetSdkVersion: 27,
+    targetSdkVersion: 28,
 
     gradlePlugins: [
-        android: "com.android.tools.build:gradle:3.0.1",
+        android: "com.android.tools.build:gradle:3.1.3",
     ]
 
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ def build = [
     targetSdkVersion: 28,
 
     gradlePlugins: [
-        android: "com.android.tools.build:gradle:3.1.3",
+        android: "com.android.tools.build:gradle:3.1.4",
     ]
 
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -50,13 +50,11 @@ android {
 }
 
 dependencies {
-    compile deps.support.appcompat
-
-    testCompile deps.test.junit4
-
+    implementation deps.support.appcompat
     annotationProcessor project(path: ":nullaway", configuration: "shadow")
-
     annotationProcessor project(path: ":sample-library-model")
+
+    testImplementation deps.test.junit4
 
     errorprone "com.google.errorprone:error_prone_core:2.1.3"
 }


### PR DESCRIPTION
- Update Gradle to 4.9
- Update android gradle plugin to 3.1.4
- Update gradle errorprone plugin to 0.0.16
- Update android sdk and build tools to 28
- Update support to 27.1.1
- Remove old examples from readme referencing `apt` plugin that is no longer required
- Update travis