### PR TITLE
Update to Error Prone 2.3.1 and centralize Java compiler flags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "com.github.sherter.google-java-format" version "0.6"
+  id "com.github.sherter.google-java-format" version "0.7.1"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
   id "com.github.sherter.google-java-format" version "0.7.1"
+  id "net.ltgt.errorprone" version "0.0.16" apply false
 }
 
 repositories {
@@ -23,7 +24,19 @@ repositories {
   jcenter()
 }
 
-subprojects {
+subprojects { project ->
+    afterEvaluate {
+        if (project.plugins.hasPlugin("java")
+            || project.plugins.hasPlugin("com.android.application")) {
+            project.apply plugin: "net.ltgt.errorprone"
+            project.dependencies {
+                errorprone deps.build.errorProneCore
+            }
+            project.tasks.withType(JavaCompile) {
+                options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror", "-Xep:StringSplitter:OFF"]
+            }
+        }
+    }
     buildscript {
         repositories {
             jcenter()
@@ -44,11 +57,7 @@ subprojects {
         google()
     }
 
-    tasks.withType(JavaCompile) {
-        options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror", "-Xep:StringSplitter:OFF"]
-    }
 }
-
 
 googleJavaFormat {
   toolVersion = "1.6"

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,14 @@ subprojects { project ->
                 errorprone deps.build.errorProneCore
             }
             project.tasks.withType(JavaCompile) {
-                options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror", "-Xep:StringSplitter:OFF"]
+                options.compilerArgs += [
+                    "-Xlint:unchecked",
+                    "-Xlint:rawtypes",
+                    "-Werror",
+                    // this check is too noisy
+                    "-Xep:StringSplitter:OFF",
+                    "-Xep:WildcardImport:ERROR"
+                ]
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,14 @@ subprojects {
         google()
     }
 
+    tasks.withType(JavaCompile) {
+        options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror", "-Xep:StringSplitter:OFF"]
+    }
 }
 
 
 googleJavaFormat {
-  toolVersion = "1.4"
+  toolVersion = "1.6"
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/compile-bench/build.gradle
+++ b/compile-bench/build.gradle
@@ -43,8 +43,5 @@ run {
         args(appArgs.split(' '))
     }
 }
-compileJava {
-    options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror"]
-}
 
 

--- a/compile-bench/build.gradle
+++ b/compile-bench/build.gradle
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 plugins {
-  id "net.ltgt.errorprone" version "0.0.13"
   id "java"
   id "application"
 }
@@ -29,8 +28,6 @@ configurations.maybeCreate("epJavac")
 dependencies {
     compile deps.build.errorProneCore
     compile project(path: ":nullaway", configuration: "shadow")
-
-    errorprone deps.build.errorProneCore
 
     epJavac deps.build.errorProneCore
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@
 def versions = [
     checkerFramework       : "2.5.0",
     checkerFrameworkNAFork : "2.5.0",
-    errorProne             : "2.1.1",
+    errorProne             : "2.3.1",
     support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
     commonscli             : "1.4",

--- a/jar-infer/android-jarinfer-models-sdk28/build.gradle
+++ b/jar-infer/android-jarinfer-models-sdk28/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "net.ltgt.errorprone" version "0.0.13"
     id "java"
 }
 
@@ -9,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    errorprone deps.build.errorProneCore
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")

--- a/jar-infer/android-jarinfer-models-sdk28/build.gradle
+++ b/jar-infer/android-jarinfer-models-sdk28/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.13"
     id "java"
 }
 
@@ -10,7 +9,6 @@ repositories {
 }
 
 dependencies {
-    errorprone deps.build.errorProneCore
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.13"
     id "com.github.johnrengelman.shadow" version "2.0.2"
     id "java"
 }
@@ -17,8 +16,6 @@ dependencies {
     compileOnly deps.build.errorProneCheckApi
 
     compile project(":jar-infer:jar-infer-lib")
-
-    errorprone deps.build.errorProneCore
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {

--- a/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
+++ b/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
@@ -33,7 +33,7 @@ public class JarInfer {
    *
    * @param args Command line arguments.
    */
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     Options options = new Options();
     HelpFormatter hf = new HelpFormatter();
     hf.setWidth(100);
@@ -94,8 +94,6 @@ public class JarInfer {
       }
     } catch (ParseException pe) {
       hf.printHelp(appName, options, true);
-    } catch (Exception e) {
-      e.printStackTrace();
     }
   }
 }

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+    testCompile project(":jar-infer:test-java-lib-jarinfer")
     epJavac deps.build.errorProneCheckApi
 }
 

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.13"
     id "java"
 }
 // we use this config to get the path of the JDK 9 javac jar, to
@@ -19,8 +18,6 @@ dependencies {
     compile deps.build.guava
     compile deps.build.commonsIO
     compileOnly deps.build.errorProneCheckApi
-
-    errorprone deps.build.errorProneCore
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -178,7 +178,10 @@ public class DefinitelyDerefedParamsDriver {
                     continue;
                   }
                 } catch (Exception e) {
-                  e.printStackTrace();
+                  LOG(
+                      DEBUG,
+                      "DEBUG",
+                      "Exception while scanning bytecodes for " + mtd + " " + e.getMessage());
                 }
                 // Make CFG
                 IR ir =
@@ -300,12 +303,10 @@ public class DefinitelyDerefedParamsDriver {
   //    StubxWriter.VERSION_0_FILE_MAGIC_NUMBER (?)
   private static void writeModel(DataOutputStream out) throws IOException {
     Map<String, String> importedAnnotations =
-        new HashMap<String, String>() {
-          {
-            put("Nonnull", "javax.annotation.Nonnull");
-            put("Nullable", "javax.annotation.Nullable");
-          }
-        };
+        ImmutableMap.<String, String>builder()
+            .put("Nonnull", "javax.annotation.Nonnull")
+            .put("Nullable", "javax.annotation.Nullable")
+            .build();
     Map<String, Set<String>> packageAnnotations = new HashMap<>();
     Map<String, Set<String>> typeAnnotations = new HashMap<>();
     Map<String, MethodAnnotationsRecord> methodRecords = new LinkedHashMap<>();
@@ -369,18 +370,16 @@ public class DefinitelyDerefedParamsDriver {
    */
   private static String getSimpleTypeName(TypeReference typ) {
     final Map<String, String> mapFullTypeName =
-        new HashMap<String, String>() {
-          {
-            put("B", "byte");
-            put("C", "char");
-            put("D", "double");
-            put("F", "float");
-            put("I", "int");
-            put("J", "long");
-            put("S", "short");
-            put("Z", "boolean");
-          }
-        };
+        ImmutableMap.<String, String>builder()
+            .put("B", "byte")
+            .put("C", "char")
+            .put("D", "double")
+            .put("F", "float")
+            .put("I", "int")
+            .put("J", "long")
+            .put("S", "short")
+            .put("Z", "boolean")
+            .build();
     if (typ.isArrayType()) return "Array";
     String typName = typ.getName().toString();
     if (typName.startsWith("L")) {

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/StubxWriter.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/StubxWriter.java
@@ -1,5 +1,6 @@
 package com.uber.nullaway.jarinfer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -43,12 +44,12 @@ public final class StubxWriter {
     int numStringEntires = 0;
     Map<String, Integer> encodingDictionary = new LinkedHashMap<>();
     List<String> strings = new ArrayList<String>();
-    Collection[] keysets = {
-      importedAnnotations.values(),
-      packageAnnotations.keySet(),
-      typeAnnotations.keySet(),
-      methodRecords.keySet()
-    };
+    List<Collection<String>> keysets =
+        ImmutableList.of(
+            importedAnnotations.values(),
+            packageAnnotations.keySet(),
+            typeAnnotations.keySet(),
+            methodRecords.keySet());
     for (Collection<String> keyset : keysets) {
       for (String key : keyset) {
         assert !encodingDictionary.containsKey(key);

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/CompilerUtil.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/CompilerUtil.java
@@ -63,7 +63,7 @@ public class CompilerUtil {
     try {
       fileManager.setLocation(StandardLocation.SOURCE_PATH, Collections.<File>emptyList());
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new RuntimeException("unexpected IOException", e);
     }
     outputStream = new ByteArrayOutputStream();
     this.compiler =

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -23,10 +23,12 @@ import com.sun.tools.javac.main.Main;
 import com.sun.tools.javac.main.Main.Result;
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -78,7 +80,7 @@ public class JarInferTest {
         verify(
             DefinitelyDerefedParamsDriver.run(
                 temporaryFolder.getRoot().getAbsolutePath(), "L" + pkg.replaceAll("\\.", "/")),
-            expected));
+            new HashMap<>(expected)));
   }
 
   /**
@@ -105,7 +107,7 @@ public class JarInferTest {
    * @param result Map of 'method signatures' to their 'inferred list of NonNull parameters'.
    * @param expected Map of 'method signatures' to their 'expected list of NonNull parameters'.
    */
-  private boolean verify(Map<String, Set<Integer>> result, Map<String, Set<Integer>> expected) {
+  private boolean verify(Map<String, Set<Integer>> result, HashMap<String, Set<Integer>> expected) {
     for (Map.Entry<String, Set<Integer>> entry : result.entrySet()) {
       String mtd_sign = entry.getKey();
       Set<Integer> ddParams = entry.getValue();
@@ -217,6 +219,7 @@ public class JarInferTest {
         "}");
   }
 
+  @Ignore("don't understand the failure")
   @Test
   public void toyJAR() throws Exception {
     testJARTemplate(

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -219,13 +218,12 @@ public class JarInferTest {
         "}");
   }
 
-  @Ignore("don't understand the failure")
   @Test
   public void toyJAR() throws Exception {
     testJARTemplate(
         "toyJAR",
         "com.uber.nullaway.jarinfer.toys.unannotated",
-        "./src/test/resources/com/uber/nullaway/jarinfer/testdata/test-java-lib-jarinfer.jar");
+        "../test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar");
   }
 
   @Test

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id "net.ltgt.apt" version "0.13"
-  id "net.ltgt.errorprone" version "0.0.13"
   id "java"
 }
 
@@ -25,8 +24,6 @@ targetCompatibility = "1.8"
 
 dependencies {
     apt project(path: ":nullaway", configuration: "shadow")
-
-    errorprone deps.build.errorProneCore
 
     compileOnly deps.build.jsr305Annotations
     compileOnly deps.test.cfQual

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -60,6 +60,13 @@ dependencies {
     epJavac deps.build.checkerDataflow
 }
 
+// NullAway ends up enabled by default for tests in this project; disable it
+tasks.withType(JavaCompile) {
+  if (name.toLowerCase().contains("test")) {
+    options.compilerArgs += ["-Xep:NullAway:OFF"]
+  }
+} 
+
 // We include and shade the checker framework jars into the NullAway jar, as we may have custom
 // changes.
 shadowJar {

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 plugins {
-  id "net.ltgt.errorprone" version "0.0.13"
   id "com.github.johnrengelman.shadow" version "2.0.2"
   id "java"
 }
@@ -42,8 +41,6 @@ dependencies {
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow
     shadow deps.build.guava
-
-    errorprone deps.build.errorProneCore
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -87,9 +87,6 @@ javadoc {
     failOnError = false
 }
 
-compileJava {
-    options.compilerArgs += ["-Xlint:unchecked", "-Xlint:rawtypes", "-Werror"]
-}
 
 test {
   maxHeapSize = "1024m"

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -139,12 +139,11 @@ import org.checkerframework.javacutil.AnnotationUtils;
  */
 @AutoService(BugChecker.class)
 @BugPattern(
-  name = "NullAway",
-  altNames = {"CheckNullabilityTypes"},
-  summary = "Nullability type error.",
-  category = JDK,
-  severity = WARNING
-)
+    name = "NullAway",
+    altNames = {"CheckNullabilityTypes"},
+    summary = "Nullability type error.",
+    category = JDK,
+    severity = WARNING)
 public class NullAway extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher,
         BugChecker.AssignmentTreeMatcher,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -51,9 +51,9 @@ import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.NullnessStore;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -543,7 +543,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
    */
   private static class StreamModelBuilder {
 
-    private final List<StreamTypeRecord> typeRecords = new LinkedList<StreamTypeRecord>();
+    private final List<StreamTypeRecord> typeRecords = new ArrayList<StreamTypeRecord>();
     private TypePredicate tp = null;
     private ImmutableSet.Builder<String> filterMethodSigs;
     private ImmutableSet.Builder<String> filterMethodSimpleNames;

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     testImplementation deps.test.junit4
 
-    errorprone "com.google.errorprone:error_prone_core:2.1.3"
+    errorprone deps.build.errorProneCore
 }
 
 tasks.withType(JavaCompile) {

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -21,12 +21,10 @@ buildscript {
     }
     dependencies {
         classpath deps.build.gradlePlugins.android
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
     }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'net.ltgt.errorprone'
 
 android {
     compileSdkVersion deps.build.compileSdkVersion
@@ -56,7 +54,6 @@ dependencies {
 
     testImplementation deps.test.junit4
 
-    errorprone deps.build.errorProneCore
 }
 
 tasks.withType(JavaCompile) {

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -15,7 +15,6 @@
  */
 
 plugins {
-  id "net.ltgt.errorprone" version "0.0.13"
   id "java"
 }
 
@@ -27,7 +26,6 @@ dependencies {
     compileOnly project(path: ":nullaway", configuration: "shadow")
     compileOnly deps.build.guava
 
-    errorprone deps.build.errorProneCore
 }
 
 tasks.withType(JavaCompile) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id "net.ltgt.apt" version "0.13"
-  id "net.ltgt.errorprone" version "0.0.13"
   id "java"
 }
 
@@ -26,8 +25,6 @@ targetCompatibility = "1.8"
 dependencies {
     apt project(path: ":nullaway", configuration: "shadow")
     apt project(path: ":sample-library-model")
-
-    errorprone deps.build.errorProneCore
 
     compileOnly deps.build.jsr305Annotations
     testCompile deps.test.junit4

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id "net.ltgt.apt" version "0.13"
-  id "net.ltgt.errorprone" version "0.0.13"
   id "java"
 }
 
@@ -25,8 +24,6 @@ targetCompatibility = "1.8"
 
 dependencies {
     apt project(path: ":nullaway", configuration: "shadow")
-
-    errorprone deps.build.errorProneCore
 
     compileOnly deps.build.jsr305Annotations
     compileOnly deps.build.javaxValidation


### PR DESCRIPTION
* Enable Error Prone and `-Werror` everywhere
* Update the Gradle plugin versions for Error Prone and GJF
* Fix some new warnings