### PR TITLE
Handle invocation of native method from initializer

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1505,7 +1505,9 @@ public class NullAway extends BugChecker
           MethodInvocationTree methodInvocationTree = (MethodInvocationTree) expressionTree;
           Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(methodInvocationTree);
           Set<Modifier> modifiers = symbol.getModifiers();
-          if ((symbol.isPrivate() || modifiers.contains(Modifier.FINAL)) && !symbol.isStatic()) {
+          if ((symbol.isPrivate() || modifiers.contains(Modifier.FINAL))
+              && !symbol.isStatic()
+              && !modifiers.contains(Modifier.NATIVE)) {
             // check it's the same class (could be an issue with inner classes)
             if (ASTHelpers.enclosingClass(symbol).equals(enclosingClassSymbol)) {
               // make sure the receiver is 'this'

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -99,7 +99,12 @@ public final class DataFlow {
                   } else if (codePath.getLeaf() instanceof MethodTree) {
                     MethodTree method = (MethodTree) codePath.getLeaf();
                     ast = new UnderlyingAST.CFGMethod(method, /*classTree*/ null);
-                    bodyPath = new TreePath(codePath, method.getBody());
+                    BlockTree body = method.getBody();
+                    if (body == null) {
+                      throw new IllegalStateException(
+                          "trying to compute CFG for method " + method + ", which has no body");
+                    }
+                    bodyPath = new TreePath(codePath, body);
                   } else {
                     // must be an initializer per findEnclosingMethodOrLambdaOrInitializer
                     ast =

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1127,4 +1127,22 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void invokeNativeFromInitializer() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "class Test {",
+            "  Object f;",
+            "  private native void foo();",
+            "  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f",
+            "  Test() {",
+            "    foo();",
+            "  }",
+            "}")
+        .doTest();
+    ;
+  }
 }


### PR DESCRIPTION
Ref #221.  We should not be treating native methods as possibly initializing fields, as we cannot analyze their implementation.