### PR TITLE
Fix empty comment added when AutoFixSuppressionComment is not set.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -186,7 +186,11 @@ public abstract class AbstractConfig implements Config {
 
   @Override
   public String getAutofixSuppressionComment() {
-    return autofixSuppressionComment;
+    if (autofixSuppressionComment.trim().length() > 0) {
+      return " /* " + autofixSuppressionComment + " */ ";
+    } else {
+      return "";
+    }
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2014,11 +2014,7 @@ public class NullAway extends BugChecker
       fix =
           SuggestedFix.prefixWith(
               suggestTree,
-              "@SuppressWarnings(\""
-                  + checkerName
-                  + "\") /* "
-                  + config.getAutofixSuppressionComment()
-                  + " */ ");
+              "@SuppressWarnings(\"" + checkerName + "\")" + config.getAutofixSuppressionComment());
     } else {
       // need to update the existing list of warnings
       List<String> suppressions = Lists.newArrayList(extantSuppressWarnings.value());
@@ -2040,10 +2036,8 @@ public class NullAway extends BugChecker
       String replacement =
           "@SuppressWarnings({"
               + Joiner.on(',').join(Iterables.transform(suppressions, s -> '"' + s + '"'))
-              + "}) "
-              + "/* "
-              + config.getAutofixSuppressionComment()
-              + " */ ";
+              + "})"
+              + config.getAutofixSuppressionComment();
       fix = SuggestedFix.replace(suppressWarningsAnnot.get(), replacement);
     }
     return builder.addFix(fix);


### PR DESCRIPTION
When `-XepOpt:NullAway:SuggestSuppressions` is set, but `-XepOpt:NullAway:AutoFixSuppressionComment` is not set, the expected behavior is to suggest `@SuppressWarnings("NullAway")` where needed, but not add any comment to it.

Before this PR, however, we were adding an empty comment (e.g. `@SuppressWarnings("NullAway") /* */`). This fixes that and adds an unit test to check for a possible regression. Thanks @jbarr21 for reporting this.