### PR TITLE
Make JarInfer generated jars fully deterministic by removing timestamps

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -52,6 +52,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -309,7 +310,12 @@ public class DefinitelyDerefedParamsDriver {
         outPath.endsWith(MODEL_JAR_SUFFIX), "invalid model file path! " + outPath);
     ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(outPath));
     if (!map_result.isEmpty()) {
-      zos.putNextEntry(new ZipEntry(DEFAULT_ASTUBX_LOCATION));
+      ZipEntry entry = new ZipEntry(DEFAULT_ASTUBX_LOCATION);
+      // Set the modification/creation time to 0 to ensure that this jars always have the same
+      // checksum
+      entry.setTime(0);
+      entry.setCreationTime(FileTime.fromMillis(0));
+      zos.putNextEntry(entry);
       writeModel(new DataOutputStream(zos));
       zos.closeEntry();
     }


### PR DESCRIPTION
This change sets the timestamp of the files inside the astubx jars generated by JarInfer to be the UNIX epoch (1970-01-01T00:00:00Z). The reason for this is to guarantee file-checksum level deterministic outputs from JarInfer which are required by the cache mechanisms of most build systems.