### PR TITLE
Add support for marking library parameters as explicitly @Nullable

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -42,6 +42,15 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters();
 
   /**
+   * @return map from the names of methods with @Nullable parameters to the indexes of the arguments
+   *     that are @Nullable.
+   *     <p>This is taken into account for override checks, requiring methods that override the
+   *     methods listed here to take @Nullable parameters on the same indexes. The main use for this
+   *     is to document which API callbacks can be passed null values.
+   */
+  ImmutableSetMultimap<MethodRef, Integer> explicitlyNullableParameters();
+
+  /**
    * @return map from the names of methods with @NonNull parameters to the indexes of the arguments
    *     that are @NonNull.
    *     <p>Note that these methods are different from the {@link #failIfNullParameters()} methods,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -101,12 +101,23 @@ abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
+  public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
+    // NoOp
+    return explicitlyNullablePositions;
+  }
+
+  @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
       NullAway analysis,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol,
       List<? extends ExpressionTree> actualParams,
       ImmutableSet<Integer> nonNullPositions) {
+    // NoOp
     return nonNullPositions;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -115,6 +115,20 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
+    for (Handler h : handlers) {
+      explicitlyNullablePositions =
+          h.onUnannotatedInvocationGetExplicitlyNullablePositions(
+              analysis, state, methodSymbol, explicitlyNullablePositions);
+    }
+    return explicitlyNullablePositions;
+  }
+
+  @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
       NullAway analysis,
       VisitorState state,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -127,6 +127,30 @@ public interface Handler {
   void onMatchReturn(NullAway analysis, ReturnTree tree, VisitorState state);
 
   /**
+   * Called when NullAway encounters an unannotated method and asks for params explicitly
+   * marked @Nullable
+   *
+   * <p>This is mostly used to force overriding methods to also use @Nullable, e.g. for callbacks
+   * that can get passed null values.
+   *
+   * <p>Note that this should be only used for parameters EXPLICLTY marked as @Nullable (e.g. by
+   * library models) rather than those considered @Nullable by NullAway's default optimistic
+   * assumptions.
+   *
+   * @param analysis A reference to the running NullAway analysis.
+   * @param state The current visitor state.
+   * @param methodSymbol The method symbol for the unannotated method in question.
+   * @param explicitlyNullablePositions Parameter nullability computed by upstream handlers (the
+   *     core analysis supplies the empty set to the first handler in the chain).
+   * @return Updated parameter nullability computed by this handler.
+   */
+  ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions);
+
+  /**
    * Called when NullAway encounters an unannotated method and asks for params default nullability
    *
    * @param analysis A reference to the running NullAway analysis.

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1143,6 +1143,48 @@ public class NullAwayTest {
             "  }",
             "}")
         .doTest();
-    ;
+  }
+
+  @Test
+  public void overrideFailsOnExplicitlyNullableLibraryModelParam() {
+    compilationHelper
+        .addSourceLines( // Dummy android.view.GestureDetector.OnGestureListener interface
+            "GestureDetector.java",
+            "package android.view;",
+            "public class GestureDetector {",
+            "  public static interface OnGestureListener {",
+            // Ignore other methods for this test, to make code shorter on both files:
+            "    boolean onScroll(MotionEvent me1, MotionEvent me2, float f1, float f2);",
+            "  }",
+            "}")
+        .addSourceLines( // Dummy android.view.MotionEvent class
+            "MotionEvent.java", "package android.view;", "public class MotionEvent { }")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import android.view.GestureDetector;",
+            "import android.view.MotionEvent;",
+            "class Test implements GestureDetector.OnGestureListener {",
+            "  Test() {  }",
+            "  @Override",
+            "  // BUG: Diagnostic contains: parameter me1 is @NonNull",
+            "  public boolean onScroll(MotionEvent me1, MotionEvent me2, float f1, float f2) {",
+            "    return false; // NoOp",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test2.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import android.view.GestureDetector;",
+            "import android.view.MotionEvent;",
+            "class Test2 implements GestureDetector.OnGestureListener {",
+            "  Test2() {  }",
+            "  @Override",
+            "  public boolean onScroll(@Nullable MotionEvent me1, MotionEvent me2, float f1, float f2) {",
+            "    return false; // NoOp",
+            "  }",
+            "}")
+        .doTest();
   }
 }

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -31,6 +31,11 @@ public class ExampleLibraryModels implements LibraryModels {
   }
 
   @Override
+  public ImmutableSetMultimap<MethodRef, Integer> explicitlyNullableParameters() {
+    return ImmutableSetMultimap.of();
+  }
+
+  @Override
   public ImmutableSetMultimap<MethodRef, Integer> nonNullParameters() {
     return ImmutableSetMultimap.of();
   }


### PR DESCRIPTION
Note that this allows us to force overriding methods to have the
corresponding parameters annotated as @Nullable.

In particular, we are marking android.view.GestureDetector.
 OnGestureListener.onScroll as taking @Nullable for the first
parameter. Since this callback can be passed null under some
circumstances.