### PR TITLE
Fix AutoFix for MethodRefs returning null.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -187,7 +187,7 @@ public abstract class AbstractConfig implements Config {
   @Override
   public String getAutofixSuppressionComment() {
     if (autofixSuppressionComment.trim().length() > 0) {
-      return " /* " + autofixSuppressionComment + " */ ";
+      return "/* " + autofixSuppressionComment + " */ ";
     } else {
       return "";
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -640,8 +640,12 @@ public class NullAway extends BugChecker
           memberReferenceTree != null
               ? memberReferenceTree
               : getTreesInstance(state).getTree(overridingMethod);
+      Tree suggestTree =
+          memberReferenceTree != null
+              ? NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(state.getPath()).getLeaf()
+              : errorTree;
       return createErrorDescription(
-          MessageTypes.WRONG_OVERRIDE_RETURN, errorTree, message, errorTree);
+          MessageTypes.WRONG_OVERRIDE_RETURN, errorTree, message, suggestTree);
     }
     // if any parameter in the super method is annotated @Nullable,
     // overriding method cannot assume @Nonnull
@@ -2014,7 +2018,10 @@ public class NullAway extends BugChecker
       fix =
           SuggestedFix.prefixWith(
               suggestTree,
-              "@SuppressWarnings(\"" + checkerName + "\")" + config.getAutofixSuppressionComment());
+              "@SuppressWarnings(\""
+                  + checkerName
+                  + "\") "
+                  + config.getAutofixSuppressionComment());
     } else {
       // need to update the existing list of warnings
       List<String> suppressions = Lists.newArrayList(extantSuppressWarnings.value());
@@ -2036,7 +2043,7 @@ public class NullAway extends BugChecker
       String replacement =
           "@SuppressWarnings({"
               + Joiner.on(',').join(Iterables.transform(suppressions, s -> '"' + s + '"'))
-              + "})"
+              + "}) "
               + config.getAutofixSuppressionComment();
       fix = SuggestedFix.replace(suppressWarningsAnnot.get(), replacement);
     }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -124,4 +124,49 @@ public class NullAwayAutoSuggestTest {
             "}");
     bcr.doTest();
   }
+
+  @Test
+  public void suggestSuppressionOnMethodRef() throws IOException {
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
+
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr.addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  public @Nullable Object doReturnNullable() {",
+            "    return null;",
+            "  }",
+            "  public static void takesNonNull(Object o) { ",
+            "    System.out.println(o.toString());",
+            "  }",
+            "  public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {",
+            "    return f.apply(this);",
+            "  }",
+            "  void test() throws Exception {",
+            "    takesNonNull(execute(Test::doReturnNullable));",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  public @Nullable Object doReturnNullable() {",
+            "    return null;",
+            "  }",
+            "  public static void takesNonNull(Object o) { ",
+            "    System.out.println(o.toString());",
+            "  }",
+            "  public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {",
+            "    return f.apply(this);",
+            "  }",
+            "  @SuppressWarnings(\"NullAway\") void test() throws Exception {",
+            "    takesNonNull(execute(Test::doReturnNullable));",
+            "  }",
+            "}");
+    bcr.doTest();
+  }
 }


### PR DESCRIPTION
This fixes a case where `@SuppressWarnings(...)` annotations would 
be added on MethodRefs at the point where the MethodRef 
is introduced, rather than the enclosing method. This happened in cases
of invalid overriding of the return parameter compared to the functional
interface.

Also, fix typo: Add a space after `@SuppressWarnings(...)` fixes,
even if no AutoFixSuppressionComment is provided.