### PR TITLE
Rename default astubx files for JarInfer.

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -80,7 +80,7 @@ public class DefinitelyDerefedParamsDriver {
   private static Result map_result = new Result();
   private static Set<String> nullableReturns = new HashSet<>();
 
-  private static final String DEFAULT_ASTUBX_LOCATION = "META-INF/nullaway/jarinfer.astubx";
+  private static final String DEFAULT_ASTUBX_LOCATION = ".jarinfer.astubx";
   private static final String MODEL_JAR_SUFFIX = ".astubx.jar";
   // TODO: Exclusions-
   // org.ow2.asm : InvalidBytecodeException on

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -23,7 +23,7 @@ evaluationDependsOn(":jar-infer:jar-infer-cli")
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
-def astubxPath = "META-INF/nullaway/jarinfer.astubx"
+def astubxPath = ".jarinfer.astubx"
 
 jar.doLast {
     javaexec {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -63,7 +63,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   }
 
   private static final int VERSION_0_FILE_MAGIC_NUMBER = 691458791;
-  private static final String DEFAULT_ASTUBX_LOCATION = "META-INF/nullaway/jarinfer.astubx";
+  private static final String DEFAULT_ASTUBX_LOCATION = ".jarinfer.astubx";
   private static final String ANDROID_ASTUBX_LOCATION = "jarinfer.astubx";
   private static final String ANDROID_MODEL_CLASS =
       "com.uber.nullaway.jarinfer.AndroidJarInferModels";


### PR DESCRIPTION
By moving them from `META-INF/nullaway/jarinfer.astubx` to
`.jarinfer.astubx`, we take advantage of default logic in
Google's apkbuilder which will strip them from Android
application bundles (.apk files).