### PR TITLE
Enable excluded class annotations to (mostly) work on inner classes

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -139,8 +139,8 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
-  public boolean isExcludedClassAnnotation(String annotationName) {
-    return excludedClassAnnotations.contains(annotationName);
+  public ImmutableSet<String> getExcludedClassAnnotations() {
+    return ImmutableSet.copyOf(excludedClassAnnotations);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway;
 
+import com.google.common.collect.ImmutableSet;
 import com.sun.tools.javac.code.Symbol;
 import javax.annotation.Nullable;
 
@@ -50,12 +51,8 @@ public interface Config {
    */
   boolean isUnannotatedClass(Symbol.ClassSymbol symbol);
 
-  /**
-   * @param annotationName fully-qualified annotation name
-   * @return true if a top-level class with this annotation should be excluded from nullability
-   *     analysis, false otherwise
-   */
-  boolean isExcludedClassAnnotation(String annotationName);
+  /** @return class annotations that should exclude a class from nullability analysis */
+  ImmutableSet<String> getExcludedClassAnnotations();
 
   /**
    * @param annotationName fully-qualified annotation name

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -25,6 +25,7 @@ package com.uber.nullaway;
 import static com.uber.nullaway.ErrorProneCLIFlagsConfig.EP_FL_NAMESPACE;
 import static com.uber.nullaway.ErrorProneCLIFlagsConfig.FL_ANNOTATED_PACKAGES;
 
+import com.google.common.collect.ImmutableSet;
 import com.sun.tools.javac.code.Symbol;
 import javax.annotation.Nullable;
 
@@ -67,7 +68,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public boolean isExcludedClassAnnotation(String annotationName) {
+  public ImmutableSet<String> getExcludedClassAnnotations() {
     throw new IllegalStateException(error_msg);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -245,9 +245,7 @@ public class NullAway extends BugChecker
     builder.addAll(super.customSuppressionAnnotations());
     for (String annotName : config.getExcludedClassAnnotations()) {
       try {
-        @SuppressWarnings("unchecked")
-        Class<Annotation> klass = (Class<Annotation>) Class.forName(annotName);
-        builder.add(klass);
+        builder.add(Class.forName(annotName).asSubclass(Annotation.class));
       } catch (ClassNotFoundException e) {
         // in this case, the annotation may be a source file currently being compiled,
         // in which case we won't be able to resolve the class

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -91,6 +91,7 @@ import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.EnclosingEnvironmentNullness;
 import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handlers;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -214,6 +215,8 @@ public class NullAway extends BugChecker
    */
   private final Map<ExpressionTree, Nullness> computedNullnessMap = new LinkedHashMap<>();
 
+  private final ImmutableSet<Class<? extends Annotation>> customSuppressionAnnotations;
+
   /**
    * Error Prone requires us to have an empty constructor for each Plugin, in addition to the
    * constructor taking an ErrorProneFlags object. This constructor should not be used anywhere
@@ -224,15 +227,33 @@ public class NullAway extends BugChecker
     config = new DummyOptionsConfig();
     handler = Handlers.buildEmpty();
     nonAnnotatedMethod = nonAnnotatedMethodCheck();
+    customSuppressionAnnotations = ImmutableSet.of();
   }
 
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = nonAnnotatedMethodCheck();
+    customSuppressionAnnotations = initCustomSuppressions();
     // workaround for Checker Framework static state bug;
     // See https://github.com/typetools/checker-framework/issues/1482
     AnnotationUtils.clear();
+  }
+
+  private ImmutableSet<Class<? extends Annotation>> initCustomSuppressions() {
+    ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builder();
+    builder.addAll(super.customSuppressionAnnotations());
+    for (String annotName : config.getExcludedClassAnnotations()) {
+      try {
+        @SuppressWarnings("unchecked")
+        Class<Annotation> klass = (Class<Annotation>) Class.forName(annotName);
+        builder.add(klass);
+      } catch (ClassNotFoundException e) {
+        // in this case, the annotation may be a source file currently being compiled,
+        // in which case we won't be able to resolve the class
+      }
+    }
+    return builder.build();
   }
 
   private Predicate<MethodInvocationNode> nonAnnotatedMethodCheck() {
@@ -246,6 +267,11 @@ public class NullAway extends BugChecker
   public String linkUrl() {
     // add a space to make it clickable from iTerm
     return config.getErrorURL() + " ";
+  }
+
+  @Override
+  public Set<Class<? extends Annotation>> customSuppressionAnnotations() {
+    return customSuppressionAnnotations;
   }
 
   /**
@@ -1727,12 +1753,12 @@ public class NullAway extends BugChecker
       return true;
     }
     // check annotations
-    for (AnnotationMirror anno : classSymbol.getAnnotationMirrors()) {
-      if (config.isExcludedClassAnnotation(anno.getAnnotationType().toString())) {
-        return true;
-      }
-    }
-    return false;
+    ImmutableSet<String> excludedClassAnnotations = config.getExcludedClassAnnotations();
+    return classSymbol
+        .getAnnotationMirrors()
+        .stream()
+        .map(anno -> anno.getAnnotationType().toString())
+        .anyMatch(excludedClassAnnotations::contains);
   }
 
   private boolean mayBeNullExpr(VisitorState state, ExpressionTree expr) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -91,6 +91,36 @@ public class NullAwayTest {
   }
 
   @Test
+  public void skipNestedClass() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.lib.MyExcluded"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  @com.uber.lib.MyExcluded",
+            "  static class Inner {",
+            "    @Nullable",
+            "    static Object foo() {",
+            "      Object x = null; x.toString();",
+            "      return x;",
+            "    }",
+            "  }",
+            "  static void bar() {",
+            "    // BUG: Diagnostic contains: dereferenced expression Inner.foo()",
+            "    Inner.foo().toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void coreNullabilitySkipPackage() {
     compilationHelper.addSourceFile("unannotated/UnannotatedClass.java").doTest();
   }

--- a/test-java-lib/src/main/java/com/uber/lib/MyExcluded.java
+++ b/test-java-lib/src/main/java/com/uber/lib/MyExcluded.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.lib;
+
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+
+@Retention(CLASS)
+public @interface MyExcluded {}


### PR DESCRIPTION
Fixes #237 

We override `BugChecker.customSuppressionAnnotations`, which works for both top-level and inner classes.

The fix has one limitation, which is that it does not work for inner classes in the same module as the annotation declaration, due to the `customSuppressionAnnotations()` API requiring `Class` objects rather than matching by name.  We will just document this limitation as fixing is rather complex and potentially costly to performance.