### PR TITLE
Assertion of not equal to null updates the access path

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -114,7 +114,7 @@ public final class DataFlow {
                             codePath.getLeaf(), (ClassTree) codePath.getParentPath().getLeaf());
                     bodyPath = codePath;
                   }
-                  return CFGBuilder.build(bodyPath, ast, false, false, env);
+                  return CFGBuilder.build(bodyPath, ast, true, false, env);
                 }
               });
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -145,6 +145,16 @@ public class NullAwayTest {
   }
 
   @Test
+  public void assertSupportPositiveCases() {
+    compilationHelper.addSourceFile("CheckAssertSupportPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void assertSupportNegativeCases() {
+    compilationHelper.addSourceFile("CheckAssertSupportNegativeCases.java").doTest();
+  }
+
+  @Test
   public void java8PositiveCases() {
     compilationHelper.addSourceFile("NullAwayJava8PositiveCases.java").doTest();
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckAssertSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckAssertSupportNegativeCases.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.testdata;
+
+import javax.annotation.Nullable;
+
+public class CheckAssertSupportNegativeCases {
+
+  class T1 {
+    @Nullable Object obj;
+  }
+
+  void someMethod() {
+    T1 t1 = new T1();
+    assert t1.obj != null;
+    t1.obj.toString();
+  }
+}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckAssertSupportPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckAssertSupportPositiveCases.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.testdata;
+
+import javax.annotation.Nullable;
+
+public class CheckAssertSupportPositiveCases {
+
+  class T1 {
+    @Nullable Object obj;
+  }
+
+  void someMethod() {
+    T1 t1 = new T1();
+    assert t1.obj == null;
+    // BUG: Diagnostic contains: dereferenced expression
+    t1.obj.toString();
+  }
+
+  void someMethod2() {
+    T1 t1 = new T1();
+    assert t1 != null;
+    // BUG: Diagnostic contains: dereferenced expression
+    t1.obj.toString();
+  }
+}


### PR DESCRIPTION
Added support for assert statements that check if the left operand is not equal to null. It will be assumed that the operand is NONNULL, and warnings will change accordingly. 

Fixes #122 
Added unit tests 
