### PR TITLE
Update to Error Prone 2.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ subprojects { project ->
                     "-Xlint:unchecked",
                     "-Xlint:rawtypes",
                     "-Werror",
-                    // don't analyze generated code; AutoValue code fails UnnecessaryParentheses check
-                    "-XepExcludedPaths:.*/build/classes/.*",
+                    // disable warnings in generated code; AutoValue code fails UnnecessaryParentheses check
+                    "-XepDisableWarningsInGeneratedCode",
                     // this check is too noisy
                     "-Xep:StringSplitter:OFF",
                     "-Xep:WildcardImport:ERROR"

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ subprojects { project ->
                     "-Xlint:unchecked",
                     "-Xlint:rawtypes",
                     "-Werror",
+                    // don't analyze generated code; AutoValue code fails UnnecessaryParentheses check
+                    "-XepExcludedPaths:.*/build/classes/.*",
                     // this check is too noisy
                     "-Xep:StringSplitter:OFF",
                     "-Xep:WildcardImport:ERROR"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,6 +32,7 @@ def apt = [
 def build = [
     errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProne}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
+    errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
     checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
                                "org.checkerframework:javacutil:${versions.checkerFramework}"],

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,14 +16,15 @@
 
 def versions = [
     checkerFramework       : "2.5.5",
-    errorProne             : "2.3.1",
+    errorProne             : "2.3.2",
     support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
     commonscli             : "1.4",
+    autoValue              : "1.6.2",
 ]
 
 def apt = [
-    autoValue   : "com.google.auto.value:auto-value:1.4.1",
+    autoValue   : ["com.google.auto.value:auto-value:${versions.autoValue}", "com.google.auto.value:auto-value-annotations:${versions.autoValue}"],
     autoService : "com.google.auto.service:auto-service:1.0-rc3",
     javaxInject : "javax.inject:javax.inject:1",
 ]

--- a/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
+++ b/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
@@ -75,7 +75,7 @@ public class JarInfer {
     options.addOption(
         Option.builder("v").argName("verbose").longOpt("verbose").desc("set verbosity").build());
     try {
-      CommandLine line = (new DefaultParser()).parse(options, args);
+      CommandLine line = new DefaultParser().parse(options, args);
       if (line.hasOption('h')) {
         hf.printHelp(appName, options, true);
         return;

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
@@ -132,7 +132,7 @@ public class DefinitelyDerefedParams {
     // Get number of params and value number of first param
     int numParam = ir.getSymbolTable().getNumberOfParameters();
     int firstParamIndex =
-        (method.isStatic()) ? 1 : 2; // 1-indexed; v1 is 'this' for non-static methods
+        method.isStatic() ? 1 : 2; // 1-indexed; v1 is 'this' for non-static methods
     LOG(DEBUG, "DEBUG", "param value numbers : " + firstParamIndex + " ... " + numParam);
     while (!nodeQueue.isEmpty()) {
       ISSABasicBlock node = nodeQueue.get(0);

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -59,8 +59,7 @@ dependencies {
     testCompile deps.apt.javaxInject
     testCompile deps.test.rxjava2
 
-    epJavac deps.build.errorProneCheckApi
-    epJavac deps.build.checkerDataflow
+    epJavac deps.build.errorProneJavac
 }
 
 // NullAway ends up enabled by default for tests in this project; disable it

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2160,7 +2160,7 @@ public class NullAway extends BugChecker
       case IDENTIFIER:
         IdentifierTree varTree = (IdentifierTree) expression;
         Symbol symbol = ASTHelpers.getSymbol(varTree);
-        return (symbol.getKind().equals(ElementKind.FIELD)) ? 2 : 1;
+        return symbol.getKind().equals(ElementKind.FIELD) ? 2 : 1;
       default:
         return 0;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -240,7 +240,7 @@ public class AccessPath {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof AccessPath)) {
       return false;
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -50,7 +50,7 @@ import org.checkerframework.javacutil.TreeUtils;
  *
  * <p>We do not allow array accesses in access paths for the moment.
  */
-public class AccessPath {
+public final class AccessPath {
 
   private final Root root;
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -110,7 +110,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
    */
   private void processClassPath() {
     URL[] classLoaderUrls =
-        ((URLClassLoader) (Thread.currentThread().getContextClassLoader())).getURLs();
+        ((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs();
     for (URL url : classLoaderUrls) {
       String path = url.getFile();
       if (path.matches(config.getJarInferRegexStripModelJarName())) {


### PR DESCRIPTION
Only a few fixes required.

I had to disable analysis of generated code since AutoValue-generated code doesn't pass the UnnecessaryParentheses check.  I tried updating AutoValue to fix this, and decided to keep the update.