### PR TITLE
Change how jarinfer finds astubx model jars.

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1074,9 +1074,7 @@ public class NullAwayTest {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-cp",
-                "../jar-infer/test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar"))
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -1100,9 +1098,7 @@ public class NullAwayTest {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:JarInferUseReturnAnnotations=true",
-                "-cp",
-                "../jar-infer/test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar"))
+                "-XepOpt:NullAway:JarInferUseReturnAnnotations=true"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",


### PR DESCRIPTION
This uses getContextClassLoader() instead of the javac args to
find the list of all classpath jars.

This removes the need of expliclty passing `-cp` on tests and
should be generally more robust to environments other than a
direct `javac` call.