### PR TITLE
Restrictive annotated method overriding

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -680,7 +680,7 @@ public class NullAway extends BugChecker
       VisitorState state) {
     final boolean isOverridenMethodUnannotated =
         NullabilityUtil.isUnannotated(overriddenMethod, config);
-    boolean overriddenMethodReturnsNonNull =
+    final boolean overriddenMethodReturnsNonNull =
         ((isOverridenMethodUnannotated
                 && handler.onUnannotatedInvocationGetExplicitlyNonNullReturn(
                     overriddenMethod, false))

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -678,15 +678,14 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol overridingMethod,
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
-    // We ignore unannotated methods for now, since we always assume they return @NonNull, but we
-    // don't actually know,
-    // so it might make sense to override them as @Nullable.
-    // TODO: Add an equivalent to Handler.onUnannotatedInvocationGetExplicitlyNullablePositions for
-    // @NonNull return
-    // values if needed.
+    final boolean isOverridenMethodUnannotated =
+        NullabilityUtil.isUnannotated(overriddenMethod, config);
     boolean overriddenMethodReturnsNonNull =
-        !(NullabilityUtil.isUnannotated(overriddenMethod, config)
-            || Nullness.hasNullableAnnotation(overriddenMethod));
+        ((isOverridenMethodUnannotated
+                && handler.onUnannotatedInvocationGetExplicitlyNonNullReturn(
+                    overriddenMethod, false))
+            || (!isOverridenMethodUnannotated
+                && !Nullness.hasNullableAnnotation(overriddenMethod)));
     // if the super method returns nonnull,
     // overriding method better not return nullable
     if (overriddenMethodReturnsNonNull

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -158,6 +158,16 @@ public enum Nullness implements AbstractValue<Nullness> {
   }
 
   /**
+   * Does the symbol have a {@code @NonNull} declaration or type-use annotation?
+   *
+   * <p>NOTE: this method does not work for checking all annotations of parameters of methods from
+   * class files. For that case, use {@link #paramHasNullableAnnotation(Symbol.MethodSymbol, int)}
+   */
+  public static boolean hasNonNullAnnotation(Symbol symbol) {
+    return hasNonNullAnnotation(NullabilityUtil.getAllAnnotations(symbol));
+  }
+
+  /**
    * Does the symbol have a {@code @Nullable} declaration or type-use annotation?
    *
    * <p>NOTE: this method does not work for checking all annotations of parameters of methods from

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -110,6 +110,13 @@ abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
+  public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
+      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+    // NoOp
+    return explicitlyNonNullReturn;
+  }
+
+  @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
       NullAway analysis,
       VisitorState state,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -128,6 +128,17 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
+      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+    for (Handler h : handlers) {
+      explicitlyNonNullReturn =
+          h.onUnannotatedInvocationGetExplicitlyNonNullReturn(
+              methodSymbol, explicitlyNonNullReturn);
+    }
+    return explicitlyNonNullReturn;
+  }
+
+  @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
       NullAway analysis,
       VisitorState state,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -151,6 +151,21 @@ public interface Handler {
       ImmutableSet<Integer> explicitlyNullablePositions);
 
   /**
+   * Called when NullAway encounters an unannotated method and asks if return value is explicitly
+   * marked @Nullable
+   *
+   * <p>Note that this should be only used for return values EXPLICLTY marked as @NonNull (e.g. by
+   * library models) rather than those considered @Nullable by NullAway's default optimistic
+   * assumptions.
+   *
+   * @param methodSymbol The method symbol for the unannotated method in question.
+   * @param explicitlyNonNullReturn return nullability computed by upstream handlers.
+   * @return Updated return nullability computed by this handler.
+   */
+  boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
+      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn);
+
+  /**
    * Called when NullAway encounters an unannotated method and asks for params default nullability
    *
    * @param analysis A reference to the running NullAway analysis.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -79,6 +79,28 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
   }
 
   @Override
+  public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
+    HashSet<Integer> positions = new HashSet<Integer>();
+    positions.addAll(explicitlyNullablePositions);
+    for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
+      if (Nullness.paramHasNullableAnnotation(methodSymbol, i)) {
+        positions.add(i);
+      }
+    }
+    return ImmutableSet.copyOf(positions);
+  }
+
+  @Override
+  public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
+      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+    return Nullness.hasNonNullAnnotation(methodSymbol) || explicitlyNonNullReturn;
+  }
+
+  @Override
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1054,13 +1054,13 @@ public class NullAwayTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
                 "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
         .addSourceLines(
-            "Test.java",
+            "TestNegativeCases.java",
             "package com.uber;",
             "import com.uber.lib.unannotated.RestrictivelyAnnotatedClass;",
             "import org.checkerframework.checker.nullness.qual.NonNull;",
             "import javax.annotation.Nullable;",
-            "public class Test extends RestrictivelyAnnotatedClass {",
-            "   Test(){ super(new Object()); }",
+            "public class TestNegativeCases extends RestrictivelyAnnotatedClass {",
+            "   TestNegativeCases(){ super(new Object()); }",
             "   @Override public void acceptsNonNull(@Nullable Object o) { }",
             "   @Override public void acceptsNonNull2(Object o) { }",
             "   @Override public void acceptsNullable2(@Nullable Object o) { }",
@@ -1069,13 +1069,13 @@ public class NullAwayTest {
             "   @Override public @Nullable Object returnsNullable2() { return new Object();}",
             "}")
         .addSourceLines(
-            "Test2.java",
+            "TestPositiveCases.java",
             "package com.uber;",
             "import com.uber.lib.unannotated.RestrictivelyAnnotatedClass;",
             "import org.checkerframework.checker.nullness.qual.NonNull;",
             "import javax.annotation.Nullable;",
-            "public class Test2 extends RestrictivelyAnnotatedClass {",
-            "   Test2(){ super(new Object()); }",
+            "public class TestPositiveCases extends RestrictivelyAnnotatedClass {",
+            "   TestPositiveCases(){ super(new Object()); }",
             "   // BUG: Diagnostic contains: parameter o is @NonNull",
             "   public void acceptsNullable(Object o) { }",
             "   // BUG: Diagnostic contains: method returns @Nullable",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1044,6 +1044,47 @@ public class NullAwayTest {
   }
 
   @Test
+  public void OverridingRestrictivelyAnnotatedMethod() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.RestrictivelyAnnotatedClass;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "import javax.annotation.Nullable;",
+            "public class Test extends RestrictivelyAnnotatedClass {",
+            "   Test(){ super(new Object()); }",
+            "   @Override public void acceptsNonNull(@Nullable Object o) { }",
+            "   @Override public void acceptsNonNull2(Object o) { }",
+            "   @Override public void acceptsNullable2(@Nullable Object o) { }",
+            "   @Override public Object returnsNonNull() { return new Object(); }",
+            "   @Override public Object returnsNullable() { return new Object(); }",
+            "   @Override public @Nullable Object returnsNullable2() { return new Object();}",
+            "}")
+        .addSourceLines(
+            "Test2.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.RestrictivelyAnnotatedClass;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "import javax.annotation.Nullable;",
+            "public class Test2 extends RestrictivelyAnnotatedClass {",
+            "   Test2(){ super(new Object()); }",
+            "   // BUG: Diagnostic contains: parameter o is @NonNull",
+            "   public void acceptsNullable(Object o) { }",
+            "   // BUG: Diagnostic contains: method returns @Nullable",
+            "   public @Nullable Object returnsNonNull2() { return new Object(); }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testCastToNonNull() {
     compilationHelper
         .addSourceFile("Util.java")

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedClass.java
@@ -25,4 +25,28 @@ public class RestrictivelyAnnotatedClass {
   public static void consumesObjectNotNull(@NotNull Object o) {}
 
   public static void consumesObjectUnannotated(Object o) {}
+
+  public void acceptsNonNull(@NonNull Object o) {}
+
+  public void acceptsNonNull2(@NonNull Object o) {}
+
+  public void acceptsNullable(@Nullable Object o) {}
+
+  public void acceptsNullable2(@Nullable Object o) {}
+
+  public @NonNull Object returnsNonNull() {
+    return new Object();
+  }
+
+  public @NonNull Object returnsNonNull2() {
+    return new Object();
+  }
+
+  public @Nullable Object returnsNullable() {
+    return null;
+  }
+
+  public @Nullable Object returnsNullable2() {
+    return null;
+  }
 }


### PR DESCRIPTION
Following changes are addressed, 
If the restrictive annotations are turned on then  
1. If the first-party overriding method has a marked `@Nullable` return and the third-party method is restrictively annotated as `@NonNull` then triggers an error.
2. If an argument to the first-party overriding method is not marked `@Nullable` but the same position argument to the overridden third-party method is restrictively annotated as `@Nullable` then also triggers an error.

Fixes #236 
Added unit tests. 
