### PR TITLE
Overriding explicitly nonnull return method from library models gives error with nullable return 

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -683,7 +683,7 @@ public class NullAway extends BugChecker
     final boolean overriddenMethodReturnsNonNull =
         ((isOverridenMethodUnannotated
                 && handler.onUnannotatedInvocationGetExplicitlyNonNullReturn(
-                    overriddenMethod, false))
+                    state, overriddenMethod, false))
             || (!isOverridenMethodUnannotated
                 && !Nullness.hasNullableAnnotation(overriddenMethod)));
     // if the super method returns nonnull,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -111,7 +111,7 @@ abstract class BaseNoOpHandler implements Handler {
 
   @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
-      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+      VisitorState state, Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
     // NoOp
     return explicitlyNonNullReturn;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -129,11 +129,11 @@ class CompositeHandler implements Handler {
 
   @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
-      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+      VisitorState state, Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
     for (Handler h : handlers) {
       explicitlyNonNullReturn =
           h.onUnannotatedInvocationGetExplicitlyNonNullReturn(
-              methodSymbol, explicitlyNonNullReturn);
+              state, methodSymbol, explicitlyNonNullReturn);
     }
     return explicitlyNonNullReturn;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -163,7 +163,7 @@ public interface Handler {
    * @return Updated return nullability computed by this handler.
    */
   boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
-      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn);
+      VisitorState state, Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn);
 
   /**
    * Called when NullAway encounters an unannotated method and asks for params default nullability

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -93,6 +93,14 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
+  public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
+      VisitorState state, Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+    return LibraryModels.LibraryModelUtil.hasNonNullReturn(
+            libraryModels, methodSymbol, state.getTypes())
+        || explicitlyNonNullReturn;
+  }
+
+  @Override
   public boolean onOverrideMayBeNullExpr(
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
     if (expr.getKind() == Tree.Kind.METHOD_INVOCATION

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -96,7 +96,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
-      Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
+      VisitorState state, Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
     return Nullness.hasNonNullAnnotation(methodSymbol) || explicitlyNonNullReturn;
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1274,6 +1274,43 @@ public class NullAwayTest {
   }
 
   @Test
+  public void overrideOnExplicitlyNonNullLibraryModelReturn() {
+    compilationHelper
+        .addSourceLines( // Dummy android.support.v4.app.Fragment class
+            "Fragment.java",
+            "package android.support.v4.app;",
+            "public interface Fragment {",
+            // Ignore other methods for this test, to make code shorter on both files:
+            "    boolean getActivity();",
+            "}")
+        .addSourceLines(
+            "TestNegative.java",
+            "package com.uber;",
+            "import android.support.v4.app.Fragment;",
+            "class TestNegative implements Fragment {",
+            "  TestNegative() {  }",
+            "  @Override",
+            "  public boolean getActivity() {",
+            "    return false; // NoOp",
+            "  }",
+            "}")
+        .addSourceLines(
+            "TestPositive.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import android.support.v4.app.Fragment;",
+            "class TestPositive implements Fragment {",
+            "  TestPositive() {  }",
+            "  @Override",
+            "  // BUG: Diagnostic contains: method returns @Nullable",
+            "  @Nullable public boolean getActivity() {",
+            "    return false; // NoOp",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testCapturingScopes() {
     compilationHelper.addSourceFile("CapturingScopes.java").doTest();
   }


### PR DESCRIPTION
The diff addresses following change. 
Overriding explicitly nonnull return method from library models with method of nullable return gives error. 

Added unit tests. 
