### PR TITLE
Fix error on checking the initTree2PrevFieldInit cache.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -942,7 +942,8 @@ public class NullAway extends BugChecker
       Symbol fieldSymbol, TreePath initTreePath, VisitorState state) {
     TreePath enclosingClassPath = initTreePath.getParentPath();
     ClassTree enclosingClass = (ClassTree) enclosingClassPath.getLeaf();
-    Multimap<Tree, Element> tree2Init = initTree2PrevFieldInit.get(enclosingClass);
+    Multimap<Tree, Element> tree2Init =
+        initTree2PrevFieldInit.get(ASTHelpers.getSymbol(enclosingClass));
     if (tree2Init == null) {
       tree2Init = computeTree2Init(enclosingClassPath, state);
       initTree2PrevFieldInit.put(ASTHelpers.getSymbol(enclosingClass), tree2Init);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -238,9 +238,6 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
           // Load model jars
           for (String modelJarPath : mapModelJarLocations.get(jarName)) {
             JarFile jar = new JarFile(modelJarPath);
-            if (jar == null) {
-              throw new Error("Cannot open jar: " + modelJarPath);
-            }
             LOG(DEBUG, "DEBUG", "Found model jar at: " + modelJarPath);
             JarEntry astubxJE = jar.getJarEntry(DEFAULT_ASTUBX_LOCATION);
             if (astubxJE == null) {


### PR DESCRIPTION
We were saving `ASTHelpers.getSymbol(enclosingClass)` (A `ClassSymbol`) but testing for `enclosingClass` itself (`ClassTree`). This didn't cause a functional problem, but it means the cache was never being hit.