### PR TITLE
Handle lambda override with AcknowledgeRestrictiveAnnotations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -534,7 +534,7 @@ public class NullAway extends BugChecker
     if (NullabilityUtil.isUnannotated(overriddenMethod, config)) {
       nullableParamsOfOverriden =
           handler.onUnannotatedInvocationGetExplicitlyNullablePositions(
-              this, state, overriddenMethod, ImmutableSet.of());
+              overriddenMethod, ImmutableSet.of());
     } else {
       ImmutableSet.Builder<Integer> builder = ImmutableSet.builder();
       for (int i = startParam; i < superParamSymbols.size(); i++) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -101,10 +101,7 @@ abstract class BaseNoOpHandler implements Handler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
+      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
     // NoOp
     return explicitlyNullablePositions;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -115,14 +115,11 @@ class CompositeHandler implements Handler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
+      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
     for (Handler h : handlers) {
       explicitlyNullablePositions =
           h.onUnannotatedInvocationGetExplicitlyNullablePositions(
-              analysis, state, methodSymbol, explicitlyNullablePositions);
+              methodSymbol, explicitlyNullablePositions);
     }
     return explicitlyNullablePositions;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -137,18 +137,13 @@ public interface Handler {
    * library models) rather than those considered @Nullable by NullAway's default optimistic
    * assumptions.
    *
-   * @param analysis A reference to the running NullAway analysis.
-   * @param state The current visitor state.
    * @param methodSymbol The method symbol for the unannotated method in question.
    * @param explicitlyNullablePositions Parameter nullability computed by upstream handlers (the
    *     core analysis supplies the empty set to the first handler in the chain).
    * @return Updated parameter nullability computed by this handler.
    */
   ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions);
+      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions);
 
   /**
    * Called when NullAway encounters an unannotated method and asks if return value is explicitly

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -80,10 +80,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
+      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
     return Sets.union(
             explicitlyNullablePositions,
             libraryModels

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -86,10 +86,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
+      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
     HashSet<Integer> positions = new HashSet<Integer>();
     positions.addAll(explicitlyNullablePositions);
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1114,6 +1114,59 @@ public class NullAwayTest {
   }
 
   @Test
+  public void lambdaPlusRestrictivePositive() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.RestrictivelyAnnotatedFI;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  void foo() {",
+            "    RestrictivelyAnnotatedFI func = (x) -> {",
+            "      // BUG: Diagnostic contains: dereferenced expression x is @Nullable",
+            "      x.toString();",
+            "      return new Object();",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void lambdaPlusRestrictiveNegative() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.RestrictivelyAnnotatedFI;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  void foo() {",
+            "    RestrictivelyAnnotatedFI func = (x) -> {",
+            "      // no error since AcknowledgeRestrictiveAnnotations disabled",
+            "      x.toString();",
+            "      return new Object();",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testCastToNonNull() {
     compilationHelper
         .addSourceFile("Util.java")

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedFI.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/RestrictivelyAnnotatedFI.java
@@ -1,0 +1,8 @@
+package com.uber.lib.unannotated;
+
+import javax.annotation.Nullable;
+
+public interface RestrictivelyAnnotatedFI {
+
+  Object takeNullable(@Nullable Object o);
+}


### PR DESCRIPTION
Unannotated lambda parameters inherit their nullability from the corresponding functional interface method.  With `AcknowledgeRestrictiveAnnotations` enabled, we were not properly inheriting `@Nullable` annotations to lambda parameters.