### PR TITLE
Stop shadowing Checker Framework libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NullAway is *fast*.  It is built as a plugin to [Error Prone](http://errorprone.
 
 ### Overview
 
-NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.1.1 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
+NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.3.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
 
 ### Gradle
 

--- a/compile-bench/build.gradle
+++ b/compile-bench/build.gradle
@@ -25,7 +25,7 @@ mainClassName = "com.uber.nullaway.benchmark.NullAwayBenchmarkHarness"
 
 dependencies {
     compile deps.build.errorProneCore
-    compile project(path: ":nullaway", configuration: "shadow")
+    compile project(":nullaway")
 }
 
 applicationDefaultJvmArgs = ["-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@
  */
 
 def versions = [
-    checkerFramework       : "2.5.5",
+    checkerFramework       : "2.5.7",
     errorProne             : "2.3.2",
     support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
@@ -34,8 +34,7 @@ def build = [
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
-    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
-                               "org.checkerframework:javacutil:${versions.checkerFramework}"],
+    checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}"],
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16",
     guava                   : "com.google.guava:guava:22.0",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
@@ -65,7 +64,8 @@ def test = [
     jetbrainsAnnotations    : "org.jetbrains:annotations:13.0",
     inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
     cfQual                  : "org.checkerframework:checker-qual:${versions.checkerFramework}",
-    cfCompatQual            : "org.checkerframework:checker-compat-qual:${versions.checkerFramework}",
+    // freeze at 2.5.5 since it's not supported afterward
+    cfCompatQual            : "org.checkerframework:checker-compat-qual:2.5.5",
     rxjava2                 : "io.reactivex.rxjava2:rxjava:2.1.2",
 ]
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import net.ltgt.gradle.errorprone.CheckSeverity
-
 plugins {
-  id "com.github.johnrengelman.shadow"
   id "java"
   // For code coverage:
   id 'jacoco'
@@ -43,7 +40,7 @@ dependencies {
 
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow
-    shadow deps.build.guava
+    compile deps.build.guava
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {
@@ -60,30 +57,9 @@ dependencies {
     testCompile deps.test.rxjava2
 }
 
-// We include and shade the checker framework jars into the NullAway jar, as we may have custom
-// changes.
-shadowJar {
-    // set classifier to null since we want the artifact uploaded to Maven Central to be the
-    // shadow jar.  Without this, the shadow jar is built with a '-all' suffix in the name.
-    classifier = null
-    relocate "org.checkerframework", "shadow.checkerframework"
-}
-// Since we set classifier to null above, both the normal jar artifact and the shadow jar have
-// the same name, which can cause races if we are not careful.  We force shadowJar to depend on
-// jar, so we know that the shadow jar will always overwrite the normal one.  We also force
-// assemble to depend on shadowJar, to avoid races between running tests / signing archives
-// and building the shadow jar.
-//
-// We also require that any other sub-projects only depend on the shadow configuration of this
-// project; otherwise weird races can occur.  Eventually, we should fix this by only renaming the
-// shadow jar artifact before the uploadArchives task runs.
-shadowJar.dependsOn jar
-assemble.dependsOn shadowJar
-
 javadoc {
     failOnError = false
 }
-
 
 test {
   maxHeapSize = "1024m"
@@ -91,26 +67,6 @@ test {
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
-
-def configurePomForShadow(pom) {
-  pom.scopeMappings.mappings.remove(project.configurations.compile)
-  pom.scopeMappings.mappings.remove(project.configurations.runtime)
-  pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
-}
-
-install {
-  repositories.mavenInstaller {
-    configurePomForShadow(pom)
-  }
-}
-install.dependsOn shadowJar
-
-uploadArchives {
-  repositories.mavenDeployer {
-    configurePomForShadow(pom)
-  }
-}
-uploadArchives.dependsOn shadowJar
 
 // From https://github.com/kt3k/coveralls-gradle-plugin
 jacocoTestReport {

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -43,8 +43,8 @@ android {
 
 dependencies {
     implementation deps.support.appcompat
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
-    annotationProcessor project(path: ":sample-library-model")
+    annotationProcessor project(":nullaway")
+    annotationProcessor project(":sample-library-model")
 
     testImplementation deps.test.junit4
 

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -26,8 +26,8 @@ targetCompatibility = "1.8"
 dependencies {
     compileOnly deps.apt.autoService
     annotationProcessor deps.apt.autoService
-    compileOnly project(path: ":nullaway", configuration: "shadow")
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    compileOnly project(":nullaway")
+    annotationProcessor project(":nullaway")
     compileOnly deps.build.guava
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,8 +24,8 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
-    annotationProcessor project(path: ":sample-library-model")
+    annotationProcessor project(":nullaway")
+    annotationProcessor project(":sample-library-model")
 
     compileOnly deps.build.jsr305Annotations
     testCompile deps.test.junit4

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    annotationProcessor project(":nullaway")
 
     compileOnly deps.build.jsr305Annotations
     compileOnly deps.build.javaxValidation


### PR DESCRIPTION
Recent versions of Error Prone depend on a recent-enough version of the Checker Framework that this is not needed.