### PR TITLE
Initial support for JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 
 jdk:
   - oraclejdk8
+  - openjdk11
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,21 @@ jdk:
   - oraclejdk8
   - openjdk11
 
+matrix:
+  include:
+    - jdk: openjdk11
+      before_install:
+        - export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
+        - yes | sdkmanager "platforms;android-28"
+    - jdk: oraclejdk8
+      before_install:
+        - yes | sdkmanager "platforms;android-28"
 android:
   components:
     - tools
     - platform-tools
     - build-tools-28.0.2
     - android-28
-
-before_install:
-  - yes | sdkmanager "platforms;android-28"
 
 script:
   - ./gradlew verGJF build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ android:
     - android-28
 
 before_install:
-  - if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]]; then export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'; fi
-  - yes | sdkmanager "platforms;android-28"
+  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then yes | sdkmanager "platforms;android-28"; fi
 
 script:
-  - ./gradlew verGJF build
+  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then ./gradlew verGJF build; fi
+  - if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]]; then ./gradlew :nullaway:test; fi
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,15 @@ jdk:
   - oraclejdk8
   - openjdk11
 
-matrix:
-  include:
-    - jdk: openjdk11
-      before_install:
-        - export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
-        - yes | sdkmanager "platforms;android-28"
-    - jdk: oraclejdk8
-      before_install:
-        - yes | sdkmanager "platforms;android-28"
 android:
   components:
     - tools
     - platform-tools
     - build-tools-28.0.2
     - android-28
+
+before_install:
+  - yes | sdkmanager "platforms;android-28"
 
 script:
   - ./gradlew verGJF build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ android:
     - android-28
 
 before_install:
+  - if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]]; then export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'; fi
   - yes | sdkmanager "platforms;android-28"
 
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ subprojects { project ->
         }
     }
 
+    if (JavaVersion.current().java9Compatible) {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += [ "--release", "8" ]
+        }
+    }
+
     repositories {
         maven {
             url "https://raw.githubusercontent.com/lazaroclapp/WALA/repository/"

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -69,6 +69,10 @@ test {
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
 
+jacoco {
+  toolVersion = "0.8.2"
+}
+
 // From https://github.com/kt3k/coveralls-gradle-plugin
 jacocoTestReport {
     reports {

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -62,7 +62,9 @@ javadoc {
 
 test {
   maxHeapSize = "1024m"
-  jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+  if (!JavaVersion.current().java9Compatible) {
+    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+  }
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -294,6 +294,11 @@ public class NullAwayTest {
 
   @Test
   public void generatedAsUnannotated() {
+    String generatedAnnot =
+        (Double.parseDouble(System.getProperty("java.specification.version")) >= 11)
+            ? "@javax.annotation.processing.Generated"
+            : "@javax.annotation.Generated";
+    System.err.println();
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -304,7 +309,7 @@ public class NullAwayTest {
         .addSourceLines(
             "Generated.java",
             "package com.uber;",
-            "@javax.annotation.Generated(\"foo\")",
+            generatedAnnot + "(\"foo\")",
             "public class Generated { public void takeObj(Object o) {} }")
         .addSourceLines(
             "Test.java",
@@ -317,6 +322,10 @@ public class NullAwayTest {
 
   @Test
   public void generatedAsUnannotatedPlusRestrictive() {
+    String generatedAnnot =
+        (Double.parseDouble(System.getProperty("java.specification.version")) >= 11)
+            ? "@javax.annotation.processing.Generated"
+            : "@javax.annotation.Generated";
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -328,7 +337,7 @@ public class NullAwayTest {
         .addSourceLines(
             "Generated.java",
             "package com.uber;",
-            "@javax.annotation.Generated(\"foo\")",
+            generatedAnnot + "(\"foo\")",
             "public class Generated {",
             "  @javax.annotation.Nullable",
             "  public Object retNull() {",

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -253,8 +253,9 @@ public class NullAwayNativeModels {
     d.offer(null);
     // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
     d.push(null);
-    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
-    d.toArray(null);
+    Object[] o = null;
+    // BUG: Diagnostic contains: passing @Nullable parameter 'o' where @NonNull is required
+    d.toArray(o);
     // this should be fine
     d.toArray();
   }
@@ -275,8 +276,9 @@ public class NullAwayNativeModels {
     d.offer(null);
     // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
     d.push(null);
-    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
-    d.toArray(null);
+    Object[] o = null;
+    // BUG: Diagnostic contains: passing @Nullable parameter 'o' where @NonNull is required
+    d.toArray(o);
   }
 
   static void guavaStuff() {


### PR DESCRIPTION
For now, only the `:nullaway:test` target is passing on CI.  We need to address issues outlined in #259 to get everything working, and it may be a while before the sample Android app can easily be built.  That said, I think this initial level of support is useful and worth landing.