### PR TITLE
Optimize library model lookups

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -536,7 +536,7 @@ public class NullAway extends BugChecker
     if (NullabilityUtil.isUnannotated(overriddenMethod, config)) {
       nullableParamsOfOverriden =
           handler.onUnannotatedInvocationGetExplicitlyNullablePositions(
-              overriddenMethod, ImmutableSet.of());
+              state.context, overriddenMethod, ImmutableSet.of());
     } else {
       ImmutableSet.Builder<Integer> builder = ImmutableSet.builder();
       for (int i = startParam; i < superParamSymbols.size(); i++) {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -208,7 +208,7 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
     NullnessStore environmentMapping =
         Objects.requireNonNull(
             environmentNullness.getEnvironmentMapping(underlyingAST.getLambdaTree()),
-            "no environment stored for lambda " + underlyingAST.getLambdaTree());
+            "no environment stored for lambda");
     NullnessStore.Builder result = environmentMapping.toBuilder();
     LambdaExpressionTree code = underlyingAST.getLambdaTree();
     // need to check annotation for i'th parameter of functional interface declaration
@@ -217,7 +217,7 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
         fiMethodSymbol.getParameters();
     ImmutableSet<Integer> nullableParamsFromHandler =
         handler.onUnannotatedInvocationGetExplicitlyNullablePositions(
-            fiMethodSymbol, ImmutableSet.of());
+            context, fiMethodSymbol, ImmutableSet.of());
 
     for (int i = 0; i < parameters.size(); i++) {
       LocalVariableNode param = parameters.get(i);
@@ -858,7 +858,7 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
         node, callee, node.getArguments(), types, values(input), thenUpdates, bothUpdates);
     NullnessHint nullnessHint =
         handler.onDataflowVisitMethodInvocation(
-            node, types, values(input), thenUpdates, elseUpdates, bothUpdates);
+            node, types, context, values(input), thenUpdates, elseUpdates, bothUpdates);
     Nullness nullness = returnValueNullness(node, input, nullnessHint);
     if (booleanReturnType(node)) {
       ResultingStore thenStore = updateStore(input.getThenStore(), thenUpdates, bothUpdates);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -28,6 +28,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -64,6 +65,7 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
@@ -101,7 +102,9 @@ abstract class BaseNoOpHandler implements Handler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
     // NoOp
     return explicitlyNullablePositions;
   }
@@ -143,6 +146,7 @@ abstract class BaseNoOpHandler implements Handler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -34,6 +34,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
@@ -115,11 +116,13 @@ class CompositeHandler implements Handler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
     for (Handler h : handlers) {
       explicitlyNullablePositions =
           h.onUnannotatedInvocationGetExplicitlyNullablePositions(
-              methodSymbol, explicitlyNullablePositions);
+              context, methodSymbol, explicitlyNullablePositions);
     }
     return explicitlyNullablePositions;
   }
@@ -174,6 +177,7 @@ class CompositeHandler implements Handler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
@@ -182,7 +186,7 @@ class CompositeHandler implements Handler {
     for (Handler h : handlers) {
       NullnessHint n =
           h.onDataflowVisitMethodInvocation(
-              node, types, inputs, thenUpdates, elseUpdates, bothUpdates);
+              node, types, context, inputs, thenUpdates, elseUpdates, bothUpdates);
       nullnessHint = nullnessHint.merge(n);
     }
     return nullnessHint;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
@@ -29,6 +29,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -90,6 +91,7 @@ public class ContractHandler extends BaseNoOpHandler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
@@ -143,7 +144,9 @@ public interface Handler {
    * @return Updated parameter nullability computed by this handler.
    */
   ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions);
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions);
 
   /**
    * Called when NullAway encounters an unannotated method and asks if return value is explicitly
@@ -229,6 +232,7 @@ public interface Handler {
   NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
@@ -163,6 +164,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -26,7 +26,6 @@ import static com.uber.nullaway.LibraryModels.MethodRef.methodRef;
 import static com.uber.nullaway.Nullness.NONNULL;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
@@ -36,16 +35,22 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
 import com.uber.nullaway.LibraryModels;
+import com.uber.nullaway.LibraryModels.MethodRef;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 
@@ -60,6 +65,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
   private final LibraryModels libraryModels;
 
+  @Nullable private OptimizedLibraryModels optLibraryModels;
+
   public LibraryModelsHandler() {
     super();
     libraryModels = loadLibraryModels();
@@ -73,19 +80,18 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       List<? extends ExpressionTree> actualParams,
       ImmutableSet<Integer> nonNullPositions) {
     return Sets.union(
-            nonNullPositions,
-            libraryModels.nonNullParameters().get(LibraryModels.MethodRef.fromSymbol(methodSymbol)))
+            nonNullPositions, getOptLibraryModels(state.context).nonNullParameters(methodSymbol))
         .immutableCopy();
   }
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
     return Sets.union(
             explicitlyNullablePositions,
-            libraryModels
-                .explicitlyNullableParameters()
-                .get(LibraryModels.MethodRef.fromSymbol(methodSymbol)))
+            getOptLibraryModels(context).explicitlyNullableParameters(methodSymbol))
         .immutableCopy();
   }
 
@@ -93,13 +99,14 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   public boolean onOverrideMayBeNullExpr(
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
     if (expr.getKind() == Tree.Kind.METHOD_INVOCATION
-        && LibraryModels.LibraryModelUtil.hasNullableReturn(
-            libraryModels, (Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
+        && getOptLibraryModels(state.context)
+            .hasNullableReturn(
+                (Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
       return analysis.nullnessFromDataflow(state, expr) || exprMayBeNull;
     }
     if (expr.getKind() == Tree.Kind.METHOD_INVOCATION
-        && LibraryModels.LibraryModelUtil.hasNonNullReturn(
-            libraryModels, (Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
+        && getOptLibraryModels(state.context)
+            .hasNonNullReturn((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
       return false;
     }
     return exprMayBeNull;
@@ -109,17 +116,18 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(node.getTree());
     Preconditions.checkNotNull(callee);
-    setUnconditionalArgumentNullness(bothUpdates, node.getArguments(), callee);
-    setConditionalArgumentNullness(thenUpdates, elseUpdates, node.getArguments(), callee);
-    if (LibraryModels.LibraryModelUtil.hasNonNullReturn(libraryModels, callee, types)) {
+    setUnconditionalArgumentNullness(bothUpdates, node.getArguments(), callee, context);
+    setConditionalArgumentNullness(thenUpdates, elseUpdates, node.getArguments(), callee, context);
+    if (getOptLibraryModels(context).hasNonNullReturn(callee, types)) {
       return NullnessHint.FORCE_NONNULL;
-    } else if (LibraryModels.LibraryModelUtil.hasNullableReturn(libraryModels, callee, types)) {
+    } else if (getOptLibraryModels(context).hasNullableReturn(callee, types)) {
       return NullnessHint.HINT_NULLABLE;
     } else {
       return NullnessHint.UNKNOWN;
@@ -130,9 +138,10 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       List<Node> arguments,
-      Symbol.MethodSymbol callee) {
+      Symbol.MethodSymbol callee,
+      Context context) {
     Set<Integer> nullImpliesTrueParameters =
-        libraryModels.nullImpliesTrueParameters().get(LibraryModels.MethodRef.fromSymbol(callee));
+        getOptLibraryModels(context).nullImpliesTrueParameters(callee);
     for (AccessPath accessPath : accessPathsAtIndexes(nullImpliesTrueParameters, arguments)) {
       elseUpdates.set(accessPath, NONNULL);
     }
@@ -154,12 +163,20 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     return result;
   }
 
+  private OptimizedLibraryModels getOptLibraryModels(Context context) {
+    if (optLibraryModels == null) {
+      optLibraryModels = new OptimizedLibraryModels(libraryModels, context);
+    }
+    return optLibraryModels;
+  }
+
   private void setUnconditionalArgumentNullness(
       AccessPathNullnessPropagation.Updates bothUpdates,
       List<Node> arguments,
-      Symbol.MethodSymbol callee) {
+      Symbol.MethodSymbol callee,
+      Context context) {
     Set<Integer> requiredNonNullParameters =
-        libraryModels.failIfNullParameters().get(LibraryModels.MethodRef.fromSymbol(callee));
+        getOptLibraryModels(context).failIfNullParameters(callee);
     for (AccessPath accessPath : accessPathsAtIndexes(requiredNonNullParameters, arguments)) {
       bothUpdates.set(accessPath, NONNULL);
     }
@@ -177,23 +194,28 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
     private static final ImmutableSetMultimap<MethodRef, Integer> FAIL_IF_NULL_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
-            .put(methodRef(Preconditions.class, "<T>checkNotNull(T)"), 0)
-            .put(methodRef("java.util.Objects", "<T>requireNonNull(T)"), 0)
-            .put(methodRef("org.junit.Assert", "assertNotNull(java.lang.Object)"), 0)
-            .put(
-                methodRef("org.junit.Assert", "assertNotNull(java.lang.String,java.lang.Object)"),
-                1)
-            .put(
-                methodRef("org.junit.jupiter.api.Assertions", "assertNotNull(java.lang.Object)"), 0)
+            .put(methodRef("com.google.common.base.Preconditions", "checkNotNull", "(T)", "<T>"), 0)
+            .put(methodRef("java.util.Objects", "requireNonNull", "(T)", "<T>"), 0)
+            .put(methodRef("org.junit.Assert", "assertNotNull", "(java.lang.Object)"), 0)
             .put(
                 methodRef(
-                    "org.junit.jupiter.api.Assertions",
-                    "assertNotNull(java.lang.Object,java.lang.String)"),
+                    "org.junit.Assert", "assertNotNull", "(java.lang.String,java.lang.Object)"),
                 1)
             .put(
                 methodRef(
+                    "org.junit.jupiter.api.Assertions", "assertNotNull", "(java.lang.Object)"),
+                0)
+            .put(
+                methodRef(
                     "org.junit.jupiter.api.Assertions",
-                    "assertNotNull(java.lang.Object,java.util.function.Supplier<String>)"),
+                    "assertNotNull",
+                    "(java.lang.Object,java.lang.String)"),
+                1)
+            .put(
+                methodRef(
+                    "org.junit.jupiter.api.Assertions",
+                    "assertNotNull",
+                    "(java.lang.Object,java.util.function.Supplier<String>)"),
                 1)
             .build();
 
@@ -202,7 +224,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(
                 methodRef(
                     "android.view.GestureDetector.OnGestureListener",
-                    "onScroll(android.view.MotionEvent,android.view.MotionEvent,float,float)"),
+                    "onScroll",
+                    "(android.view.MotionEvent,android.view.MotionEvent,float,float)"),
                 0)
             .build();
 
@@ -211,159 +234,188 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(
                 methodRef(
                     "com.android.sdklib.build.ApkBuilder",
-                    "ApkBuilder(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
+                    "ApkBuilder",
+                    "(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
                 0)
             .put(
                 methodRef(
                     "com.android.sdklib.build.ApkBuilder",
-                    "ApkBuilder(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
+                    "ApkBuilder",
+                    "(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
                 1)
-            .put(methodRef("com.google.common.collect.ImmutableList.Builder", "add(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableList.Builder", "add", "(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableList.Builder",
-                    "addAll(java.lang.Iterable<? extends E>)"),
+                    "addAll",
+                    "(java.lang.Iterable<? extends E>)"),
                 0)
-            .put(methodRef("com.google.common.collect.ImmutableSet.Builder", "add(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableSet.Builder", "add", "(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableSet.Builder",
-                    "addAll(java.lang.Iterable<? extends E>)"),
+                    "addAll",
+                    "(java.lang.Iterable<? extends E>)"),
                 0)
-            .put(methodRef("com.google.common.collect.ImmutableSortedSet.Builder", "add(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableSortedSet.Builder", "add", "(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableSortedSet.Builder",
-                    "addAll(java.lang.Iterable<? extends E>)"),
+                    "addAll",
+                    "(java.lang.Iterable<? extends E>)"),
                 0)
             .put(
                 methodRef(
                     "com.google.common.collect.Iterables",
-                    "<T>getFirst(java.lang.Iterable<? extends T>,T)"),
+                    "getFirst",
+                    "(java.lang.Iterable<? " + "extends T>,T)",
+                    "<T>"),
                 0)
             .put(
                 methodRef(
                     "com.google.common.util.concurrent.SettableFuture",
-                    "setException(java.lang.Throwable)"),
+                    "setException",
+                    "(java.lang.Throwable)"),
                 0)
-            .put(methodRef("java.io.File", "File(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Class", "getResource(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Class", "isAssignableFrom(java.lang.Class<?>)"), 0)
-            .put(methodRef("java.lang.System", "getProperty(java.lang.String)"), 0)
+            .put(methodRef("java.io.File", "<init>", "(java.lang.String)"), 0)
+            .put(methodRef("java.lang.Class", "getResource", "(java.lang.String)"), 0)
+            .put(methodRef("java.lang.Class", "isAssignableFrom", "(java.lang.Class<?>)"), 0)
+            .put(methodRef("java.lang.System", "getProperty", "(java.lang.String)"), 0)
             .put(
                 methodRef(
-                    "java.net.URLClassLoader", "newInstance(java.net.URL[],java.lang.ClassLoader)"),
-                0)
-            .put(
-                methodRef(
-                    "javax.lang.model.element.Element", "<A>getAnnotation(java.lang.Class<A>)"),
-                0)
-            .put(
-                methodRef(
-                    "javax.lang.model.util.Elements", "getPackageElement(java.lang.CharSequence)"),
+                    "java.net.URLClassLoader",
+                    "newInstance",
+                    "(java.net.URL[],java.lang.ClassLoader)"),
                 0)
             .put(
                 methodRef(
-                    "javax.lang.model.util.Elements", "getTypeElement(java.lang.CharSequence)"),
+                    "javax.lang.model.element.Element",
+                    "getAnnotation",
+                    "(java.lang" + ".Class<A>)",
+                    "<A>"),
                 0)
             .put(
                 methodRef(
                     "javax.lang.model.util.Elements",
-                    "getDocComment(javax.lang.model.element.Element)"),
+                    "getPackageElement",
+                    "(java.lang.CharSequence)"),
                 0)
-            .put(methodRef("java.util.Deque", "addFirst(E)"), 0)
-            .put(methodRef("java.util.Deque", "addLast(E)"), 0)
-            .put(methodRef("java.util.Deque", "offerFirst(E)"), 0)
-            .put(methodRef("java.util.Deque", "offerLast(E)"), 0)
-            .put(methodRef("java.util.Deque", "add(E)"), 0)
-            .put(methodRef("java.util.Deque", "offer(E)"), 0)
-            .put(methodRef("java.util.Deque", "push(E)"), 0)
-            .put(methodRef("java.util.Collection", "<T>toArray(T[])"), 0)
-            .put(methodRef("java.util.ArrayDeque", "addFirst(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "addLast(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offerFirst(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offerLast(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "add(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offer(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "push(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "<T>toArray(T[])"), 0)
+            .put(
+                methodRef(
+                    "javax.lang.model.util.Elements", "getTypeElement", "(java.lang.CharSequence)"),
+                0)
+            .put(
+                methodRef(
+                    "javax.lang.model.util.Elements",
+                    "getDocComment",
+                    "(javax.lang.model.element.Element)"),
+                0)
+            .put(methodRef("java.util.Deque", "addFirst", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "addLast", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "offerFirst", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "offerLast", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "add", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "offer", "(E)"), 0)
+            .put(methodRef("java.util.Deque", "push", "(E)"), 0)
+            .put(methodRef("java.util.Collection", "toArray", "(T[])", "<T>"), 0)
+            .put(methodRef("java.util.ArrayDeque", "addFirst", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "addLast", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offerFirst", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offerLast", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "add", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offer", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "push", "(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "toArray", "(T[])", "<T>"), 0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_TRUE_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
-            .put(methodRef(Strings.class, "isNullOrEmpty(java.lang.String)"), 0)
-            .put(methodRef(Objects.class, "isNull(java.lang.Object)"), 0)
-            .put(methodRef("android.text.TextUtils", "isEmpty(java.lang.CharSequence)"), 0)
-            .put(methodRef("org.apache.commons.lang.StringUtils", "isEmpty(java.lang.String)"), 0)
+            .put(
+                methodRef("com.google.common.base.Strings", "isNullOrEmpty", "(java.lang.String)"),
+                0)
+            .put(methodRef("java.util.Objects", "isNull", "(java.lang.Object)"), 0)
+            .put(methodRef("android.text.TextUtils", "isEmpty", "(java.lang.CharSequence)"), 0)
+            .put(
+                methodRef("org.apache.commons.lang.StringUtils", "isEmpty", "(java.lang.String)"),
+                0)
             .put(
                 methodRef(
-                    "org.apache.commons.lang3.StringUtils", "isEmpty(java.lang.CharSequence)"),
+                    "org.apache.commons.lang3.StringUtils", "isEmpty", "(java.lang.CharSequence)"),
                 0)
             .build();
 
     private static final ImmutableSet<MethodRef> NULLABLE_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
-            .add(methodRef("java.lang.ref.Reference", "get()"))
-            .add(methodRef("java.lang.ref.PhantomReference", "get()"))
-            .add(methodRef("java.lang.ref.SoftReference", "get()"))
-            .add(methodRef("java.lang.ref.WeakReference", "get()"))
-            .add(methodRef("java.util.concurrent.atomic.AtomicReference", "get()"))
-            .add(methodRef("java.util.Map", "get(java.lang.Object)"))
-            .add(methodRef("javax.lang.model.element.Element", "getEnclosingElement()"))
-            .add(methodRef("javax.lang.model.element.ExecutableElement", "getDefaultValue()"))
-            .add(methodRef("javax.lang.model.element.PackageElement", "getEnclosingElement()"))
-            .add(methodRef("javax.lang.model.element.VariableElement", "getConstantValue()"))
-            .add(methodRef("javax.lang.model.type.WildcardType", "getSuperBound()"))
-            .add(methodRef("android.app.ActivityManager", "getRunningAppProcesses()"))
-            .add(methodRef("android.view.View", "getHandler()"))
-            .add(methodRef("java.lang.Throwable", "getMessage()"))
-            .add(methodRef("android.webkit.WebView", "getUrl()"))
+            .add(methodRef("java.lang.ref.Reference", "get", "()"))
+            .add(methodRef("java.lang.ref.PhantomReference", "get", "()"))
+            .add(methodRef("java.lang.ref.SoftReference", "get", "()"))
+            .add(methodRef("java.lang.ref.WeakReference", "get", "()"))
+            .add(methodRef("java.util.concurrent.atomic.AtomicReference", "get", "()"))
+            .add(methodRef("java.util.Map", "get", "(java.lang.Object)"))
+            .add(methodRef("javax.lang.model.element.Element", "getEnclosingElement", "()"))
+            .add(methodRef("javax.lang.model.element.ExecutableElement", "getDefaultValue", "()"))
+            .add(methodRef("javax.lang.model.element.PackageElement", "getEnclosingElement", "()"))
+            .add(methodRef("javax.lang.model.element.VariableElement", "getConstantValue", "()"))
+            .add(methodRef("javax.lang.model.type.WildcardType", "getSuperBound", "()"))
+            .add(methodRef("android.app.ActivityManager", "getRunningAppProcesses", "()"))
+            .add(methodRef("android.view.View", "getHandler", "()"))
+            .add(methodRef("java.lang.Throwable", "getMessage", "()"))
+            .add(methodRef("android.webkit.WebView", "getUrl", "()"))
             .build();
 
     private static final ImmutableSet<MethodRef> NONNULL_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
-            .add(methodRef("com.google.gson", "<T>fromJson(String,Class)"))
-            .add(methodRef("android.app.Activity", "<T>findViewById(int)"))
-            .add(methodRef("android.view.View", "<T>findViewById(int)"))
-            .add(methodRef("android.view.View", "getResources()"))
-            .add(methodRef("android.view.ViewGroup", "getChildAt(int)"))
+            .add(methodRef("com.google.gson", "fromJson", "(String,Class)", "<T>"))
+            .add(methodRef("android.app.Activity", "findViewById", "(int)", "<T>"))
+            .add(methodRef("android.view.View", "findViewById", "(int)", "<T>"))
+            .add(methodRef("android.view.View", "getResources", "()"))
+            .add(methodRef("android.view.ViewGroup", "getChildAt", "(int)"))
             .add(
                 methodRef(
                     "android.content.res.Resources",
-                    "getDrawable(int,android.content.res.Resources.Theme)"))
-            .add(methodRef("android.support.v4.app.Fragment", "getActivity()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getActivity()"))
-            .add(methodRef("android.support.v4.app.Fragment", "getArguments()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getArguments()"))
-            .add(methodRef("android.support.v4.app.Fragment", "getContext()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getContext()"))
+                    "getDrawable",
+                    "(int,android.content.res.Resources.Theme)"))
+            .add(methodRef("android.support.v4.app.Fragment", "getActivity", "()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getActivity", "()"))
+            .add(methodRef("android.support.v4.app.Fragment", "getArguments", "()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getArguments", "()"))
+            .add(methodRef("android.support.v4.app.Fragment", "getContext", "()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getContext", "()"))
             .add(
                 methodRef(
                     "android.support.v4.app.Fragment",
-                    "onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
+                    "onCreateView",
+                    "(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
             .add(
                 methodRef(
                     "androidx.fragment.app.Fragment",
-                    "onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
+                    "onCreateView",
+                    "(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
             .add(
                 methodRef(
                     "android.support.v4.content.ContextCompat",
-                    "getDrawable(android.content.Context,int)"))
+                    "getDrawable",
+                    "(android.content.Context,int)"))
             .add(
                 methodRef(
                     "androidx.core.content.ContextCompat",
-                    "getDrawable(android.content.Context,int)"))
-            .add(methodRef("android.support.v7.app.AppCompatDialog", "<T>findViewById(int)"))
-            .add(methodRef("androidx.appcompat.app.AppCompatDialog", "<T>findViewById(int)"))
+                    "getDrawable",
+                    "(android.content.Context,int)"))
+            .add(
+                methodRef("android.support.v7.app.AppCompatDialog", "findViewById", "(int)", "<T>"))
+            .add(
+                methodRef("androidx.appcompat.app.AppCompatDialog", "findViewById", "(int)", "<T>"))
             .add(
                 methodRef(
                     "android.support.v7.content.res.AppCompatResources",
-                    "getDrawable(android.content.Context,int)"))
+                    "getDrawable",
+                    "(android.content.Context,int)"))
             .add(
                 methodRef(
                     "androidx.appcompat.content.res.AppCompatResources",
-                    "getDrawable(android.content.Context,int)"))
-            .add(methodRef("android.support.design.widget.TextInputLayout", "getEditText()"))
+                    "getDrawable",
+                    "(android.content.Context,int)"))
+            .add(methodRef("android.support.design.widget.TextInputLayout", "getEditText", "()"))
             .build();
 
     @Override
@@ -480,6 +532,138 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     @Override
     public ImmutableSet<MethodRef> nonNullReturns() {
       return nonNullReturns;
+    }
+  }
+
+  /**
+   * A view of library models optimized to make lookup of {@link
+   * com.sun.tools.javac.code.Symbol.MethodSymbol}s fast
+   */
+  private static class OptimizedLibraryModels {
+
+    /**
+     * Mapping from {@link MethodRef} to some state, where lookups first check for a matching method
+     * name as an optimization. The {@link Name} data structure is used to avoid unnecessary String
+     * conversions when looking up {@link com.sun.tools.javac.code.Symbol.MethodSymbol}s.
+     *
+     * @param <T>
+     */
+    private static class NameIndexedMap<T> {
+
+      private final Map<Name, Map<MethodRef, T>> state;
+
+      NameIndexedMap(Map<Name, Map<MethodRef, T>> state) {
+        this.state = state;
+      }
+
+      @Nullable
+      public T get(Symbol.MethodSymbol symbol) {
+        Map<MethodRef, T> methodRefTMap = state.get(symbol.name);
+        if (methodRefTMap == null) {
+          return null;
+        }
+        MethodRef ref = MethodRef.fromSymbol(symbol);
+        return methodRefTMap.get(ref);
+      }
+
+      public boolean nameNotPresent(Symbol.MethodSymbol symbol) {
+        return state.get(symbol.name) == null;
+      }
+    }
+
+    private final NameIndexedMap<ImmutableSet<Integer>> failIfNullParams;
+    private final NameIndexedMap<ImmutableSet<Integer>> explicitlyNullableParams;
+    private final NameIndexedMap<ImmutableSet<Integer>> nonNullParams;
+    private final NameIndexedMap<ImmutableSet<Integer>> nullImpliesTrueParams;
+    private final NameIndexedMap<Boolean> nullableRet;
+    private final NameIndexedMap<Boolean> nonNullRet;
+
+    public OptimizedLibraryModels(LibraryModels models, Context context) {
+      Names names = Names.instance(context);
+      failIfNullParams = makeOptimizedIntSetLookup(names, models.failIfNullParameters());
+      explicitlyNullableParams =
+          makeOptimizedIntSetLookup(names, models.explicitlyNullableParameters());
+      nonNullParams = makeOptimizedIntSetLookup(names, models.nonNullParameters());
+      nullImpliesTrueParams = makeOptimizedIntSetLookup(names, models.nullImpliesTrueParameters());
+      nullableRet = makeOptimizedBoolLookup(names, models.nullableReturns());
+      nonNullRet = makeOptimizedBoolLookup(names, models.nonNullReturns());
+    }
+
+    public boolean hasNonNullReturn(Symbol.MethodSymbol symbol, Types types) {
+      return lookupHandlingOverrides(symbol, types, nonNullRet) != null;
+    }
+
+    public boolean hasNullableReturn(Symbol.MethodSymbol symbol, Types types) {
+      return lookupHandlingOverrides(symbol, types, nullableRet) != null;
+    }
+
+    ImmutableSet<Integer> failIfNullParameters(Symbol.MethodSymbol symbol) {
+      return lookupImmutableSet(symbol, failIfNullParams);
+    }
+
+    ImmutableSet<Integer> explicitlyNullableParameters(Symbol.MethodSymbol symbol) {
+      return lookupImmutableSet(symbol, explicitlyNullableParams);
+    }
+
+    ImmutableSet<Integer> nonNullParameters(Symbol.MethodSymbol symbol) {
+      return lookupImmutableSet(symbol, nonNullParams);
+    }
+
+    ImmutableSet<Integer> nullImpliesTrueParameters(Symbol.MethodSymbol symbol) {
+      return lookupImmutableSet(symbol, nullImpliesTrueParams);
+    }
+
+    private ImmutableSet<Integer> lookupImmutableSet(
+        Symbol.MethodSymbol symbol, NameIndexedMap<ImmutableSet<Integer>> lookup) {
+      ImmutableSet<Integer> result = lookup.get(symbol);
+      return (result == null) ? ImmutableSet.of() : result;
+    }
+
+    private NameIndexedMap<ImmutableSet<Integer>> makeOptimizedIntSetLookup(
+        Names names, ImmutableSetMultimap<MethodRef, Integer> ref2Ints) {
+      return makeOptimizedLookup(names, ref2Ints.keySet(), ref2Ints::get);
+    }
+
+    private NameIndexedMap<Boolean> makeOptimizedBoolLookup(
+        Names names, ImmutableSet<MethodRef> refs) {
+      return makeOptimizedLookup(names, refs, (ref) -> true);
+    }
+
+    private <T> NameIndexedMap<T> makeOptimizedLookup(
+        Names names, Set<MethodRef> refs, Function<MethodRef, T> fun) {
+      Map<Name, Map<MethodRef, T>> finalThing = new LinkedHashMap<>();
+      for (MethodRef ref : refs) {
+        Name methodName = names.fromString(ref.methodName);
+        Map<MethodRef, T> forName = finalThing.get(methodName);
+        if (forName == null) {
+          forName = new LinkedHashMap<>();
+          finalThing.put(methodName, forName);
+        }
+        forName.put(ref, fun.apply(ref));
+      }
+      return new NameIndexedMap<>(finalThing);
+    }
+
+    /**
+     * checks if symbol is present in the NameIndexedMap or if it overrides some method in the
+     * NameIndexedMap
+     */
+    @Nullable
+    private static Symbol.MethodSymbol lookupHandlingOverrides(
+        Symbol.MethodSymbol symbol, Types types, NameIndexedMap<Boolean> optLookup) {
+      if (optLookup.nameNotPresent(symbol)) {
+        // no model matching the method name, so we don't need to check for overridden methods
+        return null;
+      }
+      if (optLookup.get(symbol) != null) {
+        return symbol;
+      }
+      for (Symbol.MethodSymbol superSymbol : ASTHelpers.findSuperMethods(symbol, types)) {
+        if (optLookup.get(superSymbol) != null) {
+          return superSymbol;
+        }
+      }
+      return null;
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -630,18 +630,18 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     }
 
     private <T> NameIndexedMap<T> makeOptimizedLookup(
-        Names names, Set<MethodRef> refs, Function<MethodRef, T> fun) {
-      Map<Name, Map<MethodRef, T>> finalThing = new LinkedHashMap<>();
+        Names names, Set<MethodRef> refs, Function<MethodRef, T> getValForRef) {
+      Map<Name, Map<MethodRef, T>> nameMapping = new LinkedHashMap<>();
       for (MethodRef ref : refs) {
         Name methodName = names.fromString(ref.methodName);
-        Map<MethodRef, T> forName = finalThing.get(methodName);
-        if (forName == null) {
-          forName = new LinkedHashMap<>();
-          finalThing.put(methodName, forName);
+        Map<MethodRef, T> mapForName = nameMapping.get(methodName);
+        if (mapForName == null) {
+          mapForName = new LinkedHashMap<>();
+          nameMapping.put(methodName, mapForName);
         }
-        forName.put(ref, fun.apply(ref));
+        mapForName.put(ref, getValForRef.apply(ref));
       }
-      return new NameIndexedMap<>(finalThing);
+      return new NameIndexedMap<>(nameMapping);
     }
 
     /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -194,28 +194,23 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
     private static final ImmutableSetMultimap<MethodRef, Integer> FAIL_IF_NULL_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
-            .put(methodRef("com.google.common.base.Preconditions", "checkNotNull", "(T)", "<T>"), 0)
-            .put(methodRef("java.util.Objects", "requireNonNull", "(T)", "<T>"), 0)
-            .put(methodRef("org.junit.Assert", "assertNotNull", "(java.lang.Object)"), 0)
+            .put(methodRef("com.google.common.base.Preconditions", "<T>checkNotNull(T)"), 0)
+            .put(methodRef("java.util.Objects", "<T>requireNonNull(T)"), 0)
+            .put(methodRef("org.junit.Assert", "assertNotNull(java.lang.Object)"), 0)
             .put(
-                methodRef(
-                    "org.junit.Assert", "assertNotNull", "(java.lang.String,java.lang.Object)"),
+                methodRef("org.junit.Assert", "assertNotNull(java.lang.String,java.lang.Object)"),
                 1)
             .put(
-                methodRef(
-                    "org.junit.jupiter.api.Assertions", "assertNotNull", "(java.lang.Object)"),
-                0)
+                methodRef("org.junit.jupiter.api.Assertions", "assertNotNull(java.lang.Object)"), 0)
             .put(
                 methodRef(
                     "org.junit.jupiter.api.Assertions",
-                    "assertNotNull",
-                    "(java.lang.Object,java.lang.String)"),
+                    "assertNotNull(java.lang.Object,java.lang.String)"),
                 1)
             .put(
                 methodRef(
                     "org.junit.jupiter.api.Assertions",
-                    "assertNotNull",
-                    "(java.lang.Object,java.util.function.Supplier<String>)"),
+                    "assertNotNull(java.lang.Object,java.util.function.Supplier<String>)"),
                 1)
             .build();
 
@@ -224,8 +219,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(
                 methodRef(
                     "android.view.GestureDetector.OnGestureListener",
-                    "onScroll",
-                    "(android.view.MotionEvent,android.view.MotionEvent,float,float)"),
+                    "onScroll(android.view.MotionEvent,android.view.MotionEvent,float,float)"),
                 0)
             .build();
 
@@ -234,188 +228,159 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(
                 methodRef(
                     "com.android.sdklib.build.ApkBuilder",
-                    "ApkBuilder",
-                    "(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
+                    "ApkBuilder(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
                 0)
             .put(
                 methodRef(
                     "com.android.sdklib.build.ApkBuilder",
-                    "ApkBuilder",
-                    "(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
+                    "ApkBuilder(java.io.File,java.io.File,java.io.File,java.lang.String,java.io.PrintStream)"),
                 1)
-            .put(methodRef("com.google.common.collect.ImmutableList.Builder", "add", "(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableList.Builder", "add(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableList.Builder",
-                    "addAll",
-                    "(java.lang.Iterable<? extends E>)"),
+                    "addAll(java.lang.Iterable<? extends E>)"),
                 0)
-            .put(methodRef("com.google.common.collect.ImmutableSet.Builder", "add", "(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableSet.Builder", "add(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableSet.Builder",
-                    "addAll",
-                    "(java.lang.Iterable<? extends E>)"),
+                    "addAll(java.lang.Iterable<? extends E>)"),
                 0)
-            .put(methodRef("com.google.common.collect.ImmutableSortedSet.Builder", "add", "(E)"), 0)
+            .put(methodRef("com.google.common.collect.ImmutableSortedSet.Builder", "add(E)"), 0)
             .put(
                 methodRef(
                     "com.google.common.collect.ImmutableSortedSet.Builder",
-                    "addAll",
-                    "(java.lang.Iterable<? extends E>)"),
+                    "addAll(java.lang.Iterable<? extends E>)"),
                 0)
             .put(
                 methodRef(
                     "com.google.common.collect.Iterables",
-                    "getFirst",
-                    "(java.lang.Iterable<? " + "extends T>,T)",
-                    "<T>"),
+                    "<T>getFirst(java.lang.Iterable<? extends T>,T)"),
                 0)
             .put(
                 methodRef(
                     "com.google.common.util.concurrent.SettableFuture",
-                    "setException",
-                    "(java.lang.Throwable)"),
+                    "setException(java.lang.Throwable)"),
                 0)
-            .put(methodRef("java.io.File", "<init>", "(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Class", "getResource", "(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Class", "isAssignableFrom", "(java.lang.Class<?>)"), 0)
-            .put(methodRef("java.lang.System", "getProperty", "(java.lang.String)"), 0)
+            .put(methodRef("java.io.File", "File(java.lang.String)"), 0)
+            .put(methodRef("java.lang.Class", "getResource(java.lang.String)"), 0)
+            .put(methodRef("java.lang.Class", "isAssignableFrom(java.lang.Class<?>)"), 0)
+            .put(methodRef("java.lang.System", "getProperty(java.lang.String)"), 0)
             .put(
                 methodRef(
-                    "java.net.URLClassLoader",
-                    "newInstance",
-                    "(java.net.URL[],java.lang.ClassLoader)"),
+                    "java.net.URLClassLoader", "newInstance(java.net.URL[],java.lang.ClassLoader)"),
                 0)
             .put(
                 methodRef(
-                    "javax.lang.model.element.Element",
-                    "getAnnotation",
-                    "(java.lang" + ".Class<A>)",
-                    "<A>"),
+                    "javax.lang.model.element.Element", "<A>getAnnotation(java.lang.Class<A>)"),
                 0)
             .put(
                 methodRef(
-                    "javax.lang.model.util.Elements",
-                    "getPackageElement",
-                    "(java.lang.CharSequence)"),
+                    "javax.lang.model.util.Elements", "getPackageElement(java.lang.CharSequence)"),
                 0)
             .put(
                 methodRef(
-                    "javax.lang.model.util.Elements", "getTypeElement", "(java.lang.CharSequence)"),
+                    "javax.lang.model.util.Elements", "getTypeElement(java.lang.CharSequence)"),
                 0)
             .put(
                 methodRef(
                     "javax.lang.model.util.Elements",
-                    "getDocComment",
-                    "(javax.lang.model.element.Element)"),
+                    "getDocComment(javax.lang.model.element.Element)"),
                 0)
-            .put(methodRef("java.util.Deque", "addFirst", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "addLast", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "offerFirst", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "offerLast", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "add", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "offer", "(E)"), 0)
-            .put(methodRef("java.util.Deque", "push", "(E)"), 0)
-            .put(methodRef("java.util.Collection", "toArray", "(T[])", "<T>"), 0)
-            .put(methodRef("java.util.ArrayDeque", "addFirst", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "addLast", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offerFirst", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offerLast", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "add", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "offer", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "push", "(E)"), 0)
-            .put(methodRef("java.util.ArrayDeque", "toArray", "(T[])", "<T>"), 0)
+            .put(methodRef("java.util.Deque", "addFirst(E)"), 0)
+            .put(methodRef("java.util.Deque", "addLast(E)"), 0)
+            .put(methodRef("java.util.Deque", "offerFirst(E)"), 0)
+            .put(methodRef("java.util.Deque", "offerLast(E)"), 0)
+            .put(methodRef("java.util.Deque", "add(E)"), 0)
+            .put(methodRef("java.util.Deque", "offer(E)"), 0)
+            .put(methodRef("java.util.Deque", "push(E)"), 0)
+            .put(methodRef("java.util.Collection", "<T>toArray(T[])"), 0)
+            .put(methodRef("java.util.ArrayDeque", "addFirst(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "addLast(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offerFirst(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offerLast(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "add(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "offer(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "push(E)"), 0)
+            .put(methodRef("java.util.ArrayDeque", "<T>toArray(T[])"), 0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_TRUE_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
-            .put(
-                methodRef("com.google.common.base.Strings", "isNullOrEmpty", "(java.lang.String)"),
-                0)
-            .put(methodRef("java.util.Objects", "isNull", "(java.lang.Object)"), 0)
-            .put(methodRef("android.text.TextUtils", "isEmpty", "(java.lang.CharSequence)"), 0)
-            .put(
-                methodRef("org.apache.commons.lang.StringUtils", "isEmpty", "(java.lang.String)"),
-                0)
+            .put(methodRef("com.google.common.base.Strings", "isNullOrEmpty(java.lang.String)"), 0)
+            .put(methodRef("java.util.Objects", "isNull(java.lang.Object)"), 0)
+            .put(methodRef("android.text.TextUtils", "isEmpty(java.lang.CharSequence)"), 0)
+            .put(methodRef("org.apache.commons.lang.StringUtils", "isEmpty(java.lang.String)"), 0)
             .put(
                 methodRef(
-                    "org.apache.commons.lang3.StringUtils", "isEmpty", "(java.lang.CharSequence)"),
+                    "org.apache.commons.lang3.StringUtils", "isEmpty(java.lang.CharSequence)"),
                 0)
             .build();
 
     private static final ImmutableSet<MethodRef> NULLABLE_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
-            .add(methodRef("java.lang.ref.Reference", "get", "()"))
-            .add(methodRef("java.lang.ref.PhantomReference", "get", "()"))
-            .add(methodRef("java.lang.ref.SoftReference", "get", "()"))
-            .add(methodRef("java.lang.ref.WeakReference", "get", "()"))
-            .add(methodRef("java.util.concurrent.atomic.AtomicReference", "get", "()"))
-            .add(methodRef("java.util.Map", "get", "(java.lang.Object)"))
-            .add(methodRef("javax.lang.model.element.Element", "getEnclosingElement", "()"))
-            .add(methodRef("javax.lang.model.element.ExecutableElement", "getDefaultValue", "()"))
-            .add(methodRef("javax.lang.model.element.PackageElement", "getEnclosingElement", "()"))
-            .add(methodRef("javax.lang.model.element.VariableElement", "getConstantValue", "()"))
-            .add(methodRef("javax.lang.model.type.WildcardType", "getSuperBound", "()"))
-            .add(methodRef("android.app.ActivityManager", "getRunningAppProcesses", "()"))
-            .add(methodRef("android.view.View", "getHandler", "()"))
-            .add(methodRef("java.lang.Throwable", "getMessage", "()"))
-            .add(methodRef("android.webkit.WebView", "getUrl", "()"))
+            .add(methodRef("java.lang.ref.Reference", "get()"))
+            .add(methodRef("java.lang.ref.PhantomReference", "get()"))
+            .add(methodRef("java.lang.ref.SoftReference", "get()"))
+            .add(methodRef("java.lang.ref.WeakReference", "get()"))
+            .add(methodRef("java.util.concurrent.atomic.AtomicReference", "get()"))
+            .add(methodRef("java.util.Map", "get(java.lang.Object)"))
+            .add(methodRef("javax.lang.model.element.Element", "getEnclosingElement()"))
+            .add(methodRef("javax.lang.model.element.ExecutableElement", "getDefaultValue()"))
+            .add(methodRef("javax.lang.model.element.PackageElement", "getEnclosingElement()"))
+            .add(methodRef("javax.lang.model.element.VariableElement", "getConstantValue()"))
+            .add(methodRef("javax.lang.model.type.WildcardType", "getSuperBound()"))
+            .add(methodRef("android.app.ActivityManager", "getRunningAppProcesses()"))
+            .add(methodRef("android.view.View", "getHandler()"))
+            .add(methodRef("java.lang.Throwable", "getMessage()"))
+            .add(methodRef("android.webkit.WebView", "getUrl()"))
             .build();
 
     private static final ImmutableSet<MethodRef> NONNULL_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
-            .add(methodRef("com.google.gson", "fromJson", "(String,Class)", "<T>"))
-            .add(methodRef("android.app.Activity", "findViewById", "(int)", "<T>"))
-            .add(methodRef("android.view.View", "findViewById", "(int)", "<T>"))
-            .add(methodRef("android.view.View", "getResources", "()"))
-            .add(methodRef("android.view.ViewGroup", "getChildAt", "(int)"))
+            .add(methodRef("com.google.gson", "<T>fromJson(String,Class)"))
+            .add(methodRef("android.app.Activity", "<T>findViewById(int)"))
+            .add(methodRef("android.view.View", "<T>findViewById(int)"))
+            .add(methodRef("android.view.View", "getResources()"))
+            .add(methodRef("android.view.ViewGroup", "getChildAt(int)"))
             .add(
                 methodRef(
                     "android.content.res.Resources",
-                    "getDrawable",
-                    "(int,android.content.res.Resources.Theme)"))
-            .add(methodRef("android.support.v4.app.Fragment", "getActivity", "()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getActivity", "()"))
-            .add(methodRef("android.support.v4.app.Fragment", "getArguments", "()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getArguments", "()"))
-            .add(methodRef("android.support.v4.app.Fragment", "getContext", "()"))
-            .add(methodRef("androidx.fragment.app.Fragment", "getContext", "()"))
+                    "getDrawable(int,android.content.res.Resources.Theme)"))
+            .add(methodRef("android.support.v4.app.Fragment", "getActivity()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getActivity()"))
+            .add(methodRef("android.support.v4.app.Fragment", "getArguments()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getArguments()"))
+            .add(methodRef("android.support.v4.app.Fragment", "getContext()"))
+            .add(methodRef("androidx.fragment.app.Fragment", "getContext()"))
             .add(
                 methodRef(
                     "android.support.v4.app.Fragment",
-                    "onCreateView",
-                    "(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
+                    "onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
             .add(
                 methodRef(
                     "androidx.fragment.app.Fragment",
-                    "onCreateView",
-                    "(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
+                    "onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)"))
             .add(
                 methodRef(
                     "android.support.v4.content.ContextCompat",
-                    "getDrawable",
-                    "(android.content.Context,int)"))
+                    "getDrawable(android.content.Context,int)"))
             .add(
                 methodRef(
                     "androidx.core.content.ContextCompat",
-                    "getDrawable",
-                    "(android.content.Context,int)"))
-            .add(
-                methodRef("android.support.v7.app.AppCompatDialog", "findViewById", "(int)", "<T>"))
-            .add(
-                methodRef("androidx.appcompat.app.AppCompatDialog", "findViewById", "(int)", "<T>"))
+                    "getDrawable(android.content.Context,int)"))
+            .add(methodRef("android.support.v7.app.AppCompatDialog", "<T>findViewById(int)"))
+            .add(methodRef("androidx.appcompat.app.AppCompatDialog", "<T>findViewById(int)"))
             .add(
                 methodRef(
                     "android.support.v7.content.res.AppCompatResources",
-                    "getDrawable",
-                    "(android.content.Context,int)"))
+                    "getDrawable(android.content.Context,int)"))
             .add(
                 methodRef(
                     "androidx.appcompat.content.res.AppCompatResources",
-                    "getDrawable",
-                    "(android.content.Context,int)"))
-            .add(methodRef("android.support.design.widget.TextInputLayout", "getEditText", "()"))
+                    "getDrawable(android.content.Context,int)"))
+            .add(methodRef("android.support.design.widget.TextInputLayout", "getEditText()"))
             .build();
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -30,6 +30,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
@@ -86,7 +87,9 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   @Override
   public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Symbol.MethodSymbol methodSymbol, ImmutableSet<Integer> explicitlyNullablePositions) {
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      ImmutableSet<Integer> explicitlyNullablePositions) {
     HashSet<Integer> positions = new HashSet<Integer>();
     positions.addAll(explicitlyNullablePositions);
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
@@ -107,6 +110,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
   public NullnessHint onDataflowVisitMethodInvocation(
       MethodInvocationNode node,
       Types types,
+      Context context,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,


### PR DESCRIPTION
NullAway was spending a lot of time checking if we had library models for methods.  This PR optimizes the process in two ways:

1. First check if we have a model for a method with the same name before checking the full method signature.
2. In 1, compare `Name` objects, as converting a `Name` to a `String` is actually costly.

