### PR TITLE
Update the compile benchmark harness script to be more usable

### DIFF
--- a/compile-bench/README.md
+++ b/compile-bench/README.md
@@ -1,0 +1,12 @@
+This is a basic harness to run a Java compilation task in a loop for
+benchmarking / profiling purposes.  Basically, you should get the
+arguments for the `javac` task you're interested in and then pass them
+here.  The easiest way to run is via Gradle (from repo root):
+```
+./gradlew :compile-bench:run --args='javac_args'
+```
+
+The `javac` arguments should use absolute paths since you're running
+from the root of the NullAway repo (and should probably include the
+`-d` argument).  If that's painful you can possibly hack around things
+by adding a symlink to the `compile-bench` folder.

--- a/compile-bench/build.gradle
+++ b/compile-bench/build.gradle
@@ -21,19 +21,14 @@ plugins {
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
-mainClassName = "com.uber.nullaway.benchmark.NullAwayBenchmarkHarness"
+application {
+    mainClassName = "com.uber.nullaway.benchmark.NullAwayBenchmarkHarness"
+    applicationDefaultJvmArgs = ["-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"]
+}
 
 dependencies {
     compile deps.build.errorProneCore
     compile project(":nullaway")
-}
-
-applicationDefaultJvmArgs = ["-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"]
-
-run {
-    if (project.hasProperty("appArgs")) {
-        args(appArgs.split(' '))
-    }
 }
 
 


### PR DESCRIPTION
Made some tweaks to the harness useful for benchmarking of targets that already make use of annotation processors.  Also added some more docs, and tweaked the `build.gradle` to take advantage being able to pass args directly as of recent Gradle versions.