### PR TITLE
Revert "Model parseXXX methods of boxed primitives as having @NonNull parameter"

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -305,17 +305,6 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(methodRef("java.util.ArrayDeque", "offer(E)"), 0)
             .put(methodRef("java.util.ArrayDeque", "push(E)"), 0)
             .put(methodRef("java.util.ArrayDeque", "<T>toArray(T[])"), 0)
-            .put(methodRef("java.lang.Integer", "parseInt(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Long", "parseLong(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Boolean", "parseBoolean(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Float", "parseFloat(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Double", "parseDouble(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Short", "parseShort(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Byte", "parseByte(java.lang.String)"), 0)
-            .put(methodRef("java.lang.Long", "parseLong(java.lang.String,int)"), 0)
-            .put(methodRef("java.lang.Integer", "parseInt(java.lang.String,int)"), 0)
-            .put(methodRef("java.lang.Byte", "parseByte(java.lang.String,int)"), 0)
-            .put(methodRef("java.lang.Short", "parseShort(java.lang.String,int)"), 0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_TRUE_PARAMETERS =

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -316,38 +316,6 @@ public class NullAwayNativeModels {
     }
   }
 
-  static void parseStringToPrimitiveTypesStuff() {
-    String s = null;
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    int a = Integer.parseInt(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    double b = Double.parseDouble(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    long c = Long.parseLong(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    float d = Float.parseFloat(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    short e = Short.parseShort(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    byte f = Byte.parseByte(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    boolean g = Boolean.parseBoolean(s);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    byte h = Byte.parseByte(s, 1);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    long i = Long.parseLong(s, 1);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    int j = Integer.parseInt(s, 1);
-    // BUG: Diagnostic contains: passing @Nullable parameter 's' where @NonNull is required
-    short k = Short.parseShort(s, 1);
-
-    s = "100";
-    // no warning expected
-    int l = Integer.parseInt(s);
-    long m = Long.parseLong(s);
-    short n = Short.parseShort(s, 1);
-  }
-
   static void apacheCommonsStuff() {
     String s = null;
     if (!org.apache.commons.lang.StringUtils.isEmpty(s)) {


### PR DESCRIPTION
Reverts uber/NullAway#270.

See #269 for an explanation. Basically, `parseXXX` throws a `NumberFormatException` when passed `null`, and making it not able to take `null` means code that is correct now (because it catches `NumberFormatException`) would be broken in NullAway in a way that can't be resolved by simply adding nullness annotations or `castToNonNull`. This is, arguably, bad design on the part of all those `parseXXX` functions, but we have no control over that.