### PR TITLE
Add support for methods taking literal constant args in Access Paths.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathElement.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathElement.java
@@ -1,0 +1,67 @@
+package com.uber.nullaway.dataflow;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Element;
+
+/**
+ * Represents a (non-root) element of an AccessPath.
+ *
+ * <p>This is just a java Element (field, method, etc) in the access-path chain (e.g. f or g() in
+ * x.f.g()). Plus, optionally, a list of constant arguments, allowing access path elements for
+ * method calls with constant values (e.g. h(3) or k("STR_KEY") in x.h(3).g().k("STR_KEY")).
+ */
+public final class AccessPathElement {
+  private final Element javaElement;
+  @Nullable private final ImmutableList<String> constantArguments;
+
+  public AccessPathElement(Element javaElement, List<String> constantArguments) {
+    this.javaElement = javaElement;
+    this.constantArguments = ImmutableList.copyOf(constantArguments);
+  }
+
+  public AccessPathElement(Element javaElement) {
+    this.javaElement = javaElement;
+    this.constantArguments = null;
+  }
+
+  public Element getJavaElement() {
+    return this.javaElement;
+  }
+
+  public ImmutableList<String> getConstantArguments() {
+    return this.constantArguments;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof AccessPathElement) {
+      AccessPathElement otherNode = (AccessPathElement) obj;
+      return this.javaElement.equals(otherNode.javaElement)
+          && (constantArguments == null
+              ? otherNode.constantArguments == null
+              : constantArguments.equals(otherNode.constantArguments));
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    int result = javaElement.hashCode();
+    result = 31 * result + (constantArguments != null ? constantArguments.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "APElement{"
+        + "javaElement="
+        + javaElement.toString()
+        + ", constantArguments="
+        + Arrays.deepToString(constantArguments.toArray())
+        + '}';
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -112,9 +112,9 @@ public final class AccessPathNullnessAnalysis {
     Set<Element> result = new LinkedHashSet<>();
     for (AccessPath ap : nonnullAccessPaths) {
       if (ap.getRoot().isReceiver()) {
-        ImmutableList<Element> elements = ap.getElements();
+        ImmutableList<AccessPathElement> elements = ap.getElements();
         if (elements.size() == 1) {
-          Element elem = elements.get(0);
+          Element elem = elements.get(0).getJavaElement();
           if (elem.getKind().equals(ElementKind.FIELD)) {
             result.add(elem);
           }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -120,9 +120,11 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
 
     if (accessPath.getElements().size() == 1) {
       AccessPath.Root root = accessPath.getRoot();
-      if (!root.isReceiver() && (accessPath.getElements().get(0) instanceof Symbol.MethodSymbol)) {
+      if (!root.isReceiver()
+          && (accessPath.getElements().get(0).getJavaElement() instanceof Symbol.MethodSymbol)) {
         final Element e = root.getVarElement();
-        final Symbol.MethodSymbol g = (Symbol.MethodSymbol) accessPath.getElements().get(0);
+        final Symbol.MethodSymbol g =
+            (Symbol.MethodSymbol) accessPath.getElements().get(0).getJavaElement();
         return e.getKind().equals(ElementKind.LOCAL_VARIABLE)
             && optionalIsGetCall(g, state.getTypes());
       }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -49,6 +49,7 @@ import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathElement;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.NullnessStore;
 import java.util.ArrayList;
@@ -393,10 +394,10 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       assert filterNullnessStore != null;
       for (AccessPath ap : filterNullnessStore.getAccessPathsWithValue(Nullness.NONNULL)) {
         // Find the access path corresponding to the current unbound method reference after binding
-        ImmutableList<Element> elements = ap.getElements();
+        ImmutableList<AccessPathElement> elements = ap.getElements();
         if (elements.size() == 1) {
           // We only care for single method call chains (e.g. this.foo(), not this.f.bar())
-          Element element = elements.get(0);
+          Element element = elements.get(0).getJavaElement();
           if (!element.getKind().equals(ElementKind.METHOD)) {
             // We are only looking for method APs
             continue;


### PR DESCRIPTION
Consider the code below:

```
if (x.get(0) != null && x.get(0).foo() != null) {
   return x.get(0).foo().bar(); 
}
```

This code is safe, but NullAway would miss that before this change, due to `get(0)` taking an argument. We handle `foo()` (a zero-arguments method) just fine. 

This patch extends our support for method calls with only literal values (and boxed literal values) being passed as arguments. I don't see a case where this would add unsoundness that isn't present on the zero-args case.