### PR TITLE
Upgrade to Error Prone 2.3.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,8 @@
 
 def versions = [
     checkerFramework       : "2.5.5",
-    errorProne             : "2.3.3",
+    errorProne             : "2.3.3", // The version of error prone running on this project
+    errorProneApi          : "2.3.1", // The version of error prone built against and shipped
     support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
     commonscli             : "1.4",
@@ -30,7 +31,7 @@ def apt = [
 ]
 
 def build = [
-    errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProne}",
+    errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProneApi}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     checkerFramework       : "2.5.5",
-    errorProne             : "2.3.2",
+    errorProne             : "2.3.3",
     support                : "27.1.1",
     wala                   : "1.5.0-uber.1",
     commonscli             : "1.4",

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
@@ -58,9 +58,6 @@ public class DefinitelyDerefedParams {
   private final ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg;
   private PrunedCFG<SSAInstruction, ISSABasicBlock> prunedCFG;
 
-  // used to resolve references to fields in putstatic instructions
-  private final IClassHierarchy cha;
-
   /** List of null test APIs and the parameter position. */
   private static final ImmutableMap<String, Integer> NULL_TEST_APIS =
       new ImmutableMap.Builder<String, Integer>()
@@ -95,7 +92,6 @@ public class DefinitelyDerefedParams {
     this.method = method;
     this.ir = ir;
     this.cfg = cfg;
-    this.cha = cha;
     prunedCFG = null;
   }
 

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -145,7 +145,6 @@ public class DefinitelyDerefedParamsDriver {
     DEBUG = dbg;
     VERBOSE = vbs;
     long start = System.currentTimeMillis();
-    String firstInPath = inPaths.split(",")[0];
     Set<String> setInPaths = new HashSet<>(Arrays.asList(inPaths.split(",")));
     for (String inPath : setInPaths) {
       InputStream jarIS = null;

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -88,12 +88,10 @@ public class JarInferTest {
   /**
    * Run a unit test with a specified jar file.
    *
-   * @param testName An useful name for the unit test.
    * @param pkg Qualified package name.
    * @param jarPath Path to the target jar file.
    */
   private void testJARTemplate(
-      String testName,
       String pkg, // in dot syntax
       String jarPath // in dot syntax
       ) throws Exception {
@@ -224,7 +222,6 @@ public class JarInferTest {
   @Test
   public void toyJAR() throws Exception {
     testJARTemplate(
-        "toyJAR",
         "com.uber.nullaway.jarinfer.toys.unannotated",
         "../test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar");
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -22,7 +22,6 @@
 
 package com.uber.nullaway;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.sun.source.tree.Tree.Kind.EXPRESSION_STATEMENT;
 import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
@@ -93,7 +92,6 @@ import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handlers;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -145,7 +143,7 @@ import org.checkerframework.javacutil.AnnotationUtils;
     name = "NullAway",
     altNames = {"CheckNullabilityTypes"},
     summary = "Nullability type error.",
-    category = JDK,
+    tags = BugPattern.StandardTags.LIKELY_ERROR,
     severity = WARNING)
 public class NullAway extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher,
@@ -428,7 +426,7 @@ public class NullAway extends BugChecker
     }
     Type lhsType = ASTHelpers.getType(tree.getVariable());
     Type stringType = state.getTypeFromString("java.lang.String");
-    if (lhsType != null && !lhsType.equals(stringType)) {
+    if (lhsType != null && !state.getTypes().isSameType(lhsType, stringType)) {
       // both LHS and RHS could get unboxed
       return doUnboxingCheck(state, tree.getVariable(), tree.getExpression());
     }
@@ -897,14 +895,14 @@ public class NullAway extends BugChecker
    * href="https://github.com/uber/NullAway/wiki/Error-Messages#initializer-method-does-not-guarantee-nonnull-field-is-initialized--nonnull-field--not-initialized">the
    * docs</a> for what is considered a safe initializer method.
    */
-  private Set<Element> safeInitByCalleeBefore(
+  private ImmutableSet<Element> safeInitByCalleeBefore(
       TreePath pathToRead, VisitorState state, TreePath enclosingBlockPath) {
-    Set<Element> result = new LinkedHashSet<>();
     Set<Element> safeInitMethods = new LinkedHashSet<>();
     Tree enclosingBlockOrMethod = enclosingBlockPath.getLeaf();
     if (enclosingBlockOrMethod instanceof VariableTree) {
-      return Collections.emptySet();
+      return ImmutableSet.of();
     }
+    ImmutableSet.Builder<Element> resultBuilder = ImmutableSet.builder();
     BlockTree blockTree =
         enclosingBlockOrMethod instanceof BlockTree
             ? (BlockTree) enclosingBlockOrMethod
@@ -919,7 +917,7 @@ public class NullAway extends BugChecker
       if (classTreePath == null) {
         throw new IllegalStateException(
             "could not find enclosing class / enum / interface for "
-                + enclosingBlockPath.getLeaf());
+                + state.getSourceForNode(enclosingBlockPath.getLeaf()));
       }
     }
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol((ClassTree) classTreePath.getLeaf());
@@ -937,12 +935,12 @@ public class NullAway extends BugChecker
           // that initialization?
           if (tryTree.getCatches().size() == 0) {
             if (tryTree.getBlock() != null) {
-              result.addAll(
+              resultBuilder.addAll(
                   safeInitByCalleeBefore(
                       pathToRead, state, new TreePath(enclosingBlockPath, tryTree.getBlock())));
             }
             if (tryTree.getFinallyBlock() != null) {
-              result.addAll(
+              resultBuilder.addAll(
                   safeInitByCalleeBefore(
                       pathToRead,
                       state,
@@ -953,8 +951,8 @@ public class NullAway extends BugChecker
       }
     }
     addGuaranteedNonNullFromInvokes(
-        state, getTreesInstance(state), safeInitMethods, getNullnessAnalysis(state), result);
-    return result;
+        state, getTreesInstance(state), safeInitMethods, getNullnessAnalysis(state), resultBuilder);
+    return resultBuilder.build();
   }
 
   private int getStartPos(JCTree tree) {
@@ -1123,7 +1121,7 @@ public class NullAway extends BugChecker
     // but this is not easy within the Error Prone APIs
     NestingKind nestingKind = classSymbol.getNestingKind();
     if (!nestingKind.isNested()) {
-      matchWithinClass = !isExcludedClass(classSymbol, state);
+      matchWithinClass = !isExcludedClass(classSymbol);
       // since we are processing a new top-level class, invalidate any cached
       // results for previous classes
       handler.onMatchTopLevelClass(this, tree, state, classSymbol);
@@ -1220,7 +1218,8 @@ public class NullAway extends BugChecker
     ExpressionTree expr = tree.getExpression();
     final ErrorMessage errorMessage =
         new ErrorMessage(
-            MessageTypes.DEREFERENCE_NULLABLE, "enhanced-for expression " + expr + " is @Nullable");
+            MessageTypes.DEREFERENCE_NULLABLE,
+            "enhanced-for expression " + state.getSourceForNode(expr) + " is @Nullable");
     if (mayBeNullExpr(state, expr)) {
       return errorBuilder.createErrorDescription(
           errorMessage, state.getPath(), buildDescription(expr));
@@ -1322,7 +1321,9 @@ public class NullAway extends BugChecker
       // make sure we are passing a non-null value
       if (mayActualBeNull) {
         String message =
-            "passing @Nullable parameter '" + actual.toString() + "' where @NonNull is required";
+            "passing @Nullable parameter '"
+                + state.getSourceForNode(actual)
+                + "' where @NonNull is required";
         return errorBuilder.createErrorDescriptionForNullAssignment(
             new ErrorMessage(MessageTypes.PASS_NULLABLE, message),
             actual,
@@ -1364,7 +1365,7 @@ public class NullAway extends BugChecker
       if (!isInitializer && !mayBeNullExpr(state, actual)) {
         String message =
             "passing known @NonNull parameter '"
-                + actual.toString()
+                + state.getSourceForNode(actual)
                 + "' to CastToNonNullMethod ("
                 + qualifiedName
                 + "). This method should only take arguments that NullAway considers @Nullable "
@@ -1458,7 +1459,7 @@ public class NullAway extends BugChecker
       FieldInitEntities entities, Set<Symbol> notInitializedInConstructors, VisitorState state) {
     Trees trees = getTreesInstance(state);
     Symbol.ClassSymbol classSymbol = entities.classSymbol();
-    Set<Element> initInSomeInitializer = new LinkedHashSet<>();
+    ImmutableSet.Builder<Element> initInSomeInitializerBuilder = ImmutableSet.builder();
     for (MethodTree initMethodTree : entities.instanceInitializerMethods()) {
       if (initMethodTree.getBody() == null) {
         continue;
@@ -1467,7 +1468,7 @@ public class NullAway extends BugChecker
           state,
           trees,
           classSymbol,
-          initInSomeInitializer,
+          initInSomeInitializerBuilder,
           initMethodTree.getBody(),
           new TreePath(state.getPath(), initMethodTree));
     }
@@ -1476,11 +1477,12 @@ public class NullAway extends BugChecker
           state,
           trees,
           classSymbol,
-          initInSomeInitializer,
+          initInSomeInitializerBuilder,
           block,
           new TreePath(state.getPath(), block));
     }
     Set<Symbol> result = new LinkedHashSet<>();
+    ImmutableSet<Element> initInSomeInitializer = initInSomeInitializerBuilder.build();
     for (Symbol fieldSymbol : notInitializedInConstructors) {
       if (!initInSomeInitializer.contains(fieldSymbol)) {
         result.add(fieldSymbol);
@@ -1493,16 +1495,16 @@ public class NullAway extends BugChecker
       VisitorState state,
       Trees trees,
       Symbol.ClassSymbol classSymbol,
-      Set<Element> initInSomeInitializer,
+      ImmutableSet.Builder<Element> initInSomeInitializerBuilder,
       BlockTree block,
       TreePath path) {
     AccessPathNullnessAnalysis nullnessAnalysis = getNullnessAnalysis(state);
     Set<Element> nonnullAtExit =
         nullnessAnalysis.getNonnullFieldsOfReceiverAtExit(path, state.context);
-    initInSomeInitializer.addAll(nonnullAtExit);
+    initInSomeInitializerBuilder.addAll(nonnullAtExit);
     Set<Element> safeInitMethods = getSafeInitMethods(block, classSymbol, state);
     addGuaranteedNonNullFromInvokes(
-        state, trees, safeInitMethods, nullnessAnalysis, initInSomeInitializer);
+        state, trees, safeInitMethods, nullnessAnalysis, initInSomeInitializerBuilder);
   }
 
   /**
@@ -1541,19 +1543,18 @@ public class NullAway extends BugChecker
         .anyMatch(config::isExternalInitClassAnnotation);
   }
 
-  private Set<Element> guaranteedNonNullForConstructor(
+  private ImmutableSet<Element> guaranteedNonNullForConstructor(
       FieldInitEntities entities, VisitorState state, Trees trees, MethodTree constructor) {
-    Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(constructor);
     Set<Element> safeInitMethods =
         getSafeInitMethods(constructor.getBody(), entities.classSymbol(), state);
     AccessPathNullnessAnalysis nullnessAnalysis = getNullnessAnalysis(state);
-    Set<Element> guaranteedNonNull = new LinkedHashSet<>();
-    guaranteedNonNull.addAll(
+    ImmutableSet.Builder<Element> guaranteedNonNullBuilder = ImmutableSet.builder();
+    guaranteedNonNullBuilder.addAll(
         nullnessAnalysis.getNonnullFieldsOfReceiverAtExit(
             new TreePath(state.getPath(), constructor), state.context));
     addGuaranteedNonNullFromInvokes(
-        state, trees, safeInitMethods, nullnessAnalysis, guaranteedNonNull);
-    return guaranteedNonNull;
+        state, trees, safeInitMethods, nullnessAnalysis, guaranteedNonNullBuilder);
+    return guaranteedNonNullBuilder.build();
   }
 
   /** does the constructor invoke another constructor in the same class via this(...)? */
@@ -1599,10 +1600,10 @@ public class NullAway extends BugChecker
       Trees trees,
       Set<Element> safeInitMethods,
       AccessPathNullnessAnalysis nullnessAnalysis,
-      Set<Element> guaranteedNonNull) {
+      ImmutableSet.Builder<Element> guaranteedNonNullBuilder) {
     for (Element invoked : safeInitMethods) {
       Tree invokedTree = trees.getTree(invoked);
-      guaranteedNonNull.addAll(
+      guaranteedNonNullBuilder.addAll(
           nullnessAnalysis.getNonnullFieldsOfReceiverAtExit(
               new TreePath(state.getPath(), invokedTree), state.context));
     }
@@ -1752,7 +1753,8 @@ public class NullAway extends BugChecker
           // do nothing
           break;
         default:
-          throw new RuntimeException(memberTree.getKind().toString() + " " + memberTree);
+          throw new RuntimeException(
+              memberTree.getKind().toString() + " " + state.getSourceForNode(memberTree));
       }
     }
 
@@ -1797,7 +1799,7 @@ public class NullAway extends BugChecker
         .anyMatch(config::isExcludedFieldAnnotation);
   }
 
-  private boolean isExcludedClass(Symbol.ClassSymbol classSymbol, VisitorState state) {
+  private boolean isExcludedClass(Symbol.ClassSymbol classSymbol) {
     String className = classSymbol.getQualifiedName().toString();
     if (config.isExcludedClass(className)) {
       return true;
@@ -1903,7 +1905,8 @@ public class NullAway extends BugChecker
         exprMayBeNull = nullnessFromDataflow(state, expr);
         break;
       default:
-        throw new RuntimeException("whoops, better handle " + expr.getKind() + " " + expr);
+        throw new RuntimeException(
+            "whoops, better handle " + expr.getKind() + " " + state.getSourceForNode(expr));
     }
     exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, state, exprMayBeNull);
     return exprMayBeNull;
@@ -1976,7 +1979,7 @@ public class NullAway extends BugChecker
     }
     if (mayBeNullExpr(state, baseExpression)) {
       final String message =
-          "dereferenced expression " + baseExpression.toString() + " is @Nullable";
+          "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";
       ErrorMessage errorMessage = new ErrorMessage(MessageTypes.DEREFERENCE_NULLABLE, message);
 
       handler.onPrepareErrorMessage(baseExpression, state, errorMessage);
@@ -1989,7 +1992,7 @@ public class NullAway extends BugChecker
 
   @SuppressWarnings("unused")
   private Description.Builder changeReturnNullabilityFix(
-      Tree suggestTree, Description.Builder builder) {
+      Tree suggestTree, Description.Builder builder, VisitorState state) {
     if (suggestTree.getKind() != Tree.Kind.METHOD) {
       throw new RuntimeException("This should be a MethodTree");
     }
@@ -1997,7 +2000,7 @@ public class NullAway extends BugChecker
     MethodTree methodTree = (MethodTree) suggestTree;
     int countNullableAnnotations = 0;
     for (AnnotationTree annotationTree : methodTree.getModifiers().getAnnotations()) {
-      if (annotationTree.getAnnotationType().toString().endsWith("Nullable")) {
+      if (state.getSourceForNode(annotationTree.getAnnotationType()).endsWith("Nullable")) {
         fixBuilder.delete(annotationTree);
         countNullableAnnotations += 1;
       }
@@ -2087,7 +2090,7 @@ public class NullAway extends BugChecker
     // taken from Error Prone MethodOverrides check
     Symbol.ClassSymbol owner = method.enclClass();
     for (Type s : types.closure(owner.type)) {
-      if (s.equals(owner.type)) {
+      if (types.isSameType(s, owner.type)) {
         continue;
       }
       for (Symbol m : s.tsym.members().getSymbolsByName(method.name)) {
@@ -2155,51 +2158,51 @@ public class NullAway extends BugChecker
         Set<MethodTree> staticInitializerMethods) {
       return new AutoValue_NullAway_FieldInitEntities(
           classSymbol,
-          nonnullInstanceFields,
-          nonnullStaticFields,
-          instanceInitializerBlocks,
-          staticInitializerBlocks,
-          constructors,
-          instanceInitializerMethods,
-          staticInitializerMethods);
+          ImmutableSet.copyOf(nonnullInstanceFields),
+          ImmutableSet.copyOf(nonnullStaticFields),
+          ImmutableList.copyOf(instanceInitializerBlocks),
+          ImmutableList.copyOf(staticInitializerBlocks),
+          ImmutableSet.copyOf(constructors),
+          ImmutableSet.copyOf(instanceInitializerMethods),
+          ImmutableSet.copyOf(staticInitializerMethods));
     }
 
     /** @return symbol for class */
     abstract Symbol.ClassSymbol classSymbol();
 
     /** @return @NonNull instance fields that are not directly initialized at declaration */
-    abstract Set<Symbol> nonnullInstanceFields();
+    abstract ImmutableSet<Symbol> nonnullInstanceFields();
 
     /** @return @NonNull static fields that are not directly initialized at declaration */
-    abstract Set<Symbol> nonnullStaticFields();
+    abstract ImmutableSet<Symbol> nonnullStaticFields();
 
     /**
      * @return the list of instance initializer blocks (e.g. blocks of the form `class X { { //Code
      *     } } ), in the order in which they appear in the class
      */
-    abstract List<BlockTree> instanceInitializerBlocks();
+    abstract ImmutableList<BlockTree> instanceInitializerBlocks();
 
     /**
      * @return the list of static initializer blocks (e.g. blocks of the form `class X { static {
      *     //Code } } ), in the order in which they appear in the class
      */
-    abstract List<BlockTree> staticInitializerBlocks();
+    abstract ImmutableList<BlockTree> staticInitializerBlocks();
 
     /** @return the list of constructor */
-    abstract Set<MethodTree> constructors();
+    abstract ImmutableSet<MethodTree> constructors();
 
     /**
      * @return the list of non-static (instance) initializer methods. This includes methods
      *     annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers
      *     or annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations
      */
-    abstract Set<MethodTree> instanceInitializerMethods();
+    abstract ImmutableSet<MethodTree> instanceInitializerMethods();
 
     /**
      * @return the list of static initializer methods. This includes static methods
      *     annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers
      *     or annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations
      */
-    abstract Set<MethodTree> staticInitializerMethods();
+    abstract ImmutableSet<MethodTree> staticInitializerMethods();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -124,7 +124,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(node.getTree());
     Preconditions.checkNotNull(callee);
     setUnconditionalArgumentNullness(bothUpdates, node.getArguments(), callee, context);
-    setConditionalArgumentNullness(thenUpdates, elseUpdates, node.getArguments(), callee, context);
+    setConditionalArgumentNullness(elseUpdates, node.getArguments(), callee, context);
     if (getOptLibraryModels(context).hasNonNullReturn(callee, types)) {
       return NullnessHint.FORCE_NONNULL;
     } else if (getOptLibraryModels(context).hasNullableReturn(callee, types)) {
@@ -135,7 +135,6 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   private void setConditionalArgumentNullness(
-      AccessPathNullnessPropagation.Updates thenUpdates,
       AccessPathNullnessPropagation.Updates elseUpdates,
       List<Node> arguments,
       Symbol.MethodSymbol callee,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RxNullabilityPropagator.java
@@ -234,7 +234,6 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
     Type receiverType = ASTHelpers.getReceiverType(tree);
     for (StreamTypeRecord streamType : RX_MODELS) {
       if (streamType.matchesType(receiverType, state)) {
-        String methodName = methodSymbol.toString();
         // Build observable call chain
         buildObservableCallChain(tree);
 
@@ -262,7 +261,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
             // Ensure that this `new B() ...` has a custom class body, otherwise, we skip for now.
             if (annonClassBody != null) {
               MaplikeMethodRecord methodRecord = streamType.getMaplikeMethodRecord(methodSymbol);
-              handleMapAnonClass(methodRecord, tree, annonClassBody, state);
+              handleMapAnonClass(methodRecord, tree, annonClassBody);
             }
           } else if (argTree instanceof LambdaExpressionTree) {
             observableCallToInnerMethodOrLambda.put(tree, (LambdaExpressionTree) argTree);
@@ -298,7 +297,6 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
       outerCallInChain = observableOuterCallInChain.get(outerCallInChain);
       // Check for a map method (which might be a pass-through method or the first method after a
       // pass-through chain)
-      MethodInvocationTree mapCallsite = observableOuterCallInChain.get(observableDotFilter);
       if (observableCallToInnerMethodOrLambda.containsKey(outerCallInChain)) {
         // Update mapToFilterMap
         Symbol.MethodSymbol mapMethod = ASTHelpers.getSymbol(outerCallInChain);
@@ -341,8 +339,7 @@ class RxNullabilityPropagator extends BaseNoOpHandler {
   private void handleMapAnonClass(
       MaplikeMethodRecord methodRecord,
       MethodInvocationTree observableDotMap,
-      ClassTree annonClassBody,
-      VisitorState state) {
+      ClassTree annonClassBody) {
     for (Tree t : annonClassBody.getMembers()) {
       if (t instanceof MethodTree
           && ((MethodTree) t).getName().toString().equals(methodRecord.getInnerMethodName())) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAndroidTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAndroidTest.java
@@ -17,6 +17,7 @@ public class NullAwayAndroidTest {
 
   private CompilationTestHelper compilationHelper;
 
+  @SuppressWarnings("CheckReturnValue")
   @Before
   public void setup() {
     compilationHelper = CompilationTestHelper.newInstance(NullAway.class, getClass());
@@ -174,6 +175,7 @@ public class NullAwayAndroidTest {
   }
 
   /** Initialises the default android classes that are commonly used. */
+  @SuppressWarnings("CheckReturnValue")
   private void initialiseAndroidCoreClasses() {
     compilationHelper
         .addSourceFile("androidstubs/core/Context.java")

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestNoCastTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestNoCastTest.java
@@ -60,8 +60,8 @@ public class NullAwayAutoSuggestNoCastTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "class Test {",
@@ -76,8 +76,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "  @SuppressWarnings(\"NullAway\") /* PR #000000 */ Object test1() {",
             "    return null;",
             "  }",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH); // Yes we can!
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH); // Yes we can!
   }
 
   @Test
@@ -86,8 +86,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "class Test {",
@@ -102,8 +102,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "  @SuppressWarnings(\"NullAway\") Object test1() {",
             "    return null;",
             "  }",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -112,8 +112,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -135,8 +135,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "    () -> {",
             "      foo.toString();",
             "    };",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -145,8 +145,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -170,8 +170,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "    () -> {",
             "      id(foo);",
             "    };",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -180,8 +180,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -205,8 +205,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "      @SuppressWarnings(\"NullAway\")",
             "      int x = foo + 1;",
             "    };",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -215,8 +215,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -245,8 +245,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "    @SuppressWarnings(\"NullAway\")",
             "    java.util.function.Function<Object,Integer> g = (x) -> { return foo + 1; };",
             "  }",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -255,8 +255,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -284,8 +284,8 @@ public class NullAwayAutoSuggestNoCastTest {
             "  static void bar() {",
             "    callFoo(Test::biz);",
             "  }",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
   @Test
@@ -294,8 +294,8 @@ public class NullAwayAutoSuggestNoCastTest {
         BugCheckerRefactoringTestHelper.newInstance(
             new NullAway(flagsNoAutoFixSuppressionComment), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -325,7 +325,7 @@ public class NullAwayAutoSuggestNoCastTest {
             "  static void bar() {",
             "    callFoo(Test::biz);",
             "  }",
-            "}");
-    bcr.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+            "}")
+        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -53,8 +53,8 @@ public class NullAwayAutoSuggestTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -64,8 +64,8 @@ public class NullAwayAutoSuggestTest {
             "    return castToNonNull(o);",
             "  }",
             "}")
-        .expectUnchanged();
-    bcr.doTest();
+        .expectUnchanged()
+        .doTest();
   }
 
   @Test
@@ -73,8 +73,8 @@ public class NullAwayAutoSuggestTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -92,8 +92,8 @@ public class NullAwayAutoSuggestTest {
             "  Object test1(@Nullable Object o) {",
             "    return castToNonNull(o);",
             "  }",
-            "}");
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -101,8 +101,8 @@ public class NullAwayAutoSuggestTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -121,8 +121,8 @@ public class NullAwayAutoSuggestTest {
             "  Object test1(Object o) {",
             "    return o;",
             "  }",
-            "}");
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -130,8 +130,8 @@ public class NullAwayAutoSuggestTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new NullAway(flags), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-    bcr.addInputLines(
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
@@ -166,7 +166,7 @@ public class NullAwayAutoSuggestTest {
             "  @SuppressWarnings(\"NullAway\") void test() throws Exception {",
             "    takesNonNull(execute(Test::doReturnNullable));",
             "  }",
-            "}");
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -40,6 +40,7 @@ public class NullAwayTest {
 
   private CompilationTestHelper compilationHelper;
 
+  @SuppressWarnings("CheckReturnValue")
   @Before
   public void setup() {
     compilationHelper = CompilationTestHelper.newInstance(NullAway.class, getClass());

--- a/sample-app/src/main/java/com/uber/myapplication/MainActivity.java
+++ b/sample-app/src/main/java/com/uber/myapplication/MainActivity.java
@@ -22,6 +22,7 @@ import android.support.v7.app.AppCompatActivity;
 import org.utilities.StringUtils;
 
 /** Sample activity. */
+@SuppressWarnings("UnusedVariable") // This is sample code
 public class MainActivity extends AppCompatActivity {
   @NonNull private Object mOnCreateInitialiedField;
 

--- a/sample-app/src/main/java/com/uber/myapplication/MainFragment.java
+++ b/sample-app/src/main/java/com/uber/myapplication/MainFragment.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+@SuppressWarnings("UnusedVariable") // This is sample code
 public class MainFragment extends Fragment {
 
   @NonNull private Object mOnCreateInitialisedField;

--- a/sample/src/main/java/com/uber/mylib/Lambdas.java
+++ b/sample/src/main/java/com/uber/mylib/Lambdas.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /** Code that uses Java 8 lambdas */
+@SuppressWarnings("UnusedVariable") // This is sample code
 public class Lambdas {
 
   @FunctionalInterface


### PR DESCRIPTION
Most of the noise in this diff falls under a few categories:
- UnusedVariable check
- Strong enforcement of immutables (no mixing, using them in autovalue)
- Use Types.isSameType() for type comparisons (instead of .equals())
- Use state.getSourceForNode() for representing trees rather than Tree#toString()
- Use fluent APIs for assertions in tests

Resolves #286 