### PR TITLE
Remove warning about @Nullable var args

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -492,24 +492,6 @@ public class NullAway extends BugChecker
         return checkOverriding(closestOverriddenMethod, methodSymbol, null, state);
       }
     }
-    // Check that var args (if any) is @Nullable, as NullAway doesn't currently support this case
-    if (methodSymbol.isVarArgs()) {
-      VarSymbol varArgsSymbol =
-          methodSymbol.getParameters().get(methodSymbol.getParameters().size() - 1);
-      if (Nullness.hasNullableAnnotation(varArgsSymbol)) {
-        String message =
-            "NullAway doesn't currently support @Nullable VarArgs. "
-                + "Consider removing the @Nullable annotation from "
-                + varArgsSymbol.toString()
-                + " in "
-                + methodSymbol.toString()
-                + " (this issue can cause other errors below, wherever the var args array is dereferenced)";
-        return errorBuilder.createErrorDescription(
-            new ErrorMessage(MessageTypes.NULLABLE_VARARGS_UNSUPPORTED, message),
-            state.getPath(),
-            buildDescription(tree));
-      }
-    }
     return Description.NO_MATCH;
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1715,7 +1715,6 @@ public class NullAwayTest {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "public class Utilities {",
-            " // BUG: Diagnostic contains: NullAway doesn't currently support @Nullable VarArgs",
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
             "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",


### PR DESCRIPTION
Unfortunatelly, it is commong to have wrapper functions that take
@Nullable var args and e.g. pass them immediately to a formatting/logging
third-party method that also takes @Nullable var args safely.

Because of this, erroring out on `@Nullable T args...` can cause a worse
experience than simply letting the local array `args` be considered a
`@Nullable` array. I am not too happy with current error reporting after
reverting this change, but the alternative blocks too many valid method
declarations.