### PR TITLE
Add support for containing class fields to RxNullabilityPropagator

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -185,6 +185,8 @@ public class NullnessStore implements Store<NullnessStore> {
     NullnessStore.Builder nullnessBuilder = NullnessStore.empty().toBuilder();
     for (AccessPath ap : contents.keySet()) {
       if (ap.getRoot().isReceiver()) {
+        AccessPath newAP = new AccessPath(new AccessPath.Root(), ap.getElements());
+        nullnessBuilder.setInformation(newAP, contents.get(ap));
         continue;
       }
       Element varElement = ap.getRoot().getVarElement();

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayRxSupportNegativeCases.java
@@ -300,6 +300,12 @@ public class NullAwayRxSupportNegativeCases {
     return observable.filter(s -> s != null && perhaps()).map(s -> s.length());
   }
 
+  @Nullable public NullableContainer xd;
+
+  private Observable<String> filterThenMapTwoGets(Observable<Void> observable) {
+    return observable.filter(s -> xd != null && xd.get() != null).map(s -> xd.get().toString());
+  }
+
   private Observable<Integer> filterThenDoOnNextThenMapLambdas(Observable<String> observable) {
     return observable
         .filter(s -> s != null && perhaps())


### PR DESCRIPTION
Class field information is propagated from `filter` to `map` in `RxNullabilityPropagator`

Fixes #282 

Added unit test
