### PR TITLE
To string fix for AccessPathElement

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathElement.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathElement.java
@@ -61,7 +61,7 @@ public final class AccessPathElement {
         + "javaElement="
         + javaElement.toString()
         + ", constantArguments="
-        + Arrays.deepToString(constantArguments.toArray())
+        + Arrays.deepToString(constantArguments != null ? constantArguments.toArray() : null)
         + '}';
   }
 }


### PR DESCRIPTION
Fixes bug which was causing NPE while testing when `constantArguments` is `null`. 
