### PR TITLE
Handle assertThat in JUnit and Hamcrest.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
@@ -66,7 +66,7 @@ public class AssertionHandler extends BaseNoOpHandler {
   private Name hamcrestAssertClass;
   private Name junitAssertClass;
 
-  // Names for matchers.
+  // Names for hamcrest matchers.
   private Name matchersClass;
   private Name isMatcher;
   private Name notMatcher;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
@@ -31,6 +31,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Name;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
+import java.util.List;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 
@@ -44,6 +45,15 @@ public class AssertionHandler extends BaseNoOpHandler {
   private static final String ASSERT_THAT_METHOD = "assertThat";
   private static final String ASSERT_THAT_OWNER = "com.google.common.truth.Truth";
 
+  private static final String HAMCREST_ASSERT_CLASS = "org.hamcrest.MatcherAssert";
+  private static final String JUNIT_ASSERT_CLASS = "org.junit.Assert";
+
+  private static final String MATCHERS_CLASS = "org.hamcrest.Matchers";
+  private static final String IS_MATCHER = "is";
+  private static final String NOT_MATCHER = "not";
+  private static final String NOT_NULL_VALUE_MATCHER = "notNullValue";
+  private static final String NULL_VALUE_MATCHER = "nullValue";
+
   // Names of the methods (and their owners) used to identify assertions in this handler. Name used
   // here refers to com.sun.tools.javac.util.Name. Comparing methods using Names is faster than
   // comparing using strings.
@@ -51,6 +61,17 @@ public class AssertionHandler extends BaseNoOpHandler {
   private Name isNotNullOwner;
   private Name assertThat;
   private Name assertThatOwner;
+
+  // Names for junit assertion libraries.
+  private Name hamcrestAssertClass;
+  private Name junitAssertClass;
+
+  // Names for matchers.
+  private Name matchersClass;
+  private Name isMatcher;
+  private Name notMatcher;
+  private Name notNullValueMatcher;
+  private Name nullValueMatcher;
 
   @Override
   public NullnessHint onDataflowVisitMethodInvocation(
@@ -86,6 +107,20 @@ public class AssertionHandler extends BaseNoOpHandler {
         }
       }
     }
+
+    // Look for statements of the form:
+    //    * assertThat(A, is(not(nullValue())))
+    //    * assertThat(A, is(notNullValue()))
+    if (isMethodHamcrestAssertThat(callee) || isMethodJunitAssertThat(callee)) {
+      List<Node> args = node.getArguments();
+      if (args.size() == 2 && isMatcherIsNotNull(args.get(1))) {
+        AccessPath ap = AccessPath.getAccessPathForNodeNoMapGet(args.get(0));
+        if (ap != null) {
+          bothUpdates.set(ap, NONNULL);
+        }
+      }
+    }
+
     return NullnessHint.UNKNOWN;
   }
 
@@ -95,6 +130,50 @@ public class AssertionHandler extends BaseNoOpHandler {
 
   private boolean isMethodAssertThat(Symbol.MethodSymbol methodSymbol) {
     return matchesMethod(methodSymbol, assertThat, assertThatOwner);
+  }
+
+  private boolean isMethodHamcrestAssertThat(Symbol.MethodSymbol methodSymbol) {
+    return matchesMethod(methodSymbol, assertThat, hamcrestAssertClass);
+  }
+
+  private boolean isMethodJunitAssertThat(Symbol.MethodSymbol methodSymbol) {
+    return matchesMethod(methodSymbol, assertThat, junitAssertClass);
+  }
+
+  private boolean isMatcherIsNotNull(Node node) {
+    // Matches with
+    //   * is(not(nullValue()))
+    //   * is(notNullValue())
+    if (matchesMatcherMethod(node, isMatcher)) {
+      // All overloads of `is` method have exactly one argument.
+      return isMatcherNotNull(((MethodInvocationNode) node).getArgument(0));
+    }
+    return false;
+  }
+
+  private boolean isMatcherNotNull(Node node) {
+    // Matches with
+    //   * not(nullValue())
+    //   * notNullValue()
+    if (matchesMatcherMethod(node, notMatcher)) {
+      // All overloads of `not` method have exactly one argument.
+      return isMatcherNull(((MethodInvocationNode) node).getArgument(0));
+    }
+    return matchesMatcherMethod(node, notNullValueMatcher);
+  }
+
+  private boolean isMatcherNull(Node node) {
+    // Matches with nullValue()
+    return matchesMatcherMethod(node, nullValueMatcher);
+  }
+
+  private boolean matchesMatcherMethod(Node node, Name matcherName) {
+    if (node instanceof MethodInvocationNode) {
+      MethodInvocationNode methodInvocationNode = (MethodInvocationNode) node;
+      Symbol.MethodSymbol callee = ASTHelpers.getSymbol(methodInvocationNode.getTree());
+      return matchesMethod(callee, matcherName, matchersClass);
+    }
+    return false;
   }
 
   private boolean matchesMethod(
@@ -112,5 +191,14 @@ public class AssertionHandler extends BaseNoOpHandler {
     isNotNullOwner = table.fromString(IS_NOT_NULL_OWNER);
     assertThat = table.fromString(ASSERT_THAT_METHOD);
     assertThatOwner = table.fromString(ASSERT_THAT_OWNER);
+
+    hamcrestAssertClass = table.fromString(HAMCREST_ASSERT_CLASS);
+    junitAssertClass = table.fromString(JUNIT_ASSERT_CLASS);
+
+    matchersClass = table.fromString(MATCHERS_CLASS);
+    isMatcher = table.fromString(IS_MATCHER);
+    notMatcher = table.fromString(NOT_MATCHER);
+    notNullValueMatcher = table.fromString(NOT_NULL_VALUE_MATCHER);
+    nullValueMatcher = table.fromString(NULL_VALUE_MATCHER);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1030,10 +1030,74 @@ public class NullAwayTest {
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
             "class Test {",
-            "  private void foo(@Nullable Object o) {",
-            "    com.google.common.truth.Truth.assertThat(o).isNotNull();",
+            "  private void foo(@Nullable Object a, @Nullable Object b, @Nullable Object c) {",
+            "    com.google.common.truth.Truth.assertThat(a).isNotNull();",
             "    // BUG: Diagnostic contains: dereferenced expression",
-            "    o.toString();",
+            "    a.toString();",
+            "    org.hamcrest.MatcherAssert.assertThat(b, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.notNullValue()));",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    b.toString();",
+            "    org.junit.Assert.assertThat(c, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.notNullValue()));",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    c.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void supportHamcrestAssertThatIsNotNull_Object() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b) {",
+            "    org.hamcrest.MatcherAssert.assertThat(a, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.notNullValue()));",
+            "    a.toString();",
+            "    org.hamcrest.MatcherAssert.assertThat(b, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.not(org.hamcrest.Matchers.nullValue())));",
+            "    b.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void supportJunitAssertThatIsNotNull_Object() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b) {",
+            "    org.junit.Assert.assertThat(a, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.notNullValue()));",
+            "    a.toString();",
+            "    org.junit.Assert.assertThat(b, org.hamcrest.Matchers.is("
+                + "org.hamcrest.Matchers.not(org.hamcrest.Matchers.nullValue())));",
+            "    b.toString();",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -968,7 +968,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void supportAssertThatIsNotNull_Object() {
+  public void supportTruthAssertThatIsNotNull_Object() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -982,9 +982,10 @@ public class NullAwayTest {
             "import java.lang.Object;",
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
+            "import static com.google.common.truth.Truth.assertThat;",
             "class Test {",
             "  private void foo(@Nullable Object o) {",
-            "    com.google.common.truth.Truth.assertThat(o).isNotNull();",
+            "    assertThat(o).isNotNull();",
             "    o.toString();",
             "  }",
             "}")
@@ -992,7 +993,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void supportAssertThatIsNotNull_String() {
+  public void supportTruthAssertThatIsNotNull_String() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1005,9 +1006,10 @@ public class NullAwayTest {
             "package com.uber;",
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
+            "import static com.google.common.truth.Truth.assertThat;",
             "class Test {",
             "  private void foo(@Nullable String s) {",
-            "    com.google.common.truth.Truth.assertThat(s).isNotNull();",
+            "    assertThat(s).isNotNull();",
             "    s.toString();",
             "  }",
             "}")
@@ -1015,7 +1017,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void doNotSupportAssertThatWhenDisabled() {
+  public void doNotSupportTruthAssertThatWhenDisabled() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1029,19 +1031,12 @@ public class NullAwayTest {
             "import java.lang.Object;",
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
+            "import static com.google.common.truth.Truth.assertThat;",
             "class Test {",
-            "  private void foo(@Nullable Object a, @Nullable Object b, @Nullable Object c) {",
-            "    com.google.common.truth.Truth.assertThat(a).isNotNull();",
+            "  private void foo(@Nullable Object a) {",
+            "    assertThat(a).isNotNull();",
             "    // BUG: Diagnostic contains: dereferenced expression",
             "    a.toString();",
-            "    org.hamcrest.MatcherAssert.assertThat(b, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.notNullValue()));",
-            "    // BUG: Diagnostic contains: dereferenced expression",
-            "    b.toString();",
-            "    org.junit.Assert.assertThat(c, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.notNullValue()));",
-            "    // BUG: Diagnostic contains: dereferenced expression",
-            "    c.toString();",
             "  }",
             "}")
         .doTest();
@@ -1062,14 +1057,41 @@ public class NullAwayTest {
             "import java.lang.Object;",
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
+            "import static org.hamcrest.MatcherAssert.assertThat;",
+            "import static org.hamcrest.Matchers.*;",
             "class Test {",
             "  private void foo(@Nullable Object a, @Nullable Object b) {",
-            "    org.hamcrest.MatcherAssert.assertThat(a, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.notNullValue()));",
+            "    assertThat(a, is(notNullValue()));",
             "    a.toString();",
-            "    org.hamcrest.MatcherAssert.assertThat(b, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.not(org.hamcrest.Matchers.nullValue())));",
+            "    assertThat(b, is(not(nullValue())));",
             "    b.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void doNotSupportHamcrestAssertThatWhenDisabled() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=false"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static org.hamcrest.MatcherAssert.assertThat;",
+            "import static org.hamcrest.Matchers.*;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    assertThat(a, is(notNullValue()));",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    a.toString();",
             "  }",
             "}")
         .doTest();
@@ -1090,14 +1112,41 @@ public class NullAwayTest {
             "import java.lang.Object;",
             "import java.util.Objects;",
             "import javax.annotation.Nullable;",
+            "import static org.junit.Assert.assertThat;",
+            "import static org.hamcrest.Matchers.*;",
             "class Test {",
             "  private void foo(@Nullable Object a, @Nullable Object b) {",
-            "    org.junit.Assert.assertThat(a, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.notNullValue()));",
+            "    assertThat(a, is(notNullValue()));",
             "    a.toString();",
-            "    org.junit.Assert.assertThat(b, org.hamcrest.Matchers.is("
-                + "org.hamcrest.Matchers.not(org.hamcrest.Matchers.nullValue())));",
+            "    assertThat(b, is(not(nullValue())));",
             "    b.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void doNotSupportJunitAssertThatWhenDisabled() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=false"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static org.junit.Assert.assertThat;",
+            "import static org.hamcrest.Matchers.*;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    assertThat(a, is(notNullValue()));",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    a.toString();",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
* This adds handling of nullness assertions using "assertThat(..., isNotNull())" statements from JUnit (<https://junit.org/junit4/javadoc/latest/org/junit/Assert.html>) and Hamcrest (https://junit.org/junit4/javadoc/4.12/org/hamcrest/MatcherAssert.html).
* Issue #301
