### PR TITLE
Make class-level caches for InferredJARModelsHandler instance fields.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -72,9 +72,9 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
 
   private static final int RETURN = -1; // '-1' indexes Return type in the Annotation Cache
 
-  private static Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache;
-  private static Map<String, Set<String>> mapModelJarLocations;
-  private static Set<String> loadedJars;
+  private final Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache;
+  private final Map<String, Set<String>> mapModelJarLocations;
+  private final Set<String> loadedJars;
 
   private final Config config;
 


### PR DESCRIPTION
Static mutable fields are incredibly dangerous in NullAway and should have been avoided. The original code actually triggers a crash when using a shared classloader for Error Prone.