### PR TITLE
Refactor the driver and annotation summary type in JarInfer

### DIFF
--- a/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
+++ b/jar-infer/jar-infer-cli/src/main/java/com/uber/nullaway/jarinfer/JarInfer.java
@@ -95,8 +95,8 @@ public class JarInfer {
       if (!pkgName.isEmpty()) {
         pkgName = "L" + pkgName.replaceAll("\\.", "/");
       }
-      DefinitelyDerefedParamsDriver.run(
-          jarPath, pkgName, outPath, annotateBytecode, debug, verbose);
+      DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+      driver.run(jarPath, pkgName, outPath, annotateBytecode, debug, verbose);
       if (!new File(outPath).exists()) {
         System.out.println("Could not write jar file: " + outPath);
       }

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -162,7 +162,7 @@ public class DefinitelyDerefedParamsDriver {
     for (String inPath : setInPaths) {
       analyzeFile(pkgName, inPath);
       if (this.annotateBytecode) {
-        WriteAnnotations(inPath, outPath);
+        writeAnnotations(inPath, outPath);
       }
     }
     if (!this.annotateBytecode) {
@@ -384,7 +384,7 @@ public class DefinitelyDerefedParamsDriver {
     StubxWriter.write(out, importedAnnotations, packageAnnotations, typeAnnotations, methodRecords);
   }
 
-  private void WriteAnnotations(String inPath, String outPath) throws IOException {
+  private void writeAnnotations(String inPath, String outPath) throws IOException {
     Preconditions.checkArgument(
         inPath.endsWith(".jar") || inPath.endsWith(".class"), "invalid input path - " + inPath);
     LOG(DEBUG, "DEBUG", "Writing Annotations to " + outPath);

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/MethodParamAnnotations.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/MethodParamAnnotations.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.jarinfer;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class MethodParamAnnotations extends HashMap<String, Set<Integer>> {}

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/MethodReturnAnnotations.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/MethodReturnAnnotations.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.jarinfer;
+
+import java.util.HashSet;
+
+public class MethodReturnAnnotations extends HashSet<String> {}

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -78,11 +78,11 @@ public class JarInferTest {
         testName + ": test compilation failed!\n" + compilerUtil.getOutput(),
         Main.Result.OK,
         compileResult);
-    DefinitelyDerefedParamsDriver.reset();
+    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
     Assert.assertTrue(
         testName + ": test failed!",
         verify(
-            DefinitelyDerefedParamsDriver.run(
+            driver.run(
                 temporaryFolder.getRoot().getAbsolutePath(), "L" + pkg.replaceAll("\\.", "/")),
             new HashMap<>(expected)));
   }
@@ -97,9 +97,9 @@ public class JarInferTest {
       String pkg, // in dot syntax
       String jarPath // in dot syntax
       ) throws Exception {
-    DefinitelyDerefedParamsDriver.reset();
-    DefinitelyDerefedParamsDriver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
-    String outJARPath = DefinitelyDerefedParamsDriver.lastOutPath;
+    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+    driver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
+    String outJARPath = driver.lastOutPath;
     Assert.assertTrue("jar file not found! - " + outJARPath, new File(outJARPath).exists());
   }
 
@@ -110,8 +110,8 @@ public class JarInferTest {
       Map<String, String> expectedToActualAnnotationsMap)
       throws Exception {
     String outputFolderPath = outputFolder.newFolder(pkg).getAbsolutePath();
-    DefinitelyDerefedParamsDriver.reset();
-    DefinitelyDerefedParamsDriver.runAndAnnotate(inputJarPath, "", outputFolderPath);
+    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+    driver.runAndAnnotate(inputJarPath, "", outputFolderPath);
 
     String inputJarName = FilenameUtils.getBaseName(inputJarPath);
     String outputJarPath = outputFolderPath + "/" + inputJarName + "-annotated.jar";
@@ -290,15 +290,15 @@ public class JarInferTest {
 
   @Test
   public void jarinferOutputJarIsBytePerByteDeterministic() throws Exception {
-    DefinitelyDerefedParamsDriver.reset();
     String jarPath = "../test-java-lib-jarinfer/build/libs/test-java-lib-jarinfer.jar";
     String pkg = "com.uber.nullaway.jarinfer.toys.unannotated";
-    DefinitelyDerefedParamsDriver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
-    byte[] checksumBytes1 = sha1sum(DefinitelyDerefedParamsDriver.lastOutPath);
+    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+    driver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
+    byte[] checksumBytes1 = sha1sum(driver.lastOutPath);
     // Wait a second to ensure system time has changed
     Thread.sleep(1);
-    DefinitelyDerefedParamsDriver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
-    byte[] checksumBytes2 = sha1sum(DefinitelyDerefedParamsDriver.lastOutPath);
+    driver.run(jarPath, "L" + pkg.replaceAll("\\.", "/"));
+    byte[] checksumBytes2 = sha1sum(driver.lastOutPath);
     Assert.assertTrue(Arrays.equals(checksumBytes1, checksumBytes2));
   }
 


### PR DESCRIPTION
* Refactored DefinitelyDerefedParamsDriver to maintain state in the object and use instance methods.
* Refactored the Map and Set types used to hold the method annotations that are inferred by the analysis. 