### PR TITLE
Different approach for param analysis

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
@@ -132,7 +132,7 @@ public class DefinitelyDerefedParams {
     Set<Integer> derefedParamList = new HashSet<>();
     Map<ISSABasicBlock, Set<Integer>> blockToDerefSetMap = new HashMap<>();
 
-    // find which params are definitely non-null in each block
+    // find which params are treated as being non-null inside each basic block
     prunedCFG.forEach(
         basicBlock -> {
           Set<Integer> derefParamSet = new HashSet<>();
@@ -140,8 +140,9 @@ public class DefinitelyDerefedParams {
           checkForUseOfParams(derefParamSet, numParam, firstParamIndex, basicBlock);
         });
 
-    // for each param check if there is a path from entry to exit going through basic blocks
-    // which do not guarantee that the param is non-null
+    // For each param p, if no path exists from the entry block to the exit block which traverses
+    // only basic blocks which do not require p being non-null (e.g. by dereferencing it), then
+    // mark p as @NonNull
     for (int i = firstParamIndex; i <= numParam; i++) {
       final Integer param = i - 1;
       if (!DFS.getReachableNodes(

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParams.java
@@ -16,6 +16,7 @@
 package com.uber.nullaway.jarinfer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.classLoader.IMethod;
@@ -33,8 +34,12 @@ import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.GraphUtil;
 import com.ibm.wala.util.graph.dominators.Dominators;
 import com.ibm.wala.util.graph.impl.GraphInverter;
+import com.ibm.wala.util.graph.traverse.DFS;
+import com.sun.istack.internal.NotNull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -45,6 +50,7 @@ import java.util.Set;
  */
 public class DefinitelyDerefedParams {
   private static final boolean DEBUG = false;
+  private boolean USE_EXTENDED_APPROACH = true;
 
   private static void LOG(boolean cond, String tag, String msg) {
     if (cond) System.out.println("[JI " + tag + "] " + msg);
@@ -98,15 +104,60 @@ public class DefinitelyDerefedParams {
   Set<Integer> analyze() {
     // Get ExceptionPrunedCFG
     LOG(DEBUG, "DEBUG", "@ " + method.getSignature());
-    Set<Integer> derefedParamList = new HashSet<Integer>();
     prunedCFG = ExceptionPrunedCFG.make(cfg);
     // In case the only control flows are exceptional, simply return.
     if (prunedCFG.getNumberOfNodes() == 2
         && prunedCFG.containsNode(cfg.entry())
         && prunedCFG.containsNode(cfg.exit())
         && GraphUtil.countEdges(prunedCFG) == 0) {
-      return derefedParamList;
+      return new HashSet<>();
     }
+
+    // Get number of params and value number of first param
+    int numParam = ir.getSymbolTable().getNumberOfParameters();
+    int firstParamIndex =
+        method.isStatic() ? 1 : 2; // 1-indexed; v1 is 'this' for non-static methods
+
+    Set<Integer> derefedParamList;
+    if (USE_EXTENDED_APPROACH) {
+      derefedParamList = computeDerefParamList(numParam, firstParamIndex);
+    } else {
+      derefedParamList = computeDerefParamListUsingPDom(numParam, firstParamIndex);
+    }
+    return derefedParamList;
+  }
+
+  @NotNull
+  private Set<Integer> computeDerefParamList(int numParam, int firstParamIndex) {
+    Set<Integer> derefedParamList = new HashSet<>();
+    Map<ISSABasicBlock, Set<Integer>> blockToDerefSetMap = new HashMap<>();
+
+    // find which params are definitely non-null in each block
+    prunedCFG.forEach(
+        basicBlock -> {
+          Set<Integer> derefParamSet = new HashSet<>();
+          blockToDerefSetMap.put(basicBlock, derefParamSet);
+          checkForUseOfParams(derefParamSet, numParam, firstParamIndex, basicBlock);
+        });
+
+    // for each param check if there is a path from entry to exit going through basic blocks
+    // which do not guarantee that the param is non-null
+    for (int i = firstParamIndex; i <= numParam; i++) {
+      final Integer param = i - 1;
+      if (!DFS.getReachableNodes(
+              prunedCFG,
+              ImmutableList.of(prunedCFG.entry()),
+              basicBlock -> !blockToDerefSetMap.get(basicBlock).contains(param))
+          .contains(prunedCFG.exit())) {
+        derefedParamList.add(param);
+      }
+    }
+    return derefedParamList;
+  }
+
+  @NotNull
+  private Set<Integer> computeDerefParamListUsingPDom(int numParam, int firstParamIndex) {
+    Set<Integer> derefedParamList = new HashSet<>();
     // Get Dominator Tree
     LOG(DEBUG, "DEBUG", "\tbuilding dominator tree...");
     Graph<ISSABasicBlock> domTree = Dominators.make(prunedCFG, prunedCFG.entry()).dominatorTree();
@@ -120,10 +171,6 @@ public class DefinitelyDerefedParams {
     LOG(DEBUG, "DEBUG", "\tfinding dereferenced params...");
     ArrayList<ISSABasicBlock> nodeQueue = new ArrayList<ISSABasicBlock>();
     nodeQueue.add(prunedCFG.exit());
-    // Get number of params and value number of first param
-    int numParam = ir.getSymbolTable().getNumberOfParameters();
-    int firstParamIndex =
-        method.isStatic() ? 1 : 2; // 1-indexed; v1 is 'this' for non-static methods
     LOG(DEBUG, "DEBUG", "param value numbers : " + firstParamIndex + " ... " + numParam);
     while (!nodeQueue.isEmpty()) {
       ISSABasicBlock node = nodeQueue.get(0);

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -344,6 +344,32 @@ public class JarInferTest {
   }
 
   @Test
+  public void toyReassigningTest() throws Exception {
+    testTemplate(
+        "toyNullTestAPI",
+        "toys",
+        "Foo",
+        ImmutableMap.of("toys.Foo:void test(String, String)", Sets.newHashSet(1)),
+        "import com.google.common.base.Preconditions;",
+        "import java.util.Objects;",
+        "import org.junit.Assert;",
+        "class Foo {",
+        "  private String foo;",
+        "  public Foo(String str) {",
+        "    if (str == null) str = \"foo\";",
+        "    this.foo = str;",
+        "  }",
+        "  public void test(String s, String t) {",
+        "    Preconditions.checkNotNull(s);",
+        "    if (t == null) {",
+        "      t = s;",
+        "    }",
+        "    Objects.requireNonNull(t);",
+        "  }",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -79,12 +79,11 @@ public class JarInferTest {
         Main.Result.OK,
         compileResult);
     DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+    Map<String, Set<Integer>> result =
+        driver.run(temporaryFolder.getRoot().getAbsolutePath(), "L" + pkg.replaceAll("\\.", "/"));
     Assert.assertTrue(
-        testName + ": test failed!",
-        verify(
-            driver.run(
-                temporaryFolder.getRoot().getAbsolutePath(), "L" + pkg.replaceAll("\\.", "/")),
-            new HashMap<>(expected)));
+        testName + ": test failed! \n" + result + " does not match " + expected,
+        verify(result, new HashMap<>(expected)));
   }
 
   /**
@@ -271,6 +270,75 @@ public class JarInferTest {
         "      t = u;",
         "    }",
         "    Objects.requireNonNull(t);",
+        "  }",
+        "}");
+  }
+
+  @Test
+  public void toyConditionalFlow() throws Exception {
+    testTemplate(
+        "toyNullTestAPI",
+        "toys",
+        "Foo",
+        ImmutableMap.of("toys.Foo:void test(String, String, String)", Sets.newHashSet(1, 2)),
+        "import com.google.common.base.Preconditions;",
+        "import java.util.Objects;",
+        "import org.junit.Assert;",
+        "class Foo {",
+        "  private String foo;",
+        "  public Foo(String str) {",
+        "    if (str == null) str = \"foo\";",
+        "    this.foo = str;",
+        "  }",
+        "  public void test(String s, String t, String u) {",
+        "    if (s.length() >= 5) {",
+        "      t.toString();",
+        "      t = s;",
+        "    } else {",
+        "      Preconditions.checkNotNull(t);",
+        "      u = t;",
+        "    }",
+        "    Objects.requireNonNull(u);",
+        "  }",
+        "}");
+  }
+
+  @Test
+  public void toyConditionalFlow2() throws Exception {
+    testTemplate(
+        "toyNullTestAPI",
+        "toys",
+        "Foo",
+        ImmutableMap.of(
+            "toys.Foo:void test(Object, Object, Object, Object)", Sets.newHashSet(1, 4)),
+        "import com.google.common.base.Preconditions;",
+        "import java.util.Objects;",
+        "import org.junit.Assert;",
+        "class Foo {",
+        "  private String foo;",
+        "  public Foo(String str) {",
+        "    if (str == null) str = \"foo\";",
+        "    this.foo = str;",
+        "  }",
+        "  public void test(Object a, Object b, Object c, Object d) {",
+        "    if (a != null) {",
+        "      b.toString();",
+        "      d.toString();",
+        "    } else {",
+        "      Preconditions.checkNotNull(c);",
+        "    }",
+        "    Objects.requireNonNull(a);",
+        "    if (b != null) {",
+        "      c.toString();",
+        "      d.toString();",
+        "    } else {",
+        "      Preconditions.checkNotNull(b);",
+        "       if (c != null) {",
+        "          d.toString();",
+        "       } else {",
+        "          Preconditions.checkNotNull(d);",
+        "       }",
+        "    }",
         "  }",
         "}");
   }


### PR DESCRIPTION
Using a different approach for param nullness analysis in jar-infer
• Pre-calculate all the params that are guaranteed to be non-null in each basic block ( Using the already existing checks)
• looks for a path from entry to exit that doesn't dereference the parameter, if it doesn't exist, it's `@NonNull`
• This covers all the cases from the current approach. Might take more time in execution than the current approach. `computeDerefParamList` uses this approach and `computeDerefParamListUsingPDom` uses the previous approach. Constant flag `USE_EXTENDED_APPROACH` can be used to switch these approaches. 

Added tests
