### PR TITLE
Fix @NullableDecl support

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -147,10 +147,8 @@ public enum Nullness implements AbstractValue<Nullness> {
   public static boolean isNullableAnnotation(String annotName) {
     return annotName.endsWith(".Nullable")
         // endsWith and not equals and no `org.`, because gradle's shadow plug in rewrites strings
-        // and will
-        // replace `org.checkerframework` with `shadow.checkerframework`. Yes, really... I assume
-        // it's something
-        // to handle reflection.
+        // and will replace `org.checkerframework` with `shadow.checkerframework`. Yes, really...
+        // I assume it's something to handle reflection.
         || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl");
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -146,7 +146,12 @@ public enum Nullness implements AbstractValue<Nullness> {
    */
   public static boolean isNullableAnnotation(String annotName) {
     return annotName.endsWith(".Nullable")
-        || annotName.equals("org.checkerframework.checker.nullness.compatqual.NullableDecl");
+        // endsWith and not equals and no `org.`, because gradle's shadow plug in rewrites strings
+        // and will
+        // replace `org.checkerframework` with `shadow.checkerframework`. Yes, really... I assume
+        // it's something
+        // to handle reflection.
+        || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl");
   }
 
   /**


### PR DESCRIPTION
This fixes a nasty little bug involving shadowing packages and string comparison.

Fun fact 1: We support "org.checkerframework.checker.nullness.compatqual.NullableDecl" as a Nullable annotation.
Fun Fact 2: We use "org.checkerframework" in NullAway but shade it as "shadow.checkerframework" in our release jar.
Fun Fact 3: The gradle shadow plug-in tries to be very clever, so it rewrites strings containing the package name, so reflection and the like keep working.

This means that, when producing a release jar for NullAway. This:

```
annotName.equals("org.checkerframework.checker.nullness.compatqual.NullableDecl")
```

Silently becomes this at runtime:

```
annotName.equals("shadow.checkerframework.checker.nullness.compatqual.NullableDecl")
```

Fun debugging times ensue.