### PR TITLE
Treat methods of final classes as final for initialization.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1673,7 +1673,10 @@ public class NullAway extends BugChecker
           MethodInvocationTree methodInvocationTree = (MethodInvocationTree) expressionTree;
           Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(methodInvocationTree);
           Set<Modifier> modifiers = symbol.getModifiers();
-          if ((symbol.isPrivate() || modifiers.contains(Modifier.FINAL))
+          Set<Modifier> classModifiers = enclosingClassSymbol.getModifiers();
+          if ((symbol.isPrivate()
+                  || modifiers.contains(Modifier.FINAL)
+                  || classModifiers.contains(Modifier.FINAL))
               && !symbol.isStatic()
               && !modifiers.contains(Modifier.NATIVE)) {
             // check it's the same class (could be an issue with inner classes)

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -158,6 +158,33 @@ public class CheckFieldInitNegativeCases {
     }
   }
 
+  final class T8 {
+
+    Object f;
+
+    @Initializer
+    public void init1() {
+      init();
+    }
+
+    public void init() {
+      f = new Object();
+    }
+  }
+
+  final class T9 {
+
+    Object f;
+
+    public T9() {
+      init();
+    }
+
+    public void init() {
+      f = new Object();
+    }
+  }
+
   abstract class Super {
 
     // to test known initializer methods


### PR DESCRIPTION
From the docs: 

> A field can also be initialized in a method called by the constructor, provided that the method is either private or final

We are currently only checking modifiers on the method itself, but if the class is `final` then all its methods are also `final` and should be considered as such for initialization checking.

See #323 
