### PR TITLE
Add support for @RecentlyNullable and @RecentlyNonNull

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -82,7 +82,7 @@ public abstract class AbstractConfig implements Config {
    */
   protected boolean treatGeneratedAsUnannotated;
 
-  protected boolean handleAndroidRecent;
+  protected boolean acknowledgeAndroidRecent;
 
   protected Set<MethodClassAndName> knownInitializers;
 
@@ -285,7 +285,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
-  public boolean handleAndroidRecent() {
-    return handleAndroidRecent;
+  public boolean acknowledgeAndroidRecent() {
+    return acknowledgeAndroidRecent;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -82,6 +82,8 @@ public abstract class AbstractConfig implements Config {
    */
   protected boolean treatGeneratedAsUnannotated;
 
+  protected boolean handleAndroidRecent;
+
   protected Set<MethodClassAndName> knownInitializers;
 
   protected Set<String> excludedClassAnnotations;
@@ -174,7 +176,7 @@ public abstract class AbstractConfig implements Config {
 
   @Override
   public boolean isExcludedFieldAnnotation(String annotationName) {
-    return Nullness.isNullableAnnotation(annotationName)
+    return Nullness.isNullableAnnotation(annotationName, this)
         || (fieldAnnotPattern != null && fieldAnnotPattern.matcher(annotationName).matches());
   }
 
@@ -280,5 +282,10 @@ public abstract class AbstractConfig implements Config {
   @Override
   public boolean treatGeneratedAsUnannotated() {
     return treatGeneratedAsUnannotated;
+  }
+
+  @Override
+  public boolean handleAndroidRecent() {
+    return handleAndroidRecent;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -170,5 +170,5 @@ public interface Config {
    * @return true if Android's {@code @RecentlyNullable} should be treated as {@code @Nullable}, and
    *     similarly for {@code @RecentlyNonNull}
    */
-  boolean handleAndroidRecent();
+  boolean acknowledgeAndroidRecent();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -165,4 +165,10 @@ public interface Config {
 
   /** @return true if generated code should be treated as unannotated */
   boolean treatGeneratedAsUnannotated();
+
+  /**
+   * @return true if Android's {@code @RecentlyNullable} should be treated as {@code @Nullable}, and
+   *     similarly for {@code @RecentlyNonNull}
+   */
+  boolean handleAndroidRecent();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -169,4 +169,9 @@ public class DummyOptionsConfig implements Config {
   public boolean treatGeneratedAsUnannotated() {
     throw new IllegalStateException(error_msg);
   }
+
+  @Override
+  public boolean handleAndroidRecent() {
+    throw new IllegalStateException(error_msg);
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -171,7 +171,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public boolean handleAndroidRecent() {
+  public boolean acknowledgeAndroidRecent() {
     throw new IllegalStateException(error_msg);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -156,7 +156,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
             .build();
     if (autofixSuppressionComment.contains("\n")) {
       throw new IllegalStateException(
-          "Invalid -XepOpt" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
+          "Invalid -XepOpt:" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
     }
     /** --- JarInfer configs --- */
     jarInferEnabled = flags.getBoolean(FL_JI_ENABLED).orElse(false);
@@ -169,9 +169,9 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     errorURL = flags.get(FL_ERROR_URL).orElse(DEFAULT_URL);
     if (acknowledgeAndroidRecent && !isAcknowledgeRestrictive) {
       throw new IllegalStateException(
-          "-XepOpt"
+          "-XepOpt:"
               + FL_ACKNOWLEDGE_ANDROID_RECENT
-              + " should only be set when -XepOpt"
+              + " should only be set when -XepOpt:"
               + FL_ACKNOWLEDGE_RESTRICTIVE
               + " is also set");
     }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -48,6 +48,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
       EP_FL_NAMESPACE + ":ExcludedClassAnnotations";
   static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
   static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
+  static final String FL_HANDLE_ANDROID_RECENT = EP_FL_NAMESPACE + ":HandleAndroidRecent";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
@@ -141,6 +142,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     handleTestAssertionLibraries =
         flags.getBoolean(FL_HANDLE_TEST_ASSERTION_LIBRARIES).orElse(false);
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
+    handleAndroidRecent = flags.getBoolean(FL_HANDLE_ANDROID_RECENT).orElse(false);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -48,7 +48,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
       EP_FL_NAMESPACE + ":ExcludedClassAnnotations";
   static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
   static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
-  static final String FL_HANDLE_ANDROID_RECENT = EP_FL_NAMESPACE + ":HandleAndroidRecent";
+  static final String FL_ACKNOWLEDGE_ANDROID_RECENT = EP_FL_NAMESPACE + ":AcknowledgeAndroidRecent";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
@@ -142,7 +142,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     handleTestAssertionLibraries =
         flags.getBoolean(FL_HANDLE_TEST_ASSERTION_LIBRARIES).orElse(false);
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
-    handleAndroidRecent = flags.getBoolean(FL_HANDLE_ANDROID_RECENT).orElse(false);
+    acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(
@@ -167,6 +167,14 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     jarInferRegexStripModelJarName = flags.get(FL_JI_REGEX_MODEL_PATH).orElse(BASENAME_REGEX);
     jarInferRegexStripCodeJarName = flags.get(FL_JI_REGEX_CODE_PATH).orElse(BASENAME_REGEX);
     errorURL = flags.get(FL_ERROR_URL).orElse(DEFAULT_URL);
+    if (acknowledgeAndroidRecent && !isAcknowledgeRestrictive) {
+      throw new IllegalStateException(
+          "-XepOpt"
+              + FL_ACKNOWLEDGE_ANDROID_RECENT
+              + " should only be set when -XepOpt"
+              + FL_ACKNOWLEDGE_RESTRICTIVE
+              + " is also set");
+    }
   }
 
   private static ImmutableSet<String> getFlagStringSet(ErrorProneFlags flags, String flagName) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -405,7 +405,7 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
 
-    if (Nullness.hasNullableAnnotation(assigned)) {
+    if (Nullness.hasNullableAnnotation(assigned, config)) {
       // field already annotated
       return Description.NO_MATCH;
     }
@@ -547,7 +547,7 @@ public class NullAway extends BugChecker
       boolean isFirstParamNull = false;
       // Two cases: for annotated code, look first at the annotation
       if (!NullabilityUtil.isUnannotated(overriddenMethod, config)) {
-        isFirstParamNull = Nullness.hasNullableAnnotation(superParamSymbols.get(0));
+        isFirstParamNull = Nullness.hasNullableAnnotation(superParamSymbols.get(0), config);
       }
       // For both annotated and unannotated code, look then at handler overrides (e.g. Library
       // Models)
@@ -586,7 +586,7 @@ public class NullAway extends BugChecker
       for (int i = startParam; i < superParamSymbols.size(); i++) {
         // we need to call paramHasNullableAnnotation here since overriddenMethod may be defined
         // in a class file
-        if (Nullness.paramHasNullableAnnotation(overriddenMethod, i)) {
+        if (Nullness.paramHasNullableAnnotation(overriddenMethod, i, config)) {
           builder.add(i);
         }
       }
@@ -604,7 +604,7 @@ public class NullAway extends BugChecker
           lambdaExpressionTree != null
               && NullabilityUtil.lambdaParamIsImplicitlyTyped(
                   lambdaExpressionTree.getParameters().get(methodParamInd));
-      if (!Nullness.hasNullableAnnotation(paramSymbol) && !implicitlyTypedLambdaParam) {
+      if (!Nullness.hasNullableAnnotation(paramSymbol, config) && !implicitlyTypedLambdaParam) {
         final String message =
             "parameter "
                 + paramSymbol.name.toString()
@@ -648,7 +648,7 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
     if (NullabilityUtil.isUnannotated(methodSymbol, config)
-        || Nullness.hasNullableAnnotation(methodSymbol)) {
+        || Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return Description.NO_MATCH;
     }
     if (mayBeNullExpr(state, retExpr)) {
@@ -738,11 +738,11 @@ public class NullAway extends BugChecker
                 && handler.onUnannotatedInvocationGetExplicitlyNonNullReturn(
                     overriddenMethod, false))
             || (!isOverridenMethodUnannotated
-                && !Nullness.hasNullableAnnotation(overriddenMethod)));
+                && !Nullness.hasNullableAnnotation(overriddenMethod, config)));
     // if the super method returns nonnull,
     // overriding method better not return nullable
     if (overriddenMethodReturnsNonNull
-        && Nullness.hasNullableAnnotation(overridingMethod)
+        && Nullness.hasNullableAnnotation(overridingMethod, config)
         && getComputedNullness(memberReferenceTree).equals(Nullness.NULLABLE)) {
       String message;
       if (memberReferenceTree != null) {
@@ -1311,7 +1311,7 @@ public class NullAway extends BugChecker
         }
         // we need to call paramHasNullableAnnotation here since the invoked method may be defined
         // in a class file
-        if (!Nullness.paramHasNullableAnnotation(methodSymbol, i)) {
+        if (!Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
           builder.add(i);
         }
       }
@@ -1945,7 +1945,7 @@ public class NullAway extends BugChecker
     if (NullabilityUtil.isUnannotated(exprSymbol, config)) {
       exprMayBeNull = false;
     }
-    if (!Nullness.hasNullableAnnotation(exprSymbol)) {
+    if (!Nullness.hasNullableAnnotation(exprSymbol, config)) {
       exprMayBeNull = false;
     }
     exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, state, exprMayBeNull);

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -186,7 +186,7 @@ public class NullabilityUtil {
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()
             || isUnannotated(symbol, config))
-        && Nullness.hasNullableAnnotation(symbol);
+        && Nullness.hasNullableAnnotation(symbol, config);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -152,7 +152,7 @@ public enum Nullness implements AbstractValue<Nullness> {
         // and will replace `org.checkerframework` with `shadow.checkerframework`. Yes, really...
         // I assume it's something to handle reflection.
         || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl")
-        || (config.handleAndroidRecent()
+        || (config.acknowledgeAndroidRecent()
             && annotName.equals("androidx.annotation.RecentlyNullable"));
   }
 
@@ -164,7 +164,7 @@ public enum Nullness implements AbstractValue<Nullness> {
     return annotName.endsWith(".NonNull")
         || annotName.endsWith(".NotNull")
         || annotName.endsWith(".Nonnull")
-        || (config.handleAndroidRecent()
+        || (config.acknowledgeAndroidRecent()
             && annotName.equals("androidx.annotation.RecentlyNonNull"));
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -128,73 +128,85 @@ public enum Nullness implements AbstractValue<Nullness> {
     return displayName;
   }
 
-  private static boolean hasNullableAnnotation(Stream<? extends AnnotationMirror> annotations) {
+  private static boolean hasNullableAnnotation(
+      Stream<? extends AnnotationMirror> annotations, Config config) {
     return annotations
         .map(anno -> anno.getAnnotationType().toString())
-        .anyMatch(Nullness::isNullableAnnotation);
+        .anyMatch(anno -> isNullableAnnotation(anno, config));
   }
 
-  private static boolean hasNonNullAnnotation(Stream<? extends AnnotationMirror> annotations) {
+  private static boolean hasNonNullAnnotation(
+      Stream<? extends AnnotationMirror> annotations, Config config) {
     return annotations
         .map(anno -> anno.getAnnotationType().toString())
-        .anyMatch(Nullness::isNonNullAnnotation);
+        .anyMatch(anno -> isNonNullAnnotation(anno, config));
   }
 
   /**
    * @param annotName annotation name
    * @return true if we treat annotName as a <code>@Nullable</code> annotation, false otherwise
    */
-  public static boolean isNullableAnnotation(String annotName) {
+  public static boolean isNullableAnnotation(String annotName, Config config) {
     return annotName.endsWith(".Nullable")
         // endsWith and not equals and no `org.`, because gradle's shadow plug in rewrites strings
         // and will replace `org.checkerframework` with `shadow.checkerframework`. Yes, really...
         // I assume it's something to handle reflection.
-        || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl");
+        || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl")
+        || (config.handleAndroidRecent()
+            && annotName.equals("androidx.annotation.RecentlyNullable"));
   }
 
   /**
    * @param annotName annotation name
    * @return true if we treat annotName as a <code>@NonNull</code> annotation, false otherwise
    */
-  public static boolean isNonNullAnnotation(String annotName) {
+  private static boolean isNonNullAnnotation(String annotName, Config config) {
     return annotName.endsWith(".NonNull")
         || annotName.endsWith(".NotNull")
-        || annotName.endsWith(".Nonnull");
+        || annotName.endsWith(".Nonnull")
+        || (config.handleAndroidRecent()
+            && annotName.equals("androidx.annotation.RecentlyNonNull"));
   }
 
   /**
    * Does the symbol have a {@code @NonNull} declaration or type-use annotation?
    *
    * <p>NOTE: this method does not work for checking all annotations of parameters of methods from
-   * class files. For that case, use {@link #paramHasNullableAnnotation(Symbol.MethodSymbol, int)}
+   * class files. For that case, use {@link #paramHasNullableAnnotation(Symbol.MethodSymbol, int,
+   * Config)}
    */
-  public static boolean hasNonNullAnnotation(Symbol symbol) {
-    return hasNonNullAnnotation(NullabilityUtil.getAllAnnotations(symbol));
+  public static boolean hasNonNullAnnotation(Symbol symbol, Config config) {
+    return hasNonNullAnnotation(NullabilityUtil.getAllAnnotations(symbol), config);
   }
 
   /**
    * Does the symbol have a {@code @Nullable} declaration or type-use annotation?
    *
    * <p>NOTE: this method does not work for checking all annotations of parameters of methods from
-   * class files. For that case, use {@link #paramHasNullableAnnotation(Symbol.MethodSymbol, int)}
+   * class files. For that case, use {@link #paramHasNullableAnnotation(Symbol.MethodSymbol, int,
+   * Config)}
    */
-  public static boolean hasNullableAnnotation(Symbol symbol) {
-    return hasNullableAnnotation(NullabilityUtil.getAllAnnotations(symbol));
+  public static boolean hasNullableAnnotation(Symbol symbol, Config config) {
+    return hasNullableAnnotation(NullabilityUtil.getAllAnnotations(symbol), config);
   }
 
   /**
    * Does the parameter of {@code symbol} at {@code paramInd} have a {@code @Nullable} declaration
    * or type-use annotation? This method works for methods defined in either source or class files.
    */
-  public static boolean paramHasNullableAnnotation(Symbol.MethodSymbol symbol, int paramInd) {
-    return hasNullableAnnotation(NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd));
+  public static boolean paramHasNullableAnnotation(
+      Symbol.MethodSymbol symbol, int paramInd, Config config) {
+    return hasNullableAnnotation(
+        NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd), config);
   }
 
   /**
    * Does the parameter of {@code symbol} at {@code paramInd} have a {@code @NonNull} declaration or
    * type-use annotation? This method works for methods defined in either source or class files.
    */
-  public static boolean paramHasNonNullAnnotation(Symbol.MethodSymbol symbol, int paramInd) {
-    return hasNonNullAnnotation(NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd));
+  public static boolean paramHasNonNullAnnotation(
+      Symbol.MethodSymbol symbol, int paramInd, Config config) {
+    return hasNonNullAnnotation(
+        NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd), config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -226,7 +226,7 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
       Nullness assumed;
       // we treat lambda parameters differently; they "inherit" the nullability of the
       // corresponding functional interface parameter, unless they are explicitly annotated
-      if (Nullness.hasNullableAnnotation((Symbol) element)) {
+      if (Nullness.hasNullableAnnotation((Symbol) element, config)) {
         assumed = NULLABLE;
       } else if (!NullabilityUtil.lambdaParamIsImplicitlyTyped(variableTree)) {
         // the parameter has a declared type with no @Nullable annotation
@@ -237,7 +237,10 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
           // assume parameter is non-null unless handler tells us otherwise
           assumed = nullableParamsFromHandler.contains(i) ? NULLABLE : NONNULL;
         } else {
-          assumed = Nullness.hasNullableAnnotation(fiMethodParameters.get(i)) ? NULLABLE : NONNULL;
+          assumed =
+              Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config)
+                  ? NULLABLE
+                  : NONNULL;
         }
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
@@ -253,7 +256,8 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
     NullnessStore.Builder result = envStore.toBuilder();
     for (LocalVariableNode param : parameters) {
       Element element = param.getElement();
-      Nullness assumed = Nullness.hasNullableAnnotation((Symbol) element) ? NULLABLE : NONNULL;
+      Nullness assumed =
+          Nullness.hasNullableAnnotation((Symbol) element, config) ? NULLABLE : NONNULL;
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }
     result = handler.onDataflowInitialStore(underlyingAST, parameters, result);
@@ -919,7 +923,7 @@ public class AccessPathNullnessPropagation implements TransferFunction<Nullness,
       nullness = input.getRegularStore().valueOfMethodCall(node, types, NULLABLE);
     } else if (node == null
         || methodReturnsNonNull.test(node)
-        || !Nullness.hasNullableAnnotation((Symbol) node.getTarget().getMethod())) {
+        || !Nullness.hasNullableAnnotation((Symbol) node.getTarget().getMethod(), config)) {
       // definite non-null return
       nullness = NONNULL;
     } else {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -58,7 +58,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
     HashSet<Integer> positions = new HashSet<Integer>();
     positions.addAll(nonNullPositions);
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
-      if (Nullness.paramHasNonNullAnnotation(methodSymbol, i)) {
+      if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
         positions.add(i);
       }
     }
@@ -76,7 +76,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
         if (config.treatGeneratedAsUnannotated() && NullabilityUtil.isGenerated(methodSymbol)) {
           return exprMayBeNull;
         } else {
-          return Nullness.hasNullableAnnotation(methodSymbol) || exprMayBeNull;
+          return Nullness.hasNullableAnnotation(methodSymbol, config) || exprMayBeNull;
         }
       } else {
         return exprMayBeNull;
@@ -93,7 +93,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
     HashSet<Integer> positions = new HashSet<Integer>();
     positions.addAll(explicitlyNullablePositions);
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
-      if (Nullness.paramHasNullableAnnotation(methodSymbol, i)) {
+      if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
         positions.add(i);
       }
     }
@@ -103,7 +103,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
   @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
       Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
-    return Nullness.hasNonNullAnnotation(methodSymbol) || explicitlyNonNullReturn;
+    return Nullness.hasNonNullAnnotation(methodSymbol, config) || explicitlyNonNullReturn;
   }
 
   @Override
@@ -117,7 +117,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       AccessPathNullnessPropagation.Updates bothUpdates) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(node.getTree());
     if (NullabilityUtil.isUnannotated(methodSymbol, config)
-        && Nullness.hasNullableAnnotation(methodSymbol)) {
+        && Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return NullnessHint.HINT_NULLABLE;
     }
     return NullnessHint.UNKNOWN;

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -36,6 +36,7 @@ tasks.withType(JavaCompile) {
     options.errorprone {
       check("NullAway", CheckSeverity.ERROR)
       option("NullAway:AnnotatedPackages", "com.uber")
+      option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }
   }
 }

--- a/test-java-lib/src/main/java/androidx/annotation/RecentlyNonNull.java
+++ b/test-java-lib/src/main/java/androidx/annotation/RecentlyNonNull.java
@@ -1,0 +1,14 @@
+package androidx.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** stub for testing */
+@Retention(CLASS)
+@Target({METHOD, PARAMETER, FIELD})
+public @interface RecentlyNonNull {}

--- a/test-java-lib/src/main/java/androidx/annotation/RecentlyNullable.java
+++ b/test-java-lib/src/main/java/androidx/annotation/RecentlyNullable.java
@@ -1,0 +1,14 @@
+package androidx.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** stub for testing */
+@Retention(CLASS)
+@Target({METHOD, PARAMETER, FIELD})
+public @interface RecentlyNullable {}

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/AndroidRecentlyAnnotatedClass.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/AndroidRecentlyAnnotatedClass.java
@@ -3,19 +3,7 @@ package com.uber.lib.unannotated;
 import androidx.annotation.RecentlyNonNull;
 import androidx.annotation.RecentlyNullable;
 
-// don't actually check this code
-@SuppressWarnings("NullAway")
 public class AndroidRecentlyAnnotatedClass {
-
-  public final Object field;
-
-  public AndroidRecentlyAnnotatedClass(Object field) {
-    this.field = field;
-  }
-
-  public @RecentlyNullable Object getField() {
-    return field;
-  }
 
   public static @RecentlyNullable Object returnsNull() {
     return null;
@@ -24,28 +12,4 @@ public class AndroidRecentlyAnnotatedClass {
   public static void consumesObjectNonNull(@RecentlyNonNull Object o) {}
 
   public static void consumesObjectUnannotated(Object o) {}
-
-  public void acceptsNonNull(@RecentlyNonNull Object o) {}
-
-  public void acceptsNonNull2(@RecentlyNonNull Object o) {}
-
-  public void acceptsNullable(@RecentlyNullable Object o) {}
-
-  public void acceptsNullable2(@RecentlyNullable Object o) {}
-
-  public @RecentlyNonNull Object returnsNonNull() {
-    return new Object();
-  }
-
-  public @RecentlyNonNull Object returnsNonNull2() {
-    return new Object();
-  }
-
-  public @RecentlyNullable Object returnsNullable() {
-    return null;
-  }
-
-  public @RecentlyNullable Object returnsNullable2() {
-    return null;
-  }
 }

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/AndroidRecentlyAnnotatedClass.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/AndroidRecentlyAnnotatedClass.java
@@ -1,0 +1,51 @@
+package com.uber.lib.unannotated;
+
+import androidx.annotation.RecentlyNonNull;
+import androidx.annotation.RecentlyNullable;
+
+// don't actually check this code
+@SuppressWarnings("NullAway")
+public class AndroidRecentlyAnnotatedClass {
+
+  public final Object field;
+
+  public AndroidRecentlyAnnotatedClass(Object field) {
+    this.field = field;
+  }
+
+  public @RecentlyNullable Object getField() {
+    return field;
+  }
+
+  public static @RecentlyNullable Object returnsNull() {
+    return null;
+  }
+
+  public static void consumesObjectNonNull(@RecentlyNonNull Object o) {}
+
+  public static void consumesObjectUnannotated(Object o) {}
+
+  public void acceptsNonNull(@RecentlyNonNull Object o) {}
+
+  public void acceptsNonNull2(@RecentlyNonNull Object o) {}
+
+  public void acceptsNullable(@RecentlyNullable Object o) {}
+
+  public void acceptsNullable2(@RecentlyNullable Object o) {}
+
+  public @RecentlyNonNull Object returnsNonNull() {
+    return new Object();
+  }
+
+  public @RecentlyNonNull Object returnsNonNull2() {
+    return new Object();
+  }
+
+  public @RecentlyNullable Object returnsNullable() {
+    return null;
+  }
+
+  public @RecentlyNullable Object returnsNullable2() {
+    return null;
+  }
+}


### PR DESCRIPTION
If the new `-XepOpt:Nullaway:AcknowledgeAndroidRecent` flag is set to `true` *and* `-XepOpt:Nullaway:AcknowledgeRestrictiveAnnotations` is set to `true`, we treat `@RecentlyNullable` as `@Nullable`, and similarly for `@RecentlyNonNull`.  We require both flags since at this point it doesn't seem to make sense to treat the Android libraries as being fully annotated according to NullAway defaults.

The change is mostly straightforward; we just need to pass a `Config` object into a few more routines.

Fixes #331 