### PR TITLE
[JarInfer] Don't compute frames on bytecode writting.

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -110,7 +110,7 @@ public final class BytecodeAnnotator extends ClassVisitor implements Opcodes {
       MethodReturnAnnotations nullableReturns)
       throws IOException {
     ClassReader cr = new ClassReader(is);
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+    ClassWriter cw = new ClassWriter(0);
     BytecodeAnnotator bytecodeAnnotator = new BytecodeAnnotator(cw, nonnullParams, nullableReturns);
     cr.accept(bytecodeAnnotator, 0);
     os.write(cw.toByteArray());


### PR DESCRIPTION
Passing the `ClassWriter.COMPUTE_FRAMES` means that ASM must do things like resolve super types, which might involve classes neither in the  processed jar, nor the classpath for the JarInfer tool. We don't actually need this flag as we are only adding annotations, not modifying the number or types or arguments or locals. If we ever do need to compute frame sizes, we might need to do so manually.