### PR TITLE
[JarInfer] Use exact jar output path when possible

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -162,7 +162,16 @@ public class DefinitelyDerefedParamsDriver {
     for (String inPath : setInPaths) {
       analyzeFile(pkgName, inPath);
       if (this.annotateBytecode) {
-        writeAnnotations(inPath, outPath);
+        String outFile = outPath;
+        if (setInPaths.size() > 1) {
+          outFile =
+              outPath
+                  + "/"
+                  + FilenameUtils.getBaseName(inPath)
+                  + "-annotated."
+                  + FilenameUtils.getExtension(inPath);
+        }
+        writeAnnotations(inPath, outFile);
       }
     }
     if (!this.annotateBytecode) {
@@ -393,16 +402,10 @@ public class DefinitelyDerefedParamsDriver {
         inPath.endsWith(".jar") || inPath.endsWith(".class"), "invalid input path - " + inPath);
     LOG(DEBUG, "DEBUG", "Writing Annotations to " + outPath);
 
-    String outFile;
+    new File(outPath).getParentFile().mkdirs();
     if (inPath.endsWith(".jar")) {
-      outFile =
-          outPath
-              + "/"
-              + FilenameUtils.getBaseName(inPath)
-              + "-annotated."
-              + FilenameUtils.getExtension(inPath);
       JarFile jar = new JarFile(inPath);
-      JarOutputStream jarOS = new JarOutputStream(new FileOutputStream(outFile));
+      JarOutputStream jarOS = new JarOutputStream(new FileOutputStream(outPath));
       BytecodeAnnotator.annotateBytecodeInJar(jar, jarOS, nonnullParams, nullableReturns, DEBUG);
       jarOS.close();
     } else if (inPath.endsWith(".aar")) {

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -109,11 +109,11 @@ public class JarInferTest {
       Map<String, String> expectedToActualAnnotationsMap)
       throws Exception {
     String outputFolderPath = outputFolder.newFolder(pkg).getAbsolutePath();
-    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
-    driver.runAndAnnotate(inputJarPath, "", outputFolderPath);
-
     String inputJarName = FilenameUtils.getBaseName(inputJarPath);
     String outputJarPath = outputFolderPath + "/" + inputJarName + "-annotated.jar";
+    DefinitelyDerefedParamsDriver driver = new DefinitelyDerefedParamsDriver();
+    driver.runAndAnnotate(inputJarPath, "", outputJarPath);
+
     Assert.assertTrue(
         testName + ": generated jar does not match the expected jar!",
         AnnotationChecker.checkMethodAnnotationsInJar(


### PR DESCRIPTION
With this, the `-o` parameter to jarinfer is always treated as the exact path to an output jar file when the input (`-i`) is a single jar. When operating on bytecode rewriting mode with multiple input jars, the path passed to `-o` is treated as a directory. This allows the caller to know exactly where the output jar will be written to on the first case, and still gracefully supports the second.