### PR TITLE
Avoid adding redundant annotations during bytecode rewriting in JarInfer

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,6 +33,7 @@ def apt = [
 
 def build = [
     asm                     : "org.ow2.asm:asm:${versions.asm}",
+    asmTree                 : "org.ow2.asm:asm-tree:${versions.asm}",
     errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProneApi}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     compile deps.build.asm
+    compile deps.build.asmTree
     compile deps.build.wala
     compile deps.build.guava
     compile deps.build.commonsIO

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -88,7 +88,7 @@ public final class BytecodeAnnotator {
           LOG(
               debug,
               "DEBUG",
-              "Added nullable parameter annotation for #" + param + " in " + methodSignature);
+              "Added nonnull parameter annotation for #" + param + " in " + methodSignature);
         }
       }
     }

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -30,13 +31,14 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
 
 /** Annotates the given methods and method parameters with the specified annotations using ASM. */
-public final class BytecodeAnnotator extends ClassVisitor implements Opcodes {
+public final class BytecodeAnnotator {
   private static boolean debug = false;
 
   private static void LOG(boolean cond, String tag, String msg) {
@@ -46,65 +48,14 @@ public final class BytecodeAnnotator extends ClassVisitor implements Opcodes {
   public static final String javaxNullableDesc = "Ljavax/annotation/Nullable;";
   public static final String javaxNonnullDesc = "Ljavax/annotation/Nonnull;";
 
-  private final MethodParamAnnotations nullableParams;
-  private final MethodReturnAnnotations nullableReturns;
-
-  private String className = "";
-
-  public BytecodeAnnotator(
-      ClassVisitor cv,
-      MethodParamAnnotations nullableParams,
-      MethodReturnAnnotations nullableReturns) {
-    super(ASM7, cv);
-    this.nullableParams = nullableParams;
-    this.nullableReturns = nullableReturns;
-  }
-
-  @Override
-  public void visit(
-      final int version,
-      final int access,
-      final String name,
-      final String signature,
-      final String superName,
-      final String[] interfaces) {
-    className = name.replace('/', '.');
-    if (cv != null) {
-      cv.visit(version, access, name, signature, superName, interfaces);
-    }
-  }
-
-  @Override
-  public MethodVisitor visitMethod(
-      final int access,
-      final String name,
-      final String desc,
-      final String signature,
-      final String[] exceptions) {
-    MethodVisitor mv = cv.visitMethod(access, name, desc, signature, exceptions);
-    LOG(debug, "DEBUG", "ClassName: " + className);
-    LOG(debug, "DEBUG", "visited method - " + name + " desc: " + desc + " sign: " + signature);
-    String methodSignature = className + "." + name + desc;
-    if (mv != null) {
-      if (nullableReturns.contains(methodSignature)) {
-        // Add a @Nullable annotation on this method to indicate that the method can return null.
-        mv.visitAnnotation(javaxNullableDesc, true);
-        LOG(debug, "DEBUG", "Added nullable return annotation for " + methodSignature);
-      }
-      Set<Integer> params = nullableParams.get(methodSignature);
-      if (params != null) {
-        boolean isStatic = (access & Opcodes.ACC_STATIC) != 0;
-        for (Integer param : params) {
-          // Add a @Nonnull annotation on this parameter.
-          mv.visitParameterAnnotation(isStatic ? param : param - 1, javaxNonnullDesc, true);
-          LOG(
-              debug,
-              "DEBUG",
-              "Added nullable parameter annotation for #" + param + " in " + methodSignature);
-        }
+  private static void addAnnotationIfNotPresent(
+      List<AnnotationNode> annotationList, String annotation) {
+    for (AnnotationNode node : annotationList) {
+      if (node.desc.equals(annotation)) {
+        return;
       }
     }
-    return mv;
+    annotationList.add(new AnnotationNode(Opcodes.ASM7, annotation));
   }
 
   private static void annotateBytecode(
@@ -115,8 +66,34 @@ public final class BytecodeAnnotator extends ClassVisitor implements Opcodes {
       throws IOException {
     ClassReader cr = new ClassReader(is);
     ClassWriter cw = new ClassWriter(0);
-    BytecodeAnnotator bytecodeAnnotator = new BytecodeAnnotator(cw, nonnullParams, nullableReturns);
-    cr.accept(bytecodeAnnotator, 0);
+    ClassNode cn = new ClassNode(Opcodes.ASM7);
+    cr.accept(cn, 0);
+
+    String className = cn.name.replace('/', '.');
+    List<MethodNode> methods = cn.methods;
+    for (MethodNode method : methods) {
+      String methodSignature = className + "." + method.name + method.desc;
+      if (nullableReturns.contains(methodSignature)) {
+        // Add a @Nullable annotation on this method to indicate that the method can return null.
+        addAnnotationIfNotPresent(method.visibleAnnotations, javaxNullableDesc);
+        LOG(debug, "DEBUG", "Added nullable return annotation for " + methodSignature);
+      }
+      Set<Integer> params = nonnullParams.get(methodSignature);
+      if (params != null) {
+        boolean isStatic = (method.access & Opcodes.ACC_STATIC) != 0;
+        for (Integer param : params) {
+          int paramNum = isStatic ? param : param - 1;
+          // Add a @Nonnull annotation on this parameter.
+          addAnnotationIfNotPresent(method.visibleParameterAnnotations[paramNum], javaxNonnullDesc);
+          LOG(
+              debug,
+              "DEBUG",
+              "Added nullable parameter annotation for #" + param + " in " + methodSignature);
+        }
+      }
+    }
+
+    cn.accept(cw);
     os.write(cw.toByteArray());
   }
 

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
@@ -105,7 +105,8 @@ public class AnnotationChecker {
 
     for (MethodNode method : cn.methods) {
       if (!checkExpectedAnnotations(method.visibleAnnotations, expectedToActualAnnotations)) {
-        System.out.println("Error: Expected annotations not found on method " + method.name);
+        System.out.println(
+            "Error: Invalid / Unexpected annotations found on method '" + method.name + "'");
         return false;
       }
       List<AnnotationNode>[] paramAnnotations = method.visibleParameterAnnotations;
@@ -113,7 +114,9 @@ public class AnnotationChecker {
       for (List<AnnotationNode> annotations : paramAnnotations) {
         if (!checkExpectedAnnotations(annotations, expectedToActualAnnotations)) {
           System.out.println(
-              "Error: Expected annotations not found in a parameter of " + method.name);
+              "Error: Invalid / Unexpected annotations found in a parameter of method '"
+                  + method.name
+                  + "'.");
           return false;
         }
       }
@@ -138,19 +141,35 @@ public class AnnotationChecker {
   private static boolean checkExpectedAnnotation(
       List<AnnotationNode> annotations, String expectAnnotation, String actualAnnotation) {
     if (containsAnnotation(annotations, expectAnnotation)) {
-      return containsAnnotation(annotations, actualAnnotation);
+      int numAnnotationsFound = countAnnotations(annotations, actualAnnotation);
+      if (numAnnotationsFound != 1) {
+        System.out.println(
+            "Error: Annotation '"
+                + actualAnnotation
+                + "' was found "
+                + numAnnotationsFound
+                + " times.");
+        return false;
+      }
+      return true;
     }
     return !containsAnnotation(annotations, actualAnnotation);
   }
 
   // Returns true iff `annotation` is found in the list `annotations`, false otherwise.
   private static boolean containsAnnotation(List<AnnotationNode> annotations, String annotation) {
-    if (annotations == null) return false;
+    return countAnnotations(annotations, annotation) > 0;
+  }
+
+  // Returns the number of times 'annotation' is present in the list 'annotations'.
+  private static int countAnnotations(List<AnnotationNode> annotations, String annotation) {
+    if (annotations == null) return 0;
+    int count = 0;
     for (AnnotationNode annotationNode : annotations) {
       if (annotationNode.desc.equals(annotation)) {
-        return true;
+        count++;
       }
     }
-    return false;
+    return count;
   }
 }

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -36,4 +36,9 @@ jar.doLast {
         commandLine "jar", "uf", "test-java-lib-jarinfer.jar", astubxPath
     }
 }
+
+dependencies {
+    implementation deps.build.jsr305Annotations
+}
+
 jar.dependsOn ":jar-infer:jar-infer-cli:assemble"

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/Toys.java
@@ -2,6 +2,7 @@ package com.uber.nullaway.jarinfer.toys.unannotated;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import javax.annotation.Nonnull;
 
 @Retention(RetentionPolicy.RUNTIME)
 @interface ExpectNullable {}
@@ -53,7 +54,7 @@ public class Toys {
     return str;
   }
 
-  public static void test(@ExpectNonnull String s, Foo f, @ExpectNonnull Bar b) {
+  public static void test(@ExpectNonnull @Nonnull String s, Foo f, @ExpectNonnull Bar b) {
     if (s.length() >= 5) {
       Foo f1 = new Foo(s);
       f1.run(s);


### PR DESCRIPTION
Issue #340

This change adds annotations to methods and method parameters only if the same annotations are not already present on them. However, if the same annotations are already present, **no** error is reported. 

This is done using the ASM Tree API (whereas the earlier version was using the ASM visitor API).

The unit test is also updated to test this particular scenario.