### PR TITLE
Handle cases when there are no annotations on methods or parameters in JarInfer

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -76,9 +76,10 @@ public final class BytecodeAnnotator {
       if (nullableReturns.contains(methodSignature)) {
         // Add a @Nullable annotation on this method to indicate that the method can return null.
         if (method.visibleAnnotations == null) {
-          method.visitAnnotation(method.desc, true);
+          method.visitAnnotation(javaxNullableDesc, true);
+        } else {
+          addAnnotationIfNotPresent(method.visibleAnnotations, javaxNullableDesc);
         }
-        addAnnotationIfNotPresent(method.visibleAnnotations, javaxNullableDesc);
         LOG(debug, "DEBUG", "Added nullable return annotation for " + methodSignature);
       }
       Set<Integer> params = nonnullParams.get(methodSignature);
@@ -90,9 +91,11 @@ public final class BytecodeAnnotator {
           if (method.visibleParameterAnnotations == null
               || method.visibleParameterAnnotations.length < paramNum
               || method.visibleParameterAnnotations[paramNum] == null) {
-            method.visitParameterAnnotation(paramNum, method.desc, true);
+            method.visitParameterAnnotation(paramNum, javaxNonnullDesc, true);
+          } else {
+            addAnnotationIfNotPresent(
+                method.visibleParameterAnnotations[paramNum], javaxNonnullDesc);
           }
-          addAnnotationIfNotPresent(method.visibleParameterAnnotations[paramNum], javaxNonnullDesc);
           LOG(
               debug,
               "DEBUG",

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -75,6 +75,9 @@ public final class BytecodeAnnotator {
       String methodSignature = className + "." + method.name + method.desc;
       if (nullableReturns.contains(methodSignature)) {
         // Add a @Nullable annotation on this method to indicate that the method can return null.
+        if (method.visibleAnnotations == null) {
+          method.visitAnnotation(method.desc, true);
+        }
         addAnnotationIfNotPresent(method.visibleAnnotations, javaxNullableDesc);
         LOG(debug, "DEBUG", "Added nullable return annotation for " + methodSignature);
       }
@@ -84,6 +87,11 @@ public final class BytecodeAnnotator {
         for (Integer param : params) {
           int paramNum = isStatic ? param : param - 1;
           // Add a @Nonnull annotation on this parameter.
+          if (method.visibleParameterAnnotations == null
+              || method.visibleParameterAnnotations.length < paramNum
+              || method.visibleParameterAnnotations[paramNum] == null) {
+            method.visitParameterAnnotation(paramNum, method.desc, true);
+          }
           addAnnotationIfNotPresent(method.visibleParameterAnnotations[paramNum], javaxNonnullDesc);
           LOG(
               debug,

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
@@ -131,7 +131,7 @@ public class AnnotationChecker {
   }
 
   // If the given method matches the expected test method name 'expectNullable', check if the method
-  // has the 'javaxNullableDesc' annotation on it exactly once.
+  // has the 'javax.annotation.Nullable' annotation on it exactly once.
   private static boolean checkTestMethodAnnotation(MethodNode method) {
     if (method.name.equals(expectNullableMethod)) {
       return countAnnotations(method.visibleAnnotations, BytecodeAnnotator.javaxNullableDesc) == 1;
@@ -140,10 +140,8 @@ public class AnnotationChecker {
   }
 
   // If the given method matches the expected test method name 'expectNonnull', check if all the
-  // parameters
-  // of the method has the 'javaxNonnullDesc' annotation on it exactly once. All such methods are
-  // also
-  // expected to have at least one parameter with this annotation.
+  // parameters of the method has the 'javax.annotation.Nonnull' annotation on it exactly once.
+  // All such methods are also  expected to have at least one parameter with this annotation.
   private static boolean checkTestMethodParamAnnotation(MethodNode method) {
     if (method.name.equals(expectNonnullParamsMethod)) {
       int numParameters = Type.getArgumentTypes(method.desc).length;

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
@@ -109,7 +109,7 @@ public class AnnotationChecker {
 
     for (MethodNode method : cn.methods) {
       if (!checkExpectedAnnotations(method.visibleAnnotations, expectedToActualAnnotations)
-          && !checkTestMethodAnnotation(method)) {
+          && !checkTestMethodAnnotationByName(method)) {
         System.out.println(
             "Error: Invalid / Unexpected annotations found on method '" + method.name + "'");
         return false;
@@ -118,7 +118,7 @@ public class AnnotationChecker {
       if (paramAnnotations == null) continue;
       for (List<AnnotationNode> annotations : paramAnnotations) {
         if (!checkExpectedAnnotations(annotations, expectedToActualAnnotations)
-            && !checkTestMethodParamAnnotation(method)) {
+            && !checkTestMethodParamAnnotationByName(method)) {
           System.out.println(
               "Error: Invalid / Unexpected annotations found in a parameter of method '"
                   + method.name
@@ -130,19 +130,30 @@ public class AnnotationChecker {
     return true;
   }
 
-  // If the given method matches the expected test method name 'expectNullable', check if the method
-  // has the 'javax.annotation.Nullable' annotation on it exactly once.
-  private static boolean checkTestMethodAnnotation(MethodNode method) {
+  /**
+   * If the given method matches the expected test method name 'expectNullable', check if the method
+   * has the 'javax.annotation.Nullable' annotation on it exactly once.
+   *
+   * @param method method to be checked.
+   * @return True if 'javax.annotation.Nullable' is present exactly once on all matching methods.
+   */
+  private static boolean checkTestMethodAnnotationByName(MethodNode method) {
     if (method.name.equals(expectNullableMethod)) {
       return countAnnotations(method.visibleAnnotations, BytecodeAnnotator.javaxNullableDesc) == 1;
     }
     return true;
   }
 
-  // If the given method matches the expected test method name 'expectNonnull', check if all the
-  // parameters of the method has the 'javax.annotation.Nonnull' annotation on it exactly once.
-  // All such methods are also  expected to have at least one parameter with this annotation.
-  private static boolean checkTestMethodParamAnnotation(MethodNode method) {
+  /**
+   * If the given method matches the expected test method name 'expectNonnull', check if all the
+   * parameters of the method has the 'javax.annotation.Nonnull' annotation on it exactly once. All
+   * such methods are also expected to have at least one parameter with this annotation.
+   *
+   * @param method method to be checked.
+   * @return True if 'javax.annotation.Nonnull' is present exactly once on all the parameters of
+   *     matching methods.
+   */
+  private static boolean checkTestMethodParamAnnotationByName(MethodNode method) {
     if (method.name.equals(expectNonnullParamsMethod)) {
       int numParameters = Type.getArgumentTypes(method.desc).length;
       if (numParameters == 0

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
@@ -30,9 +30,13 @@ import jdk.internal.org.objectweb.asm.ClassReader;
 import jdk.internal.org.objectweb.asm.tree.AnnotationNode;
 import jdk.internal.org.objectweb.asm.tree.ClassNode;
 import jdk.internal.org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.Type;
 
 /** Class to check if the methods in the given class / jar files have the expected annotations. */
 public class AnnotationChecker {
+  private static final String expectNullableMethod = "expectNullable";
+  private static final String expectNonnullParamsMethod = "expectNonnull";
+
   /**
    * Checks if the given aar file contains the expected annotations. The annotations that are
    * expected are specified in the form of a map. For example: map = {"ExpectNullable;",
@@ -104,7 +108,8 @@ public class AnnotationChecker {
     cr.accept(cn, 0);
 
     for (MethodNode method : cn.methods) {
-      if (!checkExpectedAnnotations(method.visibleAnnotations, expectedToActualAnnotations)) {
+      if (!checkExpectedAnnotations(method.visibleAnnotations, expectedToActualAnnotations)
+          && !checkTestMethodAnnotation(method)) {
         System.out.println(
             "Error: Invalid / Unexpected annotations found on method '" + method.name + "'");
         return false;
@@ -112,11 +117,43 @@ public class AnnotationChecker {
       List<AnnotationNode>[] paramAnnotations = method.visibleParameterAnnotations;
       if (paramAnnotations == null) continue;
       for (List<AnnotationNode> annotations : paramAnnotations) {
-        if (!checkExpectedAnnotations(annotations, expectedToActualAnnotations)) {
+        if (!checkExpectedAnnotations(annotations, expectedToActualAnnotations)
+            && !checkTestMethodParamAnnotation(method)) {
           System.out.println(
               "Error: Invalid / Unexpected annotations found in a parameter of method '"
                   + method.name
                   + "'.");
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // If the given method matches the expected test method name 'expectNullable', check if the method
+  // has the 'javaxNullableDesc' annotation on it exactly once.
+  private static boolean checkTestMethodAnnotation(MethodNode method) {
+    if (method.name.equals(expectNullableMethod)) {
+      return countAnnotations(method.visibleAnnotations, BytecodeAnnotator.javaxNullableDesc) == 1;
+    }
+    return true;
+  }
+
+  // If the given method matches the expected test method name 'expectNonnull', check if all the
+  // parameters
+  // of the method has the 'javaxNonnullDesc' annotation on it exactly once. All such methods are
+  // also
+  // expected to have at least one parameter with this annotation.
+  private static boolean checkTestMethodParamAnnotation(MethodNode method) {
+    if (method.name.equals(expectNonnullParamsMethod)) {
+      int numParameters = Type.getArgumentTypes(method.desc).length;
+      if (numParameters == 0
+          || method.visibleParameterAnnotations == null
+          || method.visibleParameterAnnotations.length < numParameters) {
+        return false;
+      }
+      for (List<AnnotationNode> annotations : method.visibleParameterAnnotations) {
+        if (countAnnotations(annotations, BytecodeAnnotator.javaxNonnullDesc) != 1) {
           return false;
         }
       }

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/Toys.java
@@ -24,6 +24,21 @@ class Foo {
     }
     return false;
   }
+
+  // This method is expected to have a 'Nullable' annotation
+  // on the result.
+  public static String expectNullable(int x, String str) {
+    if (x < 10) {
+      return null;
+    }
+    return str;
+  }
+
+  // This method is expected to have a 'Nonnull' annotation on
+  // its parameter.
+  public static int expectNonnull(String str) {
+    return str.length();
+  }
 }
 
 class Bar {


### PR DESCRIPTION
Issue #341 

When there are no annotations on the methods or parameters of methods, the corresponding field in `MethodNode` would be `null`. This change handles those cases appropriately. 

Since the testing strategy used here is to have 'Expect*' annotations wherever actual annotations are expected, we cannot use the same to test this particular scenario. So, this change expands the test to look for methods with specific names, e.g. `expectNullable`, `expectNonnull`, and check that they have appropriate annotations.