### PR TITLE
Optional get call on assignment gives a correct warning

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1119,12 +1119,15 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
     VarSymbol symbol = ASTHelpers.getSymbol(tree);
+
     if (symbol.type.isPrimitive() && tree.getInitializer() != null) {
       return doUnboxingCheck(state, tree.getInitializer());
     }
-    if (!symbol.getKind().equals(ElementKind.FIELD)) {
+    if (!symbol.getKind().equals(ElementKind.FIELD)
+        && !handler.isMethodInvocationForOptionalGet(tree.getInitializer(), state)) {
       return Description.NO_MATCH;
     }
+
     ExpressionTree initializer = tree.getInitializer();
     if (initializer != null) {
       if (!symbol.type.isPrimitive() && !skipDueToFieldAnnotation(symbol)) {
@@ -1133,6 +1136,7 @@ public class NullAway extends BugChecker
               new ErrorMessage(
                   MessageTypes.ASSIGN_FIELD_NULLABLE,
                   "assigning @Nullable expression to @NonNull field");
+          handler.onPrepareErrorMessage(initializer, state, errorMessage);
           return errorBuilder.createErrorDescriptionForNullAssignment(
               errorMessage, initializer, state.getPath(), buildDescription(tree));
         }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1124,7 +1124,7 @@ public class NullAway extends BugChecker
       return doUnboxingCheck(state, tree.getInitializer());
     }
     if (!symbol.getKind().equals(ElementKind.FIELD)
-        && !handler.isMethodInvocationForOptionalGet(tree.getInitializer(), state)) {
+        && !handler.isMethodInvocationForOptionalGet(tree.getInitializer(), state.getTypes())) {
       return Description.NO_MATCH;
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -176,6 +176,11 @@ abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+    return false;
+  }
+
+  @Override
   public boolean includeApInfoInSavedContext(AccessPath accessPath, VisitorState state) {
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -176,7 +176,7 @@ abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, Types types) {
     return false;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -211,10 +211,10 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, Types types) {
     boolean isOptionalGetInvocation = false;
     for (Handler h : handlers) {
-      isOptionalGetInvocation |= h.isMethodInvocationForOptionalGet(expr, state);
+      isOptionalGetInvocation |= h.isMethodInvocationForOptionalGet(expr, types);
     }
     return isOptionalGetInvocation;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -211,6 +211,15 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+    boolean isOptionalGetInvocation = false;
+    for (Handler h : handlers) {
+      isOptionalGetInvocation |= h.isMethodInvocationForOptionalGet(expr, state);
+    }
+    return isOptionalGetInvocation;
+  }
+
+  @Override
   public void onPrepareErrorMessage(
       ExpressionTree expr, VisitorState state, ErrorMessage errorMessage) {
     for (Handler h : handlers) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -286,10 +286,10 @@ public interface Handler {
    * Called to check if the expression is a get call on {@link java.util.Optional}.
    *
    * @param expr The AST node for the expression being matched.
-   * @param state The current visitor state.
+   * @param types The current types.
    * @return true if the expression is a method call to Optional get.
    */
-  boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state);
+  boolean isMethodInvocationForOptionalGet(ExpressionTree expr, Types types);
 
   /**
    * Called when the store access paths are filtered for local variable information before an

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -283,6 +283,15 @@ public interface Handler {
   void onPrepareErrorMessage(ExpressionTree expr, VisitorState state, ErrorMessage errorMessage);
 
   /**
+   * Called to check if the expression is a get call on {@link java.util.Optional}.
+   *
+   * @param expr The AST node for the expression being matched.
+   * @param state The current visitor state.
+   * @return true if the expression is a method call to Optional get.
+   */
+  boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state);
+
+  /**
    * Called when the store access paths are filtered for local variable information before an
    * expression.
    *

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -62,8 +62,7 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
   @Override
   public boolean onOverrideMayBeNullExpr(
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
-    if (expr.getKind() == Tree.Kind.METHOD_INVOCATION
-        && optionalIsGetCall((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
+    if (isMethodInvocationForOptionalGet(expr, state)) {
       return true;
     }
     return exprMayBeNull;
@@ -108,8 +107,7 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
   @Override
   public void onPrepareErrorMessage(
       ExpressionTree expr, VisitorState state, ErrorMessage errorMessage) {
-    if (expr.getKind() == Tree.Kind.METHOD_INVOCATION
-        && optionalIsGetCall((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes())) {
+    if (isMethodInvocationForOptionalGet(expr, state)) {
       final int exprStringSize = expr.toString().length();
       // Name of the optional is extracted from the expression
       final String message =
@@ -118,6 +116,13 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
               + " can be empty, dereferenced get() call on it";
       errorMessage.updateErrorMessage(ErrorMessage.MessageTypes.GET_ON_EMPTY_OPTIONAL, message);
     }
+  }
+
+  @Override
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+    return expr != null
+        && expr.getKind() == Tree.Kind.METHOD_INVOCATION
+        && optionalIsGetCall((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes());
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -62,7 +62,7 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
   @Override
   public boolean onOverrideMayBeNullExpr(
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
-    if (isMethodInvocationForOptionalGet(expr, state)) {
+    if (isMethodInvocationForOptionalGet(expr, state.getTypes())) {
       return true;
     }
     return exprMayBeNull;
@@ -107,7 +107,7 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
   @Override
   public void onPrepareErrorMessage(
       ExpressionTree expr, VisitorState state, ErrorMessage errorMessage) {
-    if (isMethodInvocationForOptionalGet(expr, state)) {
+    if (isMethodInvocationForOptionalGet(expr, state.getTypes())) {
       final int exprStringSize = expr.toString().length();
       // Name of the optional is extracted from the expression
       final String message =
@@ -119,10 +119,10 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, VisitorState state) {
+  public boolean isMethodInvocationForOptionalGet(ExpressionTree expr, Types types) {
     return expr != null
         && expr.getKind() == Tree.Kind.METHOD_INVOCATION
-        && optionalIsGetCall((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), state.getTypes());
+        && optionalIsGetCall((Symbol.MethodSymbol) ASTHelpers.getSymbol(expr), types);
   }
 
   @Override

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1778,6 +1778,75 @@ public class NullAwayTest {
   }
 
   @Test
+  public void OptionalEmptinessAssignmentCheckPositiveTest() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true"))
+        .addSourceLines(
+            "TestPositive.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Function;",
+            "public class TestPositive {",
+            "  void foo() {",
+            "    Optional<Object> a = Optional.empty();",
+            "    // BUG: Diagnostic contains: Optional a can be empty",
+            "    Object x = a.get();",
+            "  }",
+            "   public void lambdaConsumer(Function a){",
+            "        return;",
+            "   }",
+            "  void bar() {",
+            "     Optional<Object> b = Optional.empty();",
+            "    // BUG: Diagnostic contains: Optional b can be empty",
+            "     lambdaConsumer(v -> {Object x = b.get();  return \"irrelevant\";});",
+            "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void OptionalEmptinessAssignmentCheckNegativeTest() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true"))
+        .addSourceLines(
+            "TestPositive.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Function;",
+            "public class TestPositive {",
+            "  void foo() {",
+            "    Optional<Object> a = Optional.empty();",
+            "    Object x = a.isPresent() ? a.get() : \"something\";",
+            "    x.toString();",
+            "  }",
+            "   public void lambdaConsumer(Function a){",
+            "        return;",
+            "   }",
+            "  void bar() {",
+            "     Optional<Object> b = Optional.empty();",
+            "      if(b.isPresent()){",
+            "          lambdaConsumer(v -> b.get().toString());",
+            "       }",
+            "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void OptionalEmptinessRxPositiveTest() {
     compilationHelper
         .setArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1798,6 +1798,7 @@ public class NullAwayTest {
             "    Optional<Object> a = Optional.empty();",
             "    // BUG: Diagnostic contains: Optional a can be empty",
             "    Object x = a.get();",
+            "    x.toString();",
             "  }",
             "   public void lambdaConsumer(Function a){",
             "        return;",


### PR DESCRIPTION
Assigning potentially empty optional get value to an object now gives a correct error

```
Optional<Integer> optionalFoo = someFunction();
Integer x = optionalFoo.get();
x.toString();
```

It will give error that `optionalFoo` can be empty.


Fixes #351 
