### PR TITLE
Update to Checker Dataflow 3.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     asm                    : "7.1",
-    checkerFramework       : "2.5.5",
+    checkerFramework       : "3.0.0",
     errorProne             : "2.3.3", // The version of error prone running on this project
     errorProneApi          : "2.3.1", // The version of error prone built against and shipped
     support                : "27.1.1",
@@ -68,7 +68,8 @@ def test = [
     jetbrainsAnnotations    : "org.jetbrains:annotations:13.0",
     inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
     cfQual                  : "org.checkerframework:checker-qual:${versions.checkerFramework}",
-    cfCompatQual            : "org.checkerframework:checker-compat-qual:${versions.checkerFramework}",
+    // 2.5.5 is the last release to contain this artifact
+    cfCompatQual            : "org.checkerframework:checker-compat-qual:2.5.5",
     rxjava2                 : "io.reactivex.rxjava2:rxjava:2.1.2",
     commonsLang3            : "org.apache.commons:commons-lang3:3.8.1",
     commonsLang             : "commons-lang:commons-lang:2.6",

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -161,7 +161,7 @@ public class NullnessStore implements Store<NullnessStore> {
   }
 
   @Override
-  public void visualize(CFGVisualizer<?, NullnessStore, ?> cfgVisualizer) {
+  public String visualize(CFGVisualizer<?, NullnessStore, ?> cfgVisualizer) {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
We may want to do performance testing on this internally at Uber.  But [Error Prone is updating](https://github.com/google/error-prone/commit/446c9fdfb6c5ef8fb585b636de498bb02226966d) and the library is pretty stable, so hopefully this is safe.