### PR TITLE
Update ErrorBuilder.java

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -301,18 +301,39 @@ public class ErrorBuilder {
     }
     return false;
   }
-
-  static String errMsgForInitializer(Set<Element> uninitFields) {
+  
+  int GetLineforField(Element uninitField, VisitorState state){
+    Tree fieldTree = getTreeInstance(state).getTree(uninitField);
+    DiagnosticPosition position = (DiagnosticPosition)fieldTree;
+    TreePath path = state.getPath();
+    JCCompilationUnit compilation = (JCCompilationUnit)path.getCompilationUnit();
+    JavaFileObject file = compilation.getSourceFile();
+    DiagnosticSource source = new DiagnosticSource(file, null);
+    return source.getLineNumber(position.getStartPosition());
+  }
+  
+  static String errMsgForInitializer(Set<Element> uninitFields, VisitorState state) {
     String message = "initializer method does not guarantee @NonNull ";
+    Element uninitField;
     if (uninitFields.size() == 1) {
-      message += "field " + uninitFields.iterator().next().toString() + " is initialized";
+      uninitField = uninitFields.iterator().next();
+      message += "field " + uninitField.toString() + "(Line:" + GetLineforField(uninitField, state) + ") is initialized";
     } else {
-      message += "fields " + Joiner.on(", ").join(uninitFields) + " are initialized";
+      message += "fields ";
+      while(uninitFields.hasNext()){
+        uninitField = uninitFields.iterator().next();
+        message += uninitField.toString() + "(Line:" + GetLineforField(uninitField, state) + ")";
+        if(uninitFields.hasNext()){
+          message += ", ";
+        }else{
+          message += " are initialized";
+        }
+      }
     }
     message += " along all control-flow paths (remember to check for exceptions or early returns).";
     return message;
   }
-
+  
   void reportInitErrorOnField(Symbol symbol, VisitorState state, Description.Builder builder) {
     if (symbolHasSuppressWarningsAnnotation(symbol, INITIALIZATION_CHECK_NAME)) {
       return;


### PR DESCRIPTION
Add the line number to errMsgForInitializer

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.

Hi, this is Zifei Wu.

Here is my change to errMsgForInitializer in order to get the line number for uninitialized fields. Also I create another function to return the line number from Element and VisitorState.

This is the response to issue uber#95

Thanks!