### PR TITLE
Give line numbers for uninitialized fields when reporting error on an initializer

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -308,13 +308,12 @@ public class ErrorBuilder {
   }
 
   static int getLineNumForElement(Element uninitField, VisitorState state) {
-    Tree fieldTree = getTreesInstance(state).getTree(uninitField);
-    if (fieldTree == null)
+    Tree tree = getTreesInstance(state).getTree(uninitField);
+    if (tree == null)
       throw new RuntimeException(
-          "When getting the line number for uninitialized field, can't get the fieldTree from the element.");
+          "When getting the line number for uninitialized field, can't get the tree from the element.");
     DiagnosticPosition position =
-        (DiagnosticPosition)
-            fieldTree; // Expect Tree to be JCTree and thus implement DiagnosticPosition
+        (DiagnosticPosition) tree; // Expect Tree to be JCTree and thus implement DiagnosticPosition
     TreePath path = state.getPath();
     JCCompilationUnit compilation = (JCCompilationUnit) path.getCompilationUnit();
     JavaFileObject file = compilation.getSourceFile();
@@ -322,7 +321,13 @@ public class ErrorBuilder {
     return source.getLineNumber(position.getStartPosition());
   }
 
-  // Generate the message for uninitialized fields, including the line number for fields.
+  /**
+   * Generate the message for uninitialized fields, including the line number for fields.
+   *
+   * @param uninitFields the set of uninitialized fields as the type of Element.
+   * @param state the VisitorState object.
+   * @return the error message for uninitialized fields with line numbers.
+   */
   static String errMsgForInitializer(Set<Element> uninitFields, VisitorState state) {
     StringBuilder message = new StringBuilder("initializer method does not guarantee @NonNull ");
     Element uninitField;
@@ -330,7 +335,7 @@ public class ErrorBuilder {
       uninitField = uninitFields.iterator().next();
       message.append("field ");
       message.append(uninitField.toString());
-      message.append("(Line ");
+      message.append(" (line ");
       message.append(getLineNumForElement(uninitField, state));
       message.append(") is initialized");
     } else {
@@ -339,7 +344,7 @@ public class ErrorBuilder {
       while (it.hasNext()) {
         uninitField = it.next();
         message.append(
-            uninitField.toString() + "(Line " + getLineNumForElement(uninitField, state) + ")");
+            uninitField.toString() + " (line " + getLineNumForElement(uninitField, state) + ")");
         if (it.hasNext()) {
           message.append(", ");
         } else {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1486,7 +1486,7 @@ public class NullAway extends BugChecker
     for (Element constructorElement : errorFieldsForInitializer.keySet()) {
       errorBuilder.reportInitializerError(
           (Symbol.MethodSymbol) constructorElement,
-          errMsgForInitializer(errorFieldsForInitializer.get(constructorElement)),
+          errMsgForInitializer(errorFieldsForInitializer.get(constructorElement), state),
           state,
           buildDescription(getTreesInstance(state).getTree(constructorElement)));
     }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -130,7 +130,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 129)
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 130)
     // is
     // initialized
     public void init() {}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -32,7 +32,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 33) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 33) is
     // initialized
     T1() {}
   }
@@ -41,8 +41,8 @@ public class CheckFieldInitPositiveCases {
 
     Object f, g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f(Line 42),
-    // g(Line 42) are
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f (line 42),
+    // g (line 42) are
     // initialized
     T2() {}
   }
@@ -71,7 +71,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 72) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 72) is
     // initialized
     T5(boolean b) {
       if (b) {
@@ -89,7 +89,7 @@ public class CheckFieldInitPositiveCases {
       this(false);
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 85) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 85) is
     // initialized
     T6(boolean b) {}
   }
@@ -99,7 +99,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
     Object g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 99) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 99) is
     // initialized
     T7(boolean b) {
       if (b) {
@@ -108,7 +108,8 @@ public class CheckFieldInitPositiveCases {
       g = new Object();
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line 100) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g (line 100)
+    // is
     // initialized
     T7() {
       init();
@@ -129,7 +130,8 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 129) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 129)
+    // is
     // initialized
     public void init() {}
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -71,7 +71,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:71) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:72) is
     // initialized
     T5(boolean b) {
       if (b) {
@@ -89,7 +89,7 @@ public class CheckFieldInitPositiveCases {
       this(false);
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:84) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:85) is
     // initialized
     T6(boolean b) {}
   }
@@ -99,7 +99,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
     Object g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:98) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:99) is
     // initialized
     T7(boolean b) {
       if (b) {
@@ -108,7 +108,7 @@ public class CheckFieldInitPositiveCases {
       g = new Object();
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:99) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:100) is
     // initialized
     T7() {
       init();
@@ -129,7 +129,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:128) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:129) is
     // initialized
     public void init() {}
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -32,7 +32,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:33) is
     // initialized
     T1() {}
   }
@@ -41,7 +41,8 @@ public class CheckFieldInitPositiveCases {
 
     Object f, g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f, g are
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f(Line:42),
+    // g(Line:42) are
     // initialized
     T2() {}
   }
@@ -70,7 +71,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:71) is
     // initialized
     T5(boolean b) {
       if (b) {
@@ -88,7 +89,7 @@ public class CheckFieldInitPositiveCases {
       this(false);
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:84) is
     // initialized
     T6(boolean b) {}
   }
@@ -98,7 +99,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
     Object g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:98) is
     // initialized
     T7(boolean b) {
       if (b) {
@@ -107,7 +108,7 @@ public class CheckFieldInitPositiveCases {
       g = new Object();
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:99) is
     // initialized
     T7() {
       init();
@@ -128,7 +129,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:128) is
     // initialized
     public void init() {}
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -32,7 +32,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:33) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 33) is
     // initialized
     T1() {}
   }
@@ -41,8 +41,8 @@ public class CheckFieldInitPositiveCases {
 
     Object f, g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f(Line:42),
-    // g(Line:42) are
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f(Line 42),
+    // g(Line 42) are
     // initialized
     T2() {}
   }
@@ -71,7 +71,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:72) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 72) is
     // initialized
     T5(boolean b) {
       if (b) {
@@ -89,7 +89,7 @@ public class CheckFieldInitPositiveCases {
       this(false);
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:85) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 85) is
     // initialized
     T6(boolean b) {}
   }
@@ -99,7 +99,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
     Object g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:99) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 99) is
     // initialized
     T7(boolean b) {
       if (b) {
@@ -108,7 +108,7 @@ public class CheckFieldInitPositiveCases {
       g = new Object();
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:100) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line 100) is
     // initialized
     T7() {
       init();
@@ -129,7 +129,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line:129) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f(Line 129) is
     // initialized
     public void init() {}
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -259,7 +259,7 @@ public class NullAwayTryFinallyCases {
       // method... mmh
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:228) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line 228) is
     // initialized
     Initializers(Object o1, Object o2, Object o3) {
       f = new Object();

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -259,7 +259,7 @@ public class NullAwayTryFinallyCases {
       // method... mmh
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line:228) is
     // initialized
     Initializers(Object o1, Object o2, Object o3) {
       f = new Object();

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -259,7 +259,8 @@ public class NullAwayTryFinallyCases {
       // method... mmh
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g(Line 228) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g (line 228)
+    // is
     // initialized
     Initializers(Object o1, Object o2, Object o3) {
       f = new Object();


### PR DESCRIPTION
This adds the line numbers for uninitialized fields when reporting error on an initializer. As a response to issue #95.

Summary of changes:

-Edit function  errMsgForInitializer() in ErrorBuilder.
-Create a new function GetLineforField() which gives back a source line number.
-Adjust the expected error messages in the test cases. 