### PR TITLE
Add @MonotonicNonNull as lazy initialization annotation.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -110,7 +110,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final ImmutableSet<String> DEFAULT_EXCLUDED_FIELD_ANNOT =
       ImmutableSet.of(
           "javax.inject.Inject", // no explicit initialization when there is dependency injection
-          "com.google.errorprone.annotations.concurrent.LazyInit");
+          "com.google.errorprone.annotations.concurrent.LazyInit",
+          "org.checkerframework.checker.nullness.qual.MonotonicNonNull");
 
   private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.testdata;
 import com.facebook.infer.annotation.Initializer;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import javax.inject.Inject;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeAll;
@@ -318,5 +319,12 @@ public class CheckFieldInitNegativeCases {
     public void setF(final Object f) {
       this.f = f;
     }
+  }
+
+  static class MonotonicNonNullUsage {
+
+    @MonotonicNonNull Object f;
+
+    MonotonicNonNullUsage() {}
   }
 }


### PR DESCRIPTION
This adds the Checker Framework `@MonotonicNonNull` as a lazy initialization annotation
by default.

Resolves #382 