### PR TITLE
Add default library model for CompilationUnitTree.getPackageName()

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -465,6 +465,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .add(methodRef("android.view.View", "getHandler()"))
             .add(methodRef("java.lang.Throwable", "getMessage()"))
             .add(methodRef("android.webkit.WebView", "getUrl()"))
+            .add(methodRef("com.sun.source.tree.CompilationUnitTree", "getPackageName()"))
             .build();
 
     private static final ImmutableSet<MethodRef> NONNULL_RETURNS =


### PR DESCRIPTION
Java code doesn't need to have a package[1], this is unexpected for
most developers, including checker developers. The unexpected `null`
return value from this method has led to checker crashes before for
us. This allows NullAway to help EP checker developers avoid this
gotcha.

[1] https://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.4.2