### PR TITLE
Improve matching of native Map methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -319,8 +319,12 @@ public final class AccessPath {
     return "AccessPath{" + "root=" + root + ", elements=" + elements + '}';
   }
 
-  private static boolean isMapMethod(Symbol.MethodSymbol symbol, Types types, String methodName) {
+  private static boolean isMapMethod(
+      Symbol.MethodSymbol symbol, Types types, String methodName, int numParams) {
     if (!symbol.getSimpleName().toString().equals(methodName)) {
+      return false;
+    }
+    if (symbol.getParameters().size() != numParams) {
       return false;
     }
     Symbol owner = symbol.owner;
@@ -337,15 +341,15 @@ public final class AccessPath {
   }
 
   private static boolean isMapGet(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "get");
+    return isMapMethod(symbol, types, "get", 1);
   }
 
   public static boolean isContainsKey(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "containsKey");
+    return isMapMethod(symbol, types, "containsKey", 1);
   }
 
   public static boolean isMapPut(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "put");
+    return isMapMethod(symbol, types, "put", 2);
   }
 
   /**


### PR DESCRIPTION
See Issue #389. 

NullAway detects and treats in a special way all methods from the `java.util.Map` interface. Before this change, the methods were identified only by simple name and by checking that the class (transitively) implements `Map`. However, this is a problem when implementing classes add new methods with the same name but different signature (e.g. number or types of arguments). 

This patch adds a check for the number of arguments. Subtyping and generics makes a check for the types of arguments involved and potentially expensive, so we don't do that for now, but will add it if the need arrises.

We include a test that would have triggered the crash from #389 in the previous NullAway commit. 