### PR TITLE
Improve suppression of subcheckers, taking into account full AST path

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -114,6 +114,12 @@ public class ErrorBuilder {
     return builder.build();
   }
 
+  private static boolean canHaveSuppressWarningsAnnotation(Tree tree) {
+    return tree instanceof MethodTree
+        || (tree instanceof ClassTree && ((ClassTree) tree).getSimpleName().length() != 0)
+        || tree instanceof VariableTree;
+  }
+
   /**
    * Find out if a particular subchecker (e.g. NullAway.Optional) is being suppressed in a given
    * path.
@@ -127,12 +133,7 @@ public class ErrorBuilder {
    */
   private boolean hasPathSuppression(TreePath treePath, String subcheckerName) {
     return StreamSupport.stream(treePath.spliterator(), false)
-        .filter(
-            tree ->
-                tree instanceof MethodTree
-                    || (tree instanceof ClassTree
-                        && ((ClassTree) tree).getSimpleName().length() != 0)
-                    || tree instanceof VariableTree)
+        .filter(ErrorBuilder::canHaveSuppressWarningsAnnotation)
         .map(tree -> ASTHelpers.getSymbol(tree))
         .filter(symbol -> symbol != null)
         .anyMatch(symbol -> symbolHasSuppressWarningsAnnotation(symbol, subcheckerName));
@@ -256,12 +257,7 @@ public class ErrorBuilder {
       return null;
     }
     return StreamSupport.stream(path.spliterator(), false)
-        .filter(
-            tree ->
-                tree instanceof MethodTree
-                    || (tree instanceof ClassTree
-                        && ((ClassTree) tree).getSimpleName().length() != 0)
-                    || tree instanceof VariableTree)
+        .filter(ErrorBuilder::canHaveSuppressWarningsAnnotation)
         .findFirst()
         .orElse(null);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -418,8 +418,8 @@ public class NullAway extends BugChecker
       return errorBuilder.createErrorDescriptionForNullAssignment(
           new ErrorMessage(MessageTypes.ASSIGN_FIELD_NULLABLE, message),
           expression,
-          state.getPath(),
-          buildDescription(tree));
+          buildDescription(tree),
+          state);
     }
     return Description.NO_MATCH;
   }
@@ -516,7 +516,7 @@ public class NullAway extends BugChecker
           new ErrorMessage(MessageTypes.SWITCH_EXPRESSION_NULLABLE, message);
 
       return errorBuilder.createErrorDescription(
-          errorMessage, switchExpression, buildDescription(switchExpression));
+          errorMessage, switchExpression, buildDescription(switchExpression), state);
     }
 
     return Description.NO_MATCH;
@@ -571,8 +571,8 @@ public class NullAway extends BugChecker
                 + " is @Nullable";
         return errorBuilder.createErrorDescription(
             new ErrorMessage(MessageTypes.WRONG_OVERRIDE_PARAM, message),
-            state.getPath(),
-            buildDescription(memberReferenceTree));
+            buildDescription(memberReferenceTree),
+            state);
       }
     }
     // for unbound member references, we need to adjust parameter indices by 1 when matching with
@@ -629,8 +629,8 @@ public class NullAway extends BugChecker
         }
         return errorBuilder.createErrorDescription(
             new ErrorMessage(MessageTypes.WRONG_OVERRIDE_PARAM, message),
-            state.getPath(),
-            buildDescription(errorTree));
+            buildDescription(errorTree),
+            state);
       }
     }
     return Description.NO_MATCH;
@@ -661,7 +661,7 @@ public class NullAway extends BugChecker
               "returning @Nullable expression from method with @NonNull return type");
 
       return errorBuilder.createErrorDescriptionForNullAssignment(
-          errorMessage, retExpr, state.getPath(), buildDescription(tree));
+          errorMessage, retExpr, buildDescription(tree), state);
     }
     return Description.NO_MATCH;
   }
@@ -769,8 +769,8 @@ public class NullAway extends BugChecker
               : getTreesInstance(state).getTree(overridingMethod);
       return errorBuilder.createErrorDescription(
           new ErrorMessage(MessageTypes.WRONG_OVERRIDE_RETURN, message),
-          state.getPath(),
-          buildDescription(errorTree));
+          buildDescription(errorTree),
+          state);
     }
     // if any parameter in the super method is annotated @Nullable,
     // overriding method cannot assume @Nonnull
@@ -896,7 +896,7 @@ public class NullAway extends BugChecker
           new ErrorMessage(
               MessageTypes.NONNULL_FIELD_READ_BEFORE_INIT,
               "read of @NonNull field " + symbol + " before initialization");
-      return errorBuilder.createErrorDescription(errorMessage, path, buildDescription(tree));
+      return errorBuilder.createErrorDescription(errorMessage, buildDescription(tree), state);
     } else {
       return Description.NO_MATCH;
     }
@@ -1136,7 +1136,7 @@ public class NullAway extends BugChecker
                   MessageTypes.ASSIGN_FIELD_NULLABLE,
                   "assigning @Nullable expression to @NonNull field");
           return errorBuilder.createErrorDescriptionForNullAssignment(
-              errorMessage, initializer, state.getPath(), buildDescription(tree));
+              errorMessage, initializer, buildDescription(tree), state);
         }
       }
     }
@@ -1257,8 +1257,7 @@ public class NullAway extends BugChecker
             MessageTypes.DEREFERENCE_NULLABLE,
             "enhanced-for expression " + state.getSourceForNode(expr) + " is @Nullable");
     if (mayBeNullExpr(state, expr)) {
-      return errorBuilder.createErrorDescription(
-          errorMessage, state.getPath(), buildDescription(expr));
+      return errorBuilder.createErrorDescription(errorMessage, buildDescription(expr), state);
     }
     return Description.NO_MATCH;
   }
@@ -1280,8 +1279,7 @@ public class NullAway extends BugChecker
         if (mayBeNullExpr(state, tree)) {
           final ErrorMessage errorMessage =
               new ErrorMessage(MessageTypes.UNBOX_NULLABLE, "unboxing of a @Nullable value");
-          return errorBuilder.createErrorDescription(
-              errorMessage, state.getPath(), buildDescription(tree));
+          return errorBuilder.createErrorDescription(errorMessage, buildDescription(tree), state);
         }
       }
     }
@@ -1376,8 +1374,8 @@ public class NullAway extends BugChecker
         return errorBuilder.createErrorDescriptionForNullAssignment(
             new ErrorMessage(MessageTypes.PASS_NULLABLE, message),
             actual,
-            state.getPath(),
-            buildDescription(actual));
+            buildDescription(actual),
+            state);
       }
     }
     // Check for @NonNull being passed to castToNonNull (if configured)
@@ -1422,7 +1420,8 @@ public class NullAway extends BugChecker
         return errorBuilder.createErrorDescription(
             new ErrorMessage(MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, message),
             tree,
-            buildDescription(tree));
+            buildDescription(tree),
+            state);
       }
     }
     return Description.NO_MATCH;
@@ -2040,17 +2039,14 @@ public class NullAway extends BugChecker
       ErrorMessage errorMessage = new ErrorMessage(MessageTypes.DEREFERENCE_NULLABLE, message);
 
       return errorBuilder.createErrorDescriptionForNullAssignment(
-          errorMessage, baseExpression, state.getPath(), buildDescription(derefExpression));
+          errorMessage, baseExpression, buildDescription(derefExpression), state);
     }
 
     Optional<ErrorMessage> handlerErrorMessage =
         handler.onExpressionDereference(derefExpression, baseExpression, state);
     if (handlerErrorMessage.isPresent()) {
       return errorBuilder.createErrorDescriptionForNullAssignment(
-          handlerErrorMessage.get(),
-          derefExpression,
-          state.getPath(),
-          buildDescription(derefExpression));
+          handlerErrorMessage.get(), derefExpression, buildDescription(derefExpression), state);
     }
 
     return Description.NO_MATCH;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ContractHandler.java
@@ -228,7 +228,8 @@ public class ContractHandler extends BaseNoOpHandler {
               .createErrorDescription(
                   new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                   errorLocTree,
-                  buildDescriptionFromChecker(errorLocTree, analysis)));
+                  buildDescriptionFromChecker(errorLocTree, analysis),
+                  this.state));
     }
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -1535,7 +1535,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessHandlerTest() {
+  public void optionalEmptinessHandlerTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1611,7 +1611,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessHandlerWithSingleCustomPathTest() {
+  public void optionalEmptinessHandlerWithSingleCustomPathTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1693,7 +1693,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessHandlerWithTwoCustomPathsTest() {
+  public void optionalEmptinessHandlerWithTwoCustomPathsTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1773,7 +1773,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessUncheckedTest() {
+  public void optionalEmptinessUncheckedTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1808,7 +1808,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessRxPositiveTest() {
+  public void optionalEmptinessRxPositiveTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1840,7 +1840,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessRxNegativeTest() {
+  public void optionalEmptinessRxNegativeTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1872,7 +1872,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessHandleAssertionLibraryTest() {
+  public void optionalEmptinessHandleAssertionLibraryTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1908,7 +1908,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessAssignmentCheckNegativeTest() {
+  public void optionalEmptinessAssignmentCheckNegativeTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1943,7 +1943,7 @@ public class NullAwayTest {
   }
 
   @Test
-  public void OptionalEmptinessAssignmentCheckPositiveTest() {
+  public void optionalEmptinessAssignmentCheckPositiveTest() {
     compilationHelper
         .setArgs(
             Arrays.asList(
@@ -1973,6 +1973,74 @@ public class NullAwayTest {
             "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b",
             "     lambdaConsumer(v -> {Object x = b.get();  return \"irrelevant\";});",
             "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void optionalEmptinessContextualSuppressionTest() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true"))
+        .addSourceLines(
+            "TestClassSuppression.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Function;",
+            "@SuppressWarnings(\"NullAway.Optional\")",
+            "public class TestClassSuppression {",
+            "  // no error since suppressed",
+            "  Function<Optional, String> lambdaField = opt -> opt.get().toString();",
+            "  void foo() {",
+            "    Optional<Object> a = Optional.empty();",
+            "    // no error since suppressed",
+            "    a.get().toString();",
+            "  }",
+            "  public void lambdaConsumer(Function a){",
+            "    return;",
+            "  }",
+            "  void bar() {",
+            "    Optional<Object> b = Optional.empty();",
+            "    // no error since suppressed",
+            "    lambdaConsumer(v -> b.get().toString());",
+            "  }",
+            "  void baz(@Nullable Object o) {",
+            "    // unrelated errors not suppressed",
+            "    // BUG: Diagnostic contains: dereferenced expression o is @Nullable",
+            "    o.toString();",
+            "  }",
+            "  public static class Inner {",
+            "    void foo() {",
+            "      Optional<Object> a = Optional.empty();",
+            "      // no error since suppressed in outer class",
+            "      a.get().toString();",
+            "    }",
+            "  }",
+            "}")
+        .addSourceLines(
+            "TestLambdaFieldNoSuppression.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import com.google.common.base.Function;",
+            "public class TestLambdaFieldNoSuppression {",
+            "  // BUG: Diagnostic contains: Invoking get() on possibly empty Optional opt",
+            "  Function<Optional, String> lambdaField = opt -> opt.get().toString();",
+            "}")
+        .addSourceLines(
+            "TestLambdaFieldWithSuppression.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import com.google.common.base.Function;",
+            "public class TestLambdaFieldWithSuppression {",
+            "  // no error since suppressed",
+            "  @SuppressWarnings(\"NullAway.Optional\")",
+            "  Function<Optional, String> lambdaField = opt -> opt.get().toString();",
             "}")
         .doTest();
   }


### PR DESCRIPTION
This currently works for `@SuppressWarnings("NullAway.Optional"),
which will be acknowledged when placed:

* On a field being assigned a lambda which would otherwise trigger
  an error.
* On a method containing a line triggering an error.
* On a class which directly or indirectly contains the line triggering
  the error.

Included test cases show all the above scenarios.

We take use `state.getPath()` to make this determination, and it
involves a tree traversal, but since it should only happen where we
would otherwise output a NullAway error message, this should not be
high overhead.