### PR TITLE
Support null implies false library models

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -64,6 +64,12 @@ public interface LibraryModels {
    */
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesTrueParameters();
 
+  /**
+   * @return map from the names of non-null-querying methods to the indexes of the arguments that
+   *     are compared against null.
+   */
+  ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters();
+
   /** @return set of library methods that may return null */
   ImmutableSet<MethodRef> nullableReturns();
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2473,4 +2473,23 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void defaultLibraryModelsObjectNonNull() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  String foo(@Nullable Object o) {",
+            "    if (Objects.nonNull(o)) {",
+            "     return o.toString();",
+            "    };",
+            "    return \"\";",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -48,6 +48,11 @@ public class ExampleLibraryModels implements LibraryModels {
   }
 
   @Override
+  public ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters() {
+    return ImmutableSetMultimap.of();
+  }
+
+  @Override
   public ImmutableSet<MethodRef> nullableReturns() {
     return ImmutableSet.of();
   }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -52,6 +52,11 @@ public class TestLibraryModels implements LibraryModels {
   }
 
   @Override
+  public ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters() {
+    return ImmutableSetMultimap.of();
+  }
+
+  @Override
   public ImmutableSet<MethodRef> nullableReturns() {
     return ImmutableSet.of();
   }


### PR DESCRIPTION
Additionally, add `Objects.nonNull(...)` as a built-in default model. 

Solves #393.