### PR TITLE
Make `@ChecksForNull` an alias for `@Nullable`

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -152,6 +152,8 @@ public enum Nullness implements AbstractValue<Nullness> {
         // and will replace `org.checkerframework` with `shadow.checkerframework`. Yes, really...
         // I assume it's something to handle reflection.
         || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl")
+        // matches javax.annotation.CheckForNull and edu.umd.cs.findbugs.annotations.CheckForNull
+        || annotName.endsWith(".CheckForNull")
         || (config.acknowledgeAndroidRecent()
             && annotName.equals("androidx.annotation.RecentlyNullable"));
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2492,4 +2492,32 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void checkForNullSupport() {
+    compilationHelper
+        .addSourceLines(
+            "Nullable.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class TestNullable {",
+            "  @Nullable",
+            "  Object nullable = new Object();",
+            "  public void setNullable(@Nullable Object nullable) {this.nullable = nullable;}",
+            "  // BUG: Diagnostic contains: dereferenced expression nullable is @Nullable",
+            "  public void run() {System.out.println(nullable.toString());}",
+            "}")
+        .addSourceLines(
+            "CheckForNull.java",
+            "package com.uber;",
+            "import javax.annotation.CheckForNull;",
+            "class TestCheckForNull {",
+            "  @CheckForNull",
+            "  Object checkForNull = new Object();",
+            "  public void setCheckForNull(@CheckForNull Object checkForNull) {this.checkForNull = checkForNull;}",
+            "  // BUG: Diagnostic contains: dereferenced expression checkForNull is @Nullable",
+            "  public void run() {System.out.println(checkForNull.toString());}",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
The `@ChecksForNull` annotation is used by [SpotBugs](https://spotbugs.github.io) (and FindBugs) and has the same semantic as `@Nullable` for NullAway. The `@Nullable` annotation is ignored by Spotbugs so projects can't use SpotBugs *and* NullAway together. For details refer to the [SpotBugs documentation](https://spotbugs.readthedocs.io/en/stable/annotations.html).

This PR fixes #99.

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.
