### PR TITLE
Fix: android-jar.py's exit code.

### DIFF
--- a/jar-infer/scripts/android-jar.py
+++ b/jar-infer/scripts/android-jar.py
@@ -50,4 +50,5 @@ cmd = "java -jar " + jarinfer + " -i " + ",".join(list(jars_to_process)) + " -o 
 if options.verbose:
   cmd += " -dv"
 print cmd
-subprocess.call(cmd, shell=True)
+returncode = subprocess.call(cmd, shell=True)
+sys.exit(returncode)


### PR DESCRIPTION
This script would not propagate the exit code from
the final call to jarinfer, leading it to potentially
return success even when jarinfer fails to run.

This is not critical, since this script is only used for
the release process and other steps will fail before publishing
to maven central. Still worth fixing, though.

Credit to Clint Gibler, R2C, and the semgrep tool for finding
this.