### PR TITLE
Allow library models of the form null param -> null return

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -81,6 +81,18 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters();
 
   /**
+   * Get (method, parameter) pairs that cause the method to return <code>null</code> when passed
+   * <code>null</code> on that parameter.
+   *
+   * <p>This is equivalent to annotating a method with <code>
+   * @Contract("!null -&gt; !null") @Nullable</code> or similar.
+   *
+   * @return map from the names of null-in-implies-null out methods to the indexes of the arguments
+   *     that determine nullness of the return.
+   */
+  ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters();
+
+  /**
    * Get the set of library methods that may return null.
    *
    * @return set of library methods that may return null

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -84,8 +84,9 @@ public interface LibraryModels {
    * Get (method, parameter) pairs that cause the method to return <code>null</code> when passed
    * <code>null</code> on that parameter.
    *
-   * <p>This is equivalent to annotating a method with <code>
-   * @Contract("!null -&gt; !null") @Nullable</code> or similar.
+   * <p>This is equivalent to annotating a method with a contract like:
+   *
+   * <pre><code>@Contract("!null -&gt; !null") @Nullable</code></pre>
    *
    * @return map from the names of null-in-implies-null out methods to the indexes of the arguments
    *     that determine nullness of the return.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -133,10 +133,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         getOptLibraryModels(context).nullImpliesNullParameters(callee);
     if (!nullImpliesNullIndexes.isEmpty()) {
       // If the method is marked as having argument dependent nullability and any of the
-      // corresponding
-      // arguments is null, then the return is nullable. If the method is marked as having argument
-      // dependent nullability but NONE of the corresponding arguments is null, then the return
-      // should be non-null.
+      // corresponding arguments is null, then the return is nullable. If the method is
+      // marked as having argument dependent nullability but NONE of the corresponding
+      // arguments is null, then the return should be non-null.
       boolean anyNull = false;
       for (int idx : nullImpliesNullIndexes) {
         if (!inputs.valueOfSubNode(node.getArgument(idx)).equals(NONNULL)) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -436,6 +436,10 @@ public class NullAwayTest {
             "  String test2(Object o2) {",
             "    return NullnessChecker.noOp(o2).toString();",
             "  }",
+            "  Object test3(@Nullable Object o1) {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return NullnessChecker.noOp(o1);",
+            "  }",
             "}")
         .doTest();
   }
@@ -2521,6 +2525,42 @@ public class NullAwayTest {
             "  public void setCheckForNull(@CheckForNull Object checkForNull) {this.checkForNull = checkForNull;}",
             "  // BUG: Diagnostic contains: dereferenced expression checkForNull is @Nullable",
             "  public void run() {System.out.println(checkForNull.toString());}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void orElseLibraryModelSupport() {
+    // Checks both Optional.orElse(...) support itself and the general nullImpliesNullParameters
+    // Library Models mechanism for encoding @Contract(!null -> !null) as a library model.
+    compilationHelper
+        // This is just to check the behavior is the same between @Nullable and @CheckForNull
+        .addSourceLines(
+            "TestOptionalOrElseNegative.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import java.util.Optional;",
+            "class TestOptionalOrElseNegative {",
+            "  public Object foo(Optional<Object> o) {",
+            "    return o.orElse(\"Something\");",
+            "  }",
+            "  public @Nullable Object bar(Optional<Object> o) {",
+            "    return o.orElse(null);",
+            "  }",
+            "}")
+        .addSourceLines(
+            "TestOptionalOrElsePositive.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "class TestOptionalOrElsePositive {",
+            "  public Object foo(Optional<Object> o) {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return o.orElse(null);",
+            "  }",
+            "  public void bar(Optional<Object> o) {",
+            "    // BUG: Diagnostic contains: dereferenced expression o.orElse(null) is @Nullable",
+            "    System.out.println(o.orElse(null).toString());",
+            "  }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2534,7 +2534,6 @@ public class NullAwayTest {
     // Checks both Optional.orElse(...) support itself and the general nullImpliesNullParameters
     // Library Models mechanism for encoding @Contract(!null -> !null) as a library model.
     compilationHelper
-        // This is just to check the behavior is the same between @Nullable and @CheckForNull
         .addSourceLines(
             "TestOptionalOrElseNegative.java",
             "package com.uber;",

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -53,6 +53,11 @@ public class ExampleLibraryModels implements LibraryModels {
   }
 
   @Override
+  public ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters() {
+    return ImmutableSetMultimap.of();
+  }
+
+  @Override
   public ImmutableSet<MethodRef> nullableReturns() {
     return ImmutableSet.of();
   }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -57,6 +57,11 @@ public class TestLibraryModels implements LibraryModels {
   }
 
   @Override
+  public ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters() {
+    return ImmutableSetMultimap.of();
+  }
+
+  @Override
   public ImmutableSet<MethodRef> nullableReturns() {
     return ImmutableSet.of();
   }


### PR DESCRIPTION
This is equivalent to what `@Contract(!null -> !null)` already
allows for first party code.

In particular, we use this to implement the nullability contract
of `Optional.orElse(...)` and solve #406 