### PR TITLE
Make excluded class annotations work on nested classes

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -316,6 +316,9 @@ public class ErrorBuilder {
       String message,
       VisitorState state,
       Description.Builder descriptionBuilder) {
+    // Check needed here, despite check in hasPathSuppression because initialization
+    // checking happens at the class-level (meaning state.getPath() might not include the
+    // method itself).
     if (symbolHasSuppressWarningsAnnotation(methodSymbol, INITIALIZATION_CHECK_NAME)) {
       return;
     }
@@ -402,6 +405,9 @@ public class ErrorBuilder {
   }
 
   void reportInitErrorOnField(Symbol symbol, VisitorState state, Description.Builder builder) {
+    // Check needed here, despite check in hasPathSuppression because initialization
+    // checking happens at the class-level (meaning state.getPath() might not include the
+    // field itself).
     if (symbolHasSuppressWarningsAnnotation(symbol, INITIALIZATION_CHECK_NAME)) {
       return;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -95,7 +95,30 @@ public class NullAwayTest {
         .doTest();
   }
 
-  // @Test // This test is actually broken, see
+  @Test
+  public void skipClass() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.lib.MyExcluded"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "@com.uber.lib.MyExcluded",
+            "public class Test {",
+            "  static void bar() {",
+            "    // No error",
+            "    Object x = null; x.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void skipNestedClass() {
     compilationHelper
         .setArgs(

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -327,4 +327,20 @@ public class CheckFieldInitNegativeCases {
 
     MonotonicNonNullUsage() {}
   }
+
+  @SuppressWarnings("NullAway.Init")
+  public Object getSuppressWarningsF() {
+    return (new Object() {
+      /*SuppressWarningsF*/
+      private Object f;
+
+      public Object getF() {
+        return f;
+      }
+
+      public void setF(Object f) {
+        this.f = f;
+      }
+    });
+  }
 }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -173,4 +173,20 @@ public class CheckFieldInitPositiveCases {
       f = new Object(); // Wrong f
     }
   }
+
+  public Object getT12() {
+    return (new Object() {
+      /*T12*/
+      // BUG: Diagnostic contains: f not initialized
+      private Object f;
+
+      public Object getF() {
+        return f;
+      }
+
+      public void setF(Object f) {
+        this.f = f;
+      }
+    });
+  }
 }


### PR DESCRIPTION
This fixes #401.
    
There is no way to check for this in the current EP
design without adding some overhead, since it's not
easy to know when we exit a nested class in order to
e.g. maintain a stack of nested classes and their
exclusion status (see comment in NullAway.java).
    
To minimize performance regressions, this takes the
following approach:
    
- Excluded class annotation in top-level classes are
      handled the same as before, setting up a compilation
      unit level flag and skipping all checking if that
      flag is true.
- Then, before generating an error, the AST path is
      traversed upwards, looking for any excluded class
      annotations. This is analogous to our handling of
      `@SuppressWarnings("NullAway.Optional")` and does
      add some overhead proportional to the error
      messages being suppressed by these annotations.
    
The advantage is that we expect no performance hit
on code that currently passes NullAway. The disadvantage
is that as user rely more on excluded class annotations
in nested classes, overhead can silently creep in.
I have no better solution for this without support
from core EP.
    
Note that this PR also generalizes the support we
already had for `@SuppressWarnings("NullAway.Init")`.
Now it is possible to put that annotation e.g. on
a method, and have it suppress initialization for
all nested classes created within the method.