### PR TITLE
[Fix] Handle WideningConversionNode in Map key specifiers

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -45,6 +45,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.StringLiteralNode;
 import org.checkerframework.dataflow.cfg.node.ThisLiteralNode;
 import org.checkerframework.dataflow.cfg.node.VariableDeclarationNode;
+import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -174,6 +175,10 @@ public final class AccessPath implements MapKey {
 
   @Nullable
   private static MapKey argumentToMapKeySpecifier(Node argument) {
+    // Required to have Node type match Tree type in some instances.
+    if (argument instanceof WideningConversionNode) {
+      argument = ((WideningConversionNode) argument).getOperand();
+    }
     // A switch at the Tree level should be faster than multiple if checks at the Node level.
     switch (argument.getTree().getKind()) {
       case STRING_LITERAL:

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -230,6 +230,11 @@ public class NullAwayNativeModels {
     }
   }
 
+  static void mapCheckWithWideningNode() {
+    Map<Long, String> m = new HashMap<>();
+    m.put(Long.valueOf(42), "");
+  }
+
   static void failIfNull(
       @Nullable Object o1,
       @Nullable Object o2,


### PR DESCRIPTION
This is a quick bug-fix to handle the case where the CFG node
being used as a Map key is a `WideningConversionNode`. This
node doesn't have it's own AST, instead using the `Tree` object
from its operand, which can cause Map key specifier detection
logic to crash if we don't check for it separately.