### PR TITLE
Update to Checker Framework 3.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     asm                    : "7.1",
-    checkerFramework       : "3.0.0",
+    checkerFramework       : "3.6.0",
     errorProne             : "2.4.0", // The version of error prone running on this project
     errorProneApi          : "2.4.0", // The version of error prone built against and shipped
     support                : "27.1.1",

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -26,15 +26,6 @@ plugins {
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
-configurations.all {
-    resolutionStrategy {
-        // Force needed, since:
-        // a) There are newer versions of CF than the one we forked
-        // b) It seems x.y.z-name < x.y.z for gradle dependency resolution purposes.
-        force deps.build.checkerDataflow
-    }
-}
-
 dependencies {
     compileOnly deps.apt.autoValue
     annotationProcessor deps.apt.autoValue

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -110,7 +110,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * Checker for nullability errors. It assumes that any field, method parameter, or return type that
@@ -239,9 +238,6 @@ public class NullAway extends BugChecker
     handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = this::isMethodUnannotated;
     errorBuilder = new ErrorBuilder(config, canonicalName(), allNames());
-    // workaround for Checker Framework static state bug;
-    // See https://github.com/typetools/checker-framework/issues/1482
-    AnnotationUtils.clear();
   }
 
   private boolean isMethodUnannotated(MethodInvocationNode invocationNode) {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -51,8 +51,8 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.VariableElement;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
+import org.checkerframework.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.dataflow.analysis.RegularTransferResult;
-import org.checkerframework.dataflow.analysis.TransferFunction;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
@@ -135,7 +135,8 @@ import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
  * com.google.errorprone.dataflow.nullnesspropagation.AbstractNullnessPropagationTransfer} and
  * {@link com.google.errorprone.dataflow.nullnesspropagation.NullnessPropagationTransfer})
  */
-public class AccessPathNullnessPropagation implements TransferFunction<Nullness, NullnessStore> {
+public class AccessPathNullnessPropagation
+    implements ForwardTransferFunction<Nullness, NullnessStore> {
 
   private static final boolean NO_STORE_CHANGE = false;
 


### PR DESCRIPTION
This required some small code changes as Checker dataflow now supports forward and backward analyses (but we only need forward).

This should be tested more thoroughly for regressions internally at Uber (changes in warnings, performance, memory leaks) before landing.  No urgency on my end.