### PR TITLE
Add library model for Service.onStartCommand

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -361,6 +361,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     private static final ImmutableSetMultimap<MethodRef, Integer> EXPLICITLY_NULLABLE_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
             .put(
+                methodRef("android.app.Service", "onStartCommand(android.content.Intent,int,int)"),
+                0)
+            .put(
                 methodRef(
                     "android.view.GestureDetector.OnGestureListener",
                     "onScroll(android.view.MotionEvent,android.view.MotionEvent,float,float)"),


### PR DESCRIPTION
In particular, force implementors of this Android
callback to handle a potentially `null`
Intent object.

This is part of series of PRs based on internal
config fixes at Uber which resulted from looking
at recent production NPE data.