### PR TITLE
435-more common libraries and files as null or not null

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -461,6 +461,18 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
             .put(methodRef("com.google.common.base.Strings", "isNullOrEmpty(java.lang.String)"), 0)
             .put(methodRef("java.util.Objects", "isNull(java.lang.Object)"), 0)
+            .put(
+                methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)
+            .put(
+                methodRef(
+                    "org.springframework.util.CollectionUtils", "isEmpty(java.util.Collection<?>)"),
+                0)
+            .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)
+            .put(methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
+            .put(methodRef("spark.utils.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)
+            .put(methodRef("spark.utils.CollectionUtils", "isEmpty(java.util.Collection<?>)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "isEmpty(java.lang.Object)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "isBlank(java.lang.CharSequence)"), 0)
             .put(methodRef("android.text.TextUtils", "isEmpty(java.lang.CharSequence)"), 0)
             .put(methodRef("org.apache.commons.lang.StringUtils", "isEmpty(java.lang.String)"), 0)
             .put(
@@ -472,11 +484,39 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 methodRef(
                     "org.apache.commons.lang3.StringUtils", "isBlank(java.lang.CharSequence)"),
                 0)
+            .put(methodRef("org.apache.commons.lang3.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_FALSE_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
             .put(methodRef("java.util.Objects", "nonNull(java.lang.Object)"), 0)
+            .put(
+                methodRef("org.springframework.util.StringUtils", "hasLength(java.lang.String)"), 0)
+            .put(methodRef("org.springframework.util.StringUtils", "hasText(java.lang.String)"), 0)
+            .put(
+                methodRef(
+                    "org.springframework.util.StringUtils", "hasText(java.lang.CharSequence)"),
+                0)
+            .put(methodRef("spark.utils.CollectionUtils", "isNotEmpty(java.util.Collection<?>)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "isNotEmpty(java.lang.String)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "isNotBlank(java.lang.CharSequence)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "hasLength(java.lang.String)"), 0)
+            .put(methodRef("spark.utils.StringUtils", "hasLength(java.lang.CharSequence)"), 0)
+            .put(
+                methodRef("org.apache.commons.lang.StringUtils", "isNotEmpty(java.lang.String)"), 0)
+            .put(
+                methodRef(
+                    "org.apache.commons.lang3.StringUtils", "isNotEmpty(java.lang.CharSequence)"),
+                0)
+            .put(
+                methodRef("org.apache.commons.lang.StringUtils", "isNotBlank(java.lang.String)"), 0)
+            .put(
+                methodRef(
+                    "org.apache.commons.lang3.StringUtils", "isNotBlank(java.lang.CharSequence)"),
+                0)
+            .put(
+                methodRef("org.apache.commons.lang3.ObjectUtils", "isNotEmpty(java.lang.Object)"),
+                0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_NULL_PARAMETERS =


### PR DESCRIPTION
Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.
  Small change including more libraries/methods in LibraryModelsHandler.java, some for sparkjava, some from Spring, some from apache commons lang

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
  Issue is https://github.com/uber/NullAway/issues/435, created by myself

  - [ ] If applicable, unit tests.
  Could not find a way to unit to this changes, so I made a project with possible and impossible NPE to see if my modified NullAway version worked. Seems to be working, the project is https://github.com/pablogrisafi1975/NullAway-tests.  