### PR TITLE
Add support for jakarta.inject-api

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,9 +26,10 @@ def versions = [
 ]
 
 def apt = [
-    autoValue   : ["com.google.auto.value:auto-value:${versions.autoValue}", "com.google.auto.value:auto-value-annotations:${versions.autoValue}"],
-    autoService : "com.google.auto.service:auto-service:1.0-rc3",
-    javaxInject : "javax.inject:javax.inject:1",
+    autoValue     : ["com.google.auto.value:auto-value:${versions.autoValue}", "com.google.auto.value:auto-value-annotations:${versions.autoValue}"],
+    autoService   : "com.google.auto.service:auto-service:1.0-rc3",
+    jakartaInject : "jakarta.inject:jakarta.inject-api:2.0.0",
+    javaxInject   : "javax.inject:javax.inject:1",
 ]
 
 def build = [

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testCompile deps.test.cfCompatQual
     testCompile project(":test-java-lib")
     testCompile deps.test.inferAnnotations
+    testCompile deps.apt.jakartaInject
     testCompile deps.apt.javaxInject
     testCompile deps.test.rxjava2
     testCompile deps.test.commonsLang

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -115,6 +115,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
 
   static final ImmutableSet<String> DEFAULT_EXCLUDED_FIELD_ANNOT =
       ImmutableSet.of(
+          "jakarta.inject.Inject", // no explicit initialization when there is dependency injection
           "javax.inject.Inject", // no explicit initialization when there is dependency injection
           "com.google.errorprone.annotations.concurrent.LazyInit",
           "org.checkerframework.checker.nullness.qual.MonotonicNonNull");

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -24,7 +24,6 @@ package com.uber.nullaway.testdata;
 
 import com.facebook.infer.annotation.Initializer;
 import com.google.errorprone.annotations.concurrent.LazyInit;
-import javax.inject.Inject;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -46,7 +45,9 @@ public class CheckFieldInitNegativeCases {
 
     Object k;
 
-    @Inject Object m;
+    @jakarta.inject.Inject Object m;
+
+    @javax.inject.Inject Object n;
 
     @LazyInit Object lazy;
 


### PR DESCRIPTION
Since moving to Jakarte EE project under the Eclipse Foundation there has been a move from the old `javax.*` namespace to the `jakarta.*` namespace for many of the APIs previously belonging to Java EE.

Additionally to the well-known `javax.inject.Inject` there's now also `jakarta.inject.Inject` which should be recognized automatically by NullAway.

----

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.
