### PR TITLE
Setup GitHub Actions CI and SNAPSHOT uploading

### DIFF
--- a/.buildscript/check_git_clean.sh
+++ b/.buildscript/check_git_clean.sh
@@ -1,0 +1,5 @@
+if [ -n "$(git status --porcelain)" ]; then
+  echo 'warning: source tree contains uncommitted changes; .gitignore patterns may need to be fixed'
+  git status
+  false
+fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,8 +35,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
       - name: Build and test using Gradle and Java 8
         run: ./gradlew verGJF build
         if: matrix.java == '8'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,6 +71,6 @@ jobs:
           java-version: 8
       - name: 'Publish'
         env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         run: ./gradlew clean uploadArchives

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,81 @@
+name: Continuous integration
+on:
+  - pull_request
+  - push
+jobs:
+  build:
+    name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            java: 8
+          - os: ubuntu-latest
+            java: 8
+          - os: ubuntu-latest
+            java: 11
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out NullAway sources
+        uses: actions/checkout@v2
+      - name: Cache Gradle caches
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-caches-
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradlew-wrapper-
+      - name: 'Set up JDK ${{ matrix.java }}'
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build and test using Gradle and Java 8
+        run: ./gradlew verGJF build
+        if: matrix.java == '8'
+      - name: Build and test using Gradle and Java 11
+        run: ./gradlew :nullaway:test
+        if: matrix.java == '11'
+      - name: Report jacoco coverage
+        run: ./gradlew jacocoTestReport coveralls
+        if: runner.os == 'Linux' && matrix.java == '8'
+      - name: Check that Git tree is clean after build and test
+        run: ./buildscript/check-git-clean.sh
+  publish_snapshot:
+    name: 'Publish snapshot'
+    needs: [build]
+    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+      - name: Cache Gradle caches
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-caches-
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradlew-wrapper-
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: 'Publish'
+        env:
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+        run: ./gradlew clean uploadArchives

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,9 @@ name: Continuous integration
 on:
   - pull_request
   - push
+    branches:
+      - master
+      - main
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
@@ -45,7 +48,7 @@ jobs:
         run: ./gradlew jacocoTestReport coveralls
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Check that Git tree is clean after build and test
-        run: ./buildscript/check-git-clean.sh
+        run: ./buildscript/check_git_clean.sh
   publish_snapshot:
     name: 'Publish snapshot'
     needs: [build]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,6 @@
 name: Continuous integration
 on:
-  - pull_request
   - push
-    branches:
-      - master
-      - main
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
   publish_snapshot:
     name: 'Publish snapshot'
     needs: [build]
-    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/lazaro_ci_to_github_actions'
+    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,10 +9,14 @@ jobs:
         include:
           - os: macos-latest
             java: 8
+          - os: macos-latest
+            java: 11
           - os: ubuntu-latest
             java: 8
           - os: ubuntu-latest
             java: 11
+          - os: windows-latest
+            java: 8
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,9 +33,9 @@ jobs:
           arguments: :nullaway:test
         if: matrix.java == '11'
       - name: Report jacoco coverage
+        uses: eskatos/gradle-command-action@v1
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        uses: eskatos/gradle-command-action@v1
         with:
           arguments: test jacocoTestReport coverallsJacoco
         if: runner.os == 'Linux' && matrix.java == '8'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
   publish_snapshot:
     name: 'Publish snapshot'
     needs: [build]
-    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/lazaro_ci_to_github_actions'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,30 +18,26 @@ jobs:
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v2
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Build and test using Gradle and Java 8
-        run: ./gradlew verGJF build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: verGJF build
         if: matrix.java == '8'
       - name: Build and test using Gradle and Java 11
-        run: ./gradlew :nullaway:test
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: :nullaway:test
         if: matrix.java == '11'
       - name: Report jacoco coverage
-        run: ./gradlew jacocoTestReport coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: test jacocoTestReport coverallsJacoco
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
-          arguments: test jacocoTestReport coverallsJacoco
+          arguments: jacocoTestReport coverallsJacoco
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew jacocoTestReport coveralls
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Check that Git tree is clean after build and test
-        run: ./buildscript/check_git_clean.sh
+        run: ./.buildscript/check_git_clean.sh
   publish_snapshot:
     name: 'Publish snapshot'
     needs: [build]
@@ -69,8 +69,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
       - name: 'Publish'
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-30.0.3
+    - android-30
 
 before_install:
-  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then yes | sdkmanager "platforms;android-28"; fi
+  - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then yes | sdkmanager "platforms;android-30"; fi
 
 script:
   - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then ./gradlew verGJF build; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,6 @@ script:
   - if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then ./gradlew verGJF build; fi
   - if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]]; then ./gradlew :nullaway:test; fi
 
-after_success:
-  - .buildscript/deploy_snapshot.sh
-  - ./gradlew jacocoTestReport coveralls
-
-env:
-  global:
-    - secure: Gmj9s887BQhPfGA2IRGBm0gusqS8L9ED8HnCUOge32fbL1huIjUx9xDfi9vsmecoIDQQOzRga33EcQCy1Yuba3KVuk2I8pk2z5OsMBf+1iR/qRO7/QNSCEqo9pTA8AVdNfpQqM6QLGpO064a1b7c35i/aRenUYDuIZlrVUhzr9v0QQ7QURjBsnQJkRd2Xb5AEDqlFQoaIRpnFlPl/B8sXQTiOratgnBp1kDm5tOZDZ6TqWdyLn0p3u4Qf6u8h6bJ3LUG0C7i48oS8qGwelZd0v1+GmivGI7bjbQw9ghBRjEIti9nW9bGkcYna1Q1EjkUJymJ4ilpKiSNEDwLtztEBiI3pSQ3NX1DJAdWsiA+XFQtId+Xi6b/u0R6VM4hCH0bWAtIASVafrY5Ad3tGbU0QMQENYoDI7odFoMwaWLMAJ3VtmfHrrDoqtBxFm2U37Lk3pDhulC9cx+elIwsQKY0s8p2V9UbWuXGgbIlcthqhST/+3CU+apwb2/Eq2DRF/gu05SnzEQnyjiL+XY8caF/qnVChD5j8LdoMaNCbzWG2qfHIxUtgIvGd/683pzshDbKW4CYST10Q5FFtsaCv6pMkCV+aLK53OQQY5PnfHPeIJQCqijcWFv+dS8mnx0WwvKhaVzGg97QX6p+Ok+9HAzkyovRwDLeGqcSlQQKyCXSW/A=
-    - secure: SiG/TzM0GQiwUrsW6Zq+5HirIxtiOOa/bjeBR50uzN2yOccK7ysqeLYNxgmO9Iu+76mMMccWfdSaP78YgjbY6aGoxGP3rOwt469AdUhXK+hslupKpnJI2UX0sYFl39mXmnHiRe/3W17aZA9NfinJyKJVBy2Bzm2aglN6kvHtS6qcBVGU35P0PIc6IwJQrJz17CcCEa7BVmKTGQPLXLQN8NrcCAjjiT5Egu3jJ6zEBzhk75xg63RM/SAV4gdRHJqo6JOZuGL9wIrvVZzc9s3jBB7BfJnSNw3W2A28JA5snfddyn+h+GTRFVhOywUToBNxplyPIiEwAkWsiAx1tpm1JPtI7tUN+TgLEj/qZgu0VIlC8jKuZ9JwtFUaprUaEGqQwiI/XjRuQYgFxiXqhqI2DVhNgBvQp1fUvEf5UD+gWr5Edh2tX6LsdzraXRgn13tULZ08aO+tTvTZUeSYpagrC9g6gQ6wq7gucmikOK/otw7+IPtOxR7DZ6qik60bvooqpaf439O2bVQh/cIwd6i8Afsf5sCAK+p54DfNBnED+03sIKcJD64IUiTFOFxjDGhwivsv/rf7/x3iyEZawWuQTP1rciDYlk9WvQjC3UkMFmT7zywa3PcFQjyn6yjNTy8plDaZ6ILXSyZTC6cW4rxy4iG3FKB+NnOfTC9tV/Z0/78=
-
 notifications:
   email: false
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ plugins {
   id "com.github.sherter.google-java-format" version "0.8"
   id "net.ltgt.errorprone" version "0.7" apply false
   id "com.github.johnrengelman.shadow" version "2.0.4" apply false
-  id 'com.github.kt3k.coveralls' version '2.10.2' apply false
-  id 'com.android.application' version '3.5.0' apply false
+  id "com.github.nbaztec.coveralls-jacoco" version "1.2.5" apply false
+  id "com.android.application" version "3.5.0" apply false
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
   id "com.github.sherter.google-java-format" version "0.8"
   id "net.ltgt.errorprone" version "0.7" apply false
   id "com.github.johnrengelman.shadow" version "2.0.4" apply false
-  id 'com.github.kt3k.coveralls' version '2.6.3' apply false
+  id 'com.github.kt3k.coveralls' version '2.10.2' apply false
   id 'com.android.application' version '3.5.0' apply false
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,11 +51,11 @@ def build = [
     commonscli              : "commons-cli:commons-cli:${versions.commonscli}",
 
     // android stuff
-    buildToolsVersion: "28.0.3",
-    compileSdkVersion: 28,
+    buildToolsVersion: "30.0.3",
+    compileSdkVersion: 30,
     ci: "true" == System.getenv("CI"),
     minSdkVersion: 16,
-    targetSdkVersion: 28,
+    targetSdkVersion: 30,
 
 ]
 

--- a/jar-infer/nullaway-integration-test/build.gradle
+++ b/jar-infer/nullaway-integration-test/build.gradle
@@ -15,9 +15,6 @@
  */
 plugins {
   id "java"
-  // For code coverage:
-  id 'jacoco'
-  id 'com.github.kt3k.coveralls'
 }
 
 sourceCompatibility = "1.8"
@@ -37,12 +34,4 @@ dependencies {
 test {
   maxHeapSize = "1024m"
   jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
-}
-
-// From https://github.com/kt3k/coveralls-gradle-plugin
-jacocoTestReport {
-    reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
-        html.enabled = true
-    }
 }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -20,7 +20,7 @@ plugins {
   id "java"
   // For code coverage:
   id 'jacoco'
-  id 'com.github.kt3k.coveralls'
+  id 'com.github.nbaztec.coveralls-jacoco'
 }
 
 sourceCompatibility = "1.8"
@@ -113,10 +113,13 @@ jacoco {
   toolVersion = "0.8.2"
 }
 
-// From https://github.com/kt3k/coveralls-gradle-plugin
 jacocoTestReport {
     reports {
         xml.enabled = true // coveralls plugin depends on xml format report
         html.enabled = true
     }
+}
+
+coverallsJacoco {
+    reportPath = "nullaway/build/reports/jacoco/test/jacocoTestReport.xml"
 }


### PR DESCRIPTION
This change sets up GitHub Actions as a parallel build CI to Travis (for now). GitHub Actions should build NullAway on MacOS X and Linux using JDK 8, and on Linux using JDK 11, mirroring our existing Travis config. 

Additionally, this migrates snapshot uploading and coverage tracking to GitHub Actions, disabling the equivalent Travis CI events as they will likely conflict. This might break snapshot uploading after landing, since it's not possible to easily test that from the PR. If it does, follow up PRs might be needed.

See #408 