### PR TITLE
GitHub Actions: Run CI on external PRs.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,6 +43,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           arguments: jacocoTestReport coverallsJacoco
+        continue-on-error: true
         if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,6 @@
 name: Continuous integration
 on:
+  - pull_request
   - push
 jobs:
   build:
@@ -42,7 +43,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           arguments: jacocoTestReport coverallsJacoco
-        if: runner.os == 'Linux' && matrix.java == '8'
+        if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
   publish_snapshot:


### PR DESCRIPTION
By default, GitHub Actions on push run only for the fork on which
the changes were pushed. Thus, if we want PRs from external contributors
to trigger CI, we need to trigger on `pull_request` in addition to
on `push`.

This might result on double jobs when the branch being used for the
PR is also in uber/NullAway, but so be it.

We also update coverage upload to happen only when the repo is
`uber/NullAway`. This avoids potential errors when the fork is
missing a `COVERALLS_REPO_TOKEN` secret.