### PR TITLE
Ignoring library models return nullability on first-party code.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -55,7 +55,7 @@ public class Handlers {
     if (config.handleTestAssertionLibraries()) {
       handlerListBuilder.add(new AssertionHandler(methodNameUtil));
     }
-    handlerListBuilder.add(new LibraryModelsHandler());
+    handlerListBuilder.add(new LibraryModelsHandler(config));
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getRxStreamNullabilityPropagator());
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator());
     handlerListBuilder.add(new ContractHandler());

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2959,4 +2959,31 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void overridingNativeModelsInAnnotatedCodeDoesNotPropagateTheModel() {
+    // See https://github.com/uber/NullAway/issues/445
+    compilationHelper
+        .addSourceLines(
+            "NonNullGetMessage.java",
+            "package com.uber;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "class NonNullGetMessage extends RuntimeException {",
+            "  NonNullGetMessage(final String message) {",
+            "     super(message);",
+            "  }",
+            "  @Override",
+            "  public String getMessage() {",
+            "    return Objects.requireNonNull(super.getMessage());",
+            "  }",
+            "  public static void foo(NonNullGetMessage e) {",
+            "    expectsNonNull(e.getMessage());",
+            "  }",
+            "  public static void expectsNonNull(String str) {",
+            "    System.out.println(str);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2986,4 +2986,26 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void overridingNativeModelsInAnnotatedCodeDoesNotGenerateSafetyHoles() {
+    // See https://github.com/uber/NullAway/issues/445
+    compilationHelper
+        .addSourceLines(
+            "NonNullGetMessage.java",
+            "package com.uber;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "class NonNullGetMessage extends RuntimeException {",
+            "  NonNullGetMessage(@Nullable String message) {",
+            "     super(message);",
+            "  }",
+            "  @Override",
+            "  public String getMessage() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return super.getMessage();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
By definition, library models are designed to handle third-party
libraries. However, as currently implemented, a library model
indicating an `@Nullable` return will apply to all subtypes of
the type in the model, including those in first-party code.
This change fixes that, ignoring library models information
whenever code is marked as unannotated.

See #445 for a discussion.

Generally, the principle behind this is that a method in
"annotated" code without an `@Nullable` annotation should
never magically just be considered to return `@Nullable`
implicitly, which is what the current/previous behavior
regarding library models did.