### PR TITLE
Replace deprecated buildDescriptionFromChecker usage with BugChecker#buildDescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NullAway is *fast*.  It is built as a plugin to [Error Prone](http://errorprone.
 
 ### Overview
 
-NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.1.1 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
+NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.4.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
 
 ### Gradle
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AbstractFieldContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AbstractFieldContractHandler.java
@@ -22,8 +22,6 @@
 
 package com.uber.nullaway.handlers;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
-
 import com.google.common.base.Preconditions;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
@@ -154,7 +152,7 @@ public abstract class AbstractFieldContractHandler extends BaseNoOpHandler {
               .createErrorDescription(
                   new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                   tree,
-                  buildDescriptionFromChecker(tree, analysis),
+                  analysis.buildDescription(tree),
                   state));
       return false;
     } else {
@@ -175,7 +173,7 @@ public abstract class AbstractFieldContractHandler extends BaseNoOpHandler {
                         new ErrorMessage(
                             ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                         tree,
-                        buildDescriptionFromChecker(tree, analysis),
+                        analysis.buildDescription(tree),
                         state));
             return false;
           } else {
@@ -198,7 +196,7 @@ public abstract class AbstractFieldContractHandler extends BaseNoOpHandler {
                   .createErrorDescription(
                       new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                       tree,
-                      buildDescriptionFromChecker(tree, analysis),
+                      analysis.buildDescription(tree),
                       state));
           return false;
         }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -147,7 +147,7 @@ public class ContractCheckHandler extends BaseNoOpHandler {
                         new ErrorMessage(
                             ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, errorMessage),
                         returnTree,
-                        analysis.buildDescription(tree),
+                        analysis.buildDescription(returnTree),
                         returnState));
           }
           return super.visitReturn(returnTree, unused);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -22,7 +22,6 @@
 
 package com.uber.nullaway.handlers.contract;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
 import static com.uber.nullaway.NullabilityUtil.getAnnotationValue;
 import static com.uber.nullaway.handlers.contract.ContractHandler.CONTRACT_ANNOTATION_NAME;
 import static com.uber.nullaway.handlers.contract.ContractUtils.getAntecedent;
@@ -148,7 +147,7 @@ public class ContractCheckHandler extends BaseNoOpHandler {
                         new ErrorMessage(
                             ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, errorMessage),
                         returnTree,
-                        buildDescriptionFromChecker(returnTree, analysis),
+                        analysis.buildDescription(tree),
                         returnState));
           }
           return super.visitReturn(returnTree, unused);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -22,7 +22,6 @@
 
 package com.uber.nullaway.handlers.contract;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
 import static com.uber.nullaway.handlers.contract.ContractUtils.getAntecedent;
 import static com.uber.nullaway.handlers.contract.ContractUtils.getConsequent;
 
@@ -159,7 +158,7 @@ public class ContractHandler extends BaseNoOpHandler {
                         new ErrorMessage(
                             ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, errorMessage),
                         node.getTree(),
-                        buildDescriptionFromChecker(node.getTree(), analysis),
+                        analysis.buildDescription(node.getTree()),
                         state));
             supported = false;
             break;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -1,7 +1,5 @@
 package com.uber.nullaway.handlers.contract;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
-
 import com.google.common.base.Function;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.Tree;
@@ -54,7 +52,7 @@ public class ContractUtils {
               .createErrorDescription(
                   new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                   tree,
-                  buildDescriptionFromChecker(tree, analysis),
+                  analysis.buildDescription(tree),
                   state));
     }
     return parts[1].trim();
@@ -101,7 +99,7 @@ public class ContractUtils {
               .createErrorDescription(
                   new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
                   tree,
-                  buildDescriptionFromChecker(tree, analysis),
+                  analysis.buildDescription(tree),
                   state));
     }
     return antecedent;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullHandler.java
@@ -22,7 +22,6 @@
 
 package com.uber.nullaway.handlers.contract.fieldcontract;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
 import static com.uber.nullaway.NullabilityUtil.getAnnotationValueArray;
 
 import com.google.common.base.Preconditions;
@@ -106,7 +105,7 @@ public class EnsuresNonNullHandler extends AbstractFieldContractHandler {
               .createErrorDescription(
                   new ErrorMessage(ErrorMessage.MessageTypes.POSTCONDITION_NOT_SATISFIED, message),
                   tree,
-                  buildDescriptionFromChecker(tree, analysis),
+                  analysis.buildDescription(tree),
                   state));
       return false;
     }
@@ -162,7 +161,7 @@ public class EnsuresNonNullHandler extends AbstractFieldContractHandler {
                     ErrorMessage.MessageTypes.WRONG_OVERRIDE_POSTCONDITION,
                     errorMessage.toString()),
                 tree,
-                buildDescriptionFromChecker(tree, analysis),
+                analysis.buildDescription(tree),
                 state));
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/RequiresNonNullHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/RequiresNonNullHandler.java
@@ -22,7 +22,6 @@
 
 package com.uber.nullaway.handlers.contract.fieldcontract;
 
-import static com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker;
 import static com.uber.nullaway.NullabilityUtil.getAnnotationValueArray;
 
 import com.google.common.base.Preconditions;
@@ -119,7 +118,7 @@ public class RequiresNonNullHandler extends AbstractFieldContractHandler {
                 new ErrorMessage(
                     ErrorMessage.MessageTypes.WRONG_OVERRIDE_PRECONDITION, errorMessage.toString()),
                 tree,
-                buildDescriptionFromChecker(tree, analysis),
+                analysis.buildDescription(tree),
                 state));
   }
 
@@ -163,7 +162,7 @@ public class RequiresNonNullHandler extends AbstractFieldContractHandler {
                 .createErrorDescription(
                     new ErrorMessage(ErrorMessage.MessageTypes.PRECONDITION_NOT_SATISFIED, message),
                     tree,
-                    buildDescriptionFromChecker(tree, analysis),
+                    analysis.buildDescription(tree),
                     state));
       }
     }


### PR DESCRIPTION
This PR replaces calls to the deprecated static `BugChecker.buildDescriptionFromChecker` method with calls to `BugChecker#buildDescription`, which was made public in google/error-prone@3ffb9ba42d54976d058ae3592e3e2eec76f48090 and available in 2.4.0 and up.

This is necessary to use NullAway with Error Prone 2.5.0 and up, as google/error-prone@704e8a1593e0017d53d5fcd9daabcdcf64c10ab6 removed `BugChecker.buildDescriptionFromChecker` in favour of `BugChecker#buildDescription`. Attempting to use NullAway 0.8.0 with Error Prone 2.5.1 results in errors such as the following (preceeding stack trace from [`gradle-errorprone-plugin`](https://github.com/tbroyer/gradle-errorprone-plugin/) omitted for brevity):

```
Caused by: java.lang.NoSuchMethodError: 'com.google.errorprone.matchers.Description$Builder com.google.errorprone.BugCheckerInfo.buildDescriptionFromChecker(com.sun.source.tree.Tree, com.google.errorprone.bugpatterns.BugChecker)'
        at com.uber.nullaway.handlers.ContractHandler.reportMatch(ContractHandler.java:231)
        at com.uber.nullaway.handlers.ContractHandler.onDataflowVisitMethodInvocation(ContractHandler.java:130)
        at com.uber.nullaway.handlers.CompositeHandler.onDataflowVisitMethodInvocation(CompositeHandler.java:191)
        at com.uber.nullaway.dataflow.AccessPathNullnessPropagation.visitMethodInvocation(AccessPathNullnessPropagation.java:867)
        at com.uber.nullaway.dataflow.AccessPathNullnessPropagation.visitMethodInvocation(AccessPathNullnessPropagation.java:138)
        at shadow.checkerframework.dataflow.cfg.node.MethodInvocationNode.accept(MethodInvocationNode.java:76)
        at shadow.checkerframework.dataflow.analysis.Analysis.callTransferFunction(Analysis.java:408)
        at shadow.checkerframework.dataflow.analysis.Analysis.performAnalysisBlock(Analysis.java:234)
        at shadow.checkerframework.dataflow.analysis.Analysis.performAnalysis(Analysis.java:187)
        at com.uber.nullaway.dataflow.DataFlow$1.load(DataFlow.java:87)
        at com.uber.nullaway.dataflow.DataFlow$1.load(DataFlow.java:78)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
        ... 219 more
```

This change unfortunately requires bumping the minimum required version of Error Prone up to 2.4.0, so I've also amended the README.md in light of this.
