### PR TITLE
Remove shadow config from nullaway module

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -16,7 +16,6 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "com.github.johnrengelman.shadow"
   id "java"
   // For code coverage:
   id 'jacoco'
@@ -34,7 +33,7 @@ dependencies {
 
     compileOnly deps.build.errorProneCheckApi
     compile deps.build.checkerDataflow
-    shadow deps.build.guava
+    compile deps.build.guava
 
     testCompile deps.test.junit4
     testCompile(deps.build.errorProneTestHelpers) {
@@ -55,26 +54,6 @@ dependencies {
     testCompile deps.test.lombok
 }
 
-// We include and shade the checker framework jars into the NullAway jar, as we may have custom
-// changes.
-shadowJar {
-    // set classifier to null since we want the artifact uploaded to Maven Central to be the
-    // shadow jar.  Without this, the shadow jar is built with a '-all' suffix in the name.
-    classifier = null
-    relocate "org.checkerframework", "shadow.checkerframework"
-}
-// Since we set classifier to null above, both the normal jar artifact and the shadow jar have
-// the same name, which can cause races if we are not careful.  We force shadowJar to depend on
-// jar, so we know that the shadow jar will always overwrite the normal one.  We also force
-// assemble to depend on shadowJar, to avoid races between running tests / signing archives
-// and building the shadow jar.
-//
-// We also require that any other sub-projects only depend on the shadow configuration of this
-// project; otherwise weird races can occur.  Eventually, we should fix this by only renaming the
-// shadow jar artifact before the uploadArchives task runs.
-shadowJar.dependsOn jar
-assemble.dependsOn shadowJar
-
 javadoc {
     failOnError = false
 }
@@ -88,26 +67,6 @@ test {
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
-
-def configurePomForShadow(pom) {
-  pom.scopeMappings.mappings.remove(project.configurations.compile)
-  pom.scopeMappings.mappings.remove(project.configurations.runtime)
-  pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
-}
-
-install {
-  repositories.mavenInstaller {
-    configurePomForShadow(pom)
-  }
-}
-install.dependsOn shadowJar
-
-uploadArchives {
-  repositories.mavenDeployer {
-    configurePomForShadow(pom)
-  }
-}
-uploadArchives.dependsOn shadowJar
 
 jacoco {
   toolVersion = "0.8.2"

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
     implementation deps.support.appcompat
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    annotationProcessor project(":nullaway")
     annotationProcessor project(path: ":sample-library-model")
 
     testImplementation deps.test.junit4

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -26,8 +26,8 @@ targetCompatibility = "1.8"
 dependencies {
     compileOnly deps.apt.autoService
     annotationProcessor deps.apt.autoService
-    compileOnly project(path: ":nullaway", configuration: "shadow")
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    compileOnly project(":nullaway")
+    annotationProcessor project(":nullaway")
     compileOnly deps.build.guava
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    annotationProcessor project(":nullaway")
     annotationProcessor project(path: ":sample-library-model")
 
     compileOnly deps.build.jsr305Annotations

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    annotationProcessor project(":nullaway")
     annotationProcessor deps.test.lombok
 
     compileOnly deps.build.jsr305Annotations

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    annotationProcessor project(":nullaway")
 
     compileOnly deps.build.jsr305Annotations
     compileOnly deps.build.javaxValidation

--- a/test-library-models/build.gradle
+++ b/test-library-models/build.gradle
@@ -26,8 +26,8 @@ targetCompatibility = "1.8"
 dependencies {
     compileOnly deps.apt.autoService
     annotationProcessor deps.apt.autoService
-    compileOnly project(path: ":nullaway", configuration: "shadow")
-    annotationProcessor project(path: ":nullaway", configuration: "shadow")
+    compileOnly project(":nullaway")
+    annotationProcessor project(":nullaway")
     compileOnly deps.build.guava
 }
 


### PR DESCRIPTION
Since we plan to require EP 2.4.0 in the next release, and it depends on [a shaded version of Checker dataflow](https://github.com/google/error-prone/blob/1e2c8ac094d6d8b8c968f722d723800c5a79fb20/core/pom.xml#L111-L116), we no longer need to use shadowing for our NullAway artifact.  This could hypothetically cause a problem if a dev wants to run NullAway and (a different version of) Checker Framework simultaneously, but that seems unlikely and I don't think we should support it unless we see a strong reason in practice.  This change will unblock a bunch of other cleanup to our Gradle config.

I wanted to remove the shadow plugin completely, but it seems JarInfer still relies on it in places; so some shadow config remains.

