### PR TITLE
[ContractHandler] Handle @Contract with empty value.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -101,7 +101,7 @@ public class ContractHandler extends BaseNoOpHandler {
     Preconditions.checkNotNull(callee);
     // Check to see if this method has an @Contract annotation
     String contractString = NullabilityUtil.getAnnotationValue(callee, CONTRACT_ANNOTATION_NAME);
-    if (contractString != null) {
+    if (contractString != null && contractString.trim().length() > 0) {
       // Found a contract, lets parse it.
       String[] clauses = contractString.split(";");
       for (String clause : clauses) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -567,6 +567,40 @@ public class NullAwayTest {
   }
 
   @Test
+  public void contractPureOnlyIgnored() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "PureLibrary.java",
+            "package com.example.library;",
+            "import org.jetbrains.annotations.Contract;",
+            "public class PureLibrary {",
+            "  @Contract(",
+            "    pure = true",
+            "  )",
+            "  public static int pi() {",
+            "    // Meh, close enough...",
+            "    return 3;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.example.library.PureLibrary;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  void test() {",
+            "    System.out.println(Integer.toString(PureLibrary.pi()));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testEnumInit() {
     compilationHelper
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -582,9 +582,9 @@ public class NullAwayTest {
             "  @Contract(",
             "    pure = true",
             "  )",
-            "  public static int pi() {",
+            "  public static String pi() {",
             "    // Meh, close enough...",
-            "    return 3;",
+            "    return Double.toString(3.14);",
             "  }",
             "}")
         .addSourceLines(
@@ -593,8 +593,14 @@ public class NullAwayTest {
             "import com.example.library.PureLibrary;",
             "import javax.annotation.Nullable;",
             "class Test {",
-            "  void test() {",
-            "    System.out.println(Integer.toString(PureLibrary.pi()));",
+            "  String piValue() {",
+            "    String pi = PureLibrary.pi();",
+            "    // Note: we must trigger dataflow to ensure that",
+            "    // ContractHandler.onDataflowVisitMethodInvocation is called",
+            "    if (pi != null) {",
+            "       return pi;",
+            "    }",
+            "    return Integer.toString(3);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
The IntelliJ `@Contract` annotation has two fields, `value`
and `pure`. When `pure = true`, `value` can be left empty.
As such, the following is a valid `@Contract` annotation:

```
@Contract(
  pure = true
)
```

See. https://www.jetbrains.com/help/idea/contract-annotations.html

Here, retriving the annotation value produces an empty
string.

However, existing ContractHandler logic expects `value` to
either be `null` or a properly formated string in
IntelliJ contract syntax (`"[...] -> [...]; [...]"`).

Previous to this change, NullAway would report an error
AND crash when seeing the `@Contract` annotation above,
rather than ignore it. This patch fixes this.