### PR TITLE
Some Gradle build file cleanup

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,13 +23,16 @@ def versions = [
     wala                   : "1.5.4",
     commonscli             : "1.4",
     autoValue              : "1.6.2",
+    autoService            : "1.0-rc7",
 ]
 
 def apt = [
-    autoValue     : ["com.google.auto.value:auto-value:${versions.autoValue}", "com.google.auto.value:auto-value-annotations:${versions.autoValue}"],
-    autoService   : "com.google.auto.service:auto-service:1.0-rc3",
-    jakartaInject : "jakarta.inject:jakarta.inject-api:2.0.0",
-    javaxInject   : "javax.inject:javax.inject:1",
+    autoValue        : "com.google.auto.value:auto-value:${versions.autoValue}",
+    autoValueAnnot   : "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
+    autoService      : "com.google.auto.service:auto-service:${versions.autoService}",
+    autoServiceAnnot : "com.google.auto.service:auto-service-annotations:${versions.autoService}",
+    jakartaInject    : "jakarta.inject:jakarta.inject-api:2.0.0",
+    javaxInject      : "javax.inject:javax.inject:1",
 ]
 
 def build = [

--- a/jar-infer/android-jarinfer-models-sdk28/build.gradle
+++ b/jar-infer/android-jarinfer-models-sdk28/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
 }
 
 sourceCompatibility = 1.8

--- a/jar-infer/android-jarinfer-models-sdk29/build.gradle
+++ b/jar-infer/android-jarinfer-models-sdk29/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
 }
 
 sourceCompatibility = 1.8

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -17,8 +17,8 @@ dependencies {
 
     compile project(":jar-infer:jar-infer-lib")
 
-    testCompile deps.test.junit4
-    testCompile(deps.build.errorProneTestHelpers) {
+    testImplementation deps.test.junit4
+    testImplementation(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
 }

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
 }
 
 sourceCompatibility = 1.8
@@ -11,21 +11,21 @@ repositories {
 }
 
 dependencies {
-    compile deps.build.asm
-    compile deps.build.asmTree
-    compile deps.build.wala
-    compile deps.build.guava
-    compile deps.build.commonsIO
+    api deps.build.asm
+    api deps.build.asmTree
+    api deps.build.wala
+    api deps.build.guava
+    api deps.build.commonsIO
     compileOnly deps.build.errorProneCheckApi
 
-    testCompile deps.test.junit4
-    testCompile(deps.build.errorProneTestHelpers) {
+    testImplementation deps.test.junit4
+    testImplementation(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
-    testCompile project(":jar-infer:test-java-lib-jarinfer")
-    testCompile project(path: ":jar-infer:test-android-lib-jarinfer", configuration: "default")
-    testCompile files("${System.properties['java.home']}/../lib/tools.jar") // is there a better way?
-    testRuntime deps.build.errorProneCheckApi
+    testImplementation project(":jar-infer:test-java-lib-jarinfer")
+    testImplementation project(path: ":jar-infer:test-android-lib-jarinfer", configuration: "default")
+    testImplementation files("${System.properties['java.home']}/../lib/tools.jar") // is there a better way?
+    testRuntimeOnly deps.build.errorProneCheckApi
 }
 
 test {

--- a/jar-infer/nullaway-integration-test/build.gradle
+++ b/jar-infer/nullaway-integration-test/build.gradle
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    testCompile deps.test.junit4
-    testCompile(deps.build.errorProneTestHelpers) {
+     testImplementation deps.test.junit4
+     testImplementation(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
-    testCompile project(":nullaway")
-    testCompile project(":jar-infer:test-java-lib-jarinfer")
+     testImplementation project(":nullaway")
+     testImplementation project(":jar-infer:test-java-lib-jarinfer")
     
 }
 

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -40,7 +40,7 @@ jar.doLast {
     javaexec {
         classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-${VERSION_NAME}.jar")
         main = "com.uber.nullaway.jarinfer.JarInfer"
-        args = ["-i", jar.archiveFile, "-o", "${jar.destinationDirectory}/${astubxPath}"]
+        args = ["-i", jar.archiveFile, "-o", "${jar.destinationDir}/${astubxPath}"]
     }
     exec {
         workingDir "./build/libs"

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 evaluationDependsOn(":jar-infer:jar-infer-cli")
@@ -40,7 +40,7 @@ jar.doLast {
     javaexec {
         classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-${VERSION_NAME}.jar")
         main = "com.uber.nullaway.jarinfer.JarInfer"
-        args = ["-i", jar.archivePath, "-o", "${jar.destinationDir}/${astubxPath}"]
+        args = ["-i", jar.archiveFile, "-o", "${jar.destinationDirectory}/${astubxPath}"]
     }
     exec {
         workingDir "./build/libs"

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -40,7 +40,7 @@ jar.doLast {
     javaexec {
         classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-${VERSION_NAME}.jar")
         main = "com.uber.nullaway.jarinfer.JarInfer"
-        args = ["-i", jar.archiveFile, "-o", "${jar.destinationDir}/${astubxPath}"]
+        args = ["-i", jar.archivePath, "-o", "${jar.destinationDir}/${astubxPath}"]
     }
     exec {
         workingDir "./build/libs"

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -16,7 +16,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id 'java-library'
   // For code coverage:
   id 'jacoco'
   id 'com.github.nbaztec.coveralls-jacoco'
@@ -26,32 +26,32 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-    compileOnly deps.apt.autoValue
+    compileOnly deps.apt.autoValueAnnot
     annotationProcessor deps.apt.autoValue
-    compileOnly deps.apt.autoService
+    compileOnly deps.apt.autoServiceAnnot
     annotationProcessor deps.apt.autoService
 
     compileOnly deps.build.errorProneCheckApi
-    compile deps.build.checkerDataflow
-    compile deps.build.guava
+    implementation deps.build.checkerDataflow
+    implementation deps.build.guava
 
-    testCompile deps.test.junit4
-    testCompile(deps.build.errorProneTestHelpers) {
+    testImplementation deps.test.junit4
+    testImplementation(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
-    testCompile deps.test.jetbrainsAnnotations
-    testCompile deps.test.junit5Jupiter
-    testCompile deps.test.cfQual
-    testCompile deps.test.cfCompatQual
-    testCompile project(":test-java-lib")
-    testCompile deps.test.inferAnnotations
-    testCompile deps.apt.jakartaInject
-    testCompile deps.apt.javaxInject
-    testCompile deps.test.rxjava2
-    testCompile deps.test.commonsLang
-    testCompile deps.test.commonsLang3
-    testCompile project(":test-library-models")
-    testCompile deps.test.lombok
+    testImplementation deps.test.jetbrainsAnnotations
+    testImplementation deps.test.junit5Jupiter
+    testImplementation deps.test.cfQual
+    testImplementation deps.test.cfCompatQual
+    testImplementation project(":test-java-lib")
+    testImplementation deps.test.inferAnnotations
+    testImplementation deps.apt.jakartaInject
+    testImplementation deps.apt.javaxInject
+    testImplementation deps.test.rxjava2
+    testImplementation deps.test.commonsLang
+    testImplementation deps.test.commonsLang3
+    testImplementation project(":test-library-models")
+    testImplementation deps.test.lombok
 }
 
 javadoc {

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"
@@ -28,7 +28,7 @@ dependencies {
     annotationProcessor project(path: ":sample-library-model")
 
     compileOnly deps.build.jsr305Annotations
-    testCompile deps.test.junit4
+    testImplementation deps.test.junit4
 }
 
 tasks.withType(JavaCompile) {

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"

--- a/test-library-models/build.gradle
+++ b/test-library-models/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java"
+  id "java-library"
 }
 
 sourceCompatibility = "1.8"


### PR DESCRIPTION
Cleanup to avoid some Gradle warnings.  These include using the `java-library` plugin where possible and removing use of `compile` and `testCompile` configurations.  I also bumped the versions of the `auto` deps and switched NullAway to only have a compile dep on the annotations.  I didn't fully fix up issues in `jar-infer/jar-infer-cli/build.gradle` as it still uses the shadow plugin and I didn't want to break it.

