### PR TITLE
Fix publication of fat jar for jar-infer-cli.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 plugins {
   id "com.github.sherter.google-java-format" version "0.8"
   id "net.ltgt.errorprone" version "0.7" apply false
-  id "com.github.johnrengelman.shadow" version "2.0.4" apply false
+  id "com.github.johnrengelman.shadow" version "6.1.0" apply false
   id "com.github.nbaztec.coveralls-jacoco" version "1.2.5" apply false
   id "com.android.application" version "3.5.0" apply false
 }

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id "com.github.johnrengelman.shadow"
     id "java"
+    id "com.vanniktech.maven.publish"
+    id "com.github.johnrengelman.shadow"
 }
 
 sourceCompatibility = "1.8"
@@ -39,12 +40,53 @@ shadowJar {
 shadowJar.dependsOn jar
 assemble.dependsOn shadowJar
 
-apply plugin: 'com.vanniktech.maven.publish'
+tasks.withType(PublishToMavenRepository) {
+    onlyIf {
+        publication == publishing.publications.shadow
+    }
+}
+tasks.withType(PublishToMavenLocal) {
+    onlyIf {
+        publication == publishing.publications.shadow
+    }
+}
 
 publishing {
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
+            afterEvaluate {
+                artifact project.sourcesJar {
+                    classifier "sources"
+                }
+                artifact project.javadocsJar {
+                    classifier "javadoc"
+                }
+            }
+            pom {
+                name = 'JarInfer'
+                description = 'A JVM bytecode null auto-annotation tool for use with NullAway'
+                url = project.property('POM_URL')
+                licenses {
+                    license {
+                        name = project.property('POM_LICENCE_NAME')
+                        url = project.property('POM_LICENCE_URL')
+                        distribution = project.property('POM_LICENCE_DIST')
+                    }
+                }
+                developers {
+                    developer {
+                        id = project.property('POM_DEVELOPER_ID')
+                        name = project.property('POM_DEVELOPER_NAME')
+                        url = project.property('POM_DEVELOPER_URL')
+                    }
+                }
+                scm {
+                    connection = project.property('POM_SCM_CONNECTION')
+                    developerConnection = project.property('POM_SCM_DEV_CONNECTION')
+                    url = project.property('POM_SCM_URL')
+                }
+            }
         }
     }
 }

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -40,6 +40,14 @@ shadowJar {
 shadowJar.dependsOn jar
 assemble.dependsOn shadowJar
 
+// We disable the default maven publications to make sure only
+// our custom shadow publication is used. Since we use the empty
+// classifier for our fat jar, it would otherwise clash with the
+// default maven publication (Also, this seems to be the only way
+// to get a pom.xml with no dependencies for our fat jar, as using
+// a classifier would result on both fat and thin jar sharing the
+// same pom.xml. Instead, we skip publishing the thin jar
+// altogether)
 tasks.withType(PublishToMavenRepository) {
     onlyIf {
         publication == publishing.publications.shadow
@@ -55,6 +63,8 @@ publishing {
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
+            // Since we are skipping the default maven publication, we append the `:sources` and
+            // `:javadoc` artifacts here. They are also required for Maven Central validation.
             afterEvaluate {
                 artifact project.sourcesJar {
                     classifier "sources"
@@ -63,6 +73,9 @@ publishing {
                     classifier "javadoc"
                 }
             }
+            // The shadow publication does not auto-configure the pom.xml file for us, so we need to
+            // set it up manually. We use the opportunity to change the name and description from
+            // the generic NullAway values to ones specific for the JarInfer tool.
             pom {
                 name = 'JarInfer'
                 description = 'A JVM bytecode null auto-annotation tool for use with NullAway'


### PR DESCRIPTION
The Gradle plugin switch from `maven` to `maven-publish` caused
by #457 broke our setup for publishing `jar-infer-cli` as a far jar.
Since the jarinfer CLI is used for processing arbitrary jars inside
other builds, including jars that it depends on (e.g. guava), it
must be a fat jar with no dependencies.

Unfortunately, so far, the best way we've found to make this work
is to skip the default `maven` publication, then make a new publication
using the result of the `shadow` plugin, and re-add to it the
sources and javadoc artifacts from the original `maven` publication.
We also had to manually set up the pom file settings for this custom
publication. It is bit of a hack, but the end result is a fat jar with a sane,
dependency-free, pom file, and passes SonaType repository closing validation.