### PR TITLE
Add library model for java.nio.file.Path.getParent()

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -543,6 +543,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .add(methodRef("java.lang.ref.PhantomReference", "get()"))
             .add(methodRef("java.lang.ref.SoftReference", "get()"))
             .add(methodRef("java.lang.ref.WeakReference", "get()"))
+            .add(methodRef("java.nio.file.Path", "getParent()"))
             .add(methodRef("java.util.concurrent.atomic.AtomicReference", "get()"))
             .add(methodRef("java.util.Map", "get(java.lang.Object)"))
             .add(methodRef("javax.lang.model.element.Element", "getEnclosingElement()"))

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2576,6 +2576,28 @@ public class NullAwayTest {
   }
 
   @Test
+  public void testJDKPathGetParentModel() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import java.nio.file.Files;",
+            "import java.nio.file.Path;",
+            "public class Test {",
+            " Optional<Path> findConfig(Path searchDir) {",
+            "    Path configFile = searchDir.resolve(\"foo.yml\");",
+            "    if (Files.exists(configFile)) {",
+            "      return Optional.of(configFile);",
+            "    }",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'searchDir.getParent()' where @NonNull",
+            "    return this.findConfig(searchDir.getParent());",
+            " }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void defaultLibraryModelsObjectNonNull() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
See #463. `Path.getParent()` is a common JDK API and can return `null` when called on the root path.