### PR TITLE
Update to Checker dataflow 3.13.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,7 @@ if (project.hasProperty("epApiVersion")) {
 }
 def versions = [
     asm                    : "7.1",
-    checkerFramework       : "3.6.0",
+    checkerFramework       : "3.13.0",
     // The version of Error Prone used to check NullAway's code
     errorProne             : "2.4.0",
     // The version of Error Prone that NullAway is compiled and tested against
@@ -61,7 +61,8 @@ def build = [
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProneApi}",
     checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
-                               "org.checkerframework:javacutil:${versions.checkerFramework}"],
+                               "org.checkerframework:javacutil:${versions.checkerFramework}",
+                               "org.plumelib:plume-util:1.5.1"],
     guava                   : "com.google.guava:guava:22.0",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1993,7 +1993,7 @@ public class NullAway extends BugChecker
     if (dereferenced == null
         || dereferenced.type.isPrimitive()
         || dereferenced.getKind() == ElementKind.PACKAGE
-        || ElementUtils.isClassElement(dereferenced)) {
+        || ElementUtils.isTypeElement(dereferenced)) {
       // we know we don't have a null dereference here
       return Description.NO_MATCH;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -46,7 +46,7 @@ import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.StringLiteralNode;
 import org.checkerframework.dataflow.cfg.node.SuperNode;
-import org.checkerframework.dataflow.cfg.node.ThisLiteralNode;
+import org.checkerframework.dataflow.cfg.node.ThisNode;
 import org.checkerframework.dataflow.cfg.node.VariableDeclarationNode;
 import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.javacutil.TreeUtils;
@@ -334,7 +334,7 @@ public final class AccessPath implements MapKey {
       elements.add(accessPathElement);
     } else if (node instanceof LocalVariableNode) {
       result = new Root(((LocalVariableNode) node).getElement());
-    } else if (node instanceof ThisLiteralNode) {
+    } else if (node instanceof ThisNode) {
       result = new Root();
     } else if (node instanceof SuperNode) {
       result = new Root();

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -65,7 +65,7 @@ import org.checkerframework.dataflow.cfg.node.ConditionalNotNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalOrNode;
 import org.checkerframework.dataflow.cfg.node.DoubleLiteralNode;
 import org.checkerframework.dataflow.cfg.node.EqualToNode;
-import org.checkerframework.dataflow.cfg.node.ExplicitThisLiteralNode;
+import org.checkerframework.dataflow.cfg.node.ExplicitThisNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.FloatLiteralNode;
 import org.checkerframework.dataflow.cfg.node.FloatingDivisionNode;
@@ -73,7 +73,7 @@ import org.checkerframework.dataflow.cfg.node.FloatingRemainderNode;
 import org.checkerframework.dataflow.cfg.node.FunctionalInterfaceNode;
 import org.checkerframework.dataflow.cfg.node.GreaterThanNode;
 import org.checkerframework.dataflow.cfg.node.GreaterThanOrEqualNode;
-import org.checkerframework.dataflow.cfg.node.ImplicitThisLiteralNode;
+import org.checkerframework.dataflow.cfg.node.ImplicitThisNode;
 import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
 import org.checkerframework.dataflow.cfg.node.IntegerDivisionNode;
 import org.checkerframework.dataflow.cfg.node.IntegerLiteralNode;
@@ -111,7 +111,7 @@ import org.checkerframework.dataflow.cfg.node.StringLiteralNode;
 import org.checkerframework.dataflow.cfg.node.SuperNode;
 import org.checkerframework.dataflow.cfg.node.SynchronizedNode;
 import org.checkerframework.dataflow.cfg.node.TernaryExpressionNode;
-import org.checkerframework.dataflow.cfg.node.ThisLiteralNode;
+import org.checkerframework.dataflow.cfg.node.ThisNode;
 import org.checkerframework.dataflow.cfg.node.ThrowNode;
 import org.checkerframework.dataflow.cfg.node.TypeCastNode;
 import org.checkerframework.dataflow.cfg.node.UnsignedRightShiftNode;
@@ -504,7 +504,7 @@ public class AccessPathNullnessPropagation
       // here we still require an access of a field of this, or a static field
       FieldAccessNode fieldAccessNode = (FieldAccessNode) target;
       Node receiver = fieldAccessNode.getReceiver();
-      if ((receiver instanceof ThisLiteralNode || fieldAccessNode.isStatic())
+      if ((receiver instanceof ThisNode || fieldAccessNode.isStatic())
           && fieldAccessNode.getElement().getKind().equals(ElementKind.FIELD)) {
         updates.set(fieldAccessNode, value);
       }
@@ -610,16 +610,14 @@ public class AccessPathNullnessPropagation
   }
 
   @Override
-  public TransferResult<Nullness, NullnessStore> visitImplicitThisLiteral(
-      ImplicitThisLiteralNode implicitThisLiteralNode,
-      TransferInput<Nullness, NullnessStore> input) {
+  public TransferResult<Nullness, NullnessStore> visitImplicitThis(
+      ImplicitThisNode implicitThisNode, TransferInput<Nullness, NullnessStore> input) {
     return noStoreChanges(NONNULL, input);
   }
 
   @Override
-  public TransferResult<Nullness, NullnessStore> visitExplicitThisLiteral(
-      ExplicitThisLiteralNode explicitThisLiteralNode,
-      TransferInput<Nullness, NullnessStore> input) {
+  public TransferResult<Nullness, NullnessStore> visitExplicitThis(
+      ExplicitThisNode explicitThisLiteralNode, TransferInput<Nullness, NullnessStore> input) {
     return noStoreChanges(NONNULL, input);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -30,7 +30,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Context context,
       Types types,
       Config config) {
-    if (parameters == null) {
+    if (underlyingAST.getKind().equals(UnderlyingAST.Kind.ARBITRARY_CODE)) {
       // not a method or a lambda; an initializer expression or block
       UnderlyingAST.CFGStatement ast = (UnderlyingAST.CFGStatement) underlyingAST;
       return getEnvNullnessStoreForClass(ast.getClassTree(), context);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -46,9 +46,9 @@ import org.checkerframework.dataflow.analysis.ForwardAnalysisImpl;
 import org.checkerframework.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.dataflow.analysis.TransferFunction;
-import org.checkerframework.dataflow.cfg.CFGBuilder;
 import org.checkerframework.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
+import org.checkerframework.dataflow.cfg.builder.CFGBuilder;
 
 /**
  * Provides a wrapper around {@link org.checkerframework.dataflow.analysis.Analysis}.

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -29,12 +29,12 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
-import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.Store;
-import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.visualize.CFGVisualizer;
+import org.checkerframework.dataflow.expression.JavaExpression;
 
 /**
  * Highly based on {@link com.google.errorprone.dataflow.LocalStore}, but for {@link AccessPath}s.
@@ -180,12 +180,12 @@ public class NullnessStore implements Store<NullnessStore> {
   }
 
   @Override
-  public boolean canAlias(FlowExpressions.Receiver receiver, FlowExpressions.Receiver receiver1) {
+  public boolean canAlias(JavaExpression a, JavaExpression b) {
     return true;
   }
 
   @Override
-  public String visualize(CFGVisualizer<?, NullnessStore, ?> cfgVisualizer) {
+  public String visualize(CFGVisualizer<?, NullnessStore, ?> viz) {
     throw new UnsupportedOperationException();
   }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -122,7 +122,7 @@ public class NullAwayTryFinallyCases {
       }
       System.out.println(o.toString()); // Safe
     } finally {
-      /// ToDo: This should be an error, but isn't.
+      // BUG: Diagnostic contains: dereferenced expression
       System.out.println(o.toString());
     }
   }


### PR DESCRIPTION
Helps out with #462.  Should land after #469 

I needed to adjust to some API changes, and re-implement some deprecated functionality that we want to keep.  Also, it looks like a try-finally false negative got fixed!  I filed https://github.com/typetools/checker-framework/issues/4612 on the need to add the explicit `plume-util` dependence.

Before landing, this should be tested internally, both for perf and also to check if new errors are reported.  Nothing urgent on my end.