### PR TITLE
Small Gradle build cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 repositories {
   // to get the google-java-format jar and dependencies
-  jcenter()
+  mavenCentral()
 }
 
 apply from: "gradle/dependencies.gradle"
@@ -73,7 +73,7 @@ subprojects { project ->
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ def build = [
     errorProneCheckApi      : "com.google.errorprone:error_prone_check_api:${versions.errorProneApi}",
     errorProneCore          : "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
-    errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
+    errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProneApi}",
     checkerDataflow         : ["org.checkerframework:dataflow:${versions.checkerFramework}",
                                "org.checkerframework:javacutil:${versions.checkerFramework}"],
     guava                   : "com.google.guava:guava:22.0",

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
         google()
     }


### PR DESCRIPTION
1. jcenter will been [sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) so we shouldn't rely on it anymore as a repository.
2. Our `errorProneTestHelpers` dependence should be based on the `errorProneAPI` version that we are building against, not the `errorProne` version controlling how our own code gets checked.