### PR TITLE
Allow Error Prone API version to be configured via a property

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
+// The oldest version of Error Prone that we support running on
+def oldestErrorProneApi = "2.4.0"
+
 def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.6.0",
-    errorProne             : "2.4.0", // The version of error prone running on this project
-    errorProneApi          : "2.4.0", // The version of error prone built against and shipped
+    // The version of Error Prone used to check NullAway code
+    errorProne             : "2.4.0",
+    // The version of Error Prone built against and used for tests
+    errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",
     wala                   : "1.5.4",
     commonscli             : "1.4",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.VersionNumber
+
 /*
  * Copyright (C) 2017. Uber Technologies
  *
@@ -17,6 +19,17 @@
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneApi = "2.4.0"
 
+if (project.hasProperty("epApiVersion")) {
+    def epApiVNum = VersionNumber.parse(epApiVersion)
+    if (epApiVNum.equals(VersionNumber.UNKNOWN)) {
+        throw new IllegalArgumentException("Invalid Error Prone API version " + epApiVersion)
+    }
+    if (epApiVNum.compareTo(VersionNumber.parse(oldestErrorProneApi)) < 0) {
+        throw new IllegalArgumentException(
+                "Error Prone API version " + epApiVersion + " is too old; "
+                + oldestErrorProneApi + " is the oldest supported version")
+    }
+}
 def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.6.0",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,9 +20,9 @@ def oldestErrorProneApi = "2.4.0"
 def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.6.0",
-    // The version of Error Prone used to check NullAway code
+    // The version of Error Prone used to check NullAway's code
     errorProne             : "2.4.0",
-    // The version of Error Prone built against and used for tests
+    // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",
     wala                   : "1.5.4",


### PR DESCRIPTION
With this change, the version of Error Prone that NullAway is compiled and tested against in a build can be changed via a project property `epApiVersion`.  E.g., to compile and test against Error Prone 2.6.0 you can run:
```
./gradlew -PepApiVersion=2.6.0 build
```
When the property is not set, we default to the oldest currently-supported version of Error Prone (currently 2.4.0).

This change will enable running separate CI jobs to test NullAway against different Error Prone versions; that change (along with some test fixes) will come in a follow-up PR.