### PR TITLE
Check our code with Error Prone 2.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.6.0",
     // The version of Error Prone used to check NullAway's code
-    errorProne             : "2.4.0",
+    errorProne             : "2.6.0",
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -38,7 +38,6 @@ tasks.withType(JavaCompile) {
     options.errorprone {
       check("NullAway", CheckSeverity.ERROR)
       check("UnusedVariable", CheckSeverity.OFF) // We are not the only checker that fails on Lombok
-      check("SameNameButDifferent", CheckSeverity.OFF) // Crashes on use of Lombok Builder
       option("NullAway:AnnotatedPackages", "com.uber")
       option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -38,6 +38,7 @@ tasks.withType(JavaCompile) {
     options.errorprone {
       check("NullAway", CheckSeverity.ERROR)
       check("UnusedVariable", CheckSeverity.OFF) // We are not the only checker that fails on Lombok
+      check("SameNameButDifferent", CheckSeverity.OFF) // Crashes on use of Lombok Builder
       option("NullAway:AnnotatedPackages", "com.uber")
       option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }

--- a/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokBuilderInit.java
+++ b/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokBuilderInit.java
@@ -28,6 +28,7 @@ import lombok.Data;
 
 @Builder
 @Data
+@SuppressWarnings("SameNameButDifferent") // check crashes with EP 2.6.0
 public class LombokBuilderInit {
   private String field;
   @Builder.Default private String fieldWithDefault = "Default";


### PR DESCRIPTION
This was surprisingly painless.  We just have to disable one new Error Prone check on the Lombok test, as it crashes.  I tested locally that adding a buggy pattern for a new EP 2.6.0 check yields a warning as expected.