### PR TITLE
Default models support for Spring's Autowired

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,6 +51,7 @@ def apt = [
     autoServiceAnnot : "com.google.auto.service:auto-service-annotations:${versions.autoService}",
     jakartaInject    : "jakarta.inject:jakarta.inject-api:2.0.0",
     javaxInject      : "javax.inject:javax.inject:1",
+    springBoot       : "org.springframework.boot:spring-boot-gradle-plugin:2.4.5",
 ]
 
 def build = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,6 @@ def apt = [
     autoServiceAnnot : "com.google.auto.service:auto-service-annotations:${versions.autoService}",
     jakartaInject    : "jakarta.inject:jakarta.inject-api:2.0.0",
     javaxInject      : "javax.inject:javax.inject:1",
-    springBoot       : "org.springframework.boot:spring-boot-gradle-plugin:2.4.5",
 ]
 
 def build = [
@@ -97,6 +96,8 @@ def test = [
     commonsLang3            : "org.apache.commons:commons-lang3:3.8.1",
     commonsLang             : "commons-lang:commons-lang:2.6",
     lombok                  : "org.projectlombok:lombok:1.18.12",
+    springBeans             : "org.springframework:spring-beans:5.3.7",
+    springContext           : "org.springframework:spring-context:5.3.7",
 ]
 
 ext.deps = [

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -52,7 +52,8 @@ dependencies {
     testImplementation deps.test.commonsLang3
     testImplementation project(":test-library-models")
     testImplementation deps.test.lombok
-    testImplementation deps.apt.springBoot
+    testImplementation deps.test.springBeans
+    testImplementation deps.test.springContext
 }
 
 javadoc {

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation deps.test.commonsLang3
     testImplementation project(":test-library-models")
     testImplementation deps.test.lombok
+    testImplementation deps.apt.springBoot
 }
 
 javadoc {

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -109,7 +109,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "org.junit.Before",
           "org.junit.BeforeClass",
           "org.junit.jupiter.api.BeforeAll",
-          "org.junit.jupiter.api.BeforeEach"); // + Anything with @Initializer as its "simple name"
+          "org.junit.jupiter.api.BeforeEach",
+          "org.springframework.beans.factory.annotation.Autowired"); // + Anything with @Initializer as its "simple name"
 
   static final ImmutableSet<String> DEFAULT_EXTERNAL_INIT_ANNOT = ImmutableSet.of("lombok.Builder");
 
@@ -118,7 +119,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "jakarta.inject.Inject", // no explicit initialization when there is dependency injection
           "javax.inject.Inject", // no explicit initialization when there is dependency injection
           "com.google.errorprone.annotations.concurrent.LazyInit",
-          "org.checkerframework.checker.nullness.qual.MonotonicNonNull");
+          "org.checkerframework.checker.nullness.qual.MonotonicNonNull",
+          "org.springframework.beans.factory.annotation.Autowired");
 
   private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
 

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -110,7 +110,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "org.junit.BeforeClass",
           "org.junit.jupiter.api.BeforeAll",
           "org.junit.jupiter.api.BeforeEach",
-          "org.springframework.beans.factory.annotation.Autowired"); // + Anything with @Initializer as its "simple name"
+          "org.springframework.beans.factory.annotation.Autowired");
+  // + Anything with @Initializer as its "simple name"
 
   static final ImmutableSet<String> DEFAULT_EXTERNAL_INIT_ANNOT = ImmutableSet.of("lombok.Builder");
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3001,14 +3001,16 @@ public class NullAwayTest {
   }
 
   @Test
-  public void springAutowiredTest() {
+  public void springAutowiredFieldTest() {
     defaultCompilationHelper
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.springframework.stereotype.Component;",
             "@Component",
             "public class Foo {",
-            "  String bar;",
+            "  @Nullable String bar;",
             "  public void setBar(String s) {",
             "    bar = s;",
             "  }",
@@ -3016,12 +3018,46 @@ public class NullAwayTest {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            //"import org.springframework.beans.factory.annotation;",
-            //"import org.springframework.beans.factory.annotation.Autowired;",
+            "import org.springframework.beans.factory.annotation.Autowired;",
+            "import org.springframework.stereotype.Service;",
             "@Service",
             "public class Test {",
             "  @Autowired",
-            "  Foo f;",
+            "  Foo f;", // Initialized by spring.
+            "  public void Fun() {",
+            "    f.setBar(\"hello\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void springAutowiredConstructorTest() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.springframework.stereotype.Component;",
+            "@Component",
+            "public class Foo {",
+            "  @Nullable String bar;",
+            "  public void setBar(String s) {",
+            "    bar = s;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.springframework.beans.factory.annotation.Autowired;",
+            "import org.springframework.stereotype.Service;",
+            "@Service",
+            "public class Test {",
+            "  Foo f;", // Initialized by spring.
+            "  @Autowired",
+            "  public void init() {",
+            "     f = new Foo();",
+            "  }",
             "  public void Fun() {",
             "    f.setBar(\"hello\");",
             "  }",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2999,4 +2999,33 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void springAutowiredTest() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "@Component",
+            "public class Foo {",
+            "  String bar;",
+            "  public void setBar(String s) {",
+            "    bar = s;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            //"import org.springframework.beans.factory.annotation;",
+            //"import org.springframework.beans.factory.annotation.Autowired;",
+            "@Service",
+            "public class Test {",
+            "  @Autowired",
+            "  Foo f;",
+            "  public void Fun() {",
+            "    f.setBar(\"hello\");",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This adds support for spring's `@Autowired` annotation as both a way to exclude fields from initialization checking (since Spring will inject them before any methods are called), and to mark methods as initializers. See [Spring's documentation](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html) and the discussion in #396 

This is based on the original PR #475 contributed by @chat-eau-lumi (note CLA signature in that PR). It adds fixes to test cases, particularly around importing Spring classes and the constructor usage of `@Autowired`, contributed by @lazaroclapp.