### PR TITLE
Ensure jmh task always runs

### DIFF
--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -39,6 +39,9 @@ task extractCaffeineSources(type: Copy) {
 
 compileJava.dependsOn(extractCaffeineSources)
 
+// always run jmh
+tasks.getByName('jmh').outputs.upToDateWhen { false }
+
 jmh {
     // seems we need more iterations to fully warm up the JIT
     warmupIterations = 10


### PR DESCRIPTION
With this change, the `:jmh:jmh` task will never appear "up to date" to Gradle, so it will never get skipped as such.