### PR TITLE
Bump Checker dataflow to 3.16.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,7 @@ if (project.hasProperty("epApiVersion")) {
 }
 def versions = [
     asm                    : "7.1",
-    checkerFramework       : "3.14.0",
+    checkerFramework       : "3.16.0",
     // The version of Error Prone used to check NullAway's code
     errorProne             : "2.7.1",
     // The version of Error Prone that NullAway is compiled and tested against


### PR DESCRIPTION
This pulls in https://github.com/typetools/checker-framework/pull/4748 which should give us a perf win