### PR TITLE
Bump to Error Prone 2.8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
             epVersion: 2.4.0
           - os: ubuntu-latest
             java: 8
-            epVersion: 2.8.0
+            epVersion: 2.8.1
           - os: ubuntu-latest
             java: 11
             epVersion: 2.4.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.16.0",
     // The version of Error Prone used to check NullAway's code
-    errorProne             : "2.8.0",
+    errorProne             : "2.8.1",
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",


### PR DESCRIPTION
Bumps the test version on CI and the version used to check NullAway code