### PR TITLE
Add Autodispose benchmark

### DIFF
--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -27,12 +27,12 @@ dependencies {
     caffeineSources('com.github.ben-manes.caffeine:caffeine:3.0.2:sources') {
         transitive = false
     }
-    autodisposeSources('com.uber.autodispose2:autodispose:2.0.0:sources') {
+    autodisposeSources('com.uber.autodispose2:autodispose:2.1.0:sources') {
         transitive = false
     }
 
     caffeineDeps 'com.github.ben-manes.caffeine:caffeine:3.0.2'
-    autodisposeDeps 'com.uber.autodispose2:autodispose:2.0.0'
+    autodisposeDeps 'com.uber.autodispose2:autodispose:2.1.0'
 
     testImplementation deps.test.junit4
 }
@@ -63,7 +63,7 @@ jmh {
     // a trick: to get the classpath for a benchmark, create a configuration that depends on the benchmark, and
     // then filter out the benchmark itself
     def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
-    def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.0.0")}).asPath
+    def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.1.0")}).asPath
 
     // pass source directories and classpaths for benchmarks as JVM arguments
     // though jvmArgsAppend is a list, it just gets converted to a single string (probably a plugin bug)

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -7,6 +7,9 @@ configurations {
     // create a configuration for the sources and dependencies of each benchmark
     caffeineSources
     caffeineDeps
+
+    autodisposeSources
+    autodisposeDeps
 }
 dependencies {
 
@@ -24,20 +27,31 @@ dependencies {
     caffeineSources('com.github.ben-manes.caffeine:caffeine:3.0.2:sources') {
         transitive = false
     }
+    autodisposeSources('com.uber.autodispose2:autodispose:2.0.0:sources') {
+        transitive = false
+    }
 
     caffeineDeps 'com.github.ben-manes.caffeine:caffeine:3.0.2'
+    autodisposeDeps 'com.uber.autodispose2:autodispose:2.0.0'
 
     testImplementation deps.test.junit4
 }
 
 def caffeineSourceDir = project.layout.buildDirectory.dir('caffeineSources')
+def autodisposeSourceDir = project.layout.buildDirectory.dir('autodisposeSources')
 
 task extractCaffeineSources(type: Copy) {
     from zipTree(configurations.caffeineSources.singleFile)
     into caffeineSourceDir
 }
 
+task extractAutodisposeSources(type: Copy) {
+    from zipTree(configurations.autodisposeSources.singleFile)
+    into autodisposeSourceDir
+}
+
 compileJava.dependsOn(extractCaffeineSources)
+compileJava.dependsOn(extractAutodisposeSources)
 
 // always run jmh
 tasks.getByName('jmh').outputs.upToDateWhen { false }
@@ -49,11 +63,15 @@ jmh {
     // a trick: to get the classpath for a benchmark, create a configuration that depends on the benchmark, and
     // then filter out the benchmark itself
     def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
+    def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.0.0")}).asPath
+
     // pass source directories and classpaths for benchmarks as JVM arguments
     // though jvmArgsAppend is a list, it just gets converted to a single string (probably a plugin bug)
     jvmArgsAppend = [
             "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()} " +
-            "-Dnullaway.caffeine.classpath=$caffeineClasspath"
+            "-Dnullaway.caffeine.classpath=$caffeineClasspath " +
+            "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()} " +
+            "-Dnullaway.autodispose.classpath=$autodisposeClasspath"
     ]
 
     // commented-out examples of how to tweak other jmh parameters; they show the default values

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
@@ -49,9 +49,7 @@ public class AutodisposeBenchmark {
             Paths.get(sourceDir), 100, (p, bfa) -> p.getFileName().toString().endsWith(".java"))) {
       List<String> sourceFileNames =
           stream.map(p -> p.toFile().getAbsolutePath()).collect(Collectors.toList());
-      nullawayJavac =
-          NullawayJavac.create(
-              sourceFileNames, "autodispose2,org.reactivestreams,io.reactivex.rxjava3", classpath);
+      nullawayJavac = NullawayJavac.create(sourceFileNames, "autodispose2", classpath);
     }
   }
 

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
@@ -55,8 +55,6 @@ public class AutodisposeBenchmark {
 
   @Benchmark
   public void compile(Blackhole bh) throws Exception {
-    boolean compile = nullawayJavac.compile();
-    if (!compile) throw new RuntimeException("failed to compile!");
-    bh.consume(compile);
+    bh.consume(nullawayJavac.compile());
   }
 }

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/AutodisposeBenchmark.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class AutodisposeBenchmark {
+
+  private NullawayJavac nullawayJavac;
+
+  @Setup
+  public void setup() throws IOException {
+    String sourceDir = System.getProperty("nullaway.autodispose.sources");
+    String classpath = System.getProperty("nullaway.autodispose.classpath");
+    try (Stream<Path> stream =
+        Files.find(
+            Paths.get(sourceDir), 100, (p, bfa) -> p.getFileName().toString().endsWith(".java"))) {
+      List<String> sourceFileNames =
+          stream.map(p -> p.toFile().getAbsolutePath()).collect(Collectors.toList());
+      nullawayJavac =
+          NullawayJavac.create(
+              sourceFileNames, "autodispose2,org.reactivestreams,io.reactivex.rxjava3", classpath);
+    }
+  }
+
+  @Benchmark
+  public void compile(Blackhole bh) throws Exception {
+    boolean compile = nullawayJavac.compile();
+    if (!compile) throw new RuntimeException("failed to compile!");
+    bh.consume(compile);
+  }
+}

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
@@ -131,7 +131,7 @@ public class NullawayJavac {
           // do nothing
         };
     // uncomment this if you want to see compile errors get printed out
-    // this.diagnosticListener = null;
+    this.diagnosticListener = null;
     this.fileManager = compiler.getStandardFileManager(diagnosticListener, null, null);
     Path outputDir = Files.createTempDirectory("classes");
     outputDir.toFile().deleteOnExit();

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
@@ -131,7 +131,7 @@ public class NullawayJavac {
           // do nothing
         };
     // uncomment this if you want to see compile errors get printed out
-    this.diagnosticListener = null;
+    // this.diagnosticListener = null;
     this.fileManager = compiler.getStandardFileManager(diagnosticListener, null, null);
     Path outputDir = Files.createTempDirectory("classes");
     outputDir.toFile().deleteOnExit();


### PR DESCRIPTION
2 benchmarks are better than 1 🙂

I'm not happy with the amount of copy-pasting plus modification in the `build.gradle` file.  But, to get rid of it would require a level of Groovy / Gradle knowledge I don't really have.  I think it's ok for now since it's just in a build script.

Also we should think about default jmh parameters, as adding this benchmark doubles the amount of time required for a JMH run (to about 25 minutes).  Maybe we want to default to fewer forks or something like that.