### PR TITLE
Compile and test with Error Prone 2.10.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
             epVersion: 2.4.0
           - os: ubuntu-latest
             java: 8
-            epVersion: 2.9.0
+            epVersion: 2.10.0
           - os: ubuntu-latest
             java: 11
             epVersion: 2.4.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.16.0",
     // The version of Error Prone used to check NullAway's code
-    errorProne             : "2.9.0",
+    errorProne             : "2.10.0",
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -48,7 +48,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
@@ -171,9 +170,6 @@ public class NullAway extends BugChecker
         BugChecker.MemberReferenceTreeMatcher,
         BugChecker.CompoundAssignmentTreeMatcher,
         BugChecker.SwitchTreeMatcher {
-
-  private static final Supplier<Type> JAVA_LANG_STRING_TYPE =
-      Suppliers.typeFromString("java.lang.String");
 
   static final String INITIALIZATION_CHECK_NAME = "NullAway.Init";
   static final String OPTIONAL_CHECK_NAME = "NullAway.Optional";
@@ -407,7 +403,7 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
     Type lhsType = ASTHelpers.getType(tree.getVariable());
-    Type stringType = JAVA_LANG_STRING_TYPE.get(state);
+    Type stringType = Suppliers.STRING_TYPE.get(state);
     if (lhsType != null && !state.getTypes().isSameType(lhsType, stringType)) {
       // both LHS and RHS could get unboxed
       return doUnboxingCheck(state, tree.getVariable(), tree.getExpression());

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -48,6 +48,8 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayAccessTree;
@@ -169,6 +171,9 @@ public class NullAway extends BugChecker
         BugChecker.MemberReferenceTreeMatcher,
         BugChecker.CompoundAssignmentTreeMatcher,
         BugChecker.SwitchTreeMatcher {
+
+  private static final Supplier<Type> JAVA_LANG_STRING_TYPE =
+      Suppliers.typeFromString("java.lang.String");
 
   static final String INITIALIZATION_CHECK_NAME = "NullAway.Init";
   static final String OPTIONAL_CHECK_NAME = "NullAway.Optional";
@@ -402,7 +407,7 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
     Type lhsType = ASTHelpers.getType(tree.getVariable());
-    Type stringType = state.getTypeFromString("java.lang.String");
+    Type stringType = JAVA_LANG_STRING_TYPE.get(state);
     if (lhsType != null && !state.getTypes().isSameType(lhsType, stringType)) {
       // both LHS and RHS could get unboxed
       return doUnboxingCheck(state, tree.getVariable(), tree.getExpression());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -23,6 +23,8 @@ package com.uber.nullaway.handlers;
 
 import com.google.common.base.Preconditions;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.tools.javac.code.Symbol;
@@ -50,6 +52,8 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
 
   private static final String TBASE_NAME = "org.apache.thrift.TBase";
 
+  private static final Supplier<Type> TBASE_TYPE_SUPPLIER = Suppliers.typeFromString(TBASE_NAME);
+
   @Nullable private Optional<Type> tbaseType;
 
   @Override
@@ -57,7 +61,7 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (tbaseType == null) {
       tbaseType =
-          Optional.ofNullable(state.getTypeFromString(TBASE_NAME)).map(state.getTypes()::erasure);
+          Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
@@ -24,6 +24,8 @@ package com.uber.nullaway.handlers;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -51,6 +53,12 @@ public class GrpcHandler extends BaseNoOpHandler {
   private static final String GRPC_CONTAINSKEY_MNAME = "containsKey";
   private static final String GRPC_GETTER_MNAME = "get";
 
+  private static final Supplier<Type> GRPC_METADATA_TYPE_SUPPLIER =
+      Suppliers.typeFromString(GRPC_METADATA_TNAME);
+
+  private static final Supplier<Type> GRPC_METADATA_KEY_TYPE_SUPPLIER =
+      Suppliers.typeFromString(GRPC_METADATA_KEY_TNAME);
+
   @Nullable private Optional<Type> grpcMetadataType;
   @Nullable private Optional<Type> grpcKeyType;
 
@@ -59,10 +67,10 @@ public class GrpcHandler extends BaseNoOpHandler {
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (grpcMetadataType == null || grpcKeyType == null) {
       grpcMetadataType =
-          Optional.ofNullable(state.getTypeFromString(GRPC_METADATA_TNAME))
+          Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state))
               .map(state.getTypes()::erasure);
       grpcKeyType =
-          Optional.ofNullable(state.getTypeFromString(GRPC_METADATA_KEY_TNAME))
+          Optional.ofNullable(GRPC_METADATA_KEY_TYPE_SUPPLIER.get(state))
               .map(state.getTypes()::erasure);
     }
   }


### PR DESCRIPTION
One new checker [MemoizeConstantVisitorStateLookups](http://errorprone.info/bugpattern/MemoizeConstantVisitorStateLookups) pointed out some inefficient code in our checkers.  Otherwise, a standard update.