### PR TITLE
Bump to Checker dataflow 3.20.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,7 @@ if (project.hasProperty("epApiVersion")) {
 }
 def versions = [
     asm                    : "7.1",
-    checkerFramework       : "3.16.0",
+    checkerFramework       : "3.20.0",
     // The version of Error Prone used to check NullAway's code
     errorProne             : "2.10.0",
     // The version of Error Prone that NullAway is compiled and tested against


### PR DESCRIPTION
The key new feature here is that the dataflow library no longer crashes on switch expressions / arrow case labels in switch statements:

https://github.com/typetools/checker-framework/blob/checker-framework-3.20.0/docs/CHANGELOG.md#version-3200-december-6-2021

This is an initial step toward fixing #289, though we will need precise control-flow graphs (which is still a WIP in Checker dataflow) to really handle these constructs properly.