### PR TITLE
Run some tests on JDK 17

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,15 +28,19 @@ jobs:
           - os: windows-latest
             java: 8
             epVersion: 2.4.0
+          - os: ubuntu-latest
+            java: 17
+            epVersion: 2.10.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v2
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - name: Build and test using Gradle, Java 8, and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
@@ -49,6 +53,11 @@ jobs:
         with:
           arguments: :nullaway:test :jmh:test
         if: matrix.java == '11'
+      - name: Build and test using Gradle and Java 17
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: :nullaway:test :jmh:test
+        if: matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -66,6 +66,22 @@ test {
   maxHeapSize = "1024m"
   if (!JavaVersion.current().java9Compatible) {
     jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+  } else {
+    // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
+    jvmArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            // Accessed by Lombok tests
+            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    ]
   }
 }
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -72,7 +72,7 @@ test {
 apply plugin: 'com.vanniktech.maven.publish'
 
 jacoco {
-  toolVersion = "0.8.2"
+  toolVersion = "0.8.7"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
This change adds a CI job so we run the same tests on JDK 17 that we currently run on JDK 11.  Currently we only test using the latest version of Error Prone; we could also test using 2.4.0 if desired.  In either case, the new job(s) should be added as "required" for future changes to land.