### PR TITLE
More JDK 11 / 17 updates

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,16 +48,11 @@ jobs:
         with:
           arguments: verGJF build
         if: matrix.java == '8'
-      - name: Build and test using Gradle and Java 11
+      - name: Build and test using Gradle and Java ${{ matrix.java }}
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: :nullaway:test :jmh:test
-        if: matrix.java == '11'
-      - name: Build and test using Gradle and Java 17
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: :nullaway:test :jmh:test
-        if: matrix.java == '17'
+          arguments: compileJava :nullaway:test :jmh:test
+        if: matrix.java == '11' || matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects { project ->
 
     if (JavaVersion.current().java9Compatible) {
         tasks.withType(JavaCompile) {
-            options.compilerArgs += [ "--release", "8" ]
+            options.release = 8
         }
     }
 

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -43,6 +43,7 @@ tasks.withType(JavaCompile) {
     }
   }
   if (JavaVersion.current().java9Compatible) {
+    // We need to fork on JDK 16+ since Lombok accesses internal compiler APIs
     options.fork = true
     options.forkOptions.jvmArgs += ["--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"]
   }

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -42,4 +42,8 @@ tasks.withType(JavaCompile) {
       option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }
   }
+  if (JavaVersion.current().java9Compatible) {
+    options.fork = true
+    options.forkOptions.jvmArgs += ["--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"]
+  }
 }


### PR DESCRIPTION
* Make the `test-java-lib-lombok` code compile on JDK 17
* Test that all Java code compiles on JDK 11 and 17 in CI (with related cleanup in `continuous-integration.yml`)
* Minor cleanup in `build.gradle`