### PR TITLE
Some fixes to GitHub Actions config

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,11 +51,16 @@ jobs:
         with:
           arguments: verGJF build
         if: matrix.java == '8'
-      - name: Build and test using Gradle and Java ${{ matrix.java }}
+      - name: Build and test using Gradle and Java 11
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build
-        if: matrix.java == '11' || matrix.java == '17'
+        if: matrix.java == '11'
+      - name: Build and test using Gradle and Java 17
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
+        if: matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }} with Error Prone ${{ matrix.epVersion }}"
@@ -51,7 +54,7 @@ jobs:
       - name: Build and test using Gradle and Java ${{ matrix.java }}
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: compileJava :nullaway:test :jmh:test
+          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build
         if: matrix.java == '11' || matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1

--- a/jar-infer/nullaway-integration-test/build.gradle
+++ b/jar-infer/nullaway-integration-test/build.gradle
@@ -32,6 +32,22 @@ dependencies {
 
 
 test {
-  maxHeapSize = "1024m"
-  jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    maxHeapSize = "1024m"
+    if (!JavaVersion.current().java9Compatible) {
+        jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    } else {
+        // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
+        jvmArgs += [
+                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        ]
+    }
 }


### PR DESCRIPTION
* Cancel outdated jobs using the GitHub Actions [`concurrency` feature](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency).  Apart from reducing wasted CI resources, I think we definitely want this on the main branch, as otherwise if we merged two PRs close together, there could possibly be weird race conditions with uploading snapshots (not 100% sure but better to be safe I think).
* Change the JDK 11 and 17 CI job config to _exclude_ building of certain submodules, rather than only _including_ a few tasks.  This way we will see if we break new stuff on these JDK versions in the future.