### PR TITLE
Fix soundness bug with dereference of ternary expressions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1992,10 +1992,10 @@ public class NullAway extends BugChecker
   private Description matchDereference(
       ExpressionTree baseExpression, ExpressionTree derefExpression, VisitorState state) {
     Symbol dereferenced = ASTHelpers.getSymbol(baseExpression);
-    if (dereferenced == null
-        || dereferenced.type.isPrimitive()
-        || dereferenced.getKind() == ElementKind.PACKAGE
-        || ElementUtils.isTypeElement(dereferenced)) {
+    if (dereferenced != null
+        && (dereferenced.type.isPrimitive()
+            || dereferenced.getKind() == ElementKind.PACKAGE
+            || ElementUtils.isTypeElement(dereferenced))) {
       // we know we don't have a null dereference here
       return Description.NO_MATCH;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1992,12 +1992,16 @@ public class NullAway extends BugChecker
   private Description matchDereference(
       ExpressionTree baseExpression, ExpressionTree derefExpression, VisitorState state) {
     Symbol baseExpressionSymbol = ASTHelpers.getSymbol(baseExpression);
-    if (baseExpressionSymbol != null
-        && (baseExpressionSymbol.type.isPrimitive()
-            || baseExpressionSymbol.getKind() == ElementKind.PACKAGE
-            || ElementUtils.isTypeElement(baseExpressionSymbol))) {
-      // we know we don't have a null dereference here
-      return Description.NO_MATCH;
+    // Note that a null dereference is possible even if baseExpressionSymbol is null,
+    // e.g., in cases where baseExpression contains conditional logic (like a ternary
+    // expression, or a switch expression in JDK 12+)
+    if (baseExpressionSymbol != null) {
+      if (baseExpressionSymbol.type.isPrimitive()
+          || baseExpressionSymbol.getKind() == ElementKind.PACKAGE
+          || ElementUtils.isTypeElement(baseExpressionSymbol)) {
+        // we know we don't have a null dereference here
+        return Description.NO_MATCH;
+      }
     }
     if (mayBeNullExpr(state, baseExpression)) {
       final String message =

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1991,11 +1991,11 @@ public class NullAway extends BugChecker
 
   private Description matchDereference(
       ExpressionTree baseExpression, ExpressionTree derefExpression, VisitorState state) {
-    Symbol dereferenced = ASTHelpers.getSymbol(baseExpression);
-    if (dereferenced != null
-        && (dereferenced.type.isPrimitive()
-            || dereferenced.getKind() == ElementKind.PACKAGE
-            || ElementUtils.isTypeElement(dereferenced))) {
+    Symbol baseExpressionSymbol = ASTHelpers.getSymbol(baseExpression);
+    if (baseExpressionSymbol != null
+        && (baseExpressionSymbol.type.isPrimitive()
+            || baseExpressionSymbol.getKind() == ElementKind.PACKAGE
+            || ElementUtils.isTypeElement(baseExpressionSymbol))) {
       // we know we don't have a null dereference here
       return Description.NO_MATCH;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3150,4 +3150,20 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void derefNullableTernary() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "public class Test {",
+            "  public void derefTernary(boolean b) {",
+            "    Object o1 = null, o2 = new Object();",
+            "    // BUG: Diagnostic contains: dereferenced expression (b ? o1 : o2) is @Nullable",
+            "    (b ? o1 : o2).toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3162,7 +3162,9 @@ public class NullAwayTest {
             "    Object o1 = null, o2 = new Object();",
             "    // BUG: Diagnostic contains: dereferenced expression (b ? o1 : o2) is @Nullable",
             "    (b ? o1 : o2).toString();",
-            "    // this is fine",
+            "    // BUG: Diagnostic contains: dereferenced expression (b ? o2 : o1) is @Nullable",
+            "    (b ? o2 : o1).toString();",
+            "    // This case is safe",
             "    (b ? o2 : o2).toString();",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3162,6 +3162,8 @@ public class NullAwayTest {
             "    Object o1 = null, o2 = new Object();",
             "    // BUG: Diagnostic contains: dereferenced expression (b ? o1 : o2) is @Nullable",
             "    (b ? o1 : o2).toString();",
+            "    // this is fine",
+            "    (b ? o2 : o2).toString();",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
Before, if a ternary expression was directly dereferenced, we wouldn't check if it was nullable 😳 Surprised we didn't spot this before.