### PR TITLE
Make jar-infer-lib tests pass on JDK 11

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Build and test using Gradle and Java 11
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build
+          arguments: build -x :sample-app:build -x :jar-infer:nullaway-integration-test:build
         if: matrix.java == '11'
       - name: Build and test using Gradle and Java 17
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build -x :sample-app:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
+          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
         if: matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build and test using Gradle and Java 17
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
+          arguments: build -x :sample-app:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
         if: matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -30,7 +30,25 @@ dependencies {
 
 test {
     maxHeapSize = "1024m"
-    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    if (!JavaVersion.current().java9Compatible) {
+        jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    } else {
+        // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
+        jvmArgs += [
+                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                // Accessed by Lombok tests
+                "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        ]
+    }
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/AnnotationChecker.java
@@ -26,11 +26,11 @@ import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import jdk.internal.org.objectweb.asm.ClassReader;
-import jdk.internal.org.objectweb.asm.tree.AnnotationNode;
-import jdk.internal.org.objectweb.asm.tree.ClassNode;
-import jdk.internal.org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
 
 /** Class to check if the methods in the given class / jar files have the expected annotations. */
 public class AnnotationChecker {

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -506,6 +506,9 @@ public class JarInferTest {
         Paths.get(baseJarPath), Paths.get(signedJarPath), StandardCopyOption.REPLACE_EXISTING);
     String ksPath =
         Thread.currentThread().getContextClassLoader().getResource("testKeyStore.jks").getPath();
+    // A public API for signing jars was added for Java 9+, but there is only an internal API on
+    // Java 8.  And we need the test code to compile on Java 8.  For simplicity and uniformity, we
+    // just run jarsigner as an executable (which slightly slows down test execution)
     String jarsignerExecutable =
         String.join(
             FileSystems.getDefault().getSeparator(),


### PR DESCRIPTION
This is needed in order to get merged code coverage reports working for this module.