### PR TITLE
Pull jmh Gradle plugin version to top level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ plugins {
   id "com.github.johnrengelman.shadow" version "6.1.0" apply false
   id "com.github.nbaztec.coveralls-jacoco" version "1.2.5" apply false
   id "com.android.application" version "3.5.0" apply false
+  id "me.champeau.jmh" version "0.6.6" apply false
 }
 
 repositories {

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id "me.champeau.jmh" version "0.6.6"
+    id 'me.champeau.jmh'
 }
 
 configurations {


### PR DESCRIPTION
Spotted here: https://github.com/uber/NullAway/pull/521#discussion_r774195230 This better matches how we list versions for other plugins.