### PR TITLE
Changes to avoid re-running Gradle tasks unnecessarily

### DIFF
--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -30,6 +30,9 @@ jar {
         'Main-Class': 'com.uber.nullaway.jarinfer.JarInfer'
         )
     }
+    // add this classifier so that the output file for the jar task differs from
+    // the output file for the shadowJar task (otherwise they overwrite each other's
+    // outputs, forcing the tasks to always re-run)
     archiveClassifier = "nonshadow"
 }
 

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -30,6 +30,7 @@ jar {
         'Main-Class': 'com.uber.nullaway.jarinfer.JarInfer'
         )
     }
+    archiveClassifier = "nonshadow"
 }
 
 shadowJar {

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -28,7 +28,6 @@ def astubxPath = "META-INF/nullaway/jarinfer.astubx"
 jar {
     manifest {
         attributes(
-                'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
                 'Created-By'     : "Gradle ${gradle.gradleVersion}",
                 'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
                 'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"


### PR DESCRIPTION
Two changes here:

* Add an `archiveClassifier` for the `:jar-infer:jar-infer-cli:jar` task, so that its output isn't the exact same file as the `shadowJar` task.  Before, the tasks would overwrite each other's outputs, forcing the tasks to re-run.
* Remove the `Build-Timestamp` from the `:jar-infer:test-java-lib-jarinfer:jar` output, as it forced the jar to be re-generated every time.

With these changes, many fewer JarInfer-related Gradle tasks are re-run unnecessarily.