### PR TITLE
Fix crash with fully-qualified names in module-info.java import

### DIFF
--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -22,6 +22,8 @@ plugins {
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)
 
 configurations {
+    // We use this configuration to expose a module path that can be used to test analysis of module-info.java files.
+    // See com.uber.nullaway.jdk17.NullAwayModuleInfoTests
     testModulePath
 }
 
@@ -49,7 +51,8 @@ test {
             "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // for use as module path in tests
+            // Expose a module path for tests as a JVM property.
+            // Used by com.uber.nullaway.jdk17.NullAwayModuleInfoTests
             "-Dtest.module.path=${configurations.testModulePath.asPath}"
     ]
 }

--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -22,7 +22,8 @@ plugins {
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)
 
 configurations {
-    // We use this configuration to expose a module path that can be used to test analysis of module-info.java files.
+    // We use this configuration to expose a module path that can be
+    // used to test analysis of module-info.java files.
     // See com.uber.nullaway.jdk17.NullAwayModuleInfoTests
     testModulePath
 }

--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -21,6 +21,10 @@ plugins {
 // Use JDK 17 for this module, via a toolchain
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)
 
+configurations {
+    testModulePath
+}
+
 dependencies {
     testImplementation project(":nullaway")
     testImplementation deps.test.junit4
@@ -28,6 +32,7 @@ dependencies {
         exclude group: "junit", module: "junit"
     }
     testImplementation deps.build.jsr305Annotations
+    testModulePath deps.test.cfQual
 }
 
 test {
@@ -44,6 +49,8 @@ test {
             "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            // for use as module path in tests
+            "-Dtest.module.path=${configurations.testModulePath.asPath}"
     ]
 }
 

--- a/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
+++ b/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
@@ -1,0 +1,41 @@
+package com.uber.nullaway.jdk17;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.NullAway;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NullAwayModuleInfoTests {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private CompilationTestHelper defaultCompilationHelper;
+
+  @Before
+  public void setup() {
+    // TODO set up module path
+    defaultCompilationHelper =
+        CompilationTestHelper.newInstance(NullAway.class, getClass())
+            .setArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "--module-path",
+                    System.getProperty("test.module.path"),
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+  }
+
+  @Test
+  public void testModuleInfo() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "module-info.java",
+            "module com.uber.mymodule {",
+            "  requires static org.checkerframework.checker.qual;",
+            "}")
+        .doTest();
+  }
+}

--- a/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
+++ b/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
@@ -16,7 +16,6 @@ public class NullAwayModuleInfoTests {
 
   @Before
   public void setup() {
-    // TODO set up module path
     defaultCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())
             .setArgs(

--- a/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
+++ b/jdk17-unit-tests/src/test/java/com/uber/nullaway/jdk17/NullAwayModuleInfoTests.java
@@ -23,6 +23,8 @@ public class NullAwayModuleInfoTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
+                    // The module path system property is set in the build.gradle file to just
+                    // include the jar for the Checker Framework qualifier annotations
                     "--module-path",
                     System.getProperty("test.module.path"),
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
@@ -30,6 +32,7 @@ public class NullAwayModuleInfoTests {
 
   @Test
   public void testModuleInfo() {
+    // just check that the tool doesn't crash
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2013,14 +2013,6 @@ public class NullAway extends BugChecker
         return Description.NO_MATCH;
       }
     }
-    if (baseExpressionSymbol == null && baseExpression.getKind().equals(Tree.Kind.MEMBER_SELECT)) {
-      // Dereferences of fields should always have a non-null symbol.  A null symbol _can_ occur for
-      // a MemberSelectTree in some cases though, e.g., in a requires clause in a module-info.java
-      // file, where the fully-qualified package name being "required" is represented using
-      // MemberSelectTrees.  In such cases, there is no possibility of a null dereference.
-      return Description.NO_MATCH;
-    }
-
     if (mayBeNullExpr(state, baseExpression)) {
       final String message =
           "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2013,6 +2013,14 @@ public class NullAway extends BugChecker
         return Description.NO_MATCH;
       }
     }
+    if (baseExpressionSymbol == null && baseExpression.getKind().equals(Tree.Kind.MEMBER_SELECT)) {
+      // Dereferences of fields should always have a non-null symbol.  A null symbol _can_ occur for
+      // a MemberSelectTree in some cases though, e.g., in a requires clause in a module-info.java
+      // file, where the fully-qualified package name being "required" is represented using
+      // MemberSelectTrees.  In such cases, there is no possibility of a null dereference.
+      return Description.NO_MATCH;
+    }
+
     if (mayBeNullExpr(state, baseExpression)) {
       final String message =
           "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -430,8 +430,10 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
     Symbol symbol = ASTHelpers.getSymbol(tree);
-    // some checks for cases where we know it is not
-    // a null dereference
+    // Some checks for cases where we know this cannot be a null dereference.  The tree's symbol may
+    // be null in cases where the tree represents a package name, e.g., in the package declaration
+    // in a class, or in a requires clause in a module-info.java file; it should never be null for a
+    // real field dereference or method call
     if (symbol == null || symbol.getSimpleName().toString().equals("class") || symbol.isEnum()) {
       return Description.NO_MATCH;
     }
@@ -1929,7 +1931,9 @@ public class NullAway extends BugChecker
         exprMayBeNull = false;
         break;
       case MEMBER_SELECT:
-        exprMayBeNull = mayBeNullFieldAccess(state, expr, exprSymbol);
+        // A MemberSelectTree for a field dereference or method call cannot have a null symbol; see
+        // comments in matchMemberSelect()
+        exprMayBeNull = exprSymbol == null ? false : mayBeNullFieldAccess(state, expr, exprSymbol);
         break;
       case IDENTIFIER:
         if (exprSymbol != null && exprSymbol.getKind().equals(ElementKind.FIELD)) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -300,20 +300,15 @@ public class NullabilityUtil {
   /**
    * Check if a field might be null, based on the type.
    *
-   * @param symbol symbol for field
+   * @param symbol symbol for field; must be non-null
    * @param config NullAway config
    * @return true if based on the type, package, and name of the field, the analysis should assume
    *     the field might be null; false otherwise
+   * @throws NullPointerException if {@code symbol} is null
    */
-  public static boolean mayBeNullFieldFromType(@Nullable Symbol symbol, Config config) {
-    if (symbol == null) {
-      // An expression representing a field dereference should always have a non-null symbol.  A
-      // `MemberSelectTree` _can_ have a null symbol in cases where it does _not_ represent a field
-      // dereference.  E.g., in a `requires` clause in a module-info.java file, the fully-qualified
-      // package name is represented using `MemberSelectTree`s.  When the symbol is null, there is
-      // no possibility of a null dereference.
-      return false;
-    }
+  public static boolean mayBeNullFieldFromType(Symbol symbol, Config config) {
+    Preconditions.checkNotNull(
+        symbol, "mayBeNullFieldFromType should never be called with a null symbol");
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()
             || isUnannotated(symbol, config))

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -307,7 +307,12 @@ public class NullabilityUtil {
    */
   public static boolean mayBeNullFieldFromType(@Nullable Symbol symbol, Config config) {
     if (symbol == null) {
-      return true;
+      // An expression representing a field dereference should always have a non-null symbol.  A
+      // `MemberSelectTree` _can_ have a null symbol in cases where it does _not_ represent a field
+      // dereference.  E.g., in a `requires` clause in a module-info.java file, the fully-qualified
+      // package name is represented using `MemberSelectTree`s.  When the symbol is null, there is
+      // no possibility of a null dereference.
+      return false;
     }
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()


### PR DESCRIPTION
Fixes #533 

We had no tests before for a `module-info.java` file, so we missed this regression.