### PR TITLE
Bump Guava dependency to 24.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ def build = [
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProneApi}",
     checkerDataflow         : "org.checkerframework:dataflow-nullaway:${versions.checkerFramework}",
-    guava                   : "com.google.guava:guava:22.0",
+    guava                   : "com.google.guava:guava:24.1.1-jre",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
     commonsIO               : "commons-io:commons-io:2.4",


### PR DESCRIPTION
This is needed, as previous versions of Guava are subject to
CVE-2018-10237.

Note that the vulnerability occurs when decerializing untrusted data.
As such, it is hard to imagine a case where NullAway would be directly
exploitable, but we still shouldn't be asking build systems to
resolve a known-vulnerable version of the library.

Also, I'd love to bump Guava to a more modern version, but internally
we still need to be able to work with Guava 24.1.1, so setting that
as the minimum version seems the safest course of action right now.