### PR TITLE
Improve nullness tracking of map calls in the presence of type casts

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -51,6 +51,7 @@ import org.checkerframework.nullaway.dataflow.cfg.node.Node;
 import org.checkerframework.nullaway.dataflow.cfg.node.StringLiteralNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.SuperNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.ThisNode;
+import org.checkerframework.nullaway.dataflow.cfg.node.TypeCastNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.VariableDeclarationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.nullaway.javacutil.TreeUtils;
@@ -249,6 +250,13 @@ public final class AccessPath implements MapKey {
     return fromMapGetCall(node, apContext);
   }
 
+  private static Node stripCasts(Node node) {
+    while (node instanceof TypeCastNode) {
+      node = ((TypeCastNode) node).getOperand();
+    }
+    return node;
+  }
+
   @Nullable
   private static MapKey argumentToMapKeySpecifier(Node argument, AccessPathContext apContext) {
     // Required to have Node type match Tree type in some instances.
@@ -265,13 +273,13 @@ public final class AccessPath implements MapKey {
         return new NumericMapKey(((LongLiteralNode) argument).getValue());
       case METHOD_INVOCATION:
         MethodAccessNode target = ((MethodInvocationNode) argument).getTarget();
+        Node receiver = stripCasts(target.getReceiver());
         List<Node> arguments = ((MethodInvocationNode) argument).getArguments();
         // Check for int/long boxing.
         if (target.getMethod().getSimpleName().toString().equals("valueOf")
             && arguments.size() == 1
-            && target.getReceiver().getTree().getKind().equals(Tree.Kind.IDENTIFIER)
-            && (target.getReceiver().toString().equals("Integer")
-                || target.getReceiver().toString().equals("Long"))) {
+            && receiver.getTree().getKind().equals(Tree.Kind.IDENTIFIER)
+            && (receiver.toString().equals("Integer") || receiver.toString().equals("Long"))) {
           return argumentToMapKeySpecifier(arguments.get(0), apContext);
         }
         // Fine to fallthrough:
@@ -289,7 +297,7 @@ public final class AccessPath implements MapKey {
       return null;
     }
     MethodAccessNode target = node.getTarget();
-    Node receiver = target.getReceiver();
+    Node receiver = stripCasts(target.getReceiver());
     List<AccessPathElement> elements = new ArrayList<>();
     Root root = populateElementsRec(receiver, elements, apContext);
     if (root == null) {
@@ -368,7 +376,7 @@ public final class AccessPath implements MapKey {
         result = new Root(fieldAccess.getElement());
       } else {
         // instance field access
-        result = populateElementsRec(fieldAccess.getReceiver(), elements, apContext);
+        result = populateElementsRec(stripCasts(fieldAccess.getReceiver()), elements, apContext);
         elements.add(new AccessPathElement(fieldAccess.getElement()));
       }
     } else if (node instanceof MethodInvocationNode) {
@@ -445,7 +453,7 @@ public final class AccessPath implements MapKey {
         }
         accessPathElement = new AccessPathElement(accessNode.getMethod(), constantArgumentValues);
       }
-      result = populateElementsRec(accessNode.getReceiver(), elements, apContext);
+      result = populateElementsRec(stripCasts(accessNode.getReceiver()), elements, apContext);
       elements.add(accessPathElement);
     } else if (node instanceof LocalVariableNode) {
       result = new Root(((LocalVariableNode) node).getElement());

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3227,4 +3227,36 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testMapGetChainWithCast() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Constants.java",
+            "package com.uber;",
+            "public class Constants {",
+            "   public static final String KEY_1 = \"key1\";",
+            "   public static final String KEY_2 = \"key2\";",
+            "   public static final String KEY_3 = \"key3\";",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Map;",
+            "class Test {",
+            "   boolean withoutCast(Map<String, Map<String, Map<String, Object>>> topLevelMap){",
+            "     return topLevelMap.get(Constants.KEY_1) == null ",
+            "       || topLevelMap.get(Constants.KEY_1).get(Constants.KEY_2) == null",
+            "       || topLevelMap.get(Constants.KEY_1).get(Constants.KEY_2).get(Constants.KEY_3) == null;",
+            "   }",
+            "   boolean withCast(Map<String, Object> topLevelMap){",
+            "     return topLevelMap.get(Constants.KEY_1) == null ",
+            "       || ((Map<String,Object>) topLevelMap.get(Constants.KEY_1)).get(Constants.KEY_2) == null",
+            "       || ((Map<String,Object>) ",
+            "              ((Map<String,Object>) topLevelMap.get(Constants.KEY_1)).get(Constants.KEY_2))",
+            "                .get(Constants.KEY_3) == null;",
+            "   }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
WIP. This is less a PR and more an issue report with a test case at this point.

When chains of `Map.get(a).get(b).get(c)` are used without casts, our existing map handling code suffices to keep track of non-null APs. However, this breaks in the presence of casts. Unfortunately, chains of maps with casts are a common way to handle hierarchical but untyped data sources, such as loaded JSON/Yaml.