### PR TITLE
Bump AutoValue and AutoService versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,8 +40,8 @@ def versions = [
     support                : "27.1.1",
     wala                   : "1.5.4",
     commonscli             : "1.4",
-    autoValue              : "1.6.2",
-    autoService            : "1.0-rc7",
+    autoValue              : "1.9",
+    autoService            : "1.0.1",
 ]
 
 def apt = [


### PR DESCRIPTION
A key benefit here is that these recent versions support Gradle incremental compilation.  I confirmed locally that with these updates, incremental compilation works for `./gradlew :nullaway:compileJava`.