### PR TITLE
Change default URL for error messages

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -129,7 +129,7 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "org.checkerframework.checker.nullness.qual.MonotonicNonNull",
           "org.springframework.beans.factory.annotation.Autowired");
 
-  private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
+  private static final String DEFAULT_URL = "https://github.com/uber/NullAway/wiki/Error-Messages";
 
   ErrorProneCLIFlagsConfig(ErrorProneFlags flags) {
     if (!flags.get(FL_ANNOTATED_PACKAGES).isPresent()) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -2250,7 +2250,7 @@ public class NullAwayTest {
             "package com.uber;",
             "class Test {",
             "  static void foo() {",
-            "    // BUG: Diagnostic contains: t.uber.com/nullaway",
+            "    // BUG: Diagnostic contains: https://github.com/uber/NullAway/wiki/Error-Messages",
             "    Object x = null; x.toString();",
             "  }",
             "}")


### PR DESCRIPTION
The default URL should point to the wiki, not to an Uber-internal page.