### PR TITLE
Add test case for unsound map reassignment handling

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3240,7 +3240,7 @@ public class NullAwayTest {
             "    if (m.containsKey(o)) {",
             "      // NullAway is currently unsound for this case.  It ignores",
             "      // the re-assignment of m and still assumes m.get(o) is non-null",
-            "      // on the next line.",
+            "      // on the subsequent line.",
             "      m = new HashMap();",
             "      m.get(o).toString();",
             "    }",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3227,4 +3227,25 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void mapReassignUnsound() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.*;",
+            "public class Test {",
+            "  public void mapReassignUnsound(Map m, Object o) {",
+            "    if (m.containsKey(o)) {",
+            "      // NullAway is currently unsound for this case.  It ignores",
+            "      // the re-assignment of m and still assumes m.get(o) is non-null",
+            "      // on the next line.",
+            "      m = new HashMap();",
+            "      m.get(o).toString();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTest.java
@@ -3227,25 +3227,4 @@ public class NullAwayTest {
             "}")
         .doTest();
   }
-
-  @Test
-  public void mapReassignUnsound() {
-    defaultCompilationHelper
-        .addSourceLines(
-            "Test.java",
-            "package com.uber;",
-            "import java.util.*;",
-            "public class Test {",
-            "  public void mapReassignUnsound(Map m, Object o) {",
-            "    if (m.containsKey(o)) {",
-            "      // NullAway is currently unsound for this case.  It ignores",
-            "      // the re-assignment of m and still assumes m.get(o) is non-null",
-            "      // on the subsequent line.",
-            "      m = new HashMap();",
-            "      m.get(o).toString();",
-            "    }",
-            "  }",
-            "}")
-        .doTest();
-  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayUnsoundnessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayUnsoundnessTests.java
@@ -1,0 +1,48 @@
+package com.uber.nullaway;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Unit tests showing cases where NullAway is unsound. Useful for documentation purposes. */
+public class NullAwayUnsoundnessTests {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private CompilationTestHelper defaultCompilationHelper;
+
+  @Before
+  public void setup() {
+    defaultCompilationHelper =
+        CompilationTestHelper.newInstance(NullAway.class, getClass())
+            .setArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+  }
+
+  @Test
+  public void mapReassignUnsound() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.*;",
+            "public class Test {",
+            "  public void mapReassignUnsound(Map m, Object o) {",
+            "    if (m.containsKey(o)) {",
+            "      // NullAway is currently unsound for this case.  It ignores",
+            "      // the re-assignment of m and still assumes m.get(o) is non-null",
+            "      // on the subsequent line.",
+            "      m = new HashMap();",
+            "      m.get(o).toString();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
It might be useful to have a suite of test cases showing where NullAway is unsound, for documentation purposes.  Here I just add one for re-assigning a `Map` variable, but we could easily add more in the future.