### PR TITLE
Add task to run NullAway on itself

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -92,27 +92,31 @@ test {
 
 apply plugin: 'com.vanniktech.maven.publish'
 
-tasks.register('buildWithNullAway', JavaCompile) {
-    // Configure compilation to run with Error Prone and NullAway
-    source = sourceSets.main.java
-    classpath = sourceSets.main.compileClasspath
-    destinationDirectory = file("$buildDir/ignoredClasses")
-    def nullawayDeps = configurations.nullawayJar.asCollection()
-    options.annotationProcessorPath = files(
-            configurations.errorprone.asCollection(),
-            sourceSets.main.annotationProcessorPath,
-            nullawayDeps)
-    options.errorprone.enabled = true
-    options.errorprone {
-        option("NullAway:AnnotatedPackages", "com.uber")
-    }
-    // Make sure the jar has already been built
-    dependsOn 'jar'
-    // Check that the NullAway jar actually exists (without this,
-    // Gradle will run the compilation even if the jar doesn't exist)
-    doFirst {
-        nullawayDeps.forEach { f ->
-            assert f.exists()
+// Create a task to build NullAway with NullAway checking enabled
+// For some reason, this doesn't work on Java 8
+if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+    tasks.register('buildWithNullAway', JavaCompile) {
+        // Configure compilation to run with Error Prone and NullAway
+        source = sourceSets.main.java
+        classpath = sourceSets.main.compileClasspath
+        destinationDirectory = file("$buildDir/ignoredClasses")
+        def nullawayDeps = configurations.nullawayJar.asCollection()
+        options.annotationProcessorPath = files(
+                configurations.errorprone.asCollection(),
+                sourceSets.main.annotationProcessorPath,
+                nullawayDeps)
+        options.errorprone.enabled = true
+        options.errorprone {
+            option("NullAway:AnnotatedPackages", "com.uber")
+        }
+        // Make sure the jar has already been built
+        dependsOn 'jar'
+        // Check that the NullAway jar actually exists (without this,
+        // Gradle will run the compilation even if the jar doesn't exist)
+        doFirst {
+            nullawayDeps.forEach { f ->
+                assert f.exists()
+            }
         }
     }
 }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -23,6 +23,9 @@ plugins {
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
+configurations {
+    nullawayRelease
+}
 dependencies {
     compileOnly deps.apt.autoValueAnnot
     annotationProcessor deps.apt.autoValue
@@ -53,6 +56,8 @@ dependencies {
     testImplementation deps.test.springBeans
     testImplementation deps.test.springContext
     testImplementation deps.test.grpcCore
+
+    nullawayRelease 'com.uber.nullaway:nullaway:0.9.4'
 }
 
 javadoc {
@@ -85,3 +90,17 @@ test {
 
 apply plugin: 'com.vanniktech.maven.publish'
 
+tasks.register('buildWithNullAway', JavaCompile) {
+    source = sourceSets.main.java
+    classpath = sourceSets.main.compileClasspath
+    destinationDirectory = file("$buildDir/ignoredClasses")
+    options.annotationProcessorPath = files(
+            configurations.errorprone.asCollection(),
+            sourceSets.main.annotationProcessorPath,
+            configurations.nullawayRelease.asCollection())
+    // Enable Error Prone
+    options.errorprone.enabled = true
+    options.errorprone {
+        option("NullAway:AnnotatedPackages", "com.uber")
+    }
+}

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -24,8 +24,9 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 configurations {
-    nullawayRelease
+    nullawayJar
 }
+
 dependencies {
     compileOnly deps.apt.autoValueAnnot
     annotationProcessor deps.apt.autoValue
@@ -57,7 +58,8 @@ dependencies {
     testImplementation deps.test.springContext
     testImplementation deps.test.grpcCore
 
-    nullawayRelease 'com.uber.nullaway:nullaway:0.9.4'
+    // This ends up being resolved to the NullAway jar under nullaway/build/libs
+    nullawayJar "com.uber.nullaway:nullaway:$VERSION_NAME"
 }
 
 javadoc {
@@ -91,16 +93,26 @@ test {
 apply plugin: 'com.vanniktech.maven.publish'
 
 tasks.register('buildWithNullAway', JavaCompile) {
+    // Configure compilation to run with Error Prone and NullAway
     source = sourceSets.main.java
     classpath = sourceSets.main.compileClasspath
     destinationDirectory = file("$buildDir/ignoredClasses")
+    def nullawayDeps = configurations.nullawayJar.asCollection()
     options.annotationProcessorPath = files(
             configurations.errorprone.asCollection(),
             sourceSets.main.annotationProcessorPath,
-            configurations.nullawayRelease.asCollection())
-    // Enable Error Prone
+            nullawayDeps)
     options.errorprone.enabled = true
     options.errorprone {
         option("NullAway:AnnotatedPackages", "com.uber")
+    }
+    // Make sure the jar has already been built
+    dependsOn 'jar'
+    // Check that the NullAway jar actually exists (without this,
+    // Gradle will run the compilation even if the jar doesn't exist)
+    doFirst {
+        nullawayDeps.forEach { f ->
+            assert f.exists()
+        }
     }
 }


### PR DESCRIPTION
The task can be run as `./gradlew :nullaway:buildWithNullAway`.  This turned out to be less challenging than I expected.  Unfortunately, the NullAway implementation does not yet pass NullAway 🙂 We will need to address that before running this task on CI.  The task only gets created when building on JDK 11+; for reasons I don't understand, the task fails to configure on JDK 8.