### PR TITLE
Tweak handling of assignments in dataflow

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -505,7 +505,8 @@ public class AccessPathNullnessPropagation
     Nullness value = values(input).valueOfSubNode(node.getExpression());
     Node target = node.getTarget();
 
-    if (target instanceof LocalVariableNode) {
+    if (target instanceof LocalVariableNode
+        && !ASTHelpers.getType(target.getTree()).isPrimitive()) {
       updates.set((LocalVariableNode) target, value);
     }
 
@@ -518,8 +519,10 @@ public class AccessPathNullnessPropagation
       // here we still require an access of a field of this, or a static field
       FieldAccessNode fieldAccessNode = (FieldAccessNode) target;
       Node receiver = fieldAccessNode.getReceiver();
+      setNonnullIfAnalyzeable(updates, receiver);
       if ((receiver instanceof ThisNode || fieldAccessNode.isStatic())
-          && fieldAccessNode.getElement().getKind().equals(ElementKind.FIELD)) {
+          && fieldAccessNode.getElement().getKind().equals(ElementKind.FIELD)
+          && !ASTHelpers.getType(target.getTree()).isPrimitive()) {
         updates.set(fieldAccessNode, value);
       }
     }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -283,6 +283,12 @@ public class NullAwayPositiveCases {
     arr.toString();
   }
 
+  static void onlyReportOneField(@Nullable Inner i) {
+    // BUG: Diagnostic contains: dereferenced expression
+    i.f1 = null;
+    i.toString();
+  }
+
   static void testCast(@Nullable Object o) {
     String x = (String) o;
     // BUG: Diagnostic contains: dereferenced expression


### PR DESCRIPTION
We add two small tweaks to assignment handling (found while reading the code):

1. If we see an assignment `e.f = ...`, treat `e` as non-null on the non-exceptional successor (since the dereference succeeded), if it's an access path that we can track.  We already did this for assignments to array elements; we should do the same for field assignments, for consistency.
2. Don't track nullability for variables and fields of primitive type, as they can never be de-referenced.  This is an optimization that could reduce the size of the stores we propagate around.  I didn't measure the impact, but it seems like an obvious, if small, win.

I put the new test input in the same place as other similar ones in `NullAwayPositiveCases`, for consistency.