### PR TITLE
Enable parallel builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,7 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 
 GROUP=com.uber.nullaway
 VERSION_NAME=0.9.6-SNAPSHOT


### PR DESCRIPTION
This Gradle feature is quite stable now, so we should use it to speed up builds.