### PR TITLE
Add dependence from coveralls task to codeCoverageReport

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
-          arguments: codeCoverageReport coveralls
+          arguments: coveralls
         continue-on-error: true
         if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.4.0' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -71,6 +71,12 @@ coveralls {
     }
 }
 
+def coverallsTask = tasks.named('coveralls')
+
+coverallsTask.configure {
+    dependsOn 'codeCoverageReport'
+}
+
 // These dependencies indicate which projects have tests or tested code we want to include
 // when computing overall coverage.  We aim to measure coverage for all code that actually ships
 // in a Maven artifact (so, e.g., we do not measure coverage for the jmh module)


### PR DESCRIPTION
This missing dependence was exposed by enabling parallel builds, which allowed for the `coveralls` task to run before `codeCoverageReport`.