### PR TITLE
Switch to temurin to fix CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          # dummy change
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Build and test using Gradle, Java 8, and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Build and test using Gradle, Java 8, and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          # dummy change
+          distribution: 'zulu'
       - name: Build and test using Gradle, Java 8, and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}


### PR DESCRIPTION
It seems like the zulu OpenJDK distribution suddenly is causing failures for us on JDK 8 and 17 on ubuntu.  No idea why.  Switching to temurin seems to fix the problem.  I don't know if this is the real root cause, but I will likely just go ahead and land to unbreak CI.