### PR TITLE
Disable parallel builds and daemon for uploading snapshots

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,4 +99,4 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew clean publish
+        run: ./gradlew clean publish --no-daemon --no-parallel


### PR DESCRIPTION
Now that parallel builds are enabled by default, we should disable them when uploading snapshots, to avoid errors due to concurrent uploads.  We also disable the daemon since that is typical for such builds.