### PR TITLE
Reason about key set iteration for subtypes of Map

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2027,8 +2027,7 @@ public class NullAway extends BugChecker
   }
 
   public AccessPathNullnessAnalysis getNullnessAnalysis(VisitorState state) {
-    return AccessPathNullnessAnalysis.instance(
-        state.context, nonAnnotatedMethod, config, this.handler);
+    return AccessPathNullnessAnalysis.instance(state, nonAnnotatedMethod, config, this.handler);
   }
 
   private boolean mayBeNullFieldAccess(VisitorState state, ExpressionTree expr, Symbol exprSymbol) {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -26,14 +26,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
-import com.google.errorprone.suppliers.Supplier;
-import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
+import com.uber.nullaway.NullabilityUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -549,40 +548,16 @@ public final class AccessPath implements MapKey {
     return "AccessPath{" + "root=" + root + ", elements=" + elements + '}';
   }
 
-  private static final Supplier<Type> MAP_TYPE_SUPPLIER = Suppliers.typeFromString("java.util.Map");
-
-  public static boolean isMapMethod(
-      Symbol.MethodSymbol symbol, VisitorState state, String methodName, int numParams) {
-    if (!symbol.getSimpleName().toString().equals(methodName)) {
-      return false;
-    }
-    if (symbol.getParameters().size() != numParams) {
-      return false;
-    }
-    Symbol owner = symbol.owner;
-    return ASTHelpers.isSubtype(owner.type, MAP_TYPE_SUPPLIER.get(state), state);
-    //    if (owner.getQualifiedName().toString().equals("java.util.Map")) {
-    //      return true;
-    //    }
-    //    com.sun.tools.javac.util.List<Type> supertypes = types.closure(owner.type);
-    //    for (Type t : supertypes) {
-    //      if (t.asElement().getQualifiedName().toString().equals("java.util.Map")) {
-    //        return true;
-    //      }
-    //    }
-    //    return false;
-  }
-
   private static boolean isMapGet(Symbol.MethodSymbol symbol, VisitorState state) {
-    return isMapMethod(symbol, state, "get", 1);
+    return NullabilityUtil.isMapMethod(symbol, state, "get", 1);
   }
 
   public static boolean isContainsKey(Symbol.MethodSymbol symbol, VisitorState state) {
-    return isMapMethod(symbol, state, "containsKey", 1);
+    return NullabilityUtil.isMapMethod(symbol, state, "containsKey", 1);
   }
 
   public static boolean isMapPut(Symbol.MethodSymbol symbol, VisitorState state) {
-    return isMapMethod(symbol, state, "put", 2);
+    return NullabilityUtil.isMapMethod(symbol, state, "put", 2);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -25,13 +25,15 @@ package com.uber.nullaway.dataflow;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -162,8 +164,8 @@ public final class AccessPath implements MapKey {
    */
   @Nullable
   static AccessPath fromMethodCall(
-      MethodInvocationNode node, @Nullable Types types, AccessPathContext apContext) {
-    if (types != null && isMapGet(ASTHelpers.getSymbol(node.getTree()), types)) {
+      MethodInvocationNode node, @Nullable VisitorState state, AccessPathContext apContext) {
+    if (state != null && isMapGet(ASTHelpers.getSymbol(node.getTree()), state)) {
       return fromMapGetCall(node, apContext);
     }
     return fromVanillaMethodCall(node, apContext);
@@ -325,20 +327,20 @@ public final class AccessPath implements MapKey {
    * </code>
    *
    * @param node AST node
-   * @param types javac {@link Types}
+   * @param state the visitor state
    * @param apContext the current access path context information (see {@link
    *     AccessPath.AccessPathContext}).
    * @return corresponding AccessPath if it exists; <code>null</code> otherwise
    */
   @Nullable
   public static AccessPath getAccessPathForNodeWithMapGet(
-      Node node, @Nullable Types types, AccessPathContext apContext) {
+      Node node, @Nullable VisitorState state, AccessPathContext apContext) {
     if (node instanceof LocalVariableNode) {
       return fromLocal((LocalVariableNode) node);
     } else if (node instanceof FieldAccessNode) {
       return fromFieldAccess((FieldAccessNode) node, apContext);
     } else if (node instanceof MethodInvocationNode) {
-      return fromMethodCall((MethodInvocationNode) node, types, apContext);
+      return fromMethodCall((MethodInvocationNode) node, state, apContext);
     } else {
       return null;
     }
@@ -547,8 +549,10 @@ public final class AccessPath implements MapKey {
     return "AccessPath{" + "root=" + root + ", elements=" + elements + '}';
   }
 
-  private static boolean isMapMethod(
-      Symbol.MethodSymbol symbol, Types types, String methodName, int numParams) {
+  private static final Supplier<Type> MAP_TYPE_SUPPLIER = Suppliers.typeFromString("java.util.Map");
+
+  public static boolean isMapMethod(
+      Symbol.MethodSymbol symbol, VisitorState state, String methodName, int numParams) {
     if (!symbol.getSimpleName().toString().equals(methodName)) {
       return false;
     }
@@ -556,28 +560,29 @@ public final class AccessPath implements MapKey {
       return false;
     }
     Symbol owner = symbol.owner;
-    if (owner.getQualifiedName().toString().equals("java.util.Map")) {
-      return true;
-    }
-    com.sun.tools.javac.util.List<Type> supertypes = types.closure(owner.type);
-    for (Type t : supertypes) {
-      if (t.asElement().getQualifiedName().toString().equals("java.util.Map")) {
-        return true;
-      }
-    }
-    return false;
+    return ASTHelpers.isSubtype(owner.type, MAP_TYPE_SUPPLIER.get(state), state);
+    //    if (owner.getQualifiedName().toString().equals("java.util.Map")) {
+    //      return true;
+    //    }
+    //    com.sun.tools.javac.util.List<Type> supertypes = types.closure(owner.type);
+    //    for (Type t : supertypes) {
+    //      if (t.asElement().getQualifiedName().toString().equals("java.util.Map")) {
+    //        return true;
+    //      }
+    //    }
+    //    return false;
   }
 
-  private static boolean isMapGet(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "get", 1);
+  private static boolean isMapGet(Symbol.MethodSymbol symbol, VisitorState state) {
+    return isMapMethod(symbol, state, "get", 1);
   }
 
-  public static boolean isContainsKey(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "containsKey", 1);
+  public static boolean isContainsKey(Symbol.MethodSymbol symbol, VisitorState state) {
+    return isMapMethod(symbol, state, "containsKey", 1);
   }
 
-  public static boolean isMapPut(Symbol.MethodSymbol symbol, Types types) {
-    return isMapMethod(symbol, types, "put", 2);
+  public static boolean isMapPut(Symbol.MethodSymbol symbol, VisitorState state) {
+    return isMapMethod(symbol, state, "put", 2);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -62,7 +62,7 @@ public final class AccessPathNullnessAnalysis {
   // Use #instance to instantiate
   private AccessPathNullnessAnalysis(
       Predicate<MethodInvocationNode> methodReturnsNonNull,
-      Context context,
+      VisitorState state,
       Config config,
       Handler handler) {
     apContext =
@@ -73,7 +73,7 @@ public final class AccessPathNullnessAnalysis {
         new AccessPathNullnessPropagation(
             Nullness.NONNULL,
             methodReturnsNonNull,
-            context,
+            state,
             apContext,
             config,
             handler,
@@ -85,7 +85,7 @@ public final class AccessPathNullnessAnalysis {
           new AccessPathNullnessPropagation(
               Nullness.NONNULL,
               methodReturnsNonNull,
-              context,
+              state,
               apContext,
               config,
               handler,
@@ -96,20 +96,21 @@ public final class AccessPathNullnessAnalysis {
   /**
    * Get the per-Javac instance of the analysis.
    *
-   * @param context Javac context
+   * @param state visitor state for the compilation
    * @param methodReturnsNonNull predicate determining whether a method is assumed to return NonNull
    *     value
    * @param config analysis config
    * @return instance of the analysis
    */
   public static AccessPathNullnessAnalysis instance(
-      Context context,
+      VisitorState state,
       Predicate<MethodInvocationNode> methodReturnsNonNull,
       Config config,
       Handler handler) {
+    Context context = state.context;
     AccessPathNullnessAnalysis instance = context.get(FIELD_NULLNESS_ANALYSIS_KEY);
     if (instance == null) {
-      instance = new AccessPathNullnessAnalysis(methodReturnsNonNull, context, config, handler);
+      instance = new AccessPathNullnessAnalysis(methodReturnsNonNull, state, config, handler);
       context.put(FIELD_NULLNESS_ANALYSIS_KEY, instance);
     }
     return instance;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -608,8 +608,7 @@ public class AccessPathNullnessPropagation
     if (receiver instanceof MethodInvocationNode) {
       MethodInvocationNode baseInvocation = (MethodInvocationNode) receiver;
       // Check for a call to java.util.Map.keySet()
-      //      if (isCallToMethod(baseInvocation, "java.util.Map", "keySet")) {
-      if (AccessPath.isMapMethod(
+      if (NullabilityUtil.isMapMethod(
           ASTHelpers.getSymbol(baseInvocation.getTree()), state, "keySet", 0)) {
         // receiver represents the map
         return baseInvocation.getTarget().getReceiver();

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.intersection;
 
 import com.google.common.collect.ImmutableMap;
-import com.sun.tools.javac.code.Types;
+import com.google.errorprone.VisitorState;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath.IteratorContentsKey;
 import java.util.HashMap;
@@ -97,10 +97,10 @@ public class NullnessStore implements Store<NullnessStore> {
    */
   public Nullness valueOfMethodCall(
       MethodInvocationNode node,
-      Types types,
+      VisitorState state,
       Nullness defaultValue,
       AccessPath.AccessPathContext apContext) {
-    AccessPath accessPath = AccessPath.fromMethodCall(node, types, apContext);
+    AccessPath accessPath = AccessPath.fromMethodCall(node, state, apContext);
     if (accessPath == null) {
       return defaultValue;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayKeySetIteratorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayKeySetIteratorTests.java
@@ -133,14 +133,26 @@ public class NullAwayKeySetIteratorTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void immutableMap() {
+  public void declaredTypeSubtypeOfMap() {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
             "package com.uber;",
             "import com.google.common.collect.ImmutableMap;",
+            "import java.util.TreeMap;",
+            "import java.util.LinkedHashMap;",
             "public class Test {",
-            "  public void keySetStuff(ImmutableMap<Object, Object> m) {",
+            "  public void keySetStuff1(ImmutableMap<Object, Object> m) {",
+            "    for (Object k: m.keySet()) {",
+            "      m.get(k).toString();",
+            "    }",
+            "  }",
+            "  public void keySetStuff2(TreeMap<Object, Object> m) {",
+            "    for (Object k: m.keySet()) {",
+            "      m.get(k).toString();",
+            "    }",
+            "  }",
+            "  public void keySetStuff3(LinkedHashMap<Object, Object> m) {",
             "    for (Object k: m.keySet()) {",
             "      m.get(k).toString();",
             "    }",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayKeySetIteratorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayKeySetIteratorTests.java
@@ -131,4 +131,21 @@ public class NullAwayKeySetIteratorTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void immutableMap() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.google.common.collect.ImmutableMap;",
+            "public class Test {",
+            "  public void keySetStuff(ImmutableMap<Object, Object> m) {",
+            "    for (Object k: m.keySet()) {",
+            "      m.get(k).toString();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #558 

Most of the changes here are to thread around a `VisitorState` instead of a `Types` object, which allows us to use recommended Error Prone APIs to get a reference to a `Type` object and do subtype tests.