### PR TITLE
Enable build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2g
 
 GROUP=com.uber.nullaway
 VERSION_NAME=0.9.6-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 GROUP=com.uber.nullaway
 VERSION_NAME=0.9.6-SNAPSHOT


### PR DESCRIPTION
The build cache feature has been around long enough now that I think we can safely enable it.  I'm often switching between Java versions and Error Prone versions when testing locally, so this will speed up my local builds.

Also, with parallel builds, I find my Gradle daemon often runs out of memory (default is 512MB).  Bump the max heap to 2GB.