### PR TITLE
Limit metaspace size for daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 GROUP=com.uber.nullaway
 VERSION_NAME=0.9.6-SNAPSHOT


### PR DESCRIPTION
Apparently without this parameter, the metaspace size can grow without limit:

https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-B29C9153-3530-4C15-9154-E74F44E3DAD9

So, it's a best practice to set some limit, so the daemon doesn't end up consuming all memory.