### PR TITLE
Update CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,9 @@ jobs:
           - os: ubuntu-latest
             java: 8
             epVersion: 2.4.0
+          - os: ubuntu-latest
+            java: 11
+            epVersion: 2.4.0
           - os: macos-latest
             java: 11
             epVersion: 2.10.0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,9 +83,10 @@ jobs:
           key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradlew-wrapper-
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: 'Publish'
         env:
           ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,24 +13,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: ubuntu-latest
             java: 8
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.4.0
-          - os: ubuntu-latest
-            java: 8
-            epVersion: 2.4.0
-          - os: ubuntu-latest
-            java: 8
             epVersion: 2.10.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.4.0
+            epVersion: 2.10.0
           - os: windows-latest
-            java: 8
-            epVersion: 2.4.0
+            java: 11
+            epVersion: 2.10.0
           - os: ubuntu-latest
             java: 17
             epVersion: 2.10.0
@@ -44,19 +38,16 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Build and test using Gradle, Java 8, and Error Prone ${{ matrix.epVersion }}
+      - name: Build and test using Gradle, Java ${{ matrix.java }}, and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: verGJF build
-        if: matrix.java == '8'
-      - name: Build and test using Gradle and Java 11
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: build
-        if: matrix.java == '11'
-      - name: Build and test using Gradle and Java 17
+        if: matrix.java != '17'
+      - name: Build and test using Gradle, Java ${{ matrix.java }}, and Error Prone ${{ matrix.epVersion }}
+        env:
+          ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
@@ -68,7 +59,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.4.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.10.0' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
   publish_snapshot:


### PR DESCRIPTION
This updates our config to run the following jobs:
* JDK 11 on all platforms, using the latest supported Error Prone version (currently 2.10.0).  This builds and tests all of our targets.
* A "legacy" job, running on Linux with JDK 8 and the oldest supported Error Prone version (currently 2.4.0).  Some targets are now disabled here, like building of sample Android apps and corresponding tests.
* A JDK 17 job with latest Error Prone that runs core NullAway tests, but still doesn't run all Android / JarInfer tests (still work to do to get them passing).

I think this is a sufficient set of CI jobs to give us good coverage of realistic configurations.  We could add a Linux / JDK 11 / EP 2.4.0 job for a bit more coverage if we like.

We'll need to update the "Required" CI jobs after this lands.