### PR TITLE
Set epApiVersion for jacoco coverage reporting

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:
+          ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           arguments: coveralls


### PR DESCRIPTION
Follow-up to #565.  This env var should be set consistently between the step that runs tests and the step that uploads Jacoco coverage.  Without that, the Gradle test tasks will unnecessarily re-run when uploading coverage info.