### PR TITLE
Compile and test against Error Prone 2.11.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.10.0
+            epVersion: 2.11.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.10.0
+            epVersion: 2.11.0
           - os: windows-latest
             java: 11
-            epVersion: 2.10.0
+            epVersion: 2.11.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.10.0
+            epVersion: 2.11.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,8 @@
+IMPORTANT: Make sure you are using a JDK 8 JVM by checking `java -version` before any
+of the steps below.  If you run the steps below on a JDK 11+ JVM, that will break Java
+8 support, as the released jars will only run on JDK 11.  We do not target Java 8 when
+building on JDK 11 since Error Prone has required Java 11 since version 2.11.0.
+
 (Recommended, but optional) Update JarInfer Android SDK Models
 ==============================================================
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,11 +68,12 @@ subprojects { project ->
         }
     }
 
-//    if (JavaVersion.current().java9Compatible) {
-//        tasks.withType(JavaCompile) {
-//            options.release = 8
-//        }
-//    }
+    if (JavaVersion.current().java9Compatible) {
+        tasks.withType(JavaCompile) {
+            java.sourceCompatibility = "11"
+            java.targetCompatibility = "11"
+        }
+    }
 
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects { project ->
         }
     }
 
-    if (JavaVersion.current().java9Compatible) {
+    if (JavaVersion.current() >= JavaVersion.VERSION_11) {
         tasks.withType(JavaCompile) {
             java.sourceCompatibility = "11"
             java.targetCompatibility = "11"

--- a/build.gradle
+++ b/build.gradle
@@ -68,11 +68,11 @@ subprojects { project ->
         }
     }
 
-    if (JavaVersion.current().java9Compatible) {
-        tasks.withType(JavaCompile) {
-            options.release = 8
-        }
-    }
+//    if (JavaVersion.current().java9Compatible) {
+//        tasks.withType(JavaCompile) {
+//            options.release = 8
+//        }
+//    }
 
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,15 @@ subprojects { project ->
             check("MutablePublicArray", CheckSeverity.OFF)
             // this check is too noisy
             check("StringSplitter", CheckSeverity.OFF)
+            // we can't fix these issues until EP 2.11.0 is our minimum version
+            check("BugPatternNaming", CheckSeverity.OFF)
             check("WildcardImport", CheckSeverity.ERROR)
             check("MissingBraces", CheckSeverity.ERROR)
         }
     }
 
+    // We target Java 11 when building on JDK 11+, but Java 8 when building on JDK 8, since
+    // EP 2.11.0+ requires Java 11
     if (JavaVersion.current() >= JavaVersion.VERSION_11) {
         tasks.withType(JavaCompile) {
             java.sourceCompatibility = "11"

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,6 @@ subprojects { project ->
             check("MutablePublicArray", CheckSeverity.OFF)
             // this check is too noisy
             check("StringSplitter", CheckSeverity.OFF)
-            // we can't fix these issues until EP 2.11.0 is our minimum version
-            check("BugPatternNaming", CheckSeverity.OFF)
             check("WildcardImport", CheckSeverity.ERROR)
             check("MissingBraces", CheckSeverity.ERROR)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,13 @@ subprojects { project ->
         }
     }
 
+    // Ensure we are running on Java 8 whenever publishing to remote repos
+    tasks.withType(PublishToMavenRepository) {
+        doFirst {
+            assert JavaVersion.current() == JavaVersion.VERSION_1_8 : "Only publish to remote repos on JDK 1.8"
+        }
+    }
+
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ subprojects { project ->
             java.sourceCompatibility = "11"
             java.targetCompatibility = "11"
         }
+    } else {
+        tasks.withType(JavaCompile) {
+            java.sourceCompatibility = "1.8"
+            java.targetCompatibility = "1.8"
+        }
     }
 
     tasks.withType(Test).configureEach {

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -21,6 +21,11 @@ plugins {
     id 'com.github.kt3k.coveralls'
 }
 
+// Use JDK 17 for this module, via a toolchain
+java.sourceCompatibility = null
+java.targetCompatibility = null
+java.toolchain.languageVersion.set JavaLanguageVersion.of(17)
+
 // A resolvable configuration to collect source code
 def sourcesPath = configurations.create("sourcesPath") {
     visible = false

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -21,7 +21,9 @@ plugins {
     id 'com.github.kt3k.coveralls'
 }
 
-// Use JDK 17 for this module, via a toolchain
+// Use JDK 17 for this module, via a toolchain.  We need JDK 17 since this module
+// depends on jdk17-unit-tests.
+// We must null out sourceCompatibility and targetCompatibility to use toolchains.
 java.sourceCompatibility = null
 java.targetCompatibility = null
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ import org.gradle.util.VersionNumber
  */
 
 // The oldest version of Error Prone that we support running on
-def oldestErrorProneApi = "2.11.0"
+def oldestErrorProneApi = "2.4.0"
 
 if (project.hasProperty("epApiVersion")) {
     def epApiVNum = VersionNumber.parse(epApiVersion)
@@ -34,7 +34,7 @@ def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.21.1",
     // The version of Error Prone used to check NullAway's code
-    errorProne             : "2.10.0",
+    errorProne             : JavaVersion.current() >= JavaVersion.VERSION_11 ? "2.11.0" : "2.10.0",
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
     support                : "27.1.1",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,8 @@ if (project.hasProperty("epApiVersion")) {
 def versions = [
     asm                    : "7.1",
     checkerFramework       : "3.21.1",
-    // The version of Error Prone used to check NullAway's code
+    // The version of Error Prone used to check NullAway's code.
+    // EP 2.10.0 was the last version compatible with Java 8
     errorProne             : JavaVersion.current() >= JavaVersion.VERSION_11 ? "2.11.0" : "2.10.0",
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ import org.gradle.util.VersionNumber
  */
 
 // The oldest version of Error Prone that we support running on
-def oldestErrorProneApi = "2.4.0"
+def oldestErrorProneApi = "2.11.0"
 
 if (project.hasProperty("epApiVersion")) {
     def epApiVNum = VersionNumber.parse(epApiVersion)

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id "com.github.johnrengelman.shadow"
 }
 
-//sourceCompatibility = "1.8"
-//targetCompatibility = "1.8"
-
 repositories {
     mavenCentral()
 }

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -4,8 +4,8 @@ plugins {
     id "com.github.johnrengelman.shadow"
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+//sourceCompatibility = "1.8"
+//targetCompatibility = "1.8"
 
 repositories {
     mavenCentral()

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -65,6 +65,7 @@ public class JarInferTest {
    * A dummy checker to allow us to use {@link CompilationTestHelper} to compile Java code for
    * testing, as it requires a {@link BugChecker} to run.
    */
+  @SuppressWarnings("BugPatternNaming") // For compat with EP pre 2.11.0
   public static class DummyChecker extends BugChecker {
     public DummyChecker() {}
   }

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -65,6 +65,7 @@ public class JarInferTest {
    * A dummy checker to allow us to use {@link CompilationTestHelper} to compile Java code for
    * testing, as it requires a {@link BugChecker} to run.
    */
+  @SuppressWarnings("BugPatternNaming") // remove once we require EP 2.11+
   public static class DummyChecker extends BugChecker {
     public DummyChecker() {}
   }

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -57,14 +57,14 @@ public class JarInferTest {
 
   private CompilationTestHelper compilationTestHelper;
 
-  @BugPattern(
-      name = "DummyChecker",
-      summary = "Dummy checker to use CompilationTestHelper",
-      severity = WARNING)
   /**
    * A dummy checker to allow us to use {@link CompilationTestHelper} to compile Java code for
    * testing, as it requires a {@link BugChecker} to run.
    */
+  @BugPattern(
+      name = "DummyChecker",
+      summary = "Dummy checker to use CompilationTestHelper",
+      severity = WARNING)
   @SuppressWarnings("BugPatternNaming") // remove once we require EP 2.11+
   public static class DummyChecker extends BugChecker {
     public DummyChecker() {}

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -65,7 +65,6 @@ public class JarInferTest {
    * A dummy checker to allow us to use {@link CompilationTestHelper} to compile Java code for
    * testing, as it requires a {@link BugChecker} to run.
    */
-  @SuppressWarnings("BugPatternNaming") // For compat with EP pre 2.11.0
   public static class DummyChecker extends BugChecker {
     public DummyChecker() {}
   }

--- a/jar-infer/nullaway-integration-test/build.gradle
+++ b/jar-infer/nullaway-integration-test/build.gradle
@@ -18,9 +18,6 @@ plugins {
   id "nullaway.jacoco-conventions"
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
-
 dependencies {
      testImplementation deps.test.junit4
      testImplementation(deps.build.errorProneTestHelpers) {

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -20,9 +20,6 @@ plugins {
 
 evaluationDependsOn(":jar-infer:jar-infer-cli")
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
-
 def astubxPath = "com/uber/nullaway/jarinfer/provider/jarinfer.astubx"
 
 jar {

--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -19,6 +19,8 @@ plugins {
 }
 
 // Use JDK 17 for this module, via a toolchain
+java.sourceCompatibility = null
+java.targetCompatibility = null
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)
 
 configurations {

--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -19,6 +19,7 @@ plugins {
 }
 
 // Use JDK 17 for this module, via a toolchain
+// We must null out sourceCompatibility and targetCompatibility to use toolchains.
 java.sourceCompatibility = null
 java.targetCompatibility = null
 java.toolchain.languageVersion.set JavaLanguageVersion.of(17)

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -20,8 +20,9 @@ plugins {
   id 'nullaway.jacoco-conventions'
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+project.sourceCompatibility = "11"
+project.targetCompatibility = "11"
+
 
 configurations {
     nullawayJar
@@ -119,4 +120,20 @@ if (JavaVersion.current() >= JavaVersion.VERSION_11) {
             }
         }
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
+    ]
 }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -89,9 +89,26 @@ test {
 
 apply plugin: 'com.vanniktech.maven.publish'
 
-// Create a task to build NullAway with NullAway checking enabled
-// For some reason, this doesn't work on Java 8
 if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+    // Required on Java 11+ since Error Prone and NullAway access a bunch of
+    // JDK-internal APIs that are not exposed otherwise
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs += [
+                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
+        ]
+    }
+    // Create a task to build NullAway with NullAway checking enabled
+    // For some reason, this doesn't work on Java 8
     tasks.register('buildWithNullAway', JavaCompile) {
         // Configure compilation to run with Error Prone and NullAway
         source = sourceSets.main.java
@@ -116,20 +133,4 @@ if (JavaVersion.current() >= JavaVersion.VERSION_11) {
             }
         }
     }
-    tasks.withType(JavaCompile).configureEach {
-        options.compilerArgs += [
-                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-                "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
-        ]
-    }
 }
-

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -20,10 +20,6 @@ plugins {
   id 'nullaway.jacoco-conventions'
 }
 
-project.sourceCompatibility = "11"
-project.targetCompatibility = "11"
-
-
 configurations {
     nullawayJar
 }
@@ -120,20 +116,20 @@ if (JavaVersion.current() >= JavaVersion.VERSION_11) {
             }
         }
     }
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs += [
+                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
+        ]
+    }
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
-    ]
-}

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -148,6 +148,7 @@ import org.checkerframework.nullaway.javacutil.TreeUtils;
     summary = "Nullability type error.",
     tags = BugPattern.StandardTags.LIKELY_ERROR,
     severity = WARNING)
+@SuppressWarnings("BugPatternNaming") // remove once we require EP 2.11+
 public class NullAway extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher,
         BugChecker.AssignmentTreeMatcher,

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -143,7 +143,6 @@ import org.checkerframework.nullaway.javacutil.TreeUtils;
  */
 @AutoService(BugChecker.class)
 @BugPattern(
-    name = "NullAway",
     altNames = {"CheckNullabilityTypes"},
     summary = "Nullability type error.",
     tags = BugPattern.StandardTags.LIKELY_ERROR,

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.uber.nullaway;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
@@ -143,10 +142,12 @@ import org.checkerframework.nullaway.javacutil.TreeUtils;
  */
 @AutoService(BugChecker.class)
 @BugPattern(
+    name = "NullAway",
     altNames = {"CheckNullabilityTypes"},
     summary = "Nullability type error.",
     tags = BugPattern.StandardTags.LIKELY_ERROR,
     severity = WARNING)
+@SuppressWarnings("BugPatternNaming") // For compat with EP pre 2.11.0
 public class NullAway extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher,
         BugChecker.AssignmentTreeMatcher,

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.nullaway;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
@@ -147,7 +148,6 @@ import org.checkerframework.nullaway.javacutil.TreeUtils;
     summary = "Nullability type error.",
     tags = BugPattern.StandardTags.LIKELY_ERROR,
     severity = WARNING)
-@SuppressWarnings("BugPatternNaming") // For compat with EP pre 2.11.0
 public class NullAway extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher,
         BugChecker.AssignmentTreeMatcher,

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -20,8 +20,8 @@ plugins {
   id "java-library"
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+//sourceCompatibility = "1.8"
+//targetCompatibility = "1.8"
 
 dependencies {
     compileOnly deps.apt.autoService

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -20,9 +20,6 @@ plugins {
   id "java-library"
 }
 
-//sourceCompatibility = "1.8"
-//targetCompatibility = "1.8"
-
 dependencies {
     compileOnly deps.apt.autoService
     annotationProcessor deps.apt.autoService

--- a/test-library-models/build.gradle
+++ b/test-library-models/build.gradle
@@ -20,8 +20,8 @@ plugins {
   id "java-library"
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+//sourceCompatibility = "1.8"
+//targetCompatibility = "1.8"
 
 dependencies {
     compileOnly deps.apt.autoService

--- a/test-library-models/build.gradle
+++ b/test-library-models/build.gradle
@@ -20,9 +20,6 @@ plugins {
   id "java-library"
 }
 
-//sourceCompatibility = "1.8"
-//targetCompatibility = "1.8"
-
 dependencies {
     compileOnly deps.apt.autoService
     annotationProcessor deps.apt.autoService


### PR DESCRIPTION
This required more significant changes than a typical Error Prone bump, since Error Prone 2.11.0 requires Java 11.  To adjust, any build of NullAway on a JDK 11+ JVM now targets Java 11, whereas builds on a JDK 8 JVM still target Java 8.  To maintain JDK 8 compatibility in releases, we need to be careful to create the release jars using a JDK 8 VM; the release instructions have been updated appropriately.