### PR TITLE
Serialize init

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -412,17 +412,15 @@ public class NullAway extends BugChecker
           buildDescription(tree),
           state,
           ASTHelpers.getSymbol(tree.getVariable()));
-    } else {
-      MethodTree initializerMethod =
-          ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class);
-      if (initializerMethod != null) {
-        handler.serializeClassFieldInitializationInfo(
-            ASTHelpers.getSymbol(initializerMethod),
-            assigned,
-            getTreesInstance(state),
-            getNullnessAnalysis(state),
-            state);
-      }
+    }
+    MethodTree initializerMethod = ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class);
+    if (initializerMethod != null) {
+      handler.serializeClassFieldInitializationInfo(
+          ASTHelpers.getSymbol(initializerMethod),
+          assigned,
+          getTreesInstance(state),
+          getNullnessAnalysis(state),
+          state);
     }
     return Description.NO_MATCH;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -412,6 +412,17 @@ public class NullAway extends BugChecker
           buildDescription(tree),
           state,
           ASTHelpers.getSymbol(tree.getVariable()));
+    } else {
+      MethodTree initializerMethod =
+          ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class);
+      if (initializerMethod != null) {
+        handler.serializeClassFieldInitializationInfo(
+            ASTHelpers.getSymbol(initializerMethod),
+            assigned,
+            getTreesInstance(state),
+            getNullnessAnalysis(state),
+            state);
+      }
     }
     return Description.NO_MATCH;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization;
 
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
+import com.uber.nullaway.fixserialization.out.FieldInitializationInfo;
 import com.uber.nullaway.fixserialization.out.SuggestedFixInfo;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,11 +43,14 @@ public class Serializer {
   private final Path errorOutputPath;
   /** Path to write suggested fix metadata. */
   private final Path suggestedFixesOutputPath;
+  /** Path to write suggested fix metadata. */
+  private final Path fieldInitializationOutputPath;
 
   public Serializer(FixSerializationConfig config) {
     String outputDirectory = config.outputDirectory;
     this.errorOutputPath = Paths.get(outputDirectory, "errors.tsv");
     this.suggestedFixesOutputPath = Paths.get(outputDirectory, "fixes.tsv");
+    this.fieldInitializationOutputPath = Paths.get(outputDirectory, "field_init.csv");
     initializeOutputFiles(config);
   }
 
@@ -71,6 +75,10 @@ public class Serializer {
   public void serializeErrorInfo(ErrorInfo errorInfo) {
     errorInfo.initEnclosing();
     appendToFile(errorInfo.tabSeparatedToString(), errorOutputPath);
+  }
+
+  public void serializeFieldInitializationInfo(FieldInitializationInfo info) {
+    appendToFile(info.tabSeparatedToString(), fieldInitializationOutputPath);
   }
 
   /** Cleared the content of the file if exists and writes the header in the first line. */

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -50,7 +50,7 @@ public class Serializer {
     String outputDirectory = config.outputDirectory;
     this.errorOutputPath = Paths.get(outputDirectory, "errors.tsv");
     this.suggestedFixesOutputPath = Paths.get(outputDirectory, "fixes.tsv");
-    this.fieldInitializationOutputPath = Paths.get(outputDirectory, "field_init.csv");
+    this.fieldInitializationOutputPath = Paths.get(outputDirectory, "field_init.tsv");
     initializeOutputFiles(config);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
@@ -114,6 +114,11 @@ public class XMLUtil {
       suggestElement.setAttribute("enclosing", String.valueOf(config.suggestEnclosing));
       rootElement.appendChild(suggestElement);
 
+      // Field Initialization
+      Element fieldInitInfoEnabled = doc.createElement("fieldInitInfo");
+      suggestElement.setAttribute("active", String.valueOf(config.fieldInitInfoEnabled));
+      rootElement.appendChild(fieldInitInfoEnabled);
+
       // Annotations
       Element annots = doc.createElement("annotation");
       Element nonnull = doc.createElement("nonnull");

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.fixserialization.out;
+
+import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.location.FixLocation;
+
+/**
+ * Stores information regarding a method that initializes a class field and leaves it @Nonnull at
+ * exit point.
+ */
+public class FieldInitializationInfo {
+
+  /** Symbol of the initializer method. */
+  private final FixLocation initializerMethodLocation;
+  /** Symbol of the initialized class field. */
+  private final Symbol.VarSymbol field;
+
+  public FieldInitializationInfo(Symbol.MethodSymbol initializerMethod, Symbol.VarSymbol field) {
+    this.initializerMethodLocation = FixLocation.createFixLocationFromSymbol(initializerMethod);
+    this.field = field;
+  }
+
+  /**
+   * returns string representation of content of an object.
+   *
+   * @return string representation of contents of an object in a line seperated by tabs.
+   */
+  public String tabSeparatedToString() {
+    return initializerMethodLocation.tabSeparatedToString()
+        + '\t'
+        + field.getSimpleName().toString();
+  }
+
+  /**
+   * Creates header of an output file containing all {@link FieldInitializationInfo} written in
+   * string which values are separated by tabs.
+   *
+   * @return string representation of the header separated by tabs.
+   */
+  public static String header() {
+    return FixLocation.header() + '\t' + "field";
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
@@ -34,9 +34,9 @@ public class FieldInitializationInfo {
   /** Symbol of the initializer method. */
   private final FixLocation initializerMethodLocation;
   /** Symbol of the initialized class field. */
-  private final Symbol.VarSymbol field;
+  private final Symbol field;
 
-  public FieldInitializationInfo(Symbol.MethodSymbol initializerMethod, Symbol.VarSymbol field) {
+  public FieldInitializationInfo(Symbol.MethodSymbol initializerMethod, Symbol field) {
     this.initializerMethodLocation = FixLocation.createFixLocationFromSymbol(initializerMethod);
     this.field = field;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -31,12 +31,14 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import java.util.List;
@@ -189,7 +191,11 @@ public abstract class BaseNoOpHandler implements Handler {
 
   @Override
   public void serializeClassFieldInitializationInfo(
-      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
+      Symbol.MethodSymbol methodSymbol,
+      Symbol.VarSymbol field,
+      Trees trees,
+      AccessPathNullnessAnalysis analysis,
+      VisitorState state) {
     // NoOp
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -192,7 +192,7 @@ public abstract class BaseNoOpHandler implements Handler {
   @Override
   public void serializeClassFieldInitializationInfo(
       Symbol.MethodSymbol methodSymbol,
-      Symbol.VarSymbol field,
+      Symbol field,
       Trees trees,
       AccessPathNullnessAnalysis analysis,
       VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -186,4 +186,10 @@ public abstract class BaseNoOpHandler implements Handler {
   public ImmutableSet<String> onRegisterImmutableTypes() {
     return ImmutableSet.of();
   }
+
+  @Override
+  public void serializeClassFieldInitializationInfo(
+      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
+    // NoOp
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -32,12 +32,14 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import java.util.List;
@@ -245,9 +247,13 @@ class CompositeHandler implements Handler {
 
   @Override
   public void serializeClassFieldInitializationInfo(
-      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
+      Symbol.MethodSymbol methodSymbol,
+      Symbol.VarSymbol field,
+      Trees trees,
+      AccessPathNullnessAnalysis analysis,
+      VisitorState state) {
     for (Handler h : handlers) {
-      h.serializeClassFieldInitializationInfo(methodSymbol, field);
+      h.serializeClassFieldInitializationInfo(methodSymbol, field, trees, analysis, state);
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -242,4 +242,12 @@ class CompositeHandler implements Handler {
     }
     return builder.build();
   }
+
+  @Override
+  public void serializeClassFieldInitializationInfo(
+      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
+    for (Handler h : handlers) {
+      h.serializeClassFieldInitializationInfo(methodSymbol, field);
+    }
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -248,7 +248,7 @@ class CompositeHandler implements Handler {
   @Override
   public void serializeClassFieldInitializationInfo(
       Symbol.MethodSymbol methodSymbol,
-      Symbol.VarSymbol field,
+      Symbol field,
       Trees trees,
       AccessPathNullnessAnalysis analysis,
       VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.handlers;
+
+import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.FixSerializationConfig;
+
+/**
+ * This handler is used to serialize information regarding methods that initialize a class field.
+ * These information helps to detect initializer methods in class.
+ */
+public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
+
+  FixSerializationConfig config;
+
+  FieldInitializationSerializationHandler(FixSerializationConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void serializeClassFieldInitializationInfo(
+      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
+    super.serializeClassFieldInitializationInfo(methodSymbol, field);
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
@@ -48,12 +48,12 @@ public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
   @Override
   public void serializeClassFieldInitializationInfo(
       Symbol.MethodSymbol methodSymbol,
-      Symbol.VarSymbol field,
+      Symbol symbol,
       Trees trees,
       AccessPathNullnessAnalysis analysis,
       VisitorState state) {
     Preconditions.checkArgument(
-        field.getKind() == ElementKind.FIELD,
+        symbol.getKind() == ElementKind.FIELD,
         "Should only get called on class field initialization.");
     Set<String> nonnullFieldsAtExitPoint =
         analysis
@@ -61,13 +61,13 @@ public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
             .stream()
             .map(element -> element.getSimpleName().toString())
             .collect(Collectors.toSet());
-    if (!nonnullFieldsAtExitPoint.contains(field.getSimpleName().toString())) {
+    if (!nonnullFieldsAtExitPoint.contains(symbol.getSimpleName().toString())) {
       // Method does not keep the field @Nonnull at exit point and fails the post condition to be an
       // Initializer.
       return;
     }
     config
         .getSerializer()
-        .serializeFieldInitializationInfo(new FieldInitializationInfo(methodSymbol, field));
+        .serializeFieldInitializationInfo(new FieldInitializationInfo(methodSymbol, symbol));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
@@ -22,7 +22,10 @@
 
 package com.uber.nullaway.handlers;
 
+import com.google.errorprone.VisitorState;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.fixserialization.FixSerializationConfig;
 
 /**
@@ -39,7 +42,9 @@ public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
 
   @Override
   public void serializeClassFieldInitializationInfo(
-      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field) {
-    super.serializeClassFieldInitializationInfo(methodSymbol, field);
-  }
+      Symbol.MethodSymbol methodSymbol,
+      Symbol.VarSymbol field,
+      Trees trees,
+      AccessPathNullnessAnalysis analysis,
+      VisitorState state) {}
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
@@ -31,7 +31,7 @@ import com.uber.nullaway.fixserialization.FixSerializationConfig;
  */
 public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
 
-  FixSerializationConfig config;
+  private final FixSerializationConfig config;
 
   FieldInitializationSerializationHandler(FixSerializationConfig config) {
     this.config = config;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/FieldInitializationSerializationHandler.java
@@ -48,26 +48,26 @@ public class FieldInitializationSerializationHandler extends BaseNoOpHandler {
   @Override
   public void serializeClassFieldInitializationInfo(
       Symbol.MethodSymbol methodSymbol,
-      Symbol symbol,
+      Symbol field,
       Trees trees,
       AccessPathNullnessAnalysis analysis,
       VisitorState state) {
     Preconditions.checkArgument(
-        symbol.getKind() == ElementKind.FIELD,
-        "Should only get called on class field initialization.");
+        field.getKind() == ElementKind.FIELD,
+        "Expected field parameter to be of type FIELD but found: " + field.getKind());
     Set<String> nonnullFieldsAtExitPoint =
         analysis
             .getNonnullFieldsOfReceiverAtExit(trees.getPath(methodSymbol), state.context)
             .stream()
             .map(element -> element.getSimpleName().toString())
             .collect(Collectors.toSet());
-    if (!nonnullFieldsAtExitPoint.contains(symbol.getSimpleName().toString())) {
+    if (!nonnullFieldsAtExitPoint.contains(field.getSimpleName().toString())) {
       // Method does not keep the field @Nonnull at exit point and fails the post condition to be an
       // Initializer.
       return;
     }
     config
         .getSerializer()
-        .serializeFieldInitializationInfo(new FieldInitializationInfo(methodSymbol, symbol));
+        .serializeFieldInitializationInfo(new FieldInitializationInfo(methodSymbol, field));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -329,7 +329,7 @@ public interface Handler {
    */
   void serializeClassFieldInitializationInfo(
       Symbol.MethodSymbol methodSymbol,
-      Symbol.VarSymbol field,
+      Symbol field,
       Trees trees,
       AccessPathNullnessAnalysis analysis,
       VisitorState state);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -315,6 +315,16 @@ public interface Handler {
   ImmutableSet<String> onRegisterImmutableTypes();
 
   /**
+   * Called when a method initializes a class field, and it will serialize information regarding the
+   * initializer method and the class field. This method helps to detect initializer methods.
+   *
+   * @param methodSymbol Symbol of the initializer method.
+   * @param field Symbol of the initialized class field.
+   */
+  void serializeClassFieldInitializationInfo(
+      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field);
+
+  /**
    * A three value enum for handlers implementing onDataflowVisitMethodInvocation to communicate
    * their knowledge of the method return nullability to the the rest of NullAway.
    */

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -31,6 +31,7 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
@@ -38,6 +39,7 @@ import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import java.util.List;
@@ -315,14 +317,22 @@ public interface Handler {
   ImmutableSet<String> onRegisterImmutableTypes();
 
   /**
-   * Called when a method initializes a class field, and it will serialize information regarding the
-   * initializer method and the class field. This method helps to detect initializer methods.
+   * Called when a method writes a {@code @Nonnull} value to a class field, if the method guarantees
+   * to leave the initialized class field to be {@code @Nonnull} at exit point, this method will
+   * serialize information regarding the initializer method and the class field.
    *
    * @param methodSymbol Symbol of the initializer method.
    * @param field Symbol of the initialized class field.
+   * @param trees Javac Trees instance.
+   * @param analysis nullness dataflow analysis
+   * @param state VisitorState.
    */
   void serializeClassFieldInitializationInfo(
-      Symbol.MethodSymbol methodSymbol, Symbol.VarSymbol field);
+      Symbol.MethodSymbol methodSymbol,
+      Symbol.VarSymbol field,
+      Trees trees,
+      AccessPathNullnessAnalysis analysis,
+      VisitorState state);
 
   /**
    * A three value enum for handlers implementing onDataflowVisitMethodInvocation to communicate

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -63,6 +63,10 @@ public class Handlers {
     handlerListBuilder.add(new GrpcHandler());
     handlerListBuilder.add(new RequiresNonNullHandler());
     handlerListBuilder.add(new EnsuresNonNullHandler());
+    if (config.serializationIsActive() && config.getSerializationConfig().fieldInitInfoEnabled) {
+      handlerListBuilder.add(
+          new FieldInitializationSerializationHandler(config.getSerializationConfig()));
+    }
     if (config.checkOptionalEmptiness()) {
       handlerListBuilder.add(new OptionalEmptinessHandler(config, methodNameUtil));
     }


### PR DESCRIPTION
This PR is a followup to enable nullability inference implemented in [AutoFixer](https://github.com/nimakarimipour/NullAwayAutoFixer). This PR provides the facility to detect initializer methods. When activated, if a method write a `@Nonnull` value to a class field, and that method guarantee to leave that field `@Nonnull` at exit point, NullAway will serialize information regarding the method and field in the serialization output directory.

It adds the following configurations settings in `FixSerializationConfig`:
* `fieldInitInfoEnabled`: flag to enable class field initializtion serialization.

Please note, `SerializeFixMetadata` flag must be set to true to enable the service above.

Please see the example below:

```java
class C{
     Object bar;
     void initBar(){
           bar = new Object();
     }

     void foo() {
           if(bar == null){
                   throw new Exception()
           }
      }
}
```

In the example above although both methods leave `bar` `@Nonnull` at exit point, only `initBar()` is serialized on output as initializer of `bar` object since it also writes a `@Nonnull` value to field `bar`.

After execution of `NullAway` a file with name `field_init.tsv` is created at serialization output directory with the information regarding `initBar()` and `bar` itself.

To activate the feature above entry below must be present in the serialization config file:
```xml
<serialization>
    <fieldInitInfo activation="true" />
</serialization>
```

Please note, I haven't added the tests for this PR yet, I will soon prepare that infrastructure.

With best regards
