### PR TITLE
Fix running Google Java Format on JDK 17

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
+          arguments: verGJF build -x :sample-app:build -x :jar-infer:jar-infer-lib:build -x :jar-infer:nullaway-integration-test:build -x :jar-infer:test-java-lib-jarinfer:build
         if: matrix.java == '17'
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,13 @@
 
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+# The --add-exports arguments are to run GJF on Java 17
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 GROUP=com.uber.nullaway
 VERSION_NAME=0.9.6-SNAPSHOT


### PR DESCRIPTION
Google Java Format requires additional JVM arguments to run on JDK 17 (see https://github.com/sherter/google-java-format-gradle-plugin/issues/67).  Without this change, NullAway's pre-commit hook fails (silently, unfortunately) when run on JDK 17.

Related to this, we should document that for developing NullAway we recommend JDK 11 (since GJF works there and all regression tests will run).