### PR TITLE
Fix bug in handling of TreatGeneratedAsUnannotated.

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testImplementation deps.test.springBeans
     testImplementation deps.test.springContext
     testImplementation deps.test.grpcCore
+    testImplementation project(":test-java-lib-lombok")
 
     // This ends up being resolved to the NullAway jar under nullaway/build/libs
     nullawayJar "com.uber.nullaway:nullaway:$VERSION_NAME"

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayFrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayFrameworkTests.java
@@ -1,5 +1,6 @@
 package com.uber.nullaway;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 public class NullAwayFrameworkTests extends NullAwayTestsBase {
@@ -269,6 +270,82 @@ public class NullAwayFrameworkTests extends NullAwayTestsBase {
             "  }",
             "  public void Fun() {",
             "    f.setBar(\"hello\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testLombokBuilderWithGeneratedAsUnannotated() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.uber.lombok.LombokDTO;",
+            "class Test {",
+            "  void testSetters(LombokDTO ldto) {",
+            "     ldto.setNullableField(null);",
+            "     // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
+            "     ldto.setField(null);",
+            "  }",
+            "  String testGetterSafe(LombokDTO ldto) {",
+            "     return ldto.getField();",
+            "  }",
+            "  String testGetterNullable(LombokDTO ldto) {",
+            "     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
+            "     return ldto.getNullableField();",
+            "  }",
+            "  LombokDTO testBuilderSafe(@Nullable String s1, String s2) {",
+            "     // Safe, because s2 is non-null and nullableField can take @Nullable",
+            "     return LombokDTO.builder().nullableField(s1).field(s2).build();",
+            "  }",
+            "  LombokDTO testBuilderUnsafe(@Nullable String s1, @Nullable String s2) {",
+            "     // No error, because the code of LombokDTO.Builder is @Generated and we are",
+            "     // building with TreatGeneratedAsUnannotated=true",
+            "     return LombokDTO.builder().nullableField(s1).field(s2).build();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testLombokBuilderWithoutGeneratedAsUnannotated() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.uber.lombok.LombokDTO;",
+            "class Test {",
+            "  void testSetters(LombokDTO ldto) {",
+            "     ldto.setNullableField(null);",
+            "     // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
+            "     ldto.setField(null);",
+            "  }",
+            "  String testGetterSafe(LombokDTO ldto) {",
+            "     return ldto.getField();",
+            "  }",
+            "  String testGetterNullable(LombokDTO ldto) {",
+            "     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
+            "     return ldto.getNullableField();",
+            "  }",
+            "  LombokDTO testBuilderSafe(@Nullable String s1, String s2) {",
+            "     // Safe, because s2 is non-null and nullableField can take @Nullable",
+            "     return LombokDTO.builder().nullableField(s1).field(s2).build();",
+            "  }",
+            "  LombokDTO testBuilderUnsafe(@Nullable String s1, @Nullable String s2) {",
+            "     // BUG: Diagnostic contains: passing @Nullable parameter 's2' where @NonNull is required",
+            "     return LombokDTO.builder().nullableField(s1).field(s2).build();",
             "  }",
             "}")
         .doTest();

--- a/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokDTO.java
+++ b/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokDTO.java
@@ -32,7 +32,9 @@ import lombok.Data;
   "SameNameButDifferent" /* crashes with EP 2.6.0 */,
   "InlineMeInliner" /* crashes with EP 2.7.1 */
 })
-public class LombokBuilderInit {
+public class LombokDTO {
+  // Note: Field initialization is done by Lombok generated code. NullAway issues no error due to
+  // field being uninitialized.
   private String field;
   @Builder.Default private String fieldWithDefault = "Default";
   @Nullable private String nullableField;

--- a/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokDTO.java
+++ b/test-java-lib-lombok/src/main/java/com/uber/lombok/LombokDTO.java
@@ -33,8 +33,9 @@ import lombok.Data;
   "InlineMeInliner" /* crashes with EP 2.7.1 */
 })
 public class LombokDTO {
-  // Note: Field initialization is done by Lombok generated code. NullAway issues no error due to
-  // field being uninitialized.
+  // Note: Lombok generates a constructor directly into this class that initializes this field, so
+  // NullAway does not
+  // issue an uninitialized field warning.
   private String field;
   @Builder.Default private String fieldWithDefault = "Default";
   @Nullable private String nullableField;

--- a/test-java-lib-lombok/src/main/java/com/uber/lombok/UsesDTO.java
+++ b/test-java-lib-lombok/src/main/java/com/uber/lombok/UsesDTO.java
@@ -22,13 +22,20 @@
 
 package com.uber.lombok;
 
-class UsesBuilder {
-  public static String foo(LombokBuilderInit lbi) {
+import javax.annotation.Nullable;
+
+class UsesDTO {
+
+  public static LombokDTO getDTOInstance(@Nullable String s1, String s2) {
+    return LombokDTO.builder().nullableField(s1).field(s2).build();
+  }
+
+  public static String foo(LombokDTO ldto) {
     String s = "";
-    s += lbi.getField().toString();
+    s += ldto.getField().toString();
     s += " ";
     // Removing this nullness check produces a NullAway error
-    s += (lbi.getNullableField() == null ? "" : lbi.getNullableField().toString());
+    s += (ldto.getNullableField() == null ? "" : ldto.getNullableField().toString());
     return s;
   }
 }


### PR DESCRIPTION
There was a bug introduced in #493 (and thus not part of our last release),
which caused `@Generated` annotations on inner classes to be ignored for
the purposes of the `TreatGeneratedAsUnannotated=true` option.

This is of particular relevance to Lombok builders, where the `@Builder`
annotation on clas `Foo`, will produce an inner `@Generated Foo.Builder`.

However, note that NullAway can handle checking of such generated code, as
Lombok will correctly propagate nullability annotations in fields to the arguments
of it's builder methods. 

Thus, for Lombok builders alone, the use of
`TreatGeneratedAsUnannotated=true` is not recommended.

Still, ignoring such annotation on inner classes - thus requiring annotation
of Lombok DTO fields - is inconsistent with the documentation and intended
effect of `TreatGeneratedAsUnannotated=true`. Additionally, other tools
might produce `@Generated` inner classes without suitable nullability info.

This PR fixes the bug by acknowledging `@Generated` on inner classes,
and treating it the same as for top-level classes.

In the future, we might want to make the distinction between "generated code
with nullability annotations" and "generated code without nullability annotations".
We could do this based on the annotation name, or allowing handlers to
override `shouldTreatAsUnannotated` below.

Note that the `shouldTreatAsUnannotated` method is also a good candidate for
part of our `@NullUnmarked` support, should that annotation become part
of JSpecify.