### PR TITLE
[JarInfer] Update Apache Commons IO dependency.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ def build = [
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
     jspecify                : "org.jspecify:jspecify:0.2.0",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
-    commonsIO               : "commons-io:commons-io:2.4",
+    commonsIO               : "commons-io:commons-io:2.11.0",
     wala                    : ["com.ibm.wala:com.ibm.wala.util:${versions.wala}",
                                "com.ibm.wala:com.ibm.wala.shrike:${versions.wala}",
                                "com.ibm.wala:com.ibm.wala.core:${versions.wala}"],


### PR DESCRIPTION
JarInfer depended on a version of commons-io susceptible to
CVE-2021-29425 (a file path sanitization vulnerability).

I don't believe JarInfer is vulnerable, since it isn't dealing with
potentially untrusted file paths from the network, but rather
relatively trusted paths as part of some build system integration.
It also doesn't directly invoke the vulnerable `FileNameUtils.normalize`
API. Thought it uses other methods from `FileNameUtils`, such as
`getFullPath(...)` and `getBaseName(...)`.

Still, for code hygiene, we should update the library to its latest
version.

Original CVE alert raised by SonaType when releasing 0.9.6.