### PR TITLE
Move JSpecify tests to correct package

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -1,6 +1,5 @@
-package com.uber.nullaway.tools;
+package com.uber.nullaway;
 
-import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
 import org.junit.Test;
 


### PR DESCRIPTION
Somehow they ended up in the `tools` sub-package by accident