### PR TITLE
Qualified Names for LocalType/Anonymous classes in fix serialization

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
@@ -40,7 +40,7 @@ public class FieldLocation extends AbstractFixLocation {
   public String tabSeparatedToString() {
     return type.toString()
         + '\t'
-        + enclosingClass
+        + enclosingClass.flatName()
         + '\t'
         + "null"
         + '\t'

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
@@ -40,7 +40,7 @@ public class MethodLocation extends AbstractFixLocation {
   public String tabSeparatedToString() {
     return type.toString()
         + '\t'
-        + enclosingClass
+        + enclosingClass.flatName()
         + '\t'
         + enclosingMethod
         + '\t'

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
@@ -61,7 +61,7 @@ public class MethodParameterLocation extends AbstractFixLocation {
   public String tabSeparatedToString() {
     return type.toString()
         + '\t'
-        + enclosingClass
+        + enclosingClass.flatName()
         + '\t'
         + enclosingMethod
         + '\t'

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/EnclosingClassAndMethodInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/EnclosingClassAndMethodInfo.java
@@ -26,12 +26,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.util.TreePath;
-import com.sun.tools.javac.code.Symbol;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
-import javax.lang.model.element.ElementKind;
 
 /** Container class of enclosing class and method of the element. */
 public class EnclosingClassAndMethodInfo {
@@ -70,27 +65,5 @@ public class EnclosingClassAndMethodInfo {
   @Nullable
   public ClassTree getClazz() {
     return clazz;
-  }
-
-  @Nullable
-  public String getClassFQN() {
-    if (clazz == null) {
-      return "null";
-    }
-    List<String> components = new ArrayList<>();
-    Symbol classSymbol = ASTHelpers.getSymbol(clazz);
-    while (classSymbol != null) {
-      components.add(classSymbol.getQualifiedName().toString());
-      if (classSymbol.getEnclosingElement() == null
-          || !classSymbol.getEnclosingElement().getKind().equals(ElementKind.METHOD)) {
-        break;
-      }
-      Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) classSymbol.getEnclosingElement();
-      // Warning: Relies on toString producing a reliable method signature!
-      components.add(methodSymbol.toString());
-      classSymbol = methodSymbol.getEnclosingElement();
-    }
-    Collections.reverse(components);
-    return String.join(".", components);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/EnclosingClassAndMethodInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/EnclosingClassAndMethodInfo.java
@@ -26,7 +26,12 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import javax.annotation.Nullable;
+import javax.lang.model.element.ElementKind;
 
 /** Container class of enclosing class and method of the element. */
 public class EnclosingClassAndMethodInfo {
@@ -65,5 +70,27 @@ public class EnclosingClassAndMethodInfo {
   @Nullable
   public ClassTree getClazz() {
     return clazz;
+  }
+
+  @Nullable
+  public String getClassFQN() {
+    if (clazz == null) {
+      return "null";
+    }
+    List<String> components = new ArrayList<>();
+    Symbol classSymbol = ASTHelpers.getSymbol(clazz);
+    while (classSymbol != null) {
+      components.add(classSymbol.getQualifiedName().toString());
+      if (classSymbol.getEnclosingElement() == null
+          || !classSymbol.getEnclosingElement().getKind().equals(ElementKind.METHOD)) {
+        break;
+      }
+      Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) classSymbol.getEnclosingElement();
+      // Warning: Relies on toString producing a reliable method signature!
+      components.add(methodSymbol.toString());
+      classSymbol = methodSymbol.getEnclosingElement();
+    }
+    Collections.reverse(components);
+    return String.join(".", components);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -81,7 +81,9 @@ public class ErrorInfo {
         + '\t'
         + escapeSpecialCharacters(errorMessage.getMessage())
         + '\t'
-        + enclosingInfo.getClassFQN()
+        + (enclosingInfo.getClazz() != null
+            ? ASTHelpers.getSymbol(enclosingInfo.getClazz()).flatName()
+            : "null")
         + '\t'
         + (enclosingInfo.getMethod() != null
             ? ASTHelpers.getSymbol(enclosingInfo.getMethod())

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -81,9 +81,7 @@ public class ErrorInfo {
         + '\t'
         + escapeSpecialCharacters(errorMessage.getMessage())
         + '\t'
-        + (enclosingInfo.getClazz() != null
-            ? ASTHelpers.getSymbol(enclosingInfo.getClazz())
-            : "null")
+        + enclosingInfo.getClassFQN()
         + '\t'
         + (enclosingInfo.getMethod() != null
             ? ASTHelpers.getSymbol(enclosingInfo.getMethod())

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
@@ -85,7 +85,9 @@ public class SuggestedFixInfo {
         + '\t'
         + annotation
         + '\t'
-        + enclosingInfo.getClassFQN()
+        + (enclosingInfo.getClazz() == null
+            ? "null"
+            : ASTHelpers.getSymbol(enclosingInfo.getClazz()).flatName())
         + '\t'
         + (enclosingInfo.getMethod() == null
             ? "null"

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
@@ -85,9 +85,7 @@ public class SuggestedFixInfo {
         + '\t'
         + annotation
         + '\t'
-        + (enclosingInfo.getClazz() == null
-            ? "null"
-            : ASTHelpers.getSymbol(enclosingInfo.getClazz()))
+        + enclosingInfo.getClassFQN()
         + '\t'
         + (enclosingInfo.getMethod() == null
             ? "null"

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -928,4 +928,110 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
         .setFactory(fieldInitDisplayFactory)
         .doTest();
   }
+
+  @Test
+  public void errorSerializationTestLocalTypes() {
+    SerializationTestHelper<ErrorDisplay> tester = new SerializationTestHelper<>(root);
+    tester
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SerializeFixMetadata=true",
+                "-XepOpt:NullAway:FixSerializationConfigPath=" + configPath))
+        .addSourceLines(
+            "com/uber/TestWithLocalType.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class TestWithLocalType {",
+            "   @Nullable String test(Object o) {",
+            "     class LocalType {",
+            "         public String returnsNullable() {",
+            "             // BUG: Diagnostic contains: returning @Nullable expression",
+            "             return null;",
+            "         }",
+            "     }",
+            "     LocalType local = new LocalType();",
+            "     return local.returnsNullable();",
+            "   }",
+            "}")
+        .setExpectedOutputs(
+            new ErrorDisplay(
+                "RETURN_NULLABLE",
+                "returning @Nullable expression from method with @NonNull return type",
+                "com.uber.TestWithLocalType.test(java.lang.Object).LocalType",
+                "returnsNullable()"))
+        .setFactory(errorDisplayFactory)
+        .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
+        .doTest();
+  }
+
+  @Test
+  public void errorSerializationTestIdenticalLocalTypes() {
+    SerializationTestHelper<ErrorDisplay> tester = new SerializationTestHelper<>(root);
+    tester
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SerializeFixMetadata=true",
+                "-XepOpt:NullAway:FixSerializationConfigPath=" + configPath))
+        .addSourceLines(
+            "com/uber/TestWithLocalTypes.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class TestWithLocalTypes {",
+            "   @Nullable String test(Object o) {",
+            "     class LocalType {",
+            "         public String returnsNullable() {",
+            "             // BUG: Diagnostic contains: returning @Nullable expression",
+            "             return null;",
+            "         }",
+            "     }",
+            "     LocalType local = new LocalType();",
+            "     return local.returnsNullable();",
+            "   }",
+            "   @Nullable String test2(Object o) {",
+            "     class LocalType {",
+            "         public String returnsNullable2() {",
+            "             // BUG: Diagnostic contains: returning @Nullable expression",
+            "             return null;",
+            "         }",
+            "     }",
+            "     LocalType local = new LocalType();",
+            "     return local.returnsNullable2();",
+            "   }",
+            "   @Nullable String test2() {",
+            "     class LocalType {",
+            "         public String returnsNullable2() {",
+            "             // BUG: Diagnostic contains: returning @Nullable expression",
+            "             return null;",
+            "         }",
+            "     }",
+            "     LocalType local = new LocalType();",
+            "     return local.returnsNullable2();",
+            "   }",
+            "}")
+        .setExpectedOutputs(
+            new ErrorDisplay(
+                "RETURN_NULLABLE",
+                "returning @Nullable expression from method with @NonNull return type",
+                "com.uber.TestWithLocalTypes.test(java.lang.Object).LocalType",
+                "returnsNullable()"),
+            new ErrorDisplay(
+                "RETURN_NULLABLE",
+                "returning @Nullable expression from method with @NonNull return type",
+                "com.uber.TestWithLocalTypes.test2(java.lang.Object).LocalType",
+                "returnsNullable2()"),
+            new ErrorDisplay(
+                "RETURN_NULLABLE",
+                "returning @Nullable expression from method with @NonNull return type",
+                "com.uber.TestWithLocalTypes.test2().LocalType",
+                "returnsNullable2()"))
+        .setFactory(errorDisplayFactory)
+        .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
+        .doTest();
+  }
 }


### PR DESCRIPTION
Unfortunately, `Symbol.toString()` and even `Symbol.getEnclosingElement()` produce
unqualified names when dealing with local types (e.g. class declarations within methods).
That causes a problem for the NullAwayInfer injector, which will fail to parse any enclosing
classes without at least a package name. A potential initial fix is to concatenate all enclosing
classes and method signatures for any class we serialize as an error or fix location. This PR
includes such a fix, and a few test cases.

This is still less than ideal, and might be missing cases such as anonymous inner classes in the
hierarchy. It also requires changes to the NullAwayInfer injector before it can parse these new
class location specifications.