### PR TITLE
[JarInfer] Bump ASM dependency to 9.3 to handle Java 16+ bytecode.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 }
 
 def versions = [
-    asm                    : "7.1",
+    asm                    : "9.3",
     checkerFramework       : "3.21.3",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,


### PR DESCRIPTION
We are currently using 7.1 which caps at JVM bytecode version 60. 

This affects not only handling of libraries requiring Java 16+, but also certain
multi-release jars, as we need to be able to analyze all the `.class` files within
the jar.
