### PR TITLE
Treat Void return type as @Nullable Void when checking return statements

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -728,6 +728,12 @@ public class NullAway extends BugChecker
       // check for unboxing
       return returnType.isPrimitive() ? doUnboxingCheck(state, retExpr) : Description.NO_MATCH;
     }
+    if (ASTHelpers.isSameType(returnType, Suppliers.JAVA_LANG_VOID_TYPE.get(state), state)) {
+      // Temporarily treat a Void return type as if it were @Nullable Void.  Change this once
+      // we are confident that all use cases can be type checked reasonably (may require generics
+      // support)
+      return Description.NO_MATCH;
+    }
     if (classAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
         || Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return Description.NO_MATCH;

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -613,7 +613,7 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "import javax.annotation.Nullable;",
             "class Test {",
             "  Void foo1() {",
-            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    // temporarily, we treat a Void return type as if it was @Nullable Void",
             "    return null;",
             "  }",
             "  @Nullable Void foo2() {",


### PR DESCRIPTION
This reverts the user-visible change from https://github.com/uber/NullAway/pull/586.  We have found use cases involving generics and method overriding where requiring writing of `@Nullable Void` currently requires adding some ugly error suppressions.  We need to think through those cases more carefully before requiring `@Nullable` on `Void`.

To be clear, this restored handling of `Void` is unsound.  We treat a `Void` return type as `@Nullable Void` when checking `return` statements (so they are allowed to return `null`), but at call sites of methods with a `Void` return type, we assume the method will return a `@NonNull` value.  Also, if an overriding method has return type `Void`, we treat it as `@NonNull Void`, which leads to unsound checking of method subtyping.