### PR TITLE
Allow zero-argument static method calls to be the root of an access path

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -600,6 +600,9 @@ public final class AccessPath implements MapKey {
      * @return the element, if not representing 'this'
      */
     public Element getElement() {
+      if (element == null) {
+        throw new RuntimeException("attempting to access element of Root representing receiver");
+      }
       return element;
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -600,7 +600,7 @@ public final class AccessPath implements MapKey {
      * @return the element, if not representing 'this'
      */
     public Element getElement() {
-      return Preconditions.checkNotNull(element);
+      return element;
     }
 
     /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -226,7 +226,7 @@ public final class AccessPathNullnessAnalysis {
           if (ap.getElements().size() == 0) {
             AccessPath.Root root = ap.getRoot();
             if (!root.isReceiver()) {
-              Element e = root.getVarElement();
+              Element e = root.getElement();
               return e.getKind().equals(ElementKind.PARAMETER)
                   || e.getKind().equals(ElementKind.LOCAL_VARIABLE);
             }
@@ -307,9 +307,9 @@ public final class AccessPathNullnessAnalysis {
     Set<Element> result = new LinkedHashSet<>();
     for (AccessPath ap : nonnullAccessPaths) {
       assert !ap.getRoot().isReceiver();
-      Element varElement = ap.getRoot().getVarElement();
-      if (varElement.getKind().equals(ElementKind.FIELD)) {
-        result.add(varElement);
+      Element element = ap.getRoot().getElement();
+      if (element.getKind().equals(ElementKind.FIELD)) {
+        result.add(element);
       }
     }
     return result;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -238,9 +238,9 @@ public class NullnessStore implements Store<NullnessStore> {
       if (ap.getRoot().isReceiver()) {
         continue;
       }
-      Element varElement = ap.getRoot().getVarElement();
+      Element element = ap.getRoot().getElement();
       for (LocalVariableNode fromVar : localVarTranslations.keySet()) {
-        if (varElement.equals(fromVar.getElement())) {
+        if (element.equals(fromVar.getElement())) {
           LocalVariableNode toVar = localVarTranslations.get(fromVar);
           AccessPath newAP =
               new AccessPath(new AccessPath.Root(toVar.getElement()), ap.getElements());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -152,7 +152,7 @@ public class OptionalEmptinessHandler extends BaseNoOpHandler {
     if (accessPath.getElements().size() == 1) {
       AccessPath.Root root = accessPath.getRoot();
       if (!root.isReceiver()) {
-        final Element e = root.getVarElement();
+        final Element e = root.getElement();
         return e.getKind().equals(ElementKind.LOCAL_VARIABLE)
             && accessPath.getElements().get(0).getJavaElement().equals(OPTIONAL_CONTENT);
       }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -622,4 +622,31 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void staticCallZeroArgsNullCheck() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @Nullable static Object nullableReturn() { return new Object(); }",
+            "  void foo() {",
+            "    if (nullableReturn() != null) {",
+            "      nullableReturn().toString();",
+            "    }",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    nullableReturn().toString();",
+            "  }",
+            "  void foo2() {",
+            "    if (Test.nullableReturn() != null) {",
+            "      nullableReturn().toString();",
+            "    }",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    Test.nullableReturn().toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This allows code like `if (System.console() != null) { System.console().readLine() }` to typecheck without storing `System.console()` in a local variable.  The treatment is unsound in principle, but we believe will rarely introduce unsoundness in practice.  (We have a similar unsoundness for zero-argument (ignoring the receiver) instance methods, which we assume are getters.)