### PR TITLE
Some fixes to computing the class and method info for error serialization

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMethodInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMethodInfo.java
@@ -25,7 +25,6 @@ package com.uber.nullaway.fixserialization.out;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import javax.annotation.Nullable;
@@ -49,43 +48,21 @@ public class ClassAndMethodInfo {
 
   /** Finds the class and method where the error is reported according to {@code path}. */
   public void findValues() {
-    method = ASTHelpers.findEnclosingNode(path, MethodTree.class);
+    method =
+        path.getLeaf() instanceof MethodTree
+            ? (MethodTree) path.getLeaf()
+            : ASTHelpers.findEnclosingNode(path, MethodTree.class);
     clazz =
-        path.getLeaf().getKind().equals(Tree.Kind.CLASS)
+        path.getLeaf() instanceof ClassTree
             ? (ClassTree) path.getLeaf()
             : ASTHelpers.findEnclosingNode(path, ClassTree.class);
-    if (clazz == null && path.getLeaf() instanceof ClassTree) {
-      clazz = (ClassTree) path.getLeaf();
-    }
-    if (path.getLeaf() instanceof MethodTree) {
-      method = (MethodTree) path.getLeaf();
-    }
     if (clazz != null && method != null) {
       Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(clazz);
       Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(method);
-      if (methodIsEnclosingClass(classSymbol, methodSymbol)) {
+      if (!methodSymbol.isEnclosedBy(classSymbol)) {
         method = null;
       }
     }
-  }
-
-  /**
-   * Returns true, if the method is enclosing the class.
-   *
-   * @param clazz class symbol.
-   * @param method method symbol.
-   * @return true, if method is enclosing class.
-   */
-  private static boolean methodIsEnclosingClass(
-      Symbol.ClassSymbol clazz, Symbol.MethodSymbol method) {
-    Symbol enclosingSymbol = method.getEnclosingElement();
-    while (enclosingSymbol != null) {
-      if (clazz.equals(enclosingSymbol)) {
-        return false;
-      }
-      enclosingSymbol = enclosingSymbol.getEnclosingElement();
-    }
-    return true;
   }
 
   @Nullable

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMethodInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMethodInfo.java
@@ -29,9 +29,9 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import javax.annotation.Nullable;
 
-/** Container class of class and method info of a program point. */
+/** Class and method corresponding to a program point at which an error was reported. */
 public class ClassAndMethodInfo {
-  /** Path to the element in source code. */
+  /** Path to the program point of the reported error */
   public final TreePath path;
 
   /**
@@ -48,15 +48,31 @@ public class ClassAndMethodInfo {
 
   /** Finds the class and method where the error is reported according to {@code path}. */
   public void findValues() {
+    // If the error is reported on a method, that method itself is the relevant program point.
+    // Otherwise, use the enclosing method (if present).
     method =
         path.getLeaf() instanceof MethodTree
             ? (MethodTree) path.getLeaf()
             : ASTHelpers.findEnclosingNode(path, MethodTree.class);
+    // If the error is reported on a class, that class itself is the relevant program point.
+    // Otherwise, use the enclosing class.
     clazz =
         path.getLeaf() instanceof ClassTree
             ? (ClassTree) path.getLeaf()
             : ASTHelpers.findEnclosingNode(path, ClassTree.class);
     if (clazz != null && method != null) {
+      // It is possible that the computed method is not enclosed by the computed class, e.g., for
+      // the following case:
+      //  class C {
+      //    void foo() {
+      //      class Local {
+      //        Object f = null; // error
+      //      }
+      //    }
+      //  }
+      // Here the above code will compute clazz to be Local and method as foo().  In such cases, set
+      // method to null, we always want the corresponding method to be nested in the corresponding
+      // class.
       Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(clazz);
       Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(method);
       if (!methodSymbol.isEnclosedBy(classSymbol)) {

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -92,7 +92,7 @@ public class ErrorInfo {
 
   /** Finds the class and method of program point where the error is reported. */
   public void initEnclosing() {
-    classAndMethodInfo.findValues(errorMessage);
+    classAndMethodInfo.findValues();
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public class ErrorInfo {
 
   private final ErrorMessage errorMessage;
-  private final EnclosingClassAndMethodInfo enclosingInfo;
+  private final ClassAndMethodInfo classAndMethodInfo;
 
   /** Special characters that need to be escaped in TSV files. */
   private static final ImmutableMap<Character, Character> escapes =
@@ -45,7 +45,7 @@ public class ErrorInfo {
           '\r', 'r');
 
   public ErrorInfo(TreePath path, ErrorMessage errorMessage) {
-    this.enclosingInfo = new EnclosingClassAndMethodInfo(path);
+    this.classAndMethodInfo = new ClassAndMethodInfo(path);
     this.errorMessage = errorMessage;
   }
 
@@ -81,18 +81,18 @@ public class ErrorInfo {
         + '\t'
         + escapeSpecialCharacters(errorMessage.getMessage())
         + '\t'
-        + (enclosingInfo.getClazz() != null
-            ? ASTHelpers.getSymbol(enclosingInfo.getClazz()).flatName()
+        + (classAndMethodInfo.getClazz() != null
+            ? ASTHelpers.getSymbol(classAndMethodInfo.getClazz()).flatName()
             : "null")
         + '\t'
-        + (enclosingInfo.getMethod() != null
-            ? ASTHelpers.getSymbol(enclosingInfo.getMethod())
+        + (classAndMethodInfo.getMethod() != null
+            ? ASTHelpers.getSymbol(classAndMethodInfo.getMethod())
             : "null");
   }
 
-  /** Finds the enclosing class and method of program point where the error is reported. */
+  /** Finds the class and method of program point where the error is reported. */
   public void initEnclosing() {
-    enclosingInfo.findEnclosing();
+    classAndMethodInfo.findValues(errorMessage);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
@@ -39,14 +39,14 @@ public class SuggestedFixInfo {
   /** Suggested annotation. */
   private final AnnotationConfig.Annotation annotation;
 
-  private final EnclosingClassAndMethodInfo enclosingInfo;
+  private final ClassAndMethodInfo classAndMethodInfo;
 
   public SuggestedFixInfo(
       TreePath path,
       FixLocation fixLocation,
       ErrorMessage errorMessage,
       AnnotationConfig.Annotation annotation) {
-    this.enclosingInfo = new EnclosingClassAndMethodInfo(path);
+    this.classAndMethodInfo = new ClassAndMethodInfo(path);
     this.fixLocation = fixLocation;
     this.errorMessage = errorMessage;
     this.annotation = annotation;
@@ -85,18 +85,18 @@ public class SuggestedFixInfo {
         + '\t'
         + annotation
         + '\t'
-        + (enclosingInfo.getClazz() == null
+        + (classAndMethodInfo.getClazz() == null
             ? "null"
-            : ASTHelpers.getSymbol(enclosingInfo.getClazz()).flatName())
+            : ASTHelpers.getSymbol(classAndMethodInfo.getClazz()).flatName())
         + '\t'
-        + (enclosingInfo.getMethod() == null
+        + (classAndMethodInfo.getMethod() == null
             ? "null"
-            : ASTHelpers.getSymbol(enclosingInfo.getMethod()));
+            : ASTHelpers.getSymbol(classAndMethodInfo.getMethod()));
   }
 
-  /** Finds the enclosing class and method of program point where triggered this type change. */
+  /** Finds the class and method of program point where triggered this type change. */
   public void initEnclosing() {
-    enclosingInfo.findEnclosing();
+    classAndMethodInfo.findValues(errorMessage);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedFixInfo.java
@@ -96,7 +96,7 @@ public class SuggestedFixInfo {
 
   /** Finds the class and method of program point where triggered this type change. */
   public void initEnclosing() {
-    classAndMethodInfo.findValues(errorMessage);
+    classAndMethodInfo.findValues();
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -71,10 +71,10 @@ public class ErrorDisplay implements Display {
         + "\n\tmessage='"
         + message
         + '\''
-        + "\n\tenclosingMethod='"
+        + "\n\tmethod='"
         + method
         + '\''
-        + "\n\tenclosingClass='"
+        + "\n\tclass='"
         + clazz
         + '\''
         + '}';

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -30,14 +30,14 @@ import java.util.Objects;
 public class ErrorDisplay implements Display {
   public final String type;
   public final String message;
-  public final String enclosingMethod;
-  public final String enclosingClass;
+  public final String method;
+  public final String clazz;
 
-  public ErrorDisplay(String type, String message, String enclosingClass, String enclosingMethod) {
+  public ErrorDisplay(String type, String message, String clazz, String method) {
     this.type = type;
     this.message = message;
-    this.enclosingMethod = enclosingMethod;
-    this.enclosingClass = enclosingClass;
+    this.method = method;
+    this.clazz = clazz;
   }
 
   @Override
@@ -53,13 +53,13 @@ public class ErrorDisplay implements Display {
         // To increase readability, a shorter version of the actual message might be present in the
         // expected output of tests.
         && (message.contains(that.message) || that.message.contains(message))
-        && enclosingMethod.equals(that.enclosingMethod)
-        && enclosingClass.equals(that.enclosingClass);
+        && method.equals(that.method)
+        && clazz.equals(that.clazz);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, message, enclosingMethod, enclosingClass);
+    return Objects.hash(type, message, method, clazz);
   }
 
   @Override
@@ -72,10 +72,10 @@ public class ErrorDisplay implements Display {
         + message
         + '\''
         + "\n\tenclosingMethod='"
-        + enclosingMethod
+        + method
         + '\''
         + "\n\tenclosingClass='"
-        + enclosingClass
+        + clazz
         + '\''
         + '}';
   }


### PR DESCRIPTION
## This PR fixes issue #598

#### Summary of this PR:
1. renamed `EnclosingClassAndMethodInfo` to `ClassAndMethodInfo` to prevent misunderstandings
2. Used the following code to determine `class` and `method` values:
```java
method = path.getLeaf() instanceof MethodTree
            ? (MethodTree) path.getLeaf()
            : ASTHelpers.findEnclosingNode(path, MethodTree.class);
clazz = path.getLeaf() instanceof ClassTree
            ? (ClassTree) path.getLeaf()
            : ASTHelpers.findEnclosingNode(path, ClassTree.class);
if (clazz != null && method != null) {
  Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(clazz);
  Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(method);
  if (!methodSymbol.isEnclosedBy(classSymbol)) {
    method = null;
  }
}
```
This better handles corner cases involving anonymous / local classes and also errors reported directly on methods.

#### Added test units
```java
public class Main {
   public void run(){
        class Foo {
            // BUG: Diagnostic contains: @NonNull field Main$1Foo.bar not initialized",
            Object bar;
        };
    }
}
```

Here, for field `bar`,  `class` and `method` values are: `Main$1Foo` and `null`. Before this PR was: `Main` and `run`.

Added two more unit tests similar above to handle `anonymous classes` and fixes regarding `method declarations`.
