### PR TITLE
Add config option to register custom `@Generated` annotations.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -93,6 +93,8 @@ public abstract class AbstractConfig implements Config {
 
   protected Set<String> excludedClassAnnotations;
 
+  protected Set<String> generatedCodeAnnotations;
+
   protected Set<String> initializerAnnotations;
 
   protected Set<String> externalInitAnnotations;
@@ -158,7 +160,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
-  public boolean shouldTreatGeneratedAsUnannotated() {
+  public boolean treatGeneratedAsUnannotated() {
     return treatGeneratedAsUnannotated;
   }
 
@@ -192,6 +194,11 @@ public abstract class AbstractConfig implements Config {
   @Override
   public ImmutableSet<String> getExcludedClassAnnotations() {
     return ImmutableSet.copyOf(excludedClassAnnotations);
+  }
+
+  @Override
+  public ImmutableSet<String> getGeneratedCodeAnnotations() {
+    return ImmutableSet.copyOf(generatedCodeAnnotations);
   }
 
   @Override
@@ -336,11 +343,6 @@ public abstract class AbstractConfig implements Config {
   @Override
   public String getErrorURL() {
     return errorURL;
-  }
-
-  @Override
-  public boolean treatGeneratedAsUnannotated() {
-    return treatGeneratedAsUnannotated;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -69,12 +69,12 @@ public interface Config {
   boolean fromExplicitlyUnannotatedPackage(String className);
 
   /**
-   * Checks if generated code should be considered always unannoatated.
+   * Checks if (tool) generated code should be considered always unannoatated.
    *
    * @return true if code marked as generated code should be treated as unannotated, even if it
    *     comes from a package otherwise configured as annotated.
    */
-  boolean shouldTreatGeneratedAsUnannotated();
+  boolean treatGeneratedAsUnannotated();
 
   /**
    * Checks if a class should be excluded.
@@ -100,6 +100,8 @@ public interface Config {
    * @return class annotations that should exclude a class from nullability analysis
    */
   ImmutableSet<String> getExcludedClassAnnotations();
+
+  ImmutableSet<String> getGeneratedCodeAnnotations();
 
   /**
    * Checks if the annotation is an @Initializer annotation.
@@ -281,13 +283,6 @@ public interface Config {
    * @return the URL to show with NullAway error messages
    */
   String getErrorURL();
-
-  /**
-   * Checks whether (tool-)generated code should be treated as unannotated.
-   *
-   * @return true if generated code should be treated as unannotated
-   */
-  boolean treatGeneratedAsUnannotated();
 
   /**
    * Checks if acknowledging {@code @RecentlyNullable} and {@code @RecentlyNonNull} annotations is

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -65,7 +65,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public boolean shouldTreatGeneratedAsUnannotated() {
+  public boolean treatGeneratedAsUnannotated() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 
@@ -91,6 +91,11 @@ public class DummyOptionsConfig implements Config {
 
   @Override
   public ImmutableSet<String> getExcludedClassAnnotations() {
+    throw new IllegalStateException(ERROR_MESSAGE);
+  }
+
+  @Override
+  public ImmutableSet<String> getGeneratedCodeAnnotations() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 
@@ -203,11 +208,6 @@ public class DummyOptionsConfig implements Config {
 
   @Override
   public String getErrorURL() {
-    throw new IllegalStateException(ERROR_MESSAGE);
-  }
-
-  @Override
-  public boolean treatGeneratedAsUnannotated() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -92,8 +92,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   // Annotations with simple name ".Generated" need not be manually listed, and are always matched
   // by default
   // TODO: org.apache.avro.specific.AvroGenerated should go here, but we are skipping it for the
-  // next
-  //  release it to better test the effect of this feature. (Users can always manually configure it)
+  // next release to better test the effect of this feature (users can always manually configure
+  // it).
   static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_GENERATED = ImmutableSet.of();
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -91,8 +91,10 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
 
   // Annotations with simple name ".Generated" need not be manually listed, and are always matched
   // by default
-  static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_GENERATED =
-      ImmutableSet.of("org.apache.avro.specific.AvroGenerated");
+  // TODO: org.apache.avro.specific.AvroGenerated should go here, but we are skipping it for the
+  // next
+  //  release it to better test the effect of this feature. (Users can always manually configure it)
+  static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_GENERATED = ImmutableSet.of();
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
       ImmutableSet.of(

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -48,6 +48,9 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_CLASS_ANNOTATIONS_TO_EXCLUDE =
       EP_FL_NAMESPACE + ":ExcludedClassAnnotations";
   static final String FL_SUGGEST_SUPPRESSIONS = EP_FL_NAMESPACE + ":SuggestSuppressions";
+
+  static final String FL_CLASS_ANNOTATIONS_GENERATED =
+      EP_FL_NAMESPACE + ":CustomGeneratedCodeAnnotations";
   static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
   static final String FL_ACKNOWLEDGE_ANDROID_RECENT = EP_FL_NAMESPACE + ":AcknowledgeAndroidRecent";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
@@ -85,6 +88,11 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
 
   static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_TO_EXCLUDE =
       ImmutableSet.of("lombok.Generated");
+
+  // Annotations with simple name ".Generated" need not be manually listed, and are always matched
+  // by default
+  static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_GENERATED =
+      ImmutableSet.of("org.apache.avro.specific.AvroGenerated");
 
   static final ImmutableSet<String> DEFAULT_KNOWN_INITIALIZERS =
       ImmutableSet.of(
@@ -158,6 +166,9 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
     excludedClassAnnotations =
         getFlagStringSet(
             flags, FL_CLASS_ANNOTATIONS_TO_EXCLUDE, DEFAULT_CLASS_ANNOTATIONS_TO_EXCLUDE);
+    generatedCodeAnnotations =
+        getFlagStringSet(
+            flags, FL_CLASS_ANNOTATIONS_GENERATED, DEFAULT_CLASS_ANNOTATIONS_GENERATED);
     initializerAnnotations =
         getFlagStringSet(flags, FL_INITIALIZER_ANNOT, DEFAULT_INITIALIZER_ANNOT);
     customNullableAnnotations = getFlagStringSet(flags, FL_NULLABLE_ANNOT, ImmutableSet.of());

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayUnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayUnannotatedTests.java
@@ -98,6 +98,43 @@ public class NullAwayUnannotatedTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void generatedAsUnannotatedCustomAnnotation() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CustomGeneratedCodeAnnotations=com.uber.MyGeneratedMarkerAnnotation",
+                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+        .addSourceLines(
+            "MyGeneratedMarkerAnnotation.java",
+            "package com.uber;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.Target;",
+            "import static java.lang.annotation.ElementType.CONSTRUCTOR;",
+            "import static java.lang.annotation.ElementType.FIELD;",
+            "import static java.lang.annotation.ElementType.TYPE;",
+            "import static java.lang.annotation.ElementType.METHOD;",
+            "import static java.lang.annotation.ElementType.PACKAGE;",
+            "import static java.lang.annotation.RetentionPolicy.SOURCE;",
+            "@Retention(SOURCE)",
+            "@Target({PACKAGE, TYPE, METHOD, CONSTRUCTOR, FIELD})",
+            "public @interface MyGeneratedMarkerAnnotation {}")
+        .addSourceLines(
+            "Generated.java",
+            "package com.uber;",
+            "@MyGeneratedMarkerAnnotation",
+            "public class Generated { public void takeObj(Object o) {} }")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "class Test {",
+            "  void foo() { (new Generated()).takeObj(null); }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void unannotatedClass() {
     makeTestHelperWithArgs(
             Arrays.asList(


### PR DESCRIPTION
This is most useful in combination with the option to treat generated
code as unannotated. It's not enough to use `ExcludedClassAnnotations`,
unfortunately, since that will still assume the code is properly annotated.
It will simply forgo checking the implementation.

Also, remove redundant config methods to check for the value
of `-XepOpt:NullAway:TreatGeneratedAsUnannotated`.