### PR TITLE
Add NullAway 0.9.7 as a JMH benchmark

### DIFF
--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -29,6 +29,7 @@ configurations {
 
     nullawayReleaseSources
     nullawayReleaseDeps
+    nullawayReleaseProcessors
 }
 dependencies {
 
@@ -56,11 +57,14 @@ dependencies {
     caffeineDeps 'com.github.ben-manes.caffeine:caffeine:3.0.2'
     autodisposeDeps 'com.uber.autodispose2:autodispose:2.1.0'
     nullawayReleaseDeps 'com.uber.nullaway:nullaway:0.9.7'
-    // TODO use fixed versions since we are compiling a particular version of NullAway
-    nullawayReleaseDeps deps.build.errorProneCoreForApi
-    nullawayReleaseDeps deps.test.inferAnnotations
-    nullawayReleaseDeps deps.test.jetbrainsAnnotations
-    // TODO pull in right version of AutoValue for NullAway
+    // Add in the compile-only dependencies of NullAway
+    // Use fixed versions here since we are compiling a particular version of NullAway
+    nullawayReleaseDeps "com.google.errorprone:error_prone_core:2.13.1"
+    nullawayReleaseDeps "com.facebook.infer.annotation:infer-annotation:0.11.0"
+    nullawayReleaseDeps "org.jetbrains:annotations:13.0"
+
+    // To run AutoValue during NullAway compilation
+    nullawayReleaseProcessors "com.google.auto.value:auto-value:1.9"
 
     testImplementation deps.test.junit4
 }
@@ -96,6 +100,9 @@ tasks.getByName('jmh').outputs.upToDateWhen { false }
 def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
 def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.1.0")}).asPath
 def nullawayReleaseClasspath = configurations.nullawayReleaseDeps.filter({f -> !f.toString().contains("nullaway-0.9.7")}).asPath
+
+def nullawayReleaseProcessorpath = configurations.nullawayReleaseProcessors.asPath
+
 def extraJVMArgs = [
         "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
         "-Dnullaway.caffeine.classpath=$caffeineClasspath",
@@ -103,6 +110,7 @@ def extraJVMArgs = [
         "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
         "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
         "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
+        "-Dnullaway.nullawayRelease.processorpath=$nullawayReleaseProcessorpath",
 ]
 
 jmh {

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -116,7 +116,7 @@ jmh {
     // for more examples see https://github.com/melix/jmh-gradle-plugin/blob/master/README.adoc#configuration-options
     // iterations = 5
     // fork = 5
-    includes = ['Autodispose']
+    includes = ['Caffeine']
 }
 
 // don't run test task on pre-JDK-11 VMs

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -127,7 +127,7 @@ jmh {
 }
 
 // don't run test task on pre-JDK-11 VMs
-test {
+tasks.named('test') {
     onlyIf { JavaVersion.current() >= JavaVersion.VERSION_11 }
     jvmArgs extraJVMArgs
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
@@ -143,5 +143,8 @@ test {
             "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
     ]
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -130,5 +130,18 @@ jmh {
 test {
     onlyIf { JavaVersion.current() >= JavaVersion.VERSION_11 }
     jvmArgs extraJVMArgs
+    // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
+    jvmArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    ]
 }
 

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -26,6 +26,9 @@ configurations {
 
     autodisposeSources
     autodisposeDeps
+
+    nullawayReleaseSources
+    nullawayReleaseDeps
 }
 dependencies {
 
@@ -46,15 +49,21 @@ dependencies {
     autodisposeSources('com.uber.autodispose2:autodispose:2.1.0:sources') {
         transitive = false
     }
+    nullawayReleaseSources('com.uber.nullaway:nullaway:0.9.7:sources') {
+        transitive = false
+    }
 
     caffeineDeps 'com.github.ben-manes.caffeine:caffeine:3.0.2'
     autodisposeDeps 'com.uber.autodispose2:autodispose:2.1.0'
+    nullawayReleaseDeps 'com.uber.nullaway:nullaway:0.9.7'
+    nullawayReleaseDeps deps.build.errorProneCoreForApi
 
     testImplementation deps.test.junit4
 }
 
 def caffeineSourceDir = project.layout.buildDirectory.dir('caffeineSources')
 def autodisposeSourceDir = project.layout.buildDirectory.dir('autodisposeSources')
+def nullawayReleaseSourceDir = project.layout.buildDirectory.dir('nullawayReleaseSources')
 
 task extractCaffeineSources(type: Copy) {
     from zipTree(configurations.caffeineSources.singleFile)
@@ -66,8 +75,14 @@ task extractAutodisposeSources(type: Copy) {
     into autodisposeSourceDir
 }
 
+task extractNullawayReleaseSources(type: Copy) {
+    from zipTree(configurations.nullawayReleaseSources.singleFile)
+    into nullawayReleaseSourceDir
+}
+
 compileJava.dependsOn(extractCaffeineSources)
 compileJava.dependsOn(extractAutodisposeSources)
+compileJava.dependsOn(extractNullawayReleaseSources)
 
 // always run jmh
 tasks.getByName('jmh').outputs.upToDateWhen { false }
@@ -80,18 +95,22 @@ jmh {
     // then filter out the benchmark itself
     def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
     def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.1.0")}).asPath
+    def nullawayReleaseClasspath = configurations.nullawayReleaseDeps.filter({f -> !f.toString().contains("nullaway-0.9.7")}).asPath
 
     jvmArgsAppend = [
             "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
             "-Dnullaway.caffeine.classpath=$caffeineClasspath",
             "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()}",
             "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
+            "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
+            "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
     ]
 
     // commented-out examples of how to tweak other jmh parameters; they show the default values
     // for more examples see https://github.com/melix/jmh-gradle-plugin/blob/master/README.adoc#configuration-options
     // iterations = 5
     // fork = 5
+    includes = ['NullawayRelease']
 }
 
 // don't run test task on pre-JDK-11 VMs

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -129,6 +129,7 @@ jmh {
 // don't run test task on pre-JDK-11 VMs
 tasks.named('test') {
     onlyIf { JavaVersion.current() >= JavaVersion.VERSION_11 }
+    // pass the extra JVM args so we can compile benchmarks in unit tests
     jvmArgs extraJVMArgs
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
@@ -143,8 +144,5 @@ tasks.named('test') {
             "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
     ]
-    testLogging {
-        exceptionFormat = 'full'
-    }
 }
 

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -103,6 +103,7 @@ def nullawayReleaseClasspath = configurations.nullawayReleaseDeps.filter({f -> !
 
 def nullawayReleaseProcessorpath = configurations.nullawayReleaseProcessors.asPath
 
+// Extra JVM arguments to expose relevant paths for compiling benchmarks
 def extraJVMArgs = [
         "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
         "-Dnullaway.caffeine.classpath=$caffeineClasspath",

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -124,7 +124,6 @@ jmh {
     // for more examples see https://github.com/melix/jmh-gradle-plugin/blob/master/README.adoc#configuration-options
     // iterations = 5
     // fork = 5
-    includes = ['Caffeine']
 }
 
 // don't run test task on pre-JDK-11 VMs

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -56,7 +56,11 @@ dependencies {
     caffeineDeps 'com.github.ben-manes.caffeine:caffeine:3.0.2'
     autodisposeDeps 'com.uber.autodispose2:autodispose:2.1.0'
     nullawayReleaseDeps 'com.uber.nullaway:nullaway:0.9.7'
+    // TODO use fixed versions since we are compiling a particular version of NullAway
     nullawayReleaseDeps deps.build.errorProneCoreForApi
+    nullawayReleaseDeps deps.test.inferAnnotations
+    nullawayReleaseDeps deps.test.jetbrainsAnnotations
+    // TODO pull in right version of AutoValue for NullAway
 
     testImplementation deps.test.junit4
 }
@@ -87,31 +91,37 @@ compileJava.dependsOn(extractNullawayReleaseSources)
 // always run jmh
 tasks.getByName('jmh').outputs.upToDateWhen { false }
 
+// a trick: to get the classpath for a benchmark, create a configuration that depends on the benchmark, and
+// then filter out the benchmark itself
+def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
+def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.1.0")}).asPath
+def nullawayReleaseClasspath = configurations.nullawayReleaseDeps.filter({f -> !f.toString().contains("nullaway-0.9.7")}).asPath
+def extraJVMArgs = [
+        "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
+        "-Dnullaway.caffeine.classpath=$caffeineClasspath",
+        "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()}",
+        "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
+        "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
+        "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
+]
+
 jmh {
     // seems we need more iterations to fully warm up the JIT
     warmupIterations = 10
 
-    // a trick: to get the classpath for a benchmark, create a configuration that depends on the benchmark, and
-    // then filter out the benchmark itself
-    def caffeineClasspath = configurations.caffeineDeps.filter({f -> !f.toString().contains("caffeine-3.0.2")}).asPath
-    def autodisposeClasspath = configurations.autodisposeDeps.filter({f -> !f.toString().contains("autodispose-2.1.0")}).asPath
-    def nullawayReleaseClasspath = configurations.nullawayReleaseDeps.filter({f -> !f.toString().contains("nullaway-0.9.7")}).asPath
 
-    jvmArgsAppend = [
-            "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
-            "-Dnullaway.caffeine.classpath=$caffeineClasspath",
-            "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()}",
-            "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
-            "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
-            "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
-    ]
+    jvmArgsAppend = extraJVMArgs
 
     // commented-out examples of how to tweak other jmh parameters; they show the default values
     // for more examples see https://github.com/melix/jmh-gradle-plugin/blob/master/README.adoc#configuration-options
     // iterations = 5
     // fork = 5
-    includes = ['NullawayRelease']
+    includes = ['Autodispose']
 }
 
 // don't run test task on pre-JDK-11 VMs
-test.onlyIf { JavaVersion.current() >= JavaVersion.VERSION_11 }
+test {
+    onlyIf { JavaVersion.current() >= JavaVersion.VERSION_11 }
+    jvmArgs extraJVMArgs
+}
+

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/CaffeineBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/CaffeineBenchmark.java
@@ -22,12 +22,7 @@
 
 package com.uber.nullaway.jmh;
 
-import com.google.common.collect.ImmutableList;
-import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -37,78 +32,15 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Benchmark)
 public class CaffeineBenchmark {
 
-  /**
-   * we use a subset of the source files since many are auto-generated and annotated with
-   * {@code @SuppressWarnings("NullAway")}
-   */
-  private static final ImmutableList<String> SOURCE_FILE_NAMES =
-      ImmutableList.of(
-          "com/github/benmanes/caffeine/cache/AbstractLinkedDeque.java",
-          "com/github/benmanes/caffeine/cache/AccessOrderDeque.java",
-          "com/github/benmanes/caffeine/cache/Async.java",
-          "com/github/benmanes/caffeine/cache/AsyncCache.java",
-          "com/github/benmanes/caffeine/cache/AsyncCacheLoader.java",
-          "com/github/benmanes/caffeine/cache/AsyncLoadingCache.java",
-          "com/github/benmanes/caffeine/cache/BoundedBuffer.java",
-          "com/github/benmanes/caffeine/cache/BoundedLocalCache.java",
-          "com/github/benmanes/caffeine/cache/Buffer.java",
-          "com/github/benmanes/caffeine/cache/Cache.java",
-          "com/github/benmanes/caffeine/cache/CacheLoader.java",
-          "com/github/benmanes/caffeine/cache/Caffeine.java",
-          "com/github/benmanes/caffeine/cache/CaffeineSpec.java",
-          "com/github/benmanes/caffeine/cache/Expiry.java",
-          "com/github/benmanes/caffeine/cache/FrequencySketch.java",
-          "com/github/benmanes/caffeine/cache/LinkedDeque.java",
-          "com/github/benmanes/caffeine/cache/LoadingCache.java",
-          "com/github/benmanes/caffeine/cache/LocalAsyncCache.java",
-          "com/github/benmanes/caffeine/cache/LocalAsyncLoadingCache.java",
-          "com/github/benmanes/caffeine/cache/LocalCache.java",
-          "com/github/benmanes/caffeine/cache/LocalCacheFactory.java",
-          "com/github/benmanes/caffeine/cache/LocalLoadingCache.java",
-          "com/github/benmanes/caffeine/cache/LocalManualCache.java",
-          "com/github/benmanes/caffeine/cache/MpscGrowableArrayQueue.java",
-          "com/github/benmanes/caffeine/cache/Node.java",
-          "com/github/benmanes/caffeine/cache/NodeFactory.java",
-          "com/github/benmanes/caffeine/cache/Pacer.java",
-          "com/github/benmanes/caffeine/cache/Policy.java",
-          "com/github/benmanes/caffeine/cache/References.java",
-          "com/github/benmanes/caffeine/cache/RemovalCause.java",
-          "com/github/benmanes/caffeine/cache/RemovalListener.java",
-          "com/github/benmanes/caffeine/cache/Scheduler.java",
-          "com/github/benmanes/caffeine/cache/SerializationProxy.java",
-          "com/github/benmanes/caffeine/cache/StripedBuffer.java",
-          "com/github/benmanes/caffeine/cache/Ticker.java",
-          "com/github/benmanes/caffeine/cache/TimerWheel.java",
-          "com/github/benmanes/caffeine/cache/UnboundedLocalCache.java",
-          "com/github/benmanes/caffeine/cache/Weigher.java",
-          "com/github/benmanes/caffeine/cache/WriteOrderDeque.java",
-          "com/github/benmanes/caffeine/cache/WriteThroughEntry.java",
-          "com/github/benmanes/caffeine/cache/stats/CacheStats.java",
-          "com/github/benmanes/caffeine/cache/stats/ConcurrentStatsCounter.java",
-          "com/github/benmanes/caffeine/cache/stats/DisabledStatsCounter.java",
-          "com/github/benmanes/caffeine/cache/stats/GuardedStatsCounter.java",
-          "com/github/benmanes/caffeine/cache/stats/StatsCounter.java");
-
-  private NullawayJavac nullawayJavac;
+  private CaffeineCompiler compiler;
 
   @Setup
   public void setup() throws IOException {
-    String caffeineSourceDir = System.getProperty("nullaway.caffeine.sources");
-    String caffeineClasspath = System.getProperty("nullaway.caffeine.classpath");
-    List<String> realSourceFileNames =
-        SOURCE_FILE_NAMES.stream()
-            .map(s -> caffeineSourceDir + File.separator + s.replaceAll("/", File.separator))
-            .collect(Collectors.toList());
-    nullawayJavac =
-        NullawayJavac.create(
-            realSourceFileNames,
-            "com.github.benmanes.caffeine",
-            caffeineClasspath,
-            Collections.emptyList());
+    compiler = new CaffeineCompiler();
   }
 
   @Benchmark
-  public void compile(Blackhole bh) throws Exception {
-    bh.consume(nullawayJavac.compile());
+  public void compile(Blackhole bh) {
+    bh.consume(compiler.compile());
   }
 }

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/CaffeineBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/CaffeineBenchmark.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.jmh;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -100,7 +101,10 @@ public class CaffeineBenchmark {
             .collect(Collectors.toList());
     nullawayJavac =
         NullawayJavac.create(
-            realSourceFileNames, "com.github.benmanes.caffeine", caffeineClasspath);
+            realSourceFileNames,
+            "com.github.benmanes.caffeine",
+            caffeineClasspath,
+            Collections.emptyList());
   }
 
   @Benchmark

--- a/jmh/src/jmh/java/com/uber/nullaway/jmh/NullawayReleaseBenchmark.java
+++ b/jmh/src/jmh/java/com/uber/nullaway/jmh/NullawayReleaseBenchmark.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
+// TODO refactor this code so we can test compilation success for each benchmark as a unit test
 public class NullawayReleaseBenchmark {
 
   private NullawayJavac nullawayJavac;

--- a/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.nullaway.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class AbstractBenchmarkCompiler {
+
+  private final NullawayJavac nullawayJavac;
+
+  public AbstractBenchmarkCompiler() throws IOException {
+    nullawayJavac =
+        NullawayJavac.create(
+            getSourceFileNames(), getAnnotatedPackages(), getClasspath(), getExtraErrorProneArgs());
+  }
+
+  public final boolean compile() {
+    return nullawayJavac.compile();
+  }
+
+  protected List<String> getSourceFileNames() throws IOException {
+    String sourceDir = getSourceDirectory();
+    try (Stream<Path> stream =
+        Files.find(
+            Paths.get(sourceDir), 100, (p, bfa) -> p.getFileName().toString().endsWith(".java"))) {
+      List<String> sourceFileNames =
+          stream.map(p -> p.toFile().getAbsolutePath()).collect(Collectors.toList());
+      return sourceFileNames;
+    }
+  }
+
+  protected abstract String getSourceDirectory();
+
+  protected abstract String getAnnotatedPackages();
+
+  protected abstract String getClasspath();
+
+  protected List<String> getExtraErrorProneArgs() {
+    return Collections.emptyList();
+  }
+}

--- a/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
@@ -37,7 +37,11 @@ public abstract class AbstractBenchmarkCompiler {
   public AbstractBenchmarkCompiler() throws IOException {
     nullawayJavac =
         NullawayJavac.create(
-            getSourceFileNames(), getAnnotatedPackages(), getClasspath(), getExtraErrorProneArgs());
+            getSourceFileNames(),
+            getAnnotatedPackages(),
+            getClasspath(),
+            getExtraErrorProneArgs(),
+            getExtraProcessorPath());
   }
 
   public final boolean compile() {
@@ -63,5 +67,9 @@ public abstract class AbstractBenchmarkCompiler {
 
   protected List<String> getExtraErrorProneArgs() {
     return Collections.emptyList();
+  }
+
+  protected String getExtraProcessorPath() {
+    return "";
   }
 }

--- a/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/AbstractBenchmarkCompiler.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/** common logic for compiling a benchmark in JMH performance testing */
 public abstract class AbstractBenchmarkCompiler {
 
   private final NullawayJavac nullawayJavac;
@@ -48,6 +49,7 @@ public abstract class AbstractBenchmarkCompiler {
     return nullawayJavac.compile();
   }
 
+  /** Get the names of source files to be compiled */
   protected List<String> getSourceFileNames() throws IOException {
     String sourceDir = getSourceDirectory();
     try (Stream<Path> stream =
@@ -59,16 +61,21 @@ public abstract class AbstractBenchmarkCompiler {
     }
   }
 
+  /** Get the root directory containing the benchmark source files */
   protected abstract String getSourceDirectory();
 
+  /** Get the value to pass for {@code -XepOpt:NullAway:AnnotatedPackages} */
   protected abstract String getAnnotatedPackages();
 
+  /** Get the classpath required to compile the benchmark */
   protected abstract String getClasspath();
 
+  /** Get any extra arguments that should be passed to Error Prone */
   protected List<String> getExtraErrorProneArgs() {
     return Collections.emptyList();
   }
 
+  /** Get a path of additional jars to be included in the processor path when compiling */
   protected String getExtraProcessorPath() {
     return "";
   }

--- a/jmh/src/main/java/com/uber/nullaway/jmh/AutodisposeCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/AutodisposeCompiler.java
@@ -19,28 +19,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.uber.nullaway.jmh;
 
 import java.io.IOException;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
-@State(Scope.Benchmark)
-public class AutodisposeBenchmark {
-
-  private AutodisposeCompiler compiler;
-
-  @Setup
-  public void setup() throws IOException {
-    compiler = new AutodisposeCompiler();
+public class AutodisposeCompiler extends AbstractBenchmarkCompiler {
+  public AutodisposeCompiler() throws IOException {
+    super();
   }
 
-  @Benchmark
-  public void compile(Blackhole bh) {
-    bh.consume(compiler.compile());
+  @Override
+  protected String getSourceDirectory() {
+    return System.getProperty("nullaway.autodispose.sources");
+  }
+
+  @Override
+  protected String getAnnotatedPackages() {
+    return "autodispose2";
+  }
+
+  @Override
+  protected String getClasspath() {
+    return System.getProperty("nullaway.autodispose.classpath");
   }
 }

--- a/jmh/src/main/java/com/uber/nullaway/jmh/CaffeineCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/CaffeineCompiler.java
@@ -95,7 +95,7 @@ public class CaffeineCompiler extends AbstractBenchmarkCompiler {
     String caffeineSourceDir = getSourceDirectory();
     List<String> realSourceFileNames =
         SOURCE_FILE_NAMES.stream()
-            .map(s -> caffeineSourceDir + File.separator + s.replaceAll("/", File.separator))
+            .map(s -> caffeineSourceDir + File.separator + s.replace("/", File.separator))
             .collect(Collectors.toList());
     return realSourceFileNames;
   }

--- a/jmh/src/main/java/com/uber/nullaway/jmh/CaffeineCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/CaffeineCompiler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.nullaway.jmh;
+
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CaffeineCompiler extends AbstractBenchmarkCompiler {
+
+  /**
+   * we use a subset of the source files since many are auto-generated and annotated with
+   * {@code @SuppressWarnings("NullAway")}
+   */
+  private static final ImmutableList<String> SOURCE_FILE_NAMES =
+      ImmutableList.of(
+          "com/github/benmanes/caffeine/cache/AbstractLinkedDeque.java",
+          "com/github/benmanes/caffeine/cache/AccessOrderDeque.java",
+          "com/github/benmanes/caffeine/cache/Async.java",
+          "com/github/benmanes/caffeine/cache/AsyncCache.java",
+          "com/github/benmanes/caffeine/cache/AsyncCacheLoader.java",
+          "com/github/benmanes/caffeine/cache/AsyncLoadingCache.java",
+          "com/github/benmanes/caffeine/cache/BoundedBuffer.java",
+          "com/github/benmanes/caffeine/cache/BoundedLocalCache.java",
+          "com/github/benmanes/caffeine/cache/Buffer.java",
+          "com/github/benmanes/caffeine/cache/Cache.java",
+          "com/github/benmanes/caffeine/cache/CacheLoader.java",
+          "com/github/benmanes/caffeine/cache/Caffeine.java",
+          "com/github/benmanes/caffeine/cache/CaffeineSpec.java",
+          "com/github/benmanes/caffeine/cache/Expiry.java",
+          "com/github/benmanes/caffeine/cache/FrequencySketch.java",
+          "com/github/benmanes/caffeine/cache/LinkedDeque.java",
+          "com/github/benmanes/caffeine/cache/LoadingCache.java",
+          "com/github/benmanes/caffeine/cache/LocalAsyncCache.java",
+          "com/github/benmanes/caffeine/cache/LocalAsyncLoadingCache.java",
+          "com/github/benmanes/caffeine/cache/LocalCache.java",
+          "com/github/benmanes/caffeine/cache/LocalCacheFactory.java",
+          "com/github/benmanes/caffeine/cache/LocalLoadingCache.java",
+          "com/github/benmanes/caffeine/cache/LocalManualCache.java",
+          "com/github/benmanes/caffeine/cache/MpscGrowableArrayQueue.java",
+          "com/github/benmanes/caffeine/cache/Node.java",
+          "com/github/benmanes/caffeine/cache/NodeFactory.java",
+          "com/github/benmanes/caffeine/cache/Pacer.java",
+          "com/github/benmanes/caffeine/cache/Policy.java",
+          "com/github/benmanes/caffeine/cache/References.java",
+          "com/github/benmanes/caffeine/cache/RemovalCause.java",
+          "com/github/benmanes/caffeine/cache/RemovalListener.java",
+          "com/github/benmanes/caffeine/cache/Scheduler.java",
+          "com/github/benmanes/caffeine/cache/SerializationProxy.java",
+          "com/github/benmanes/caffeine/cache/StripedBuffer.java",
+          "com/github/benmanes/caffeine/cache/Ticker.java",
+          "com/github/benmanes/caffeine/cache/TimerWheel.java",
+          "com/github/benmanes/caffeine/cache/UnboundedLocalCache.java",
+          "com/github/benmanes/caffeine/cache/Weigher.java",
+          "com/github/benmanes/caffeine/cache/WriteOrderDeque.java",
+          "com/github/benmanes/caffeine/cache/WriteThroughEntry.java",
+          "com/github/benmanes/caffeine/cache/stats/CacheStats.java",
+          "com/github/benmanes/caffeine/cache/stats/ConcurrentStatsCounter.java",
+          "com/github/benmanes/caffeine/cache/stats/DisabledStatsCounter.java",
+          "com/github/benmanes/caffeine/cache/stats/GuardedStatsCounter.java",
+          "com/github/benmanes/caffeine/cache/stats/StatsCounter.java");
+
+  public CaffeineCompiler() throws IOException {
+    super();
+  }
+
+  @Override
+  protected String getSourceDirectory() {
+    return System.getProperty("nullaway.caffeine.sources");
+  }
+
+  @Override
+  protected List<String> getSourceFileNames() throws IOException {
+    String caffeineSourceDir = getSourceDirectory();
+    List<String> realSourceFileNames =
+        SOURCE_FILE_NAMES.stream()
+            .map(s -> caffeineSourceDir + File.separator + s.replaceAll("/", File.separator))
+            .collect(Collectors.toList());
+    return realSourceFileNames;
+  }
+
+  @Override
+  protected String getAnnotatedPackages() {
+    return "com.github.benmanes.caffeine";
+  }
+
+  @Override
+  protected String getClasspath() {
+    return System.getProperty("nullaway.caffeine.classpath");
+  }
+}

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayJavac.java
@@ -169,6 +169,8 @@ public class NullawayJavac {
             "-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages="
                 + annotatedPackages
                 + String.join(" ", extraErrorProneArgs)));
+    // add these options since we have at least one benchmark that only compiles with access to
+    // javac-internal APIs
     options.addAll(
         Arrays.asList(
             "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
@@ -53,4 +53,9 @@ public class NullawayReleaseCompiler extends AbstractBenchmarkCompiler {
   protected String getClasspath() {
     return System.getProperty("nullaway.nullawayRelease.classpath");
   }
+
+  @Override
+  protected String getExtraProcessorPath() {
+    return System.getProperty("nullaway.nullawayRelease.processorpath");
+  }
 }

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
@@ -19,28 +19,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.uber.nullaway.jmh;
 
 import java.io.IOException;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
+import java.util.Arrays;
+import java.util.List;
 
-@State(Scope.Benchmark)
-public class AutodisposeBenchmark {
+public class NullawayReleaseCompiler extends AbstractBenchmarkCompiler {
 
-  private AutodisposeCompiler compiler;
-
-  @Setup
-  public void setup() throws IOException {
-    compiler = new AutodisposeCompiler();
+  public NullawayReleaseCompiler() throws IOException {
+    super();
   }
 
-  @Benchmark
-  public void compile(Blackhole bh) {
-    bh.consume(compiler.compile());
+  @Override
+  protected String getSourceDirectory() {
+    return System.getProperty("nullaway.nullawayRelease.sources");
+  }
+
+  @Override
+  protected List<String> getExtraErrorProneArgs() {
+    return Arrays.asList(
+        "-XepOpt:NullAway:CheckOptionalEmptiness=true",
+        "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true",
+        "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.NullabilityUtil.castToNonNull");
+  }
+
+  @Override
+  protected String getAnnotatedPackages() {
+    return "com.uber,org.checkerframework.nullaway";
+  }
+
+  @Override
+  protected String getClasspath() {
+    return System.getProperty("nullaway.nullawayRelease.classpath");
   }
 }

--- a/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
+++ b/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
@@ -1,0 +1,24 @@
+package com.uber.nullaway.jmh;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class BenchmarkCompilationTest {
+
+  @Test
+  public void testAutodispose() throws IOException {
+    assertTrue(new AutodisposeCompiler().compile());
+  }
+
+  @Test
+  public void testCaffeine() throws IOException {
+    assertTrue(new CaffeineCompiler().compile());
+  }
+
+  @Test
+  public void testNullawayRelease() throws IOException {
+    assertTrue(new NullawayReleaseCompiler().compile());
+  }
+}

--- a/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
+++ b/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import org.junit.Test;
 
+/** Tests that all our JMH benchmarks compile successfully */
 public class BenchmarkCompilationTest {
 
   @Test


### PR DESCRIPTION
We now include NullAway 0.9.7 as a JMH benchmark for NullAway.  As part of this change, we significantly refactor the JMH code, to enable writing regression tests checking that the benchmarks compile.  (This was motivated by the fact that NullAway was a bit tricky to get compiling under JMH as it requires AutoValue.)  The logic for compiling the benchmarks has moved into the `*Compiler` classes, and the JMH harnesses are now just simple calls into those classes.  