### PR TITLE
Add support for Preconditions.checkArgument through custom CFG translation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-  }
+    }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
     repositories {
         mavenCentral()
         google() // For Gradle 4.0+
+        mavenLocal() // TODO: Remove!
     }
 
     dependencies {
@@ -45,6 +46,7 @@ plugins {
 repositories {
   // to get the google-java-format jar and dependencies
   mavenCentral()
+  mavenLocal() // TODO: Remove!
 }
 
 apply from: "gradle/dependencies.gradle"
@@ -105,7 +107,8 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-    }
+        mavenLocal() // TODO: Remove!
+  }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ buildscript {
     repositories {
         mavenCentral()
         google() // For Gradle 4.0+
-        mavenLocal() // TODO: Remove!
     }
 
     dependencies {
@@ -46,7 +45,6 @@ plugins {
 repositories {
   // to get the google-java-format jar and dependencies
   mavenCentral()
-  mavenLocal() // TODO: Remove!
 }
 
 apply from: "gradle/dependencies.gradle"
@@ -107,7 +105,6 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-        mavenLocal() // TODO: Remove!
   }
 
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -80,7 +80,7 @@ public final class AccessPathNullnessAnalysis {
             config,
             handler,
             new CoreNullnessStoreInitializer());
-    this.dataFlow = new DataFlow(config.assertsEnabled());
+    this.dataFlow = new DataFlow(config.assertsEnabled(), handler);
 
     if (config.checkContracts()) {
       this.contractNullnessPropagation =

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -38,6 +38,8 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullabilityUtil;
+import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
+import com.uber.nullaway.handlers.Handler;
 import javax.annotation.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import org.checkerframework.nullaway.dataflow.analysis.AbstractValue;
@@ -49,7 +51,6 @@ import org.checkerframework.nullaway.dataflow.analysis.Store;
 import org.checkerframework.nullaway.dataflow.analysis.TransferFunction;
 import org.checkerframework.nullaway.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
-import org.checkerframework.nullaway.dataflow.cfg.builder.CFGBuilder;
 
 /**
  * Provides a wrapper around {@link org.checkerframework.nullaway.dataflow.analysis.Analysis}.
@@ -70,8 +71,11 @@ public final class DataFlow {
 
   private final boolean assertsEnabled;
 
-  DataFlow(boolean assertsEnabled) {
+  private final Handler handler;
+
+  DataFlow(boolean assertsEnabled, Handler handler) {
     this.assertsEnabled = assertsEnabled;
+    this.handler = handler;
   }
 
   private final LoadingCache<AnalysisParams, Analysis<?, ?, ?>> analysisCache =
@@ -130,7 +134,8 @@ public final class DataFlow {
                     bodyPath = codePath;
                   }
 
-                  return CFGBuilder.build(bodyPath, ast, assertsEnabled, !assertsEnabled, env);
+                  return NullAwayCFGBuilder.build(
+                      bodyPath, ast, assertsEnabled, !assertsEnabled, env, handler);
                 }
               });
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/cfg/NullAwayCFGBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/cfg/NullAwayCFGBuilder.java
@@ -1,0 +1,156 @@
+package com.uber.nullaway.dataflow.cfg;
+
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ThrowTree;
+import com.sun.source.tree.TreeVisitor;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.handlers.Handler;
+import javax.annotation.Nullable;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Name;
+import javax.lang.model.type.TypeMirror;
+import org.checkerframework.nullaway.dataflow.cfg.ControlFlowGraph;
+import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
+import org.checkerframework.nullaway.dataflow.cfg.builder.CFGBuilder;
+import org.checkerframework.nullaway.dataflow.cfg.builder.CFGTranslationPhaseOne;
+import org.checkerframework.nullaway.dataflow.cfg.builder.CFGTranslationPhaseThree;
+import org.checkerframework.nullaway.dataflow.cfg.builder.CFGTranslationPhaseTwo;
+import org.checkerframework.nullaway.dataflow.cfg.builder.ConditionalJump;
+import org.checkerframework.nullaway.dataflow.cfg.builder.ExtendedNode;
+import org.checkerframework.nullaway.dataflow.cfg.builder.Label;
+import org.checkerframework.nullaway.dataflow.cfg.builder.PhaseOneResult;
+import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.nullaway.dataflow.cfg.node.ThrowNode;
+import org.checkerframework.nullaway.javacutil.AnnotationProvider;
+import org.checkerframework.nullaway.javacutil.BasicAnnotationProvider;
+import org.checkerframework.nullaway.javacutil.trees.TreeBuilder;
+
+public class NullAwayCFGBuilder extends CFGBuilder {
+
+  /** This class should never be instantiated. */
+  private NullAwayCFGBuilder() {}
+
+  public static ControlFlowGraph build(
+      TreePath bodyPath,
+      UnderlyingAST underlyingAST,
+      boolean assumeAssertionsEnabled,
+      boolean assumeAssertionsDisabled,
+      ProcessingEnvironment env,
+      Handler handler) {
+    TreeBuilder builder = new TreeBuilder(env);
+    AnnotationProvider annotationProvider = new BasicAnnotationProvider();
+    CFGTranslationPhaseOne phase1translator =
+        new NullAwayCFGTranslationPhaseOne(
+            builder,
+            annotationProvider,
+            assumeAssertionsEnabled,
+            assumeAssertionsDisabled,
+            env,
+            handler);
+    PhaseOneResult phase1result = phase1translator.process(bodyPath, underlyingAST);
+    if (bodyPath
+        .getCompilationUnit()
+        .getSourceFile()
+        .getName()
+        .contains("NullAwayPreconditionTest")) {
+      System.err.println("Phase 1:");
+      System.err.println("============");
+      System.err.println(phase1result.toString());
+      System.err.println("============");
+    }
+    ControlFlowGraph phase2result = CFGTranslationPhaseTwo.process(phase1result);
+    ControlFlowGraph phase3result = CFGTranslationPhaseThree.process(phase2result);
+    if (bodyPath
+        .getCompilationUnit()
+        .getSourceFile()
+        .getName()
+        .contains("NullAwayPreconditionTest")) {
+      System.err.println("Phase 3:");
+      System.err.println("============");
+      System.err.println(phase3result.toString());
+      System.err.println("============");
+    }
+    return phase3result;
+  }
+
+  private static class NullAwayCFGTranslationPhaseOne extends CFGTranslationPhaseOne {
+
+    private static final String PRECONDITIONS_CLASS_NAME = "com.google.common.base.Preconditions";
+    private static final String CHECK_ARGUMENT_METHOD_NAME = "checkArgument";
+
+    @Nullable private Name preconditionsClass;
+    @Nullable private Name checkArgumentMethod;
+
+    final TypeMirror preconditionErrorType;
+
+    @SuppressWarnings("UnusedVariable")
+    private final Handler handler;
+
+    public NullAwayCFGTranslationPhaseOne(
+        TreeBuilder builder,
+        AnnotationProvider annotationProvider,
+        boolean assumeAssertionsEnabled,
+        boolean assumeAssertionsDisabled,
+        ProcessingEnvironment env,
+        Handler handler) {
+      super(builder, annotationProvider, assumeAssertionsEnabled, assumeAssertionsDisabled, env);
+      this.handler = handler;
+      this.preconditionErrorType = this.getTypeMirror(IllegalArgumentException.class);
+    }
+
+    @SuppressWarnings("NullAway") // (Void)null issue
+    @Override
+    public MethodInvocationNode visitMethodInvocation(MethodInvocationTree tree, Void p) {
+      // Add nodes before
+      MethodInvocationNode originalNode = super.visitMethodInvocation(tree, p);
+      // Add nodes after
+      // ToDo: Move to handler call
+      Symbol.MethodSymbol callee = ASTHelpers.getSymbol(tree);
+      if (preconditionsClass == null) {
+        preconditionsClass = callee.name.table.fromString(PRECONDITIONS_CLASS_NAME);
+        checkArgumentMethod = callee.name.table.fromString(CHECK_ARGUMENT_METHOD_NAME);
+      }
+      if (callee.enclClass().getQualifiedName().equals(preconditionsClass)
+          && callee.name.equals(checkArgumentMethod)
+          && callee.getParameters().size() > 0) {
+        Label falsePreconditionEntry = new Label();
+        Label endPrecondition = new Label();
+        // Node preconditionExpressionNode = originalNode.getArgument(0);
+        // this.extendWithNode(preconditionExpressionNode);
+        this.scan(tree.getArguments().get(0), (Void) null);
+        ConditionalJump cjump = new ConditionalJump(endPrecondition, falsePreconditionEntry);
+        this.extendWithExtendedNode(cjump);
+        this.addLabelForNextNode(falsePreconditionEntry);
+        ExtendedNode exNode =
+            this.extendWithNodeWithException(
+                new ThrowNode(
+                    new ThrowTree() {
+                      @Override
+                      public ExpressionTree getExpression() {
+                        return tree.getArguments().get(0);
+                      }
+
+                      @Override
+                      public Kind getKind() {
+                        return Kind.THROW;
+                      }
+
+                      @Override
+                      public <R, D> R accept(TreeVisitor<R, D> visitor, D data) {
+                        return visitor.visitThrow(this, data);
+                      }
+                    },
+                    originalNode,
+                    this.getProcessingEnvironment().getTypeUtils()),
+                this.preconditionErrorType);
+        exNode.setTerminatesExecution(true);
+        this.addLabelForNextNode(endPrecondition);
+      }
+      // ToDo: End of handler call
+      return originalNode;
+    }
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -40,6 +40,7 @@ import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
+import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -192,5 +193,13 @@ public abstract class BaseNoOpHandler implements Handler {
   public void onNonNullFieldAssignment(
       Symbol field, AccessPathNullnessAnalysis analysis, VisitorState state) {
     // NoOp
+  }
+
+  @Override
+  public MethodInvocationNode onCFGBuildPhase1AfterVisitMethodInvocation(
+      NullAwayCFGBuilder.NullAwayCFGTranslationPhaseOne phase,
+      MethodInvocationTree tree,
+      MethodInvocationNode originalNode) {
+    return originalNode;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -41,6 +41,7 @@ import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
+import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -250,5 +251,17 @@ class CompositeHandler implements Handler {
     for (Handler h : handlers) {
       h.onNonNullFieldAssignment(field, analysis, state);
     }
+  }
+
+  @Override
+  public MethodInvocationNode onCFGBuildPhase1AfterVisitMethodInvocation(
+      NullAwayCFGBuilder.NullAwayCFGTranslationPhaseOne phase,
+      MethodInvocationTree tree,
+      MethodInvocationNode originalNode) {
+    MethodInvocationNode currentNode = originalNode;
+    for (Handler h : handlers) {
+      currentNode = h.onCFGBuildPhase1AfterVisitMethodInvocation(phase, tree, currentNode);
+    }
+    return currentNode;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -41,6 +41,7 @@ import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
+import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
 import java.util.Optional;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -324,6 +325,22 @@ public interface Handler {
    */
   void onNonNullFieldAssignment(
       Symbol field, AccessPathNullnessAnalysis analysis, VisitorState state);
+
+  /**
+   * Called during AST to CFG translation (CFGTranslationPhaseOne) immediately after translating a
+   * MethodInvocationTree.
+   *
+   * @param phase a reference to the NullAwayCFGTranslationPhaseOne object and its utility
+   *     functions.
+   * @param tree the MethodInvocationTree being translated.
+   * @param originalNode the resulting MethodInvocationNode right before this handler is called.
+   * @return a MethodInvocationNode which might be originalNode or a modified version, this is
+   *     passed to the next handler in the chain.
+   */
+  MethodInvocationNode onCFGBuildPhase1AfterVisitMethodInvocation(
+      NullAwayCFGBuilder.NullAwayCFGTranslationPhaseOne phase,
+      MethodInvocationTree tree,
+      MethodInvocationNode originalNode);
 
   /**
    * A three value enum for handlers implementing onDataflowVisitMethodInvocation to communicate

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -55,6 +55,7 @@ public class Handlers {
     if (config.handleTestAssertionLibraries()) {
       handlerListBuilder.add(new AssertionHandler(methodNameUtil));
     }
+    handlerListBuilder.add(new PreconditionsHandler());
     handlerListBuilder.add(new LibraryModelsHandler(config));
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getRxStreamNullabilityPropagator());
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
@@ -1,3 +1,44 @@
 package com.uber.nullaway.handlers;
 
-public class PreconditionsHandler extends BaseNoOpHandler {}
+import com.google.common.base.Preconditions;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Name;
+import javax.lang.model.type.TypeMirror;
+import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
+
+public class PreconditionsHandler extends BaseNoOpHandler {
+
+  private static final String PRECONDITIONS_CLASS_NAME = "com.google.common.base.Preconditions";
+  private static final String CHECK_ARGUMENT_METHOD_NAME = "checkArgument";
+  private static final String CHECK_STATE_METHOD_NAME = "checkState";
+
+  @Nullable private Name preconditionsClass;
+  @Nullable private Name checkArgumentMethod;
+  @Nullable private Name checkStateMethod;
+  @Nullable TypeMirror preconditionErrorType;
+
+  @Override
+  public MethodInvocationNode onCFGBuildPhase1AfterVisitMethodInvocation(
+      NullAwayCFGBuilder.NullAwayCFGTranslationPhaseOne phase,
+      MethodInvocationTree tree,
+      MethodInvocationNode originalNode) {
+    Symbol.MethodSymbol callee = ASTHelpers.getSymbol(tree);
+    if (preconditionsClass == null) {
+      preconditionsClass = callee.name.table.fromString(PRECONDITIONS_CLASS_NAME);
+      checkArgumentMethod = callee.name.table.fromString(CHECK_ARGUMENT_METHOD_NAME);
+      checkStateMethod = callee.name.table.fromString(CHECK_STATE_METHOD_NAME);
+      preconditionErrorType = phase.classToErrorType(IllegalArgumentException.class);
+    }
+    Preconditions.checkNotNull(preconditionErrorType);
+    if (callee.enclClass().getQualifiedName().equals(preconditionsClass)
+        && (callee.name.equals(checkArgumentMethod) || callee.name.equals(checkStateMethod))
+        && callee.getParameters().size() > 0) {
+      phase.insertThrowOnFalse(originalNode.getArgument(0), preconditionErrorType);
+    }
+    return originalNode;
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
@@ -1,0 +1,3 @@
+package com.uber.nullaway.handlers;
+
+public class PreconditionsHandler extends BaseNoOpHandler {}

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
@@ -1,0 +1,134 @@
+package com.uber.nullaway;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class NullAwayPreconditionTests extends NullAwayTestsBase {
+
+  @Test
+  public void checkNotNullTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkNotNull(a);",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void simpleCheckArgumentTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(a != null);",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void simpleCheckArgumentWithMessageTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(a != null, \"a ought to be non-null\");",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void compoundCheckArgumentTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(a != null && !a.equals(this));",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void compoundCheckArgumentLastTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "NullAwayPreconditionTest.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class NullAwayPreconditionTest {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(this.hashCode() != 5 && a != null);",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nestedCallCheckArgumentTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "import com.google.common.base.Strings;",
+            "class Test {",
+            "  private void foo(@Nullable String a) {",
+            "    Preconditions.checkArgument(!Strings.isNullOrEmpty(a));",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
@@ -48,6 +48,28 @@ public class NullAwayPreconditionTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void simpleCheckStateTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  @Nullable private Object a;",
+            "  private void foo() {",
+            "    Preconditions.checkState(this.a != null);",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void simpleCheckArgumentWithMessageTest() {
     makeTestHelperWithArgs(
             Arrays.asList(
@@ -97,14 +119,39 @@ public class NullAwayPreconditionTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
-            "NullAwayPreconditionTest.java",
+            "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "import com.google.common.base.Preconditions;",
-            "class NullAwayPreconditionTest {",
+            "class Test {",
             "  private void foo(@Nullable Object a) {",
             "    Preconditions.checkArgument(this.hashCode() != 5 && a != null);",
             "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void compoundCheckArgumentLongTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b, @Nullable Object c, @Nullable Object d, @Nullable Object e) {",
+            "    Preconditions.checkArgument(a != null && b != null && c != null && d != null && e != null);",
+            "    a.toString();",
+            "    b.toString();",
+            "    c.toString();",
+            "    d.toString();",
+            "    e.toString();",
             "  }",
             "}")
         .doTest();
@@ -126,6 +173,50 @@ public class NullAwayPreconditionTests extends NullAwayTestsBase {
             "class Test {",
             "  private void foo(@Nullable String a) {",
             "    Preconditions.checkArgument(!Strings.isNullOrEmpty(a));",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void irrelevantCheckArgumentTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(this.hashCode() != 5);",
+            "    // BUG: Diagnostic contains: dereferenced expression a is @Nullable",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void inconclusiveCheckArgumentTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    Preconditions.checkArgument(this.hashCode() != 5 || a != null);",
+            "    // BUG: Diagnostic contains: dereferenced expression a is @Nullable",
             "    a.toString();",
             "  }",
             "}")


### PR DESCRIPTION
See #47 for discussion.

This PR adds support for `Preconditions.checkArgument(...)` and `Preconditions.checkState(...)`
throw a new `PreconditionsHandler` handler. 

In order to implement said handler, we need a custom CFG translation pipeline in NullAway 
(`NullAwayCFGBuilder`) which subclasses the Checker Framework's `CFGBuilder` 
(which we were using directly before this change). This pipeline allows us to add handler
callbacks during the AST to CFG translation process. At the moment, we add a single
such callback, right after visiting a `MethodInvocationTree`. We also add a more or less
generic method to insert a conditional jump and a throw based on a given boolean expression
node.

Abstracting some details about our AST and CFG structures, we translate:

```
Preconditions.checkArgument($someBoolExpr[, $someString]);
``` 

Into something resembling:

```
Preconditions.checkArgument($someBoolExpr[, $someString]);
if ($someBoolExpr) {
   throw new IllegalArgumentException();
}
``` 

Note that this causes `$someBoolExpr` to be evaluated twice. This is necessary based on how
NullAway evaluates branch conditionals, since we currently do not track boolean values through
our dataflow (e.g. `boolean b = (o == null); if (b) { throw [...] }; o.toString();` produces a dereference
according to NullAway, independent on whether that code was added by rewriting or directly on the
source.

That said, note that obviously this doesn't change the code being compiled or bytecode being produced,
the rewrite is only ever used by/visible to NullAway itself.

Finally, our implementation of `NullAwayCFGBuilder` and particularly `NullAwayCFGTranslationPhaseOne`
in this PR, depend on a Checker Framework APIs that are currently private. We are simultaneously
submitting a PR to change the visibility of these APIs (see [CheckerFramework#5156](https://github.com/typetools/checker-framework/pull/5156))
