### PR TITLE
Fix false positive involving type parameter @Nullable annotations.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -271,11 +271,17 @@ public class NullabilityUtil {
                         && t.position.parameter_index == paramInd));
   }
 
-  private static Stream<? extends AnnotationMirror> getTypeUseAnnotations(Symbol symbol) {
+  public static Stream<? extends AnnotationMirror> getTypeUseAnnotations(Symbol symbol) {
     Stream<Attribute.TypeCompound> rawTypeAttributes = symbol.getRawTypeAttributes().stream();
     if (symbol instanceof Symbol.MethodSymbol) {
       // for methods, we want the type-use annotations on the return type
-      return rawTypeAttributes.filter((t) -> t.position.type.equals(TargetType.METHOD_RETURN));
+      return rawTypeAttributes.filter(
+          (t) ->
+              // location is a list of TypePathEntry objects, indicating whether the annotation is
+              // on an array, inner type, wildcard, or type argument. If it's empty, then the
+              // annotation
+              // is directly on the return type.
+              t.position.type.equals(TargetType.METHOD_RETURN) && t.position.location.isEmpty());
     }
     return rawTypeAttributes;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -271,7 +271,7 @@ public class NullabilityUtil {
                         && t.position.parameter_index == paramInd));
   }
 
-  public static Stream<? extends AnnotationMirror> getTypeUseAnnotations(Symbol symbol) {
+  private static Stream<? extends AnnotationMirror> getTypeUseAnnotations(Symbol symbol) {
     Stream<Attribute.TypeCompound> rawTypeAttributes = symbol.getRawTypeAttributes().stream();
     if (symbol instanceof Symbol.MethodSymbol) {
       // for methods, we want the type-use annotations on the return type

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTypeUseAnnotationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTypeUseAnnotationTests.java
@@ -1,0 +1,38 @@
+package com.uber.nullaway;
+
+import org.junit.Test;
+
+public class NullAwayTypeUseAnnotationTests extends NullAwayTestsBase {
+  @Test
+  public void typeParameterAnnotationIsDistinctFromMethodReturnAnnotation() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.nullness.Nullable;",
+            "import java.util.function.Supplier;",
+            "public class Test {",
+            "  public static <R> @Nullable Supplier<@Nullable R> getNullableSupplierOfNullable() {",
+            "    return new Supplier<R>() {",
+            "      @Nullable",
+            "      public R get() { return null; }",
+            "    };",
+            "  }",
+            "  public static <R> Supplier<@Nullable R> getNonNullSupplierOfNullable() {",
+            "    return new Supplier<R>() {",
+            "      @Nullable",
+            "      public R get() { return null; }",
+            "    };",
+            "  }",
+            "  public static String test1() {",
+            "    // BUG: Diagnostic contains: dereferenced expression getNullableSupplierOfNullable() is @Nullable",
+            "    return getNullableSupplierOfNullable().toString();",
+            "  }",
+            "  public static String test2() {",
+            "    // The supplier contains null, but isn't itself nullable. Check against a past FP",
+            "    return getNonNullSupplierOfNullable().toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
NullAway doesn't currently support `@Nullable` annotations on type
parameters. However, we had an error where a `@Nullable` annotation
in a type parameter of the return type of a method was being
interpreted as applying to the method return itself.

For example:

```
public static <R> Foo<@Nullable R> bar() { ... }

public static void baz() {
  bar().toString();
}
```

would mistakenly be considered a null dereference.

We introduce an additional check to `NullabilityUtil.getTypeUseAnnotations(...)`
which will retrieve the method return annotation for the following cases:

```
@Nullable public static <R> Foo<R> bar()
@Nullable public static <R> Foo<@Nullable R> bar()
public static <R> @Nullable Foo<R> bar()
```

Yet ignore the annotation inside the type parameter of `Foo`.

It is possible we might need to refactor this check when we actually start
handling nullability of type parameters.