### PR TITLE
Update to Checker Framework 3.22.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.21.3",
+    checkerFramework       : "3.22.2",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.


### PR DESCRIPTION
Needed for our changes in #608, which requires visibility into some previously
`package` or `private` level internals of Checker Framework's CFG:

- https://github.com/typetools/checker-framework/pull/5152
- https://github.com/typetools/checker-framework/pull/5156