### PR TITLE
Generalize support for castToNonNull methods, using library models

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -108,6 +108,26 @@ public interface LibraryModels {
   ImmutableSet<MethodRef> nonNullReturns();
 
   /**
+   * Get (method, parameter) pairs that act as castToNonNull(...) methods.
+   *
+   * <p>Here, the parameter index determines the argument position of the reference being cast to
+   * non-null.
+   *
+   * <p>We still provide the CLI configuration `-XepOpt:NullAway:CastToNonNullMethod` as the default
+   * way to define the common case of a single-argument <code>
+   * @NonNull Object castToNonNull(@Nullable Object o)}</code> cast method.
+   *
+   * <p>However, in some cases, the user might wish to have a cast method that takes multiple
+   * arguments, in addition to the <code>@Nullable</code> value being cast. For these cases,
+   * providing a library model allows for more precise error reporting whenever a known non-null
+   * value is passed to such method, rendering the cast unnecessary.
+   *
+   * <p>Note that we can't auto-add castToNonNull(...) methods taking more than one argument, simply
+   * because there might be no general, automated way of synthesizing the required arguments.
+   */
+  ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods();
+
+  /**
    * representation of a method as a qualified class name + a signature for the method
    *
    * <p>The formatting of a method signature should match the result of calling {@link

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1504,12 +1504,20 @@ public class NullAway extends BugChecker
       List<? extends ExpressionTree> actualParams) {
     String qualifiedName =
         ASTHelpers.enclosingClass(methodSymbol) + "." + methodSymbol.getSimpleName().toString();
-    if (qualifiedName.equals(config.getCastToNonNullMethod())) {
-      if (actualParams.size() != 1) {
-        throw new RuntimeException(
-            "Invalid number of parameters passed to configured CastToNonNullMethod.");
-      }
-      ExpressionTree actual = actualParams.get(0);
+    ImmutableSet<Integer> castToNonNullPositions;
+    if (qualifiedName.equals(config.getCastToNonNullMethod())
+        && methodSymbol.getParameters().size() == 1) {
+      // castToNonNull method passed to CLI config, it acts as a cast-to-non-null on its first
+      // argument.
+      // since this works only for the single argument method, we skip further querying of handlers.
+      castToNonNullPositions = ImmutableSet.of(0);
+    } else {
+      castToNonNullPositions =
+          handler.castToNonNullArgumentPositionsForMethod(
+              this, state, methodSymbol, actualParams, ImmutableSet.of());
+    }
+    for (Integer idx : castToNonNullPositions) {
+      ExpressionTree actual = actualParams.get(idx);
       TreePath enclosingMethodOrLambda =
           NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(state.getPath());
       boolean isInitializer;
@@ -1530,7 +1538,9 @@ public class NullAway extends BugChecker
                 + state.getSourceForNode(actual)
                 + "' to CastToNonNullMethod ("
                 + qualifiedName
-                + "). This method should only take arguments that NullAway considers @Nullable "
+                + ") at position "
+                + idx
+                + ". This method argument should only take values that NullAway considers @Nullable "
                 + "at the invocation site, but which are known not to be null at runtime.";
         return errorBuilder.createErrorDescription(
             new ErrorMessage(MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, message),

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -202,4 +202,15 @@ public abstract class BaseNoOpHandler implements Handler {
       MethodInvocationNode originalNode) {
     return originalNode;
   }
+
+  @Override
+  public ImmutableSet<Integer> castToNonNullArgumentPositionsForMethod(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      List<? extends ExpressionTree> actualParams,
+      ImmutableSet<Integer> castToNonNullPositions) {
+    // NoOp
+    return castToNonNullPositions;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -264,4 +264,19 @@ class CompositeHandler implements Handler {
     }
     return currentNode;
   }
+
+  @Override
+  public ImmutableSet<Integer> castToNonNullArgumentPositionsForMethod(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      List<? extends ExpressionTree> actualParams,
+      ImmutableSet<Integer> castToNonNullPositions) {
+    for (Handler h : handlers) {
+      castToNonNullPositions =
+          h.castToNonNullArgumentPositionsForMethod(
+              analysis, state, methodSymbol, actualParams, castToNonNullPositions);
+    }
+    return castToNonNullPositions;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -35,6 +35,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
+import com.uber.nullaway.LibraryModels;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -341,6 +342,28 @@ public interface Handler {
       NullAwayCFGBuilder.NullAwayCFGTranslationPhaseOne phase,
       MethodInvocationTree tree,
       MethodInvocationNode originalNode);
+
+  /**
+   * Called to determine when a method acts as a cast-to-non-null operation on its parameters.
+   *
+   * <p>See {@link LibraryModels#castToNonNullMethods()} for more information about general
+   * configuration of <code>castToNonNull</code> methods.
+   *
+   * @param analysis A reference to the running NullAway analysis.
+   * @param state The current visitor state.
+   * @param methodSymbol The method symbol for the potential castToNonNull method.
+   * @param actualParams The actual parameters from the invocation node
+   * @param castToNonNullPositions The list of parameters for the method for which the method acts
+   *     as a cast, as computed by upstream handlers (the core analysis supplies a default set to
+   *     the first handler in the chain, based on CLI config).
+   * @return Updated parameter list computed by this handler
+   */
+  ImmutableSet<Integer> castToNonNullArgumentPositionsForMethod(
+      NullAway analysis,
+      VisitorState state,
+      Symbol.MethodSymbol methodSymbol,
+      List<? extends ExpressionTree> actualParams,
+      ImmutableSet<Integer> castToNonNullPositions);
 
   /**
    * A three value enum for handlers implementing onDataflowVisitMethodInvocation to communicate

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -254,6 +254,36 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void testCastToNonNullExtraArgsWarning() {
+    defaultCompilationHelper
+        .addSourceFile("Util.java")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  Object test1(Object o) {",
+            "    // BUG: Diagnostic contains: passing known @NonNull parameter 'o' to CastToNonNullMethod",
+            "    return castToNonNull(o, \"o should be @Nullable but never actually null\");",
+            "  }",
+            "  Object test2(Object o) {",
+            "    // BUG: Diagnostic contains: passing known @NonNull parameter 'o' to CastToNonNullMethod",
+            "    return castToNonNull(\"o should be @Nullable but never actually null\", o, 0);",
+            "  }",
+            "  Object test3(@Nullable Object o) {",
+            "    // Expected use of cast",
+            "    return castToNonNull(o, \"o should be @Nullable but never actually null\");",
+            "  }",
+            "  Object test4(@Nullable Object o) {",
+            "    // Expected use of cast",
+            "    return castToNonNull(o, \"o should be @Nullable but never actually null\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testReadStaticInConstructor() {
     defaultCompilationHelper
         .addSourceLines(

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/Util.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/Util.java
@@ -33,6 +33,21 @@ public class Util {
     return x;
   }
 
+  public static <T> T castToNonNull(@Nullable T x, String msg) {
+    if (x == null) {
+      throw new RuntimeException(msg);
+    }
+    return x;
+  }
+
+  public static <T> T castToNonNull(String msg, @Nullable T x, int counter) {
+    // counter is needed to distinguish this method from the previous one when T == String
+    if (x == null) {
+      throw new RuntimeException(msg);
+    }
+    return x;
+  }
+
   public static <T> T id(T x) {
     return x;
   }

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -66,4 +66,9 @@ public class ExampleLibraryModels implements LibraryModels {
   public ImmutableSet<MethodRef> nonNullReturns() {
     return ImmutableSet.of();
   }
+
+  @Override
+  public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
+    return ImmutableSetMultimap.of();
+  }
 }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -70,4 +70,16 @@ public class TestLibraryModels implements LibraryModels {
   public ImmutableSet<MethodRef> nonNullReturns() {
     return ImmutableSet.of();
   }
+
+  @Override
+  public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
+    return ImmutableSetMultimap.<MethodRef, Integer>builder()
+        .put(
+            methodRef("com.uber.nullaway.testdata.Util", "<T>castToNonNull(T,java.lang.String)"), 0)
+        .put(
+            methodRef(
+                "com.uber.nullaway.testdata.Util", "<T>castToNonNull(java.lang.String,T,int)"),
+            1)
+        .build();
+  }
 }


### PR DESCRIPTION
This allows for `castToNonNull` methods taking additional arguments, such as a custom message
or a specific logger object to be monitored, in order to detect and warn about values known
statically to be non-null flowing into them, and also for special treatment during initialization. 
See #594 for more details.

Since these more complex `castToNonNull` method definitions require custom library models,
we still should support the basic identity `castToNonNull` configuration through 
`-XepOpt:NullAway:CastToNonNullMethod`, simply for ease of use. 

Also, please note that NullAway can't use the more complex `castToNonNull` method signatures for 
automated suppressions, since doing so would require being able to synthesize their non-casted arguments. 
In the future, we could detect the single-argument `castToNonNull` equivalently whether it is added 
by the CLI flag or via a library model, but, for now, the mechanisms are disjoint and the library models 
are only really taken into account for our `checkCastToNonNullTakesNullable` check. Using casts as 
fix suggestions _requires_ passing the CLI flag.

A good portion of this diff is library models and handler plumbing.