### PR TITLE
Clean-up: Remove unused fix suggestion code.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -45,13 +45,11 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayAccessTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BinaryTree;
@@ -2178,50 +2176,6 @@ public class NullAway extends BugChecker
     }
 
     return Description.NO_MATCH;
-  }
-
-  @SuppressWarnings("unused")
-  private Description.Builder changeReturnNullabilityFix(
-      Tree suggestTree, Description.Builder builder, VisitorState state) {
-    if (suggestTree.getKind() != Tree.Kind.METHOD) {
-      throw new RuntimeException("This should be a MethodTree");
-    }
-    SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
-    MethodTree methodTree = (MethodTree) suggestTree;
-    int countNullableAnnotations = 0;
-    for (AnnotationTree annotationTree : methodTree.getModifiers().getAnnotations()) {
-      if (castToNonNull(state.getSourceForNode(annotationTree.getAnnotationType()))
-          .endsWith("Nullable")) {
-        fixBuilder.delete(annotationTree);
-        countNullableAnnotations += 1;
-      }
-    }
-    assert countNullableAnnotations > 1;
-    return builder.addFix(fixBuilder.build());
-  }
-
-  @SuppressWarnings("unused")
-  private Description.Builder changeParamNullabilityFix(
-      Tree suggestTree, Description.Builder builder) {
-    return builder.addFix(SuggestedFix.prefixWith(suggestTree, "@Nullable "));
-  }
-
-  @SuppressWarnings("unused")
-  private int depth(ExpressionTree expression) {
-    switch (expression.getKind()) {
-      case MEMBER_SELECT:
-        MemberSelectTree selectTree = (MemberSelectTree) expression;
-        return 1 + depth(selectTree.getExpression());
-      case METHOD_INVOCATION:
-        MethodInvocationTree invTree = (MethodInvocationTree) expression;
-        return depth(invTree.getMethodSelect());
-      case IDENTIFIER:
-        IdentifierTree varTree = (IdentifierTree) expression;
-        Symbol symbol = ASTHelpers.getSymbol(varTree);
-        return symbol.getKind().equals(ElementKind.FIELD) ? 2 : 1;
-      default:
-        return 0;
-    }
   }
 
   private static boolean isThisIdentifier(ExpressionTree expressionTree) {


### PR DESCRIPTION
This code has laid untouched and `@SuppressWarnings("unused")` since 2018 (see e.g. #149).

I think that, at this point, even if we wanted to incorporate auto-fixing capabilities into NullAway directly,
separate from NullAwayInfer, we probably would want to start from scratch rather than re-enable this code.
If it turns out that I am wrong, well, we still have it in the git commit history.