### PR TITLE
Fix inconsistent treatment of generated code with restrictive annotations

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -110,7 +110,8 @@ def test = [
     springBeans             : "org.springframework:spring-beans:5.3.7",
     springContext           : "org.springframework:spring-context:5.3.7",
     grpcCore                : "io.grpc:grpc-core:1.15.1", // Should upgrade, but this matches our guava version
-    mockito                 : "org.mockito:mockito-core:4.6.1"
+    mockito                 : "org.mockito:mockito-core:4.6.1",
+    javaxAnnotationApi      : "javax.annotation:javax.annotation-api:1.3.2",
 ]
 
 ext.deps = [

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation deps.test.grpcCore
     testImplementation project(":test-java-lib-lombok")
     testImplementation deps.test.mockito
+    testImplementation deps.test.javaxAnnotationApi
 
     // This ends up being resolved to the NullAway jar under nullaway/build/libs
     nullawayJar "com.uber.nullaway:nullaway:$VERSION_NAME"

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -130,7 +130,14 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(node.getTree());
-    if (getClassAnnotationInfo(context).isSymbolUnannotated(methodSymbol, config)
+    ClassAnnotationInfo classAnnotationInfo = getClassAnnotationInfo(context);
+    // with the generated-as-unannotated option enabled, we want to ignore
+    // annotations in generated code
+    if (config.treatGeneratedAsUnannotated()
+        && classAnnotationInfo.isGenerated(methodSymbol, config)) {
+      return NullnessHint.UNKNOWN;
+    }
+    if (classAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
         && Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return NullnessHint.HINT_NULLABLE;
     }


### PR DESCRIPTION
Without this change, we have a bug whenever the following flags are
used together:

```
-XepOpt:NullAway:TreatGeneratedAsUnannotated=true
-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true
```

and a method inside `@Generated` code is explicitly marked as having a
`@Nullable` return.

In this case, the `RestrictiveAnnotationHandler` would treat the method
as definitely `@NonNull` when handling the `onOverrideMayBeNullExpr` extension
point, but as `@Nullable` for the purposes of `onDataflowVisitMethodInvocation`.

This is inconsistent on its own, but it produces even more undesirable behavior
if a `castToNonNull` method is configured (whether through library models or
`-XepOpt:NullAway:CastToNonNullMethod`).

If `foo` is such a `@Generated`+`@Nullable` method, then, in the above
configuration:

```
Object o = castToNonNull(foo());
o.toString();
```

Produces an error, claiming that a known `@NonNull` value is being passed to
the cast.

Yet the following code:
```
Object o = foo();
o.toString();
```

Causes NullAway to complain about a `@Nullable` dereference (due to dataflow
concluding `o` is `@Nullable`).

To fix this, we need to make sure that the behavior of `AcknowledgeRestrictiveAnnotations`
is consistent.

One option is to not care about `@Generated` vs non-generated code, or
about `TreatGeneratedAsUnannotated`, and always use restrictive annotations
if available. Unfortunatelly, this is a change that will increase the number of
errors from NullAway on existing codebases (internally, we use
`TreatGeneratedAsUnannotated` explicitly as a way to relax our checks around
thrift generated code which does have `@Nullable` annotations). Thus, the one
remaining answer seems to be that, in this configuration, generated code should
be treated optimistically for both `onOverrideMayBeNullExpr` and dataflow.
