### PR TITLE
Upstream API Analysis

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2148,8 +2148,8 @@ public class NullAway extends BugChecker
   }
 
   public boolean nullnessFromDataflow(VisitorState state, ExpressionTree expr) {
-    Nullness nullness =
-        getNullnessAnalysis(state).getNullness(new TreePath(state.getPath(), expr), state.context);
+    AccessPathNullnessAnalysis analysis = getNullnessAnalysis(state);
+    Nullness nullness = analysis.getNullness(new TreePath(state.getPath(), expr), state.context);
     if (nullness == null) {
       // this may be unsound, like for field initializers
       // figure out if we care

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2148,8 +2148,8 @@ public class NullAway extends BugChecker
   }
 
   public boolean nullnessFromDataflow(VisitorState state, ExpressionTree expr) {
-    AccessPathNullnessAnalysis analysis = getNullnessAnalysis(state);
-    Nullness nullness = analysis.getNullness(new TreePath(state.getPath(), expr), state.context);
+    Nullness nullness =
+        getNullnessAnalysis(state).getNullness(new TreePath(state.getPath(), expr), state.context);
     if (nullness == null) {
       // this may be unsound, like for field initializers
       // figure out if we care

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
@@ -27,6 +27,7 @@ import com.uber.nullaway.fixserialization.qual.AnnotationConfig;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -237,7 +238,8 @@ public class FixSerializationConfig {
     }
     Set<UpstreamMethod> methods = new HashSet<>();
     try (BufferedReader reader =
-        new BufferedReader(new FileReader(upstreamDependencyAPIInfoFile))) {
+        new BufferedReader(
+            new FileReader(upstreamDependencyAPIInfoFile, Charset.defaultCharset()))) {
       // to skip header
       reader.readLine();
       String line = reader.readLine();
@@ -267,10 +269,11 @@ public class FixSerializationConfig {
    * @return true, the method is available through upstream dependencies.
    */
   public boolean isUpstreamMethod(String clazz, String method) {
-    return upstreamMethods.stream()
-        .anyMatch(
-            upstreamMethod ->
-                upstreamMethod.clazz.equals(clazz) && upstreamMethod.method.equals(method));
+    return apiAnalysisFromUpstreamDependencyEnabled
+        && upstreamMethods.stream()
+            .anyMatch(
+                upstreamMethod ->
+                    upstreamMethod.clazz.equals(clazz) && upstreamMethod.method.equals(method));
   }
 
   /** Builder class for Serialization Config */

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
@@ -228,7 +228,8 @@ public class FixSerializationConfig {
    * @return Set of methods stored in {@link FixSerializationConfig#upstreamDependencyAPIInfoFile}.
    */
   private Set<UpstreamMethod> readUpstreamMethods(
-      boolean apiAnalysisFromUpstreamDependencyEnabled, String upstreamDependencyAPIInfoFile) {
+      boolean apiAnalysisFromUpstreamDependencyEnabled,
+      @Nullable String upstreamDependencyAPIInfoFile) {
     if (!apiAnalysisFromUpstreamDependencyEnabled) {
       return Collections.emptySet();
     }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/FixSerializationConfig.java
@@ -25,7 +25,6 @@ package com.uber.nullaway.fixserialization;
 import com.google.common.base.Preconditions;
 import com.uber.nullaway.fixserialization.qual.AnnotationConfig;
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -239,8 +238,8 @@ public class FixSerializationConfig {
     }
     Set<UpstreamMethod> methods = new HashSet<>();
     try (BufferedReader reader =
-        new BufferedReader(
-            new FileReader(upstreamDependencyAPIInfoFile, Charset.defaultCharset()))) {
+        Files.newBufferedReader(
+            Paths.get(upstreamDependencyAPIInfoFile), Charset.defaultCharset())) {
       // to skip header
       reader.readLine();
       String line = reader.readLine();

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
@@ -143,6 +143,14 @@ public class XMLUtil {
       outputDir.setTextContent(config.outputDirectory);
       rootElement.appendChild(outputDir);
 
+      // UP Stream API Analysis
+      Element upstreamAPIAnalysis =
+          doc.createElement("/serialization/apiAnalysisFromUpstreamDependency");
+      upstreamAPIAnalysis.setAttribute(
+          "active", String.valueOf(config.apiAnalysisFromUpstreamDependencyEnabled));
+      upstreamAPIAnalysis.setAttribute("path", config.upstreamDependencyAPIInfoFile);
+      rootElement.appendChild(upstreamAPIAnalysis);
+
       // Writings
       TransformerFactory transformerFactory = TransformerFactory.newInstance();
       Transformer transformer = transformerFactory.newTransformer();

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/XMLUtil.java
@@ -144,8 +144,7 @@ public class XMLUtil {
       rootElement.appendChild(outputDir);
 
       // UP Stream API Analysis
-      Element upstreamAPIAnalysis =
-          doc.createElement("/serialization/apiAnalysisFromUpstreamDependency");
+      Element upstreamAPIAnalysis = doc.createElement("apiAnalysisFromUpstreamDependency");
       upstreamAPIAnalysis.setAttribute(
           "active", String.valueOf(config.apiAnalysisFromUpstreamDependencyEnabled));
       upstreamAPIAnalysis.setAttribute("path", config.upstreamDependencyAPIInfoFile);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -64,13 +64,17 @@ public class Handlers {
     handlerListBuilder.add(new GrpcHandler());
     handlerListBuilder.add(new RequiresNonNullHandler());
     handlerListBuilder.add(new EnsuresNonNullHandler());
-    if (config.serializationIsActive() && config.getSerializationConfig().fieldInitInfoEnabled) {
-      handlerListBuilder.add(
-          new FieldInitializationSerializationHandler(config.getSerializationConfig()));
-    }
-    if (config.serializationIsActive()
-        && config.getSerializationConfig().methodParamProtectionTestEnabled) {
-      handlerListBuilder.add(new MethodParamNullableInjectorHandler(config));
+    if (config.serializationIsActive()) {
+      if (config.getSerializationConfig().fieldInitInfoEnabled) {
+        handlerListBuilder.add(
+            new FieldInitializationSerializationHandler(config.getSerializationConfig()));
+      }
+      if (config.getSerializationConfig().methodParamProtectionTestEnabled) {
+        handlerListBuilder.add(new MethodParamNullableInjectorHandler(config));
+      }
+      if (config.getSerializationConfig().apiAnalysisFromUpstreamDependencyEnabled) {
+        handlerListBuilder.add(new UpstreamAPIAnalysisHandler(config.getSerializationConfig()));
+      }
     }
     if (config.checkOptionalEmptiness()) {
       handlerListBuilder.add(new OptionalEmptinessHandler(config, methodNameUtil));

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/UpstreamAPIAnalysisHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/UpstreamAPIAnalysisHandler.java
@@ -1,0 +1,90 @@
+package com.uber.nullaway.handlers;
+
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
+import com.uber.nullaway.NullAway;
+import com.uber.nullaway.Nullness;
+import com.uber.nullaway.dataflow.AccessPath;
+import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
+import com.uber.nullaway.fixserialization.FixSerializationConfig;
+import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
+
+/**
+ * This handler is used to compute effects of making methods in upstream dependencies
+ * {@code @Nullable} on downstream dependencies (current module). If enabled, NullAway will assume
+ * all methods stored {@link
+ * com.uber.nullaway.fixserialization.FixSerializationConfig#upstreamDependencyAPIInfoFile} file
+ * returns {@code @Nullable}
+ */
+public class UpstreamAPIAnalysisHandler extends BaseNoOpHandler {
+
+  private final FixSerializationConfig config;
+
+  public UpstreamAPIAnalysisHandler(FixSerializationConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public NullnessHint onDataflowVisitMethodInvocation(
+      MethodInvocationNode node,
+      Types types,
+      Context context,
+      AccessPath.AccessPathContext apContext,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
+      AccessPathNullnessPropagation.Updates thenUpdates,
+      AccessPathNullnessPropagation.Updates elseUpdates,
+      AccessPathNullnessPropagation.Updates bothUpdates) {
+    Symbol.MethodSymbol sym = ASTHelpers.getSymbol(node.getTree());
+    String method = sym.toString();
+    String clazz = sym.enclClass().toString();
+    if (config.isUpstreamMethod(clazz, method)) {
+      AccessPath path =
+          AccessPath.fromBaseAndElement(node.getTarget().getReceiver(), sym, apContext);
+      if (path != null) {
+        bothUpdates.set(path, Nullness.NULLABLE);
+      }
+      return NullnessHint.HINT_NULLABLE;
+    }
+    return super.onDataflowVisitMethodInvocation(
+        node, types, context, apContext, inputs, thenUpdates, elseUpdates, bothUpdates);
+  }
+
+  @Override
+  public boolean onOverrideMayBeNullExpr(
+      NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
+    Symbol symbol = ASTHelpers.getSymbol(expr);
+    if (expr instanceof MethodInvocationTree && symbol instanceof Symbol.MethodSymbol) {
+      String method = symbol.toString();
+      String clazz = symbol.enclClass().toString();
+      return config.isUpstreamMethod(clazz, method);
+    }
+    return super.onOverrideMayBeNullExpr(analysis, expr, state, exprMayBeNull);
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -33,7 +33,6 @@ import com.uber.nullaway.tools.FieldInitDisplay;
 import com.uber.nullaway.tools.FixDisplay;
 import com.uber.nullaway.tools.SerializationTestHelper;
 import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
@@ -1397,8 +1396,7 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
       // for all serialization tests.
       Files.deleteIfExists(config);
       BufferedWriter writer =
-          new BufferedWriter(
-              new FileWriter(upstreamAPIFilePath.toFile(), Charset.defaultCharset()));
+          Files.newBufferedWriter(upstreamAPIFilePath, Charset.defaultCharset());
       writer.write("CLASS\tMETHOD\n");
       writer.write("com.uber.UnAnnot" + "\t" + "retNull()" + "\n");
       writer.write("com.uber.UnAnnot" + "\t" + "staticRetNull()" + "\n");
@@ -1483,8 +1481,7 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
       // for all serialization tests.
       Files.deleteIfExists(config);
       BufferedWriter writer =
-          new BufferedWriter(
-              new FileWriter(upstreamAPIFilePath.toFile(), Charset.defaultCharset()));
+          Files.newBufferedWriter(upstreamAPIFilePath, Charset.defaultCharset());
       writer.write("CLASS\tMETHOD\n");
       writer.write("com.uber.UnAnnot" + "\t" + "retNull()" + "\n");
       writer.flush();


### PR DESCRIPTION
This PR enables [Annotator](https://github.com/nimakarimipour/NullAwayAnnotator) to compute effect of making a method `@Nullable` in target module on downstream dependencies without injecting any annotations. List of methods in upstream depencencies is given to `NullAway` as a `.tsv` file format which every row is the containing class and method symbol of the method declared in the upstream dependency.

While analysing the source code, `NullAway` will assume all methods of upstream dependency given in the list returns `@Nullable`.

To enable this feature, in the `FixSerializationConfig`, `apiAnalysisFromUpstreamDependencyEnabled` should be set to `true` along the path to the `.tsv` file which contains the list of methods in upstream dependency in `upstreamDependencyAPIInfoFile`.

The equivalent of the flags above in the `.xml` config files are: 
```xml
<serialization>
     <apiAnalysisFromUpstreamDependency "active"=true, "path"="path_to_file.tsv">
</serialization>
```