### PR TITLE
Update to Checker Framework 3.24.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.22.2",
+    checkerFramework       : "3.24.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.


### PR DESCRIPTION
Apart from staying up to date, this pulls in https://github.com/typetools/checker-framework/pull/5178 (and follow-up https://github.com/typetools/checker-framework/pull/5210) which should give us a bit of an overhead reduction, particularly for large methods