### PR TITLE
Add library model for Guava's Closer.register

### DIFF
--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -41,7 +41,8 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common"));
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
+                    "-XepOpt:NullAway:AcknowledgeLibraryModelsOfAnnotatedCode=true"));
   }
 
   @Test
@@ -85,6 +86,34 @@ public class NullAwayGuavaParametricNullnessTests {
             "    }",
             "    public static @Nullable String test2() {",
             "        return Iterables.getFirst(ImmutableList.<String>of(), null);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testCloserParametricNullness() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.google.common.io.Closer;",
+            "import java.io.Closeable;",
+            "import java.io.FileInputStream;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "    public static FileInputStream test1(Closer closer, FileInputStream fis1) {",
+            "        // safe: non-null arg to non-null return",
+            "        return closer.register(fis1);",
+            "    }",
+            "    @Nullable",
+            "    public static FileInputStream test2(Closer closer, @Nullable FileInputStream fis2) {",
+            "        // safe: nullable arg to nullable return",
+            "        return closer.register(fis2);",
+            "    }",
+            "    public static FileInputStream test3(Closer closer, @Nullable FileInputStream fis3) {",
+            "        // BUG: Diagnostic contains: returning @Nullable expression",
+            "        return closer.register(fis3);",
             "    }",
             "}")
         .doTest();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -583,6 +583,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_NULL_PARAMETERS =
         new ImmutableSetMultimap.Builder<MethodRef, Integer>()
             .put(methodRef("java.util.Optional", "orElse(T)"), 0)
+            .put(methodRef("com.google.common.io.Closer", "<C>register(C)"), 0)
             .build();
 
     private static final ImmutableSet<MethodRef> NULLABLE_RETURNS =


### PR DESCRIPTION
This is a follow up to #628 and our support for `@ParametricNullness` in NullAway 0.9.9.
It turns out that `com.google.common.io.Closer` annotates it's `register` method as:

```
  @CanIgnoreReturnValue
  @ParametricNullness
  public <C extends @Nullable Closeable> C register(@ParametricNullness C closeable) {...}
```

Where the return is only really `@Nullable` if the argument is `@Nullable` (it is the same reference).

This PR adds a Library Model for this method, which is equivalent to adding the `@Contract("null -> null")`
annotation to it.

Note that, in order for this model to be helpful, `AcknowledgeLibraryModelsOfAnnotatedCode` 
must be set, which would seem to argue for making that the default.