### PR TITLE
Make library models override annotations by default.

### DIFF
--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -41,8 +41,7 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
-                    "-XepOpt:NullAway:AcknowledgeLibraryModelsOfAnnotatedCode=true"));
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common"));
   }
 
   @Test

--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -129,8 +129,6 @@ public abstract class AbstractConfig implements Config {
 
   protected FixSerializationConfig fixSerializationConfig;
 
-  protected boolean acknowledgeLibraryModelsOfAnnotatedCode;
-
   @Override
   public boolean serializationIsActive() {
     return serializationActivationFlag;
@@ -350,10 +348,5 @@ public abstract class AbstractConfig implements Config {
   @Override
   public boolean acknowledgeAndroidRecent() {
     return acknowledgeAndroidRecent;
-  }
-
-  @Override
-  public boolean acknowledgeLibraryModelsOfAnnotatedCode() {
-    return acknowledgeLibraryModelsOfAnnotatedCode;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -292,12 +292,4 @@ public interface Config {
    *     similarly for {@code @RecentlyNonNull}
    */
   boolean acknowledgeAndroidRecent();
-
-  /**
-   * Checks if {@link LibraryModels} can override annotations on annotated source code.
-   *
-   * @return true if NullAway should use information provided by {@link LibraryModels} on annotated
-   *     source code.
-   */
-  boolean acknowledgeLibraryModelsOfAnnotatedCode();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -215,9 +215,4 @@ public class DummyOptionsConfig implements Config {
   public boolean acknowledgeAndroidRecent() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
-
-  @Override
-  public boolean acknowledgeLibraryModelsOfAnnotatedCode() {
-    throw new IllegalStateException(ERROR_MESSAGE);
-  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -84,9 +84,6 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
   static final String FL_FIX_SERIALIZATION_CONFIG_PATH =
       EP_FL_NAMESPACE + ":FixSerializationConfigPath";
 
-  static final String FL_ACKNOWLEDGE_LIBRARY_MODELS_OF_ANNOTATED_CODE =
-      EP_FL_NAMESPACE + ":AcknowledgeLibraryModelsOfAnnotatedCode";
-
   private static final String DELIMITER = ",";
 
   static final ImmutableSet<String> DEFAULT_CLASS_ANNOTATIONS_TO_EXCLUDE =
@@ -251,8 +248,6 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
               + FL_SUGGEST_SUPPRESSIONS
               + ")");
     }
-    acknowledgeLibraryModelsOfAnnotatedCode =
-        flags.getBoolean(FL_ACKNOWLEDGE_LIBRARY_MODELS_OF_ANNOTATED_CODE).orElse(false);
   }
 
   private static ImmutableSet<String> getFlagStringSet(ErrorProneFlags flags, String flagName) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -107,9 +107,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     if (expr.getKind() == Tree.Kind.METHOD_INVOCATION) {
       OptimizedLibraryModels optLibraryModels = getOptLibraryModels(state.context);
       Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) ASTHelpers.getSymbol(expr);
-      // When looking up library models of annotated code, we match the exact method signature only,
-      // overriding implementations that share the same model must be explicitly given their own
-      // library model.
+      // When looking up library models of annotated code, we match the exact method signature only;
+      // overriding methods in subclasses must be explicitly given their own library model.
       // When dealing with unannotated code, we default to generality: a model applies to a method
       // and any of its overriding implementations.
       // see https://github.com/uber/NullAway/issues/445 for why this is needed.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -111,8 +111,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       // overriding implementations that share the same model must be explicitly given their own
       // library model.
       // When dealing with unannotated code, we default to generality: a model applies to a method
-      // and
-      // any of its overriding implementations.
+      // and any of its overriding implementations.
       // see https://github.com/uber/NullAway/issues/445 for why this is needed.
       boolean isMethodAnnotated =
           !getClassAnnotationInfo(state.context).isSymbolUnannotated(methodSymbol, this.config);

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
@@ -51,8 +51,7 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             Arrays.asList(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeLibraryModelsOfAnnotatedCode=true"))
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
@@ -69,34 +68,6 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             "       // just to make sure, flow analysis is also impacted by library models information",
             "      Object temp = bar();",
             "       // BUG: Diagnostic contains: assigning @Nullable",
-            "      this.field = temp;",
-            "   }",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void allowLibraryModelsOverrideAnnotationsFlagTest() {
-    makeLibraryModelsTestHelperWithArgs(
-            Arrays.asList(
-                "-d",
-                temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeLibraryModelsOfAnnotatedCode=false"))
-        .addSourceLines(
-            "Foo.java",
-            "package com.uber;",
-            "public class Foo {",
-            "   Object field = new Object();",
-            "   Object bar() {",
-            "      return new Object();",
-            "   }",
-            "   Object nullableReturn() {",
-            "       return bar();",
-            "   }",
-            "   void run() {",
-            "       // just to make sure, flow analysis is not impacted by library models information",
-            "      Object temp = bar();",
             "      this.field = temp;",
             "   }",
             "}")


### PR DESCRIPTION
This change removes the short-lived `AcknowledgeLibraryModelsOfAnnotatedCode`
configuration flag.

It sets the behavior of NullAway to always allow library models to override
the nullability of annotated code, with an important caveat regarding #445:

Whenever we have a method `D.m` which overrides a method `C.m` for which we
have a library model, NullAway's behavior depends on whether `D.m` is an
annotated or unannotated method:

1) If `D.m` is within unannotated / third-party code, we consider the library
   model of `C.m` to extend to `D.m` (and to all such third-party overriding
   methods of `C.m`). This minimizes redundancy in our library models and makes
   them more robust to the changes within third-party library internals.
2) However, for an overriding `D.m` within annotated code, we don't propagate
   the library model, requiring either `D.m` to be annotated in a compatible
   manner or else a separate library model for it.

This makes it so that libraries for which the user doesn't have the source code
(i.e. can't add annotations), but which they wish to add to the `AnnotatedPackages`
list, require more comprehensive library models than "unannotated" libraries.
However, this is fully consistent with the intent behind marking code as annotated,
which is stricter checking of its nullability.