### PR TITLE
Generalize handler APIs for argument nullability on (un-)annotated code.

### DIFF
--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -117,4 +117,26 @@ public class NullAwayGuavaParametricNullnessTests {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testFunctionMethodOverride() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.google.common.base.Function;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "    public static void testFoo() {",
+            "        Function<Object, Object> f = new Function<Object, Object>() {",
+            "            @Override",
+            "            @Nullable",
+            "            public Object apply(Object input) {",
+            "                return null;",
+            "             }",
+            "        };",
+            "    }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -678,7 +678,7 @@ public class NullAway extends BugChecker
       if (overriddenMethodArgNullnessMap
           .getOrDefault(i, Nullness.NONNULL)
           .equals(Nullness.NONNULL)) {
-        // No need to check, unless teh argument of the overridden method is effectively @Nullable,
+        // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridding a @NonNull arg.
         continue;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -95,17 +95,17 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     com.sun.tools.javac.util.List<Symbol.VarSymbol> fiMethodParameters =
         fiMethodSymbol.getParameters();
     Map<Integer, Nullness> fiArgumentPositionNullness = new LinkedHashMap<>();
-    for (int i = 0; i < fiMethodParameters.size(); i++) {
-      fiArgumentPositionNullness.put(
-          i,
-          Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config) ? NULLABLE : NONNULL);
+    final boolean isFIAnnotated = !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config);
+    if (isFIAnnotated) {
+      for (int i = 0; i < fiMethodParameters.size(); i++) {
+        fiArgumentPositionNullness.put(
+            i,
+            Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config) ? NULLABLE : NONNULL);
+      }
     }
     fiArgumentPositionNullness =
         handler.onOverrideMethodInvocationParametersNullability(
-            context,
-            fiMethodSymbol,
-            !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config),
-            fiArgumentPositionNullness);
+            context, fiMethodSymbol, isFIAnnotated, fiArgumentPositionNullness);
 
     for (int i = 0; i < parameters.size(); i++) {
       LocalVariableNode param = parameters.get(i);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -3,7 +3,6 @@ package com.uber.nullaway.dataflow;
 import static com.uber.nullaway.Nullness.NONNULL;
 import static com.uber.nullaway.Nullness.NULLABLE;
 
-import com.google.common.collect.ImmutableSet;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.VariableTree;
@@ -15,7 +14,9 @@ import com.uber.nullaway.Config;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.handlers.Handler;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.lang.model.element.Element;
@@ -93,9 +94,18 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     Symbol.MethodSymbol fiMethodSymbol = NullabilityUtil.getFunctionalInterfaceMethod(code, types);
     com.sun.tools.javac.util.List<Symbol.VarSymbol> fiMethodParameters =
         fiMethodSymbol.getParameters();
-    ImmutableSet<Integer> nullableParamsFromHandler =
-        handler.onUnannotatedInvocationGetExplicitlyNullablePositions(
-            context, fiMethodSymbol, ImmutableSet.of());
+    Map<Integer, Nullness> fiArgumentPositionNullness = new LinkedHashMap<>();
+    for (int i = 0; i < fiMethodParameters.size(); i++) {
+      fiArgumentPositionNullness.put(
+          i,
+          Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config) ? NULLABLE : NONNULL);
+    }
+    fiArgumentPositionNullness =
+        handler.onOverrideMethodInvocationParametersNullability(
+            context,
+            fiMethodSymbol,
+            !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config),
+            fiArgumentPositionNullness);
 
     for (int i = 0; i < parameters.size(); i++) {
       LocalVariableNode param = parameters.get(i);
@@ -111,15 +121,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         // treat as non-null
         assumed = NONNULL;
       } else {
-        if (classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config)) {
-          // assume parameter is non-null unless handler tells us otherwise
-          assumed = nullableParamsFromHandler.contains(i) ? NULLABLE : NONNULL;
-        } else {
-          assumed =
-              Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config)
-                  ? NULLABLE
-                  : NONNULL;
-        }
+        assumed = fiArgumentPositionNullness.getOrDefault(i, NONNULL);
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -36,12 +36,14 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.NullAway;
+import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -107,15 +109,6 @@ public abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
-    // NoOp
-    return explicitlyNullablePositions;
-  }
-
-  @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
       Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
     // NoOp
@@ -123,14 +116,13 @@ public abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
-      NullAway analysis,
-      VisitorState state,
+  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+      Context context,
       Symbol.MethodSymbol methodSymbol,
-      List<? extends ExpressionTree> actualParams,
-      ImmutableSet<Integer> nonNullPositions) {
+      boolean isAnnotated,
+      Map<Integer, Nullness> argumentPositionNullness) {
     // NoOp
-    return nonNullPositions;
+    return argumentPositionNullness;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -37,12 +37,14 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.NullAway;
+import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -121,19 +123,6 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions) {
-    for (Handler h : handlers) {
-      explicitlyNullablePositions =
-          h.onUnannotatedInvocationGetExplicitlyNullablePositions(
-              context, methodSymbol, explicitlyNullablePositions);
-    }
-    return explicitlyNullablePositions;
-  }
-
-  @Override
   public boolean onUnannotatedInvocationGetExplicitlyNonNullReturn(
       Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn) {
     for (Handler h : handlers) {
@@ -145,18 +134,17 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
-      NullAway analysis,
-      VisitorState state,
+  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+      Context context,
       Symbol.MethodSymbol methodSymbol,
-      List<? extends ExpressionTree> actualParams,
-      ImmutableSet<Integer> nonNullPositions) {
+      boolean isAnnotated,
+      Map<Integer, Nullness> argumentPositionNullness) {
     for (Handler h : handlers) {
-      nonNullPositions =
-          h.onUnannotatedInvocationGetNonNullPositions(
-              analysis, state, methodSymbol, actualParams, nonNullPositions);
+      argumentPositionNullness =
+          h.onOverrideMethodInvocationParametersNullability(
+              context, methodSymbol, isAnnotated, argumentPositionNullness);
     }
-    return nonNullPositions;
+    return argumentPositionNullness;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -44,6 +44,7 @@ import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -135,27 +136,6 @@ public interface Handler {
   void onMatchReturn(NullAway analysis, ReturnTree tree, VisitorState state);
 
   /**
-   * Called when NullAway encounters an unannotated method and asks for params explicitly
-   * marked @Nullable
-   *
-   * <p>This is mostly used to force overriding methods to also use @Nullable, e.g. for callbacks
-   * that can get passed null values.
-   *
-   * <p>Note that this should be only used for parameters EXPLICLTY marked as @Nullable (e.g. by
-   * library models) rather than those considered @Nullable by NullAway's default optimistic
-   * assumptions.
-   *
-   * @param methodSymbol The method symbol for the unannotated method in question.
-   * @param explicitlyNullablePositions Parameter nullability computed by upstream handlers (the
-   *     core analysis supplies the empty set to the first handler in the chain).
-   * @return Updated parameter nullability computed by this handler.
-   */
-  ImmutableSet<Integer> onUnannotatedInvocationGetExplicitlyNullablePositions(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      ImmutableSet<Integer> explicitlyNullablePositions);
-
-  /**
    * Called when NullAway encounters an unannotated method and asks if return value is explicitly
    * marked @Nullable
    *
@@ -171,24 +151,6 @@ public interface Handler {
       Symbol.MethodSymbol methodSymbol, boolean explicitlyNonNullReturn);
 
   /**
-   * Called when NullAway encounters an unannotated method and asks for params default nullability
-   *
-   * @param analysis A reference to the running NullAway analysis.
-   * @param state The current visitor state.
-   * @param methodSymbol The method symbol for the unannotated method in question.
-   * @param actualParams The actual parameters from the invocation node
-   * @param nonNullPositions Parameter nullability computed by upstream handlers (the core analysis
-   *     supplies the empty set to the first handler in the chain).
-   * @return Updated parameter nullability computed by this handler.
-   */
-  ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
-      NullAway analysis,
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      List<? extends ExpressionTree> actualParams,
-      ImmutableSet<Integer> nonNullPositions);
-
-  /**
    * Called after the analysis determines if a expression can be null or not, allowing handlers to
    * override.
    *
@@ -201,6 +163,31 @@ public interface Handler {
    */
   boolean onOverrideMayBeNullExpr(
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull);
+
+  /**
+   * Called after the analysis determines the nullability of a method's arguments, allowing handlers
+   * to override.
+   *
+   * <p>The passed Map object maps argument positions to nullness information and is sparse, where
+   * the nullness of missing indexes is determined by base analysis and depends on if the code is
+   * considered isAnnotated or not. We use a mutable map for performance, but it should not outlive
+   * the chain of handler invocations.
+   *
+   * @param context The current context.
+   * @param methodSymbol The method symbol for the unannotated method in question.
+   * @param isAnnotated A boolean flag indicating whether the called method is considered to be
+   *     within isAnnotated or unannotated code, used to avoid querying for this information
+   *     multiple times within the same handler chain.
+   * @param argumentPositionNullness The argument position to nullness map computed by upstream
+   *     handlers and/or the base analysis (though information from the base analysis is allowed to
+   *     be incomplete/sparse at this point).
+   * @return The updated argument position to nullness map, as computed by the current handler.
+   */
+  Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+      Context context,
+      Symbol.MethodSymbol methodSymbol,
+      boolean isAnnotated,
+      Map<Integer, Nullness> argumentPositionNullness);
 
   /**
    * Called when the Dataflow analysis generates the initial NullnessStore for a method or lambda.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -138,7 +138,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
       // for annotated code is if we expect/want JarInfer results to override the results of another
       // handler, such as restrictive annotations, but a library models is a safer place to perform
       // such an override.
-      // Additionally, by default, InferredJARModelsHandler is used only to load our Android SKD
+      // Additionally, by default, InferredJARModelsHandler is used only to load our Android SDK
       // JarInfer models (i.e. `com.uber.nullaway:JarInferAndroidModelsSDK##`), since the default
       // model of JarInfer on a normal jar/aar is to add bytecode annotations.
       return argumentPositionNullness;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -23,8 +23,6 @@
 package com.uber.nullaway.handlers;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -36,6 +34,7 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
+import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.jarinfer.JarInferStubxProvider;
@@ -44,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -126,12 +124,31 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public ImmutableSet<Integer> onUnannotatedInvocationGetNonNullPositions(
-      NullAway analysis,
-      VisitorState state,
+  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+      Context context,
       Symbol.MethodSymbol methodSymbol,
-      List<? extends ExpressionTree> actualParams,
-      ImmutableSet<Integer> nonNullPositions) {
+      boolean isAnnotated,
+      Map<Integer, Nullness> argumentPositionNullness) {
+    if (isAnnotated) {
+      // We currently do not load JarInfer models for code marked as annotated.
+      // This is unlikely to change, as the behavior of JarInfer on arguments is to explicitly mark
+      // as @NonNull those
+      // arguments that are shallowly dereferenced within the analyzed method. By convention,
+      // annotated code has no
+      // use for explicit @NonNull annotations, since `T` already means `@NonNull T` within
+      // annotated code. The only
+      // case where we would want to enable this for annotated code is if we expect/want JarInfer
+      // results to override
+      // the results of another handler, such as restrictive annotations, but a library models is a
+      // safer place to
+      // perform such override.
+      // Additionally, by default, InferredJARModelsHandler is used only to load our Android SKD
+      // JarInfer models
+      // (i.e. `com.uber.nullaway:JarInferAndroidModelsSDK##`), since the default model of JarInfer
+      // on a normal jar/aar
+      // is to add bytecode annotations.
+      return argumentPositionNullness;
+    }
     Symbol.ClassSymbol classSymbol = methodSymbol.enclClass();
     String className = classSymbol.getQualifiedName().toString();
     if (methodSymbol.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -139,28 +156,30 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
           VERBOSE,
           "Warn",
           "Skipping abstract method: " + className + " : " + methodSymbol.getQualifiedName());
-      return nonNullPositions;
+      return argumentPositionNullness;
     }
     if (!argAnnotCache.containsKey(className)) {
-      return nonNullPositions;
+      return argumentPositionNullness;
     }
     String methodSign = getMethodSignature(methodSymbol);
     Map<Integer, Set<String>> methodArgAnnotations = lookupMethodInCache(className, methodSign);
     if (methodArgAnnotations == null) {
-      return nonNullPositions;
+      return argumentPositionNullness;
     }
     Set<Integer> jiNonNullParams = new LinkedHashSet<>();
     for (Map.Entry<Integer, Set<String>> annotationEntry : methodArgAnnotations.entrySet()) {
       if (annotationEntry.getKey() != RETURN
           && annotationEntry.getValue().contains("javax.annotation.Nonnull")) {
         // Skip 'this' param for non-static methods
-        jiNonNullParams.add(annotationEntry.getKey() - (methodSymbol.isStatic() ? 0 : 1));
+        int nonNullPosition = annotationEntry.getKey() - (methodSymbol.isStatic() ? 0 : 1);
+        jiNonNullParams.add(nonNullPosition);
+        argumentPositionNullness.put(nonNullPosition, Nullness.NONNULL);
       }
     }
     if (!jiNonNullParams.isEmpty()) {
       LOG(DEBUG, "DEBUG", "Nonnull params: " + jiNonNullParams.toString() + " for " + methodSign);
     }
-    return Sets.union(nonNullPositions, jiNonNullParams).immutableCopy();
+    return argumentPositionNullness;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -132,21 +132,15 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
     if (isAnnotated) {
       // We currently do not load JarInfer models for code marked as annotated.
       // This is unlikely to change, as the behavior of JarInfer on arguments is to explicitly mark
-      // as @NonNull those
-      // arguments that are shallowly dereferenced within the analyzed method. By convention,
-      // annotated code has no
-      // use for explicit @NonNull annotations, since `T` already means `@NonNull T` within
-      // annotated code. The only
-      // case where we would want to enable this for annotated code is if we expect/want JarInfer
-      // results to override
-      // the results of another handler, such as restrictive annotations, but a library models is a
-      // safer place to
-      // perform such override.
+      // as @NonNull those arguments that are shallowly dereferenced within the analyzed method. By
+      // convention, annotated code has no use for explicit @NonNull annotations, since `T` already
+      // means `@NonNull T` within annotated code. The only case where we would want to enable this
+      // for annotated code is if we expect/want JarInfer results to override the results of another
+      // handler, such as restrictive annotations, but a library models is a safer place to perform
+      // such an override.
       // Additionally, by default, InferredJARModelsHandler is used only to load our Android SKD
-      // JarInfer models
-      // (i.e. `com.uber.nullaway:JarInferAndroidModelsSDK##`), since the default model of JarInfer
-      // on a normal jar/aar
-      // is to add bytecode annotations.
+      // JarInfer models (i.e. `com.uber.nullaway:JarInferAndroidModelsSDK##`), since the default
+      // model of JarInfer on a normal jar/aar is to add bytecode annotations.
       return argumentPositionNullness;
     }
     Symbol.ClassSymbol classSymbol = methodSymbol.enclClass();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -92,7 +92,9 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       return argumentPositionNullness;
     }
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
-      if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
+      if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
+        argumentPositionNullness.put(i, Nullness.NONNULL);
+      } else if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
         argumentPositionNullness.put(i, Nullness.NULLABLE);
       }
     }

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -52,7 +52,7 @@ android {
         }
     }
     
-    // If you want to disable NullAway in justs tests, you can do the below
+    // If you want to disable NullAway in just tests, you can do the below
 //    DomainObjectSet<BaseVariant> testVariants = getTestVariants()
 //    testVariants.addAll(getUnitTestVariants())
 //    testVariants.configureEach { variant ->


### PR DESCRIPTION
In particular, this allows library models to change the nullability of method
arguments in annotated code.

This change replaces two separate an overly specific `Handler` callbacks:

- `onUnannotatedInvocationGetExplicitlyNullablePositions`
- `onUnannotatedInvocationGetNonNullPositions`

With a single more general callback:

- `onOverrideMethodInvocationParametersNullability`

which is explicitly meant to handle overriding/changing method parameter nullability
for both annotated and unannotated code (thus solving issue #637).

This requires some refactoring (mostly simplifying logic) in the core NullAway class,
as well as changes to the different handlers, which must now explicitly skip annotated
code if they aren't designed to work with it (e.g. `RestrictiveAnnotationHandler`).