### PR TITLE
Support for Map.computeIfAbsent(...)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -128,14 +128,14 @@ public enum Nullness implements AbstractValue<Nullness> {
     return displayName;
   }
 
-  private static boolean hasNullableAnnotation(
+  public static boolean hasNullableAnnotation(
       Stream<? extends AnnotationMirror> annotations, Config config) {
     return annotations
         .map(anno -> anno.getAnnotationType().toString())
         .anyMatch(anno -> isNullableAnnotation(anno, config));
   }
 
-  private static boolean hasNonNullAnnotation(
+  public static boolean hasNonNullAnnotation(
       Stream<? extends AnnotationMirror> annotations, Config config) {
     return annotations
         .map(anno -> anno.getAnnotationType().toString())

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -588,6 +588,10 @@ public final class AccessPath implements MapKey {
         || NullabilityUtil.isMapMethod(symbol, state, "putIfAbsent", 2);
   }
 
+  public static boolean isMapComputeIfAbsent(Symbol.MethodSymbol symbol, VisitorState state) {
+    return NullabilityUtil.isMapMethod(symbol, state, "computeIfAbsent", 2);
+  }
+
   private static final class StringMapKey implements MapKey {
 
     private final String key;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -942,8 +942,7 @@ public class AccessPathNullnessPropagation
       AccessPath getAccessPath = AccessPath.getForMapInvocation(node, apContext);
       if (getAccessPath != null) {
         // TODO: For now, Function<K, V> implies a @NonNull V. We need to revisit this once we
-        // support generics,
-        // but we do include a couple defensive tests below.
+        // support generics, but we do include a couple defensive tests below.
         if (arguments.size() < 2) {
           return;
         }
@@ -958,8 +957,7 @@ public class AccessPathNullnessPropagation
         Type functionReturnType = classType.getTypeArguments().get(1);
         // Unfortunately, functionReturnType.tsym seems to elide annotation info, so we can't call
         // the Nullness.* methods that deal with Symbol. We might have better APIs for this kind of
-        // check
-        // once we have real generics support.
+        // check once we have real generics support.
         if (!Nullness.hasNullableAnnotation(
             functionReturnType.getAnnotationMirrors().stream(), config)) {
           bothUpdates.set(getAccessPath, NONNULL);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -45,6 +45,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
 import org.checkerframework.nullaway.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.nullaway.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.nullaway.dataflow.analysis.RegularTransferResult;
@@ -936,6 +937,33 @@ public class AccessPathNullnessPropagation
       if (getAccessPath != null) {
         Nullness value = inputs.valueOfSubNode(arguments.get(1));
         bothUpdates.set(getAccessPath, value);
+      }
+    } else if (AccessPath.isMapComputeIfAbsent(callee, state)) {
+      AccessPath getAccessPath = AccessPath.getForMapInvocation(node, apContext);
+      if (getAccessPath != null) {
+        // TODO: For now, Function<K, V> implies a @NonNull V. We need to revisit this once we
+        // support generics,
+        // but we do include a couple defensive tests below.
+        if (arguments.size() < 2) {
+          return;
+        }
+        Node funcNode = arguments.get(1);
+        if (!funcNode.getType().getKind().equals(TypeKind.DECLARED)) {
+          return;
+        }
+        Type.ClassType classType = (Type.ClassType) funcNode.getType();
+        if (classType.getTypeArguments().size() != 2) {
+          return;
+        }
+        Type functionReturnType = classType.getTypeArguments().get(1);
+        // Unfortunately, functionReturnType.tsym seems to elide annotation info, so we can't call
+        // the Nullness.* methods that deal with Symbol. We might have better APIs for this kind of
+        // check
+        // once we have real generics support.
+        if (!Nullness.hasNullableAnnotation(
+            functionReturnType.getAnnotationMirrors().stream(), config)) {
+          bothUpdates.set(getAccessPath, NONNULL);
+        }
       }
     }
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -564,8 +564,8 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "package com.uber;",
             "import java.util.Map;",
             "import java.util.function.Function;",
-            "import org.jspecify.nullness.Nullable;", // Need JSpecify (vs javax) for annotating
-                                                      // generics
+            // Need JSpecify (vs javax) for annotating generics
+            "import org.jspecify.nullness.Nullable;",
             "class Test {",
             "   Object testComputeIfAbsent(String key, Function<String, Object> f, Map<String, Object> m){",
             "     m.computeIfAbsent(key, f);",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -557,6 +557,39 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void testMapComputeIfAbsent() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Map;",
+            "import java.util.function.Function;",
+            "import org.jspecify.nullness.Nullable;", // Need JSpecify (vs javax) for annotating
+                                                      // generics
+            "class Test {",
+            "   Object testComputeIfAbsent(String key, Function<String, Object> f, Map<String, Object> m){",
+            "     m.computeIfAbsent(key, f);",
+            "     return m.get(key);",
+            "   }",
+            "   Object testComputeIfAbsentLambda(String key, Map<String, Object> m){",
+            "     m.computeIfAbsent(key, k -> k);",
+            "     return m.get(key);",
+            "   }",
+            "   Object testComputeIfAbsentNull(String key, Function<String, @Nullable Object> f, Map<String, Object> m){",
+            "     m.computeIfAbsent(key, f);",
+            "     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
+            "     return m.get(key);",
+            "   }",
+            "   // ToDo: should error somewhere, but doesn't, due to limited checking of generics",
+            "   Object testComputeIfAbsentNullLambda(String key, Map<String, Object> m){",
+            "     m.computeIfAbsent(key, k -> null);",
+            "     return m.get(key);",
+            "   }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void tryFinallySupport() {
     defaultCompilationHelper.addSourceFile("NullAwayTryFinallyCases.java").doTest();
   }


### PR DESCRIPTION
This method should be treated as `Map.put(...)`, with the caveat that we need to check if
the `Function<K, V>` passed to `computeIfAbsent(...)` can return a `@Nullable V`, rather
than just checking for the nullness of the argument itself.

Without full support for nullability of type parameters, we can't check that we are dealing
with `Function<K, V>` vs `Function<K, @Nullable V>` in the general case. For usability, we
default to marking the map key access path as non-null if `computeIfAbsent(...)` is called
for that key. We add a few sanity checks, but as the test cases show, those checks _can_ be
incomplete. In practice, we expect `computeIfAbsent(...)` to compute a non-null value in all
but extremely rare instances, but long-term it would be ideal if we could properly check this.
