### PR TITLE
Augment error serializarion info

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -139,7 +139,7 @@ public class ErrorBuilder {
       if (nonNullTarget != null) {
         SerializationService.serializeFixSuggestion(config, state, nonNullTarget, errorMessage);
       }
-      SerializationService.serializeReportingError(config, state, errorMessage);
+      SerializationService.serializeReportingError(config, state, nonNullTarget, errorMessage);
     }
 
     // #letbuildersbuild

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/SerializationService.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/SerializationService.java
@@ -31,9 +31,10 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.Nullness;
-import com.uber.nullaway.fixserialization.location.FixLocation;
+import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 import com.uber.nullaway.fixserialization.out.SuggestedNullableFixInfo;
+import javax.annotation.Nullable;
 
 /** A facade class to interact with fix serialization package. */
 public class SerializationService {
@@ -64,7 +65,7 @@ public class SerializationService {
     if (trees.getPath(target) == null) {
       return;
     }
-    FixLocation location = FixLocation.createFixLocationFromSymbol(target);
+    SymbolLocation location = SymbolLocation.createLocationFromSymbol(target);
     SuggestedNullableFixInfo suggestedNullableFixInfo =
         buildFixMetadata(state.getPath(), errorMessage, location);
     Serializer serializer = serializationConfig.getSerializer();
@@ -82,18 +83,18 @@ public class SerializationService {
    * @param errorMessage Error caused by the target.
    */
   public static void serializeReportingError(
-      Config config, VisitorState state, ErrorMessage errorMessage) {
+      Config config, VisitorState state, @Nullable Symbol target, ErrorMessage errorMessage) {
     Serializer serializer = config.getSerializationConfig().getSerializer();
     Preconditions.checkNotNull(
         serializer, "Serializer shouldn't be null at this point, error in configuration setting!");
-    serializer.serializeErrorInfo(new ErrorInfo(state.getPath(), errorMessage));
+    serializer.serializeErrorInfo(new ErrorInfo(state.getPath(), errorMessage, target));
   }
 
   /**
    * Builds the {@link SuggestedNullableFixInfo} instance based on the {@link ErrorMessage} type.
    */
   private static SuggestedNullableFixInfo buildFixMetadata(
-      TreePath path, ErrorMessage errorMessage, FixLocation location) {
+      TreePath path, ErrorMessage errorMessage, SymbolLocation location) {
     SuggestedNullableFixInfo suggestedNullableFixInfo;
     switch (errorMessage.getMessageType()) {
       case RETURN_NULLABLE:

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/AbstractSymbolLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/AbstractSymbolLocation.java
@@ -30,8 +30,8 @@ import com.sun.tools.javac.code.Symbol;
 import java.net.URI;
 import javax.lang.model.element.ElementKind;
 
-/** abstract base class for {@link FixLocation}. */
-public abstract class AbstractFixLocation implements FixLocation {
+/** abstract base class for {@link SymbolLocation}. */
+public abstract class AbstractSymbolLocation implements SymbolLocation {
 
   /** Element kind of the targeted symbol */
   protected final ElementKind type;
@@ -40,7 +40,7 @@ public abstract class AbstractFixLocation implements FixLocation {
   /** Enclosing class of the symbol. */
   protected final Symbol.ClassSymbol enclosingClass;
 
-  public AbstractFixLocation(ElementKind type, Symbol target) {
+  public AbstractSymbolLocation(ElementKind type, Symbol target) {
     Preconditions.checkArgument(
         type.equals(target.getKind()),
         "Cannot instantiate element of type: "

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
@@ -25,8 +25,8 @@ package com.uber.nullaway.fixserialization.location;
 import com.sun.tools.javac.code.Symbol;
 import javax.lang.model.element.ElementKind;
 
-/** subtype of {@link AbstractFixLocation} targeting class fields. */
-public class FieldLocation extends AbstractFixLocation {
+/** subtype of {@link AbstractSymbolLocation} targeting class fields. */
+public class FieldLocation extends AbstractSymbolLocation {
 
   /** Symbol of targeted class field */
   protected final Symbol.VarSymbol variableSymbol;

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
@@ -38,16 +38,13 @@ public class FieldLocation extends AbstractSymbolLocation {
 
   @Override
   public String tabSeparatedToString() {
-    return type.toString()
-        + '\t'
-        + enclosingClass.flatName()
-        + '\t'
-        + "null"
-        + '\t'
-        + variableSymbol
-        + '\t'
-        + "null"
-        + '\t'
-        + uri.toASCIIString();
+    return String.join(
+        "\t",
+        type.toString(),
+        enclosingClass.flatName(),
+        "null",
+        variableSymbol.toString(),
+        "null",
+        uri.toASCIIString());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
@@ -25,8 +25,8 @@ package com.uber.nullaway.fixserialization.location;
 import com.sun.tools.javac.code.Symbol;
 import javax.lang.model.element.ElementKind;
 
-/** subtype of {@link AbstractFixLocation} targeting methods. */
-public class MethodLocation extends AbstractFixLocation {
+/** subtype of {@link AbstractSymbolLocation} targeting methods. */
+public class MethodLocation extends AbstractSymbolLocation {
 
   /** Symbol of the targeted method. */
   protected final Symbol.MethodSymbol enclosingMethod;

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
@@ -38,16 +38,13 @@ public class MethodLocation extends AbstractSymbolLocation {
 
   @Override
   public String tabSeparatedToString() {
-    return type.toString()
-        + '\t'
-        + enclosingClass.flatName()
-        + '\t'
-        + enclosingMethod
-        + '\t'
-        + "null"
-        + '\t'
-        + "null"
-        + '\t'
-        + uri.toASCIIString();
+    return String.join(
+        "\t",
+        type.toString(),
+        enclosingClass.flatName(),
+        enclosingMethod.toString(),
+        "null",
+        "null",
+        uri.toASCIIString());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
@@ -59,16 +59,13 @@ public class MethodParameterLocation extends AbstractSymbolLocation {
 
   @Override
   public String tabSeparatedToString() {
-    return type.toString()
-        + '\t'
-        + enclosingClass.flatName()
-        + '\t'
-        + enclosingMethod
-        + '\t'
-        + paramSymbol
-        + '\t'
-        + index
-        + '\t'
-        + uri.toASCIIString();
+    return String.join(
+        "\t",
+        type.toString(),
+        enclosingClass.flatName(),
+        enclosingMethod.toString(),
+        paramSymbol.toString(),
+        String.valueOf(index),
+        uri.toASCIIString());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
@@ -26,19 +26,19 @@ import com.google.common.base.Preconditions;
 import com.sun.tools.javac.code.Symbol;
 import javax.lang.model.element.ElementKind;
 
-/** subtype of {@link AbstractFixLocation} targeting a method parameter. */
-public class MethodParameterLocation extends AbstractFixLocation {
+/** subtype of {@link AbstractSymbolLocation} targeting a method parameter. */
+public class MethodParameterLocation extends AbstractSymbolLocation {
 
   /** Symbol of the targeted method. */
   private final Symbol.MethodSymbol enclosingMethod;
   /** Symbol of the targeted method parameter. */
-  private final Symbol.VarSymbol variableSymbol;
+  private final Symbol.VarSymbol paramSymbol;
   /** Index of the method parameter in the containing method's argument list. */
   private final int index;
 
   public MethodParameterLocation(Symbol target) {
     super(ElementKind.PARAMETER, target);
-    this.variableSymbol = (Symbol.VarSymbol) target;
+    this.paramSymbol = (Symbol.VarSymbol) target;
     Symbol cursor = target;
     // Look for the enclosing method.
     while (cursor != null
@@ -65,7 +65,7 @@ public class MethodParameterLocation extends AbstractFixLocation {
         + '\t'
         + enclosingMethod
         + '\t'
-        + variableSymbol
+        + paramSymbol
         + '\t'
         + index
         + '\t'

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
@@ -43,8 +43,7 @@ public interface SymbolLocation {
    * @return string representation of the header separated by tabs.
    */
   static String header() {
-    return "kind" + '\t' + "class" + '\t' + "method" + '\t' + "param" + '\t' + "index" + '\t'
-        + "uri";
+    return String.join("\t", "kind", "class", "method", "param", "index", "uri");
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
@@ -24,11 +24,11 @@ package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
 
-/** Provides method for fix locations. */
-public interface FixLocation {
+/** Provides method for symbol locations. */
+public interface SymbolLocation {
 
   /**
-   * returns string representation of contents of the instance. It must have the format below: type
+   * returns string representation of contents of the instance. It must have the format below: kind
    * of the element, symbol of the containing class, symbol of the enclosing method, symbol of the
    * variable, index of the element and uri to containing file.
    *
@@ -37,32 +37,23 @@ public interface FixLocation {
   String tabSeparatedToString();
 
   /**
-   * Creates header of an output file containing all {@link FixLocation} written in string which
+   * Creates header of an output file containing all {@link SymbolLocation} written in string which
    * values are separated tabs.
    *
    * @return string representation of the header separated by tabs.
    */
   static String header() {
-    return "location"
-        + '\t'
-        + "class"
-        + '\t'
-        + "method"
-        + '\t'
-        + "param"
-        + '\t'
-        + "index"
-        + '\t'
+    return "kind" + '\t' + "class" + '\t' + "method" + '\t' + "param" + '\t' + "index" + '\t'
         + "uri";
   }
 
   /**
-   * returns the appropriate subtype of {@link FixLocation} based on the target kind.
+   * returns the appropriate subtype of {@link SymbolLocation} based on the target kind.
    *
    * @param target Target element.
-   * @return subtype of {@link FixLocation} matching target's type.
+   * @return subtype of {@link SymbolLocation} matching target's type.
    */
-  static FixLocation createFixLocationFromSymbol(Symbol target) {
+  static SymbolLocation createLocationFromSymbol(Symbol target) {
     switch (target.getKind()) {
       case PARAMETER:
         return new MethodParameterLocation(target);

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -121,6 +121,16 @@ public class ErrorInfo {
    */
   public static String header() {
     return String.join(
-        "\t", "message_type", "message", "enc_class", "enc_method", SymbolLocation.header());
+        "\t",
+        "message_type",
+        "message",
+        "enc_class",
+        "enc_method",
+        "target_kind",
+        "target_class",
+        "target_method",
+        "param",
+        "index",
+        "uri");
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -93,21 +93,19 @@ public class ErrorInfo {
    * @return string representation of contents of an object in a line seperated by tabs.
    */
   public String tabSeparatedToString() {
-    return errorMessage.getMessageType().toString()
-        + '\t'
-        + escapeSpecialCharacters(errorMessage.getMessage())
-        + '\t'
-        + (classAndMethodInfo.getClazz() != null
+    return String.join(
+        "\t",
+        errorMessage.getMessageType().toString(),
+        escapeSpecialCharacters(errorMessage.getMessage()),
+        (classAndMethodInfo.getClazz() != null
             ? ASTHelpers.getSymbol(classAndMethodInfo.getClazz()).flatName()
-            : "null")
-        + '\t'
-        + (classAndMethodInfo.getMethod() != null
-            ? ASTHelpers.getSymbol(classAndMethodInfo.getMethod())
-            : "null")
-        + '\t'
-        + (nonnullTarget != null
+            : "null"),
+        (classAndMethodInfo.getMethod() != null
+            ? ASTHelpers.getSymbol(classAndMethodInfo.getMethod()).toString()
+            : "null"),
+        (nonnullTarget != null
             ? SymbolLocation.createLocationFromSymbol(nonnullTarget).tabSeparatedToString()
-            : EMPTY_NONNULL_TARGET_LOCATION_STRING);
+            : EMPTY_NONNULL_TARGET_LOCATION_STRING));
   }
 
   /** Finds the class and method of program point where the error is reported. */
@@ -122,14 +120,7 @@ public class ErrorInfo {
    * @return string representation of the header separated by tabs.
    */
   public static String header() {
-    return "message_type"
-        + '\t'
-        + "message"
-        + '\t'
-        + "enc_class"
-        + '\t'
-        + "enc_method"
-        + '\t'
-        + SymbolLocation.header();
+    return String.join(
+        "\t", "message_type", "message", "enc_class", "enc_method", SymbolLocation.header());
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ErrorInfo.java
@@ -25,15 +25,30 @@ package com.uber.nullaway.fixserialization.out;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.ErrorMessage;
+import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /** Stores information regarding an error which will be reported by NullAway. */
 public class ErrorInfo {
 
   private final ErrorMessage errorMessage;
   private final ClassAndMethodInfo classAndMethodInfo;
+
+  /**
+   * if non-null, this error involved a pseudo-assignment of a @Nullable expression into a @NonNull
+   * target, and this field is the Symbol for that target.
+   */
+  @Nullable private final Symbol nonnullTarget;
+  /**
+   * In cases where {@link ErrorInfo#nonnullTarget} is {@code null}, we serialize this value at its
+   * placeholder in the output tsv file.
+   */
+  private static final String EMPTY_NONNULL_TARGET_LOCATION_STRING =
+      "null\tnull\tnull\tnull\tnull\tnull";
 
   /** Special characters that need to be escaped in TSV files. */
   private static final ImmutableMap<Character, Character> escapes =
@@ -44,9 +59,10 @@ public class ErrorInfo {
           '\b', 'b',
           '\r', 'r');
 
-  public ErrorInfo(TreePath path, ErrorMessage errorMessage) {
+  public ErrorInfo(TreePath path, ErrorMessage errorMessage, @Nullable Symbol nonnullTarget) {
     this.classAndMethodInfo = new ClassAndMethodInfo(path);
     this.errorMessage = errorMessage;
+    this.nonnullTarget = nonnullTarget;
   }
 
   /**
@@ -87,7 +103,11 @@ public class ErrorInfo {
         + '\t'
         + (classAndMethodInfo.getMethod() != null
             ? ASTHelpers.getSymbol(classAndMethodInfo.getMethod())
-            : "null");
+            : "null")
+        + '\t'
+        + (nonnullTarget != null
+            ? SymbolLocation.createLocationFromSymbol(nonnullTarget).tabSeparatedToString()
+            : EMPTY_NONNULL_TARGET_LOCATION_STRING);
   }
 
   /** Finds the class and method of program point where the error is reported. */
@@ -102,6 +122,14 @@ public class ErrorInfo {
    * @return string representation of the header separated by tabs.
    */
   public static String header() {
-    return "MESSAGE_TYPE" + '\t' + "MESSAGE" + '\t' + "CLASS" + '\t' + "METHOD";
+    return "message_type"
+        + '\t'
+        + "message"
+        + '\t'
+        + "enc_class"
+        + '\t'
+        + "enc_method"
+        + '\t'
+        + SymbolLocation.header();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
@@ -23,7 +23,7 @@
 package com.uber.nullaway.fixserialization.out;
 
 import com.sun.tools.javac.code.Symbol;
-import com.uber.nullaway.fixserialization.location.FixLocation;
+import com.uber.nullaway.fixserialization.location.SymbolLocation;
 
 /**
  * Stores information regarding a method that initializes a class field and leaves it
@@ -32,12 +32,12 @@ import com.uber.nullaway.fixserialization.location.FixLocation;
 public class FieldInitializationInfo {
 
   /** Symbol of the initializer method. */
-  private final FixLocation initializerMethodLocation;
+  private final SymbolLocation initializerMethodLocation;
   /** Symbol of the initialized class field. */
   private final Symbol field;
 
   public FieldInitializationInfo(Symbol.MethodSymbol initializerMethod, Symbol field) {
-    this.initializerMethodLocation = FixLocation.createFixLocationFromSymbol(initializerMethod);
+    this.initializerMethodLocation = SymbolLocation.createLocationFromSymbol(initializerMethod);
     this.field = field;
   }
 
@@ -59,6 +59,6 @@ public class FieldInitializationInfo {
    * @return string representation of the header separated by tabs.
    */
   public static String header() {
-    return FixLocation.header() + '\t' + "field";
+    return SymbolLocation.header() + '\t' + "field";
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 /** Stores information suggesting adding @Nullable on an element in source code. */
 public class SuggestedNullableFixInfo {
 
-  /** FixLocation of the target element in source code. */
+  /** SymbolLocation of the target element in source code. */
   private final SymbolLocation symbolLocation;
   /** Error which will be resolved by this type change. */
   private final ErrorMessage errorMessage;

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
@@ -71,19 +71,17 @@ public class SuggestedNullableFixInfo {
    * @return string representation of contents of an object in a line separated by tabs.
    */
   public String tabSeparatedToString() {
-    return symbolLocation.tabSeparatedToString()
-        + '\t'
-        + errorMessage.getMessageType().toString()
-        + '\t'
-        + "nullable"
-        + '\t'
-        + (classAndMethodInfo.getClazz() == null
+    return String.join(
+        "\t",
+        symbolLocation.tabSeparatedToString(),
+        errorMessage.getMessageType().toString(),
+        "nullable",
+        (classAndMethodInfo.getClazz() == null
             ? "null"
-            : ASTHelpers.getSymbol(classAndMethodInfo.getClazz()).flatName())
-        + '\t'
-        + (classAndMethodInfo.getMethod() == null
+            : ASTHelpers.getSymbol(classAndMethodInfo.getClazz()).flatName()),
+        (classAndMethodInfo.getMethod() == null
             ? "null"
-            : ASTHelpers.getSymbol(classAndMethodInfo.getMethod()));
+            : ASTHelpers.getSymbol(classAndMethodInfo.getMethod()).toString()));
   }
 
   /** Finds the class and method of program point where triggered this type change. */
@@ -98,14 +96,7 @@ public class SuggestedNullableFixInfo {
    * @return string representation of the header separated by tabs.
    */
   public static String header() {
-    return SymbolLocation.header()
-        + '\t'
-        + "reason"
-        + '\t'
-        + "annotation"
-        + '\t'
-        + "rootClass"
-        + '\t'
-        + "rootMethod";
+    return String.join(
+        "\t", SymbolLocation.header(), "reason", "annotation", "rootClass", "rootMethod");
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
@@ -25,23 +25,23 @@ package com.uber.nullaway.fixserialization.out;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.util.TreePath;
 import com.uber.nullaway.ErrorMessage;
-import com.uber.nullaway.fixserialization.location.FixLocation;
+import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import java.util.Objects;
 
 /** Stores information suggesting adding @Nullable on an element in source code. */
 public class SuggestedNullableFixInfo {
 
   /** FixLocation of the target element in source code. */
-  private final FixLocation fixLocation;
+  private final SymbolLocation symbolLocation;
   /** Error which will be resolved by this type change. */
   private final ErrorMessage errorMessage;
 
   private final ClassAndMethodInfo classAndMethodInfo;
 
   public SuggestedNullableFixInfo(
-      TreePath path, FixLocation fixLocation, ErrorMessage errorMessage) {
+      TreePath path, SymbolLocation symbolLocation, ErrorMessage errorMessage) {
     this.classAndMethodInfo = new ClassAndMethodInfo(path);
-    this.fixLocation = fixLocation;
+    this.symbolLocation = symbolLocation;
     this.errorMessage = errorMessage;
   }
 
@@ -54,7 +54,7 @@ public class SuggestedNullableFixInfo {
       return false;
     }
     SuggestedNullableFixInfo suggestedNullableFixInfo = (SuggestedNullableFixInfo) o;
-    return Objects.equals(fixLocation, suggestedNullableFixInfo.fixLocation)
+    return Objects.equals(symbolLocation, suggestedNullableFixInfo.symbolLocation)
         && Objects.equals(
             errorMessage.getMessageType().toString(),
             suggestedNullableFixInfo.errorMessage.getMessageType().toString());
@@ -62,7 +62,7 @@ public class SuggestedNullableFixInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(fixLocation, errorMessage.getMessageType().toString());
+    return Objects.hash(symbolLocation, errorMessage.getMessageType().toString());
   }
 
   /**
@@ -71,7 +71,7 @@ public class SuggestedNullableFixInfo {
    * @return string representation of contents of an object in a line separated by tabs.
    */
   public String tabSeparatedToString() {
-    return fixLocation.tabSeparatedToString()
+    return symbolLocation.tabSeparatedToString()
         + '\t'
         + errorMessage.getMessageType().toString()
         + '\t'
@@ -98,7 +98,7 @@ public class SuggestedNullableFixInfo {
    * @return string representation of the header separated by tabs.
    */
   public static String header() {
-    return FixLocation.header()
+    return SymbolLocation.header()
         + '\t'
         + "reason"
         + '\t'

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -75,9 +75,11 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
     this.errorDisplayFactory =
         values -> {
           Preconditions.checkArgument(
-              values.length == 4,
-              "Needs exactly 4 values to create ErrorDisplay object but found: " + values.length);
-          return new ErrorDisplay(values[0], values[1], values[2], values[3]);
+              values.length == 10,
+              "Needs exactly 10 values to create ErrorDisplay object but found: " + values.length);
+          return new ErrorDisplay(
+              values[0], values[1], values[2], values[3], values[4], values[5], values[6],
+              values[7], values[8], values[9]);
         };
     this.fieldInitDisplayFactory =
         values -> {
@@ -624,6 +626,9 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
             "     // BUG: Diagnostic contains: returning @Nullable expression",
             "     return null;",
             "   }",
+            "   protected void expectNonNull(Object o) {",
+            "     System.out.println(o);",
+            "   }",
             "}")
         .addSourceLines(
             "com/uber/SubClass.java",
@@ -634,6 +639,8 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
             "      super(b);",
             "      // BUG: Diagnostic contains: passing @Nullable parameter",
             "      test(null);",
+            "      // BUG: Diagnostic contains: passing @Nullable parameter",
+            "      expectNonNull(null);",
             "   }",
             "   // BUG: Diagnostic contains: method returns @Nullable, but superclass",
             "   @Nullable String test(Object o) {",
@@ -650,7 +657,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "ASSIGN_FIELD_NULLABLE",
                 "assigning @Nullable expression to @NonNull field",
                 "com.uber.Super",
-                "test(java.lang.Object)"),
+                "test(java.lang.Object)",
+                "FIELD",
+                "com.uber.Super",
+                "null",
+                "foo",
+                "null",
+                "com/uber/Super.java"),
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
                 "dereferenced expression o is @Nullable",
@@ -660,17 +673,46 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method",
                 "com.uber.Super",
-                "test(java.lang.Object)"),
+                "test(java.lang.Object)",
+                "METHOD",
+                "com.uber.Super",
+                "test(java.lang.Object",
+                "null",
+                "null",
+                "com/uber/Super.java"),
             new ErrorDisplay(
                 "PASS_NULLABLE",
                 "passing @Nullable parameter",
                 "com.uber.SubClass",
-                "SubClass(boolean)"),
+                "SubClass(boolean)",
+                "PARAMETER",
+                "com.uber.SubClass",
+                "test(java.lang.Object)",
+                "o",
+                "0",
+                "com/uber/SubClass.java"),
+            new ErrorDisplay(
+                "PASS_NULLABLE",
+                "passing @Nullable parameter",
+                "com.uber.SubClass",
+                "SubClass(boolean)",
+                "PARAMETER",
+                "com.uber.Super",
+                "expectNonNull(java.lang.Object)",
+                "o",
+                "0",
+                "com/uber/Super.java"),
             new ErrorDisplay(
                 "WRONG_OVERRIDE_RETURN",
                 "method returns @Nullable, but superclass",
                 "com.uber.SubClass",
-                "test(java.lang.Object)"))
+                "test(java.lang.Object)",
+                "METHOD",
+                "com.uber.Super",
+                "test(java.lang.Object)",
+                "null",
+                "null",
+                "com/uber/Super.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -707,7 +749,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "PASS_NULLABLE",
                 "passing @Nullable parameter 'm.hashCode() == 2 || m.toString().equals('\\\\t') ? \\t\\n\\t\\n new Object() : null'",
                 "com.uber.Test",
-                "run()"))
+                "run()",
+                "PARAMETER",
+                "com.uber.Test",
+                "foo(java.lang.Object)",
+                "o",
+                "0",
+                "com/uber/Test.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -815,12 +863,24 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithAnonymousRunnable$1",
-                "returnsNullable()"),
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithAnonymousRunnable$1",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithAnonymousRunnable.java"),
             new ErrorDisplay(
                 "PASS_NULLABLE",
                 "passing @Nullable parameter 'null' where @NonNull is required",
                 "com.uber.TestWithAnonymousRunnable$1",
-                "run()"))
+                "run()",
+                "PARAMETER",
+                "com.uber.TestWithAnonymousRunnable",
+                "takesNonNull(java.lang.String)",
+                "s",
+                "0",
+                "com/uber/TestWithAnonymousRunnable.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -858,7 +918,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalType$1LocalType",
-                "returnsNullable()"))
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithLocalType$1LocalType",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalType.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -917,17 +983,35 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalTypes$1LocalType",
-                "returnsNullable()"),
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithLocalTypes$1LocalType",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalTypes.java"),
             new ErrorDisplay(
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalTypes$2LocalType",
-                "returnsNullable2()"),
+                "returnsNullable2()",
+                "METHOD",
+                "com.uber.TestWithLocalTypes$2LocalType",
+                "returnsNullable2()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalTypes.java"),
             new ErrorDisplay(
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalTypes$3LocalType",
-                "returnsNullable2()"))
+                "returnsNullable2()",
+                "METHOD",
+                "com.uber.TestWithLocalTypes$3LocalType",
+                "returnsNullable2()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalTypes.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1007,7 +1091,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalType$1LocalTypeA$1LocalTypeB",
-                "returnsNullable()"))
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithLocalType$1LocalTypeA$1LocalTypeB",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalType.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1066,12 +1156,24 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalTypes$1LocalType",
-                "returnsNullable()"),
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithLocalTypes$1LocalType",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalTypes.java"),
             new ErrorDisplay(
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method with @NonNull return type",
                 "com.uber.TestWithLocalTypes$3LocalType",
-                "returnsNullable()"))
+                "returnsNullable()",
+                "METHOD",
+                "com.uber.TestWithLocalTypes$3LocalType",
+                "returnsNullable()",
+                "null",
+                "null",
+                "com/uber/TestWithLocalTypes.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1113,7 +1215,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "WRONG_OVERRIDE_PARAM",
                 "parameter o is @NonNull, but parameter in superclass method com.uber.Foo.bar(java.lang.Object) is @Nullable",
                 "com.uber.Main$1",
-                "bar(java.lang.Object)"))
+                "bar(java.lang.Object)",
+                "PARAMETER",
+                "com.uber.Main$1",
+                "bar(java.lang.Object)",
+                "o",
+                "0",
+                "com/uber/Main.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1157,7 +1265,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "WRONG_OVERRIDE_RETURN",
                 "method returns @Nullable, but superclass method com.uber.Foo.bar() returns @NonNull",
                 "com.uber.Main$1",
-                "bar()"))
+                "bar()",
+                "METHOD",
+                "com.uber.Foo",
+                "bar()",
+                "null",
+                "null",
+                "com/uber/Foo.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1192,7 +1306,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "FIELD_NO_INIT",
                 "@NonNull field Main$1.bar not initialized",
                 "com.uber.Main$1",
-                "null"))
+                "null",
+                "FIELD",
+                "com.uber.Main$1",
+                "null",
+                "bar",
+                "null",
+                "com/uber/Main.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
@@ -1226,7 +1346,13 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "FIELD_NO_INIT",
                 "@NonNull field Main$1Foo.bar not initialized",
                 "com.uber.Main$1Foo",
-                "null"))
+                "null",
+                "FIELD",
+                "com.uber.Main$1Foo",
+                "null",
+                "bar",
+                "null",
+                "com/uber/Main.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -676,7 +676,7 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "test(java.lang.Object)",
                 "METHOD",
                 "com.uber.Super",
-                "test(java.lang.Object",
+                "test(java.lang.Object)",
                 "null",
                 "null",
                 "com/uber/Super.java"),

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -30,14 +30,41 @@ import java.util.Objects;
 public class ErrorDisplay implements Display {
   public final String type;
   public final String message;
-  public final String method;
+  public final String encMethod;
+  public final String encClass;
+  public final String kind;
   public final String clazz;
+  public final String method;
+  public final String variable;
+  public final String index;
+  public final String uri;
 
-  public ErrorDisplay(String type, String message, String clazz, String method) {
+  public ErrorDisplay(
+      String type,
+      String message,
+      String encClass,
+      String encMethod,
+      String kind,
+      String clazz,
+      String method,
+      String variable,
+      String index,
+      String uri) {
     this.type = type;
     this.message = message;
-    this.method = method;
+    this.encMethod = encMethod;
+    this.encClass = encClass;
+    this.kind = kind;
     this.clazz = clazz;
+    this.method = method;
+    this.variable = variable;
+    this.index = index;
+    // relative paths are getting compared.
+    this.uri = uri.contains("com/uber/") ? uri.substring(uri.indexOf("com/uber/")) : uri;
+  }
+
+  public ErrorDisplay(String type, String message, String encClass, String encMethod) {
+    this(type, message, encClass, encMethod, "null", "null", "null", "null", "null", "null");
   }
 
   @Override
@@ -50,16 +77,19 @@ public class ErrorDisplay implements Display {
     }
     ErrorDisplay that = (ErrorDisplay) o;
     return type.equals(that.type)
-        // To increase readability, a shorter version of the actual message might be present in the
-        // expected output of tests.
+        && encMethod.equals(that.encMethod)
+        && encClass.equals(that.encClass)
+        && kind.equals(that.kind)
+        && clazz.equals(that.clazz)
         && (message.contains(that.message) || that.message.contains(message))
-        && method.equals(that.method)
-        && clazz.equals(that.clazz);
+        && variable.equals(that.variable)
+        && index.equals(that.index)
+        && uri.equals(that.uri);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, message, method, clazz);
+    return Objects.hash(type, message, encMethod, encClass);
   }
 
   @Override
@@ -71,11 +101,29 @@ public class ErrorDisplay implements Display {
         + "\n\tmessage='"
         + message
         + '\''
+        + "\n\tencMethod='"
+        + encMethod
+        + '\''
+        + "\n\tencClass='"
+        + encClass
+        + '\''
+        + "\n\tkind='"
+        + kind
+        + '\''
+        + "\n\tclazz='"
+        + clazz
+        + '\''
         + "\n\tmethod='"
         + method
         + '\''
-        + "\n\tclass='"
-        + clazz
+        + "\n\tvariable='"
+        + variable
+        + '\''
+        + "\n\tindex='"
+        + index
+        + '\''
+        + "\n\turi='"
+        + uri
         + '\''
         + '}';
   }

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -81,6 +81,8 @@ public class ErrorDisplay implements Display {
         && encClass.equals(that.encClass)
         && kind.equals(that.kind)
         && clazz.equals(that.clazz)
+        // To increase readability, a shorter version of the actual message might be present in the
+        // expected output of tests.
         && (message.contains(that.message) || that.message.contains(message))
         && variable.equals(that.variable)
         && index.equals(that.index)

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -77,13 +77,14 @@ public class ErrorDisplay implements Display {
     }
     ErrorDisplay that = (ErrorDisplay) o;
     return type.equals(that.type)
+        // To increase readability, a shorter version of the actual message might be present in the
+        // expected output of tests.
+        && (message.contains(that.message) || that.message.contains(message))
         && encMethod.equals(that.encMethod)
         && encClass.equals(that.encClass)
         && kind.equals(that.kind)
         && clazz.equals(that.clazz)
-        // To increase readability, a shorter version of the actual message might be present in the
-        // expected output of tests.
-        && (message.contains(that.message) || that.message.contains(message))
+        && method.equals(that.method)
         && variable.equals(that.variable)
         && index.equals(that.index)
         && uri.equals(that.uri);

--- a/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/ErrorDisplay.java
@@ -91,7 +91,8 @@ public class ErrorDisplay implements Display {
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, message, encMethod, encClass);
+    return Objects.hash(
+        type, message, encMethod, encClass, kind, clazz, method, variable, index, uri);
   }
 
   @Override


### PR DESCRIPTION
This PR augments error information serialized by NullAway. At current state, if `SerializeFixMetada` is active, all reporting errors will be serialized to `errors.tsv` output file where each row has the format below:
```
MESSAGE_TYPE    MESSAGE   CLASS   METHOD
```
The above information does not contain any information regarding the `element` which involved in a pseudo-assignment of a `@Nullable` expression into a `@NonNull`. This information is crucial to detect origins of the error and other computable features.

With this PR, the format of the `errors.tsv` is changed to below to serialize all the required information to denote the involved element in the error:
```
message_type    message    enc_class    enc_method    kind    class   method     param    index    uri    
```



This PR involves other small refactoring (mostly renaming) as it was necessary to reuse the existing methods to produce the desired outputs.
