### PR TITLE
[JSpecify] Support @NullMarked on methods.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -38,8 +38,8 @@ import javax.lang.model.element.ElementKind;
 
 /**
  * Provides APIs for querying whether code is annotated for nullness checking, and for related
- * queries on what annotations are present on a class and/or enclosing classes. Makes use of caching
- * internally for performance.
+ * queries on what annotations are present on a class/method and/or on relevant enclosing scopes
+ * (i.e. enclosing classes or methods). Makes use of caching internally for performance.
  */
 public final class CodeAnnotationInfo {
 
@@ -168,7 +168,7 @@ public final class CodeAnnotationInfo {
       Symbol.MethodSymbol enclosingMethod = null;
       if (owner.getKind().equals(ElementKind.METHOD)
           || owner.getKind().equals(ElementKind.CONSTRUCTOR)) {
-        enclosingMethod = (Symbol.MethodSymbol) owner; // Potentially null!
+        enclosingMethod = (Symbol.MethodSymbol) owner;
       }
       Symbol.ClassSymbol enclosingClass = ASTHelpers.enclosingClass(classSymbol);
       // enclosingClass can be null in weird cases like for array methods

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -53,7 +53,7 @@ public final class CodeAnnotationInfo {
   private CodeAnnotationInfo() {}
 
   /**
-   * Get the ClassAnnotationInfo for the given javac context. We ensure there is one instance per
+   * Get the CodeAnnotationInfo for the given javac context. We ensure there is one instance per
    * context (as opposed to using static fields) to avoid memory leaks.
    */
   public static CodeAnnotationInfo instance(Context context) {

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -22,39 +22,44 @@
 
 package com.uber.nullaway;
 
+import static com.uber.nullaway.NullabilityUtil.NULLMARKED_SIMPLE_NAME;
 import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.util.Context;
+import java.util.HashMap;
+import java.util.Map;
+import javax.lang.model.element.ElementKind;
 
 /**
  * Provides APIs for querying whether code is annotated for nullness checking, and for related
  * queries on what annotations are present on a class and/or enclosing classes. Makes use of caching
  * internally for performance.
  */
-public final class ClassAnnotationInfo {
+public final class CodeAnnotationInfo {
 
-  private static final Context.Key<ClassAnnotationInfo> ANNOTATION_INFO_KEY = new Context.Key<>();
+  private static final Context.Key<CodeAnnotationInfo> ANNOTATION_INFO_KEY = new Context.Key<>();
 
-  private static final int MAX_CACHE_SIZE = 200;
+  private static final int MAX_CLASS_CACHE_SIZE = 200;
 
-  private final Cache<Symbol.ClassSymbol, CacheRecord> cache =
-      CacheBuilder.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
+  private final Cache<Symbol.ClassSymbol, ClassCacheRecord> classCache =
+      CacheBuilder.newBuilder().maximumSize(MAX_CLASS_CACHE_SIZE).build();
 
-  private ClassAnnotationInfo() {}
+  private CodeAnnotationInfo() {}
 
   /**
    * Get the ClassAnnotationInfo for the given javac context. We ensure there is one instance per
    * context (as opposed to using static fields) to avoid memory leaks.
    */
-  public static ClassAnnotationInfo instance(Context context) {
-    ClassAnnotationInfo annotationInfo = context.get(ANNOTATION_INFO_KEY);
+  public static CodeAnnotationInfo instance(Context context) {
+    CodeAnnotationInfo annotationInfo = context.get(ANNOTATION_INFO_KEY);
     if (annotationInfo == null) {
-      annotationInfo = new ClassAnnotationInfo();
+      annotationInfo = new CodeAnnotationInfo();
       context.put(ANNOTATION_INFO_KEY, annotationInfo);
     }
     return annotationInfo;
@@ -113,7 +118,14 @@ public final class ClassAnnotationInfo {
    *     otherwise
    */
   public boolean isSymbolUnannotated(Symbol symbol, Config config) {
-    return !get(castToNonNull(ASTHelpers.enclosingClass(symbol)), config).isNullnessAnnotated;
+    final ClassCacheRecord classCacheRecord =
+        get(castToNonNull(ASTHelpers.enclosingClass(symbol)), config);
+    boolean inAnnotatedClass = classCacheRecord.isNullnessAnnotated;
+    if (symbol.getKind().equals(ElementKind.METHOD)) {
+      return !classCacheRecord.isMethodNullnessAnnotated((Symbol.MethodSymbol) symbol);
+    } else {
+      return !inAnnotatedClass;
+    }
   }
 
   /**
@@ -139,20 +151,29 @@ public final class ClassAnnotationInfo {
    *     annotations on enclosing classes, the containing package, and other NullAway configuration
    *     like annotated packages
    */
-  private CacheRecord get(Symbol.ClassSymbol classSymbol, Config config) {
-    CacheRecord record = cache.getIfPresent(classSymbol);
+  private ClassCacheRecord get(Symbol.ClassSymbol classSymbol, Config config) {
+    ClassCacheRecord record = classCache.getIfPresent(classSymbol);
     if (record != null) {
       return record;
     }
     if (classSymbol.getNestingKind().isNested()) {
+      Symbol owner = classSymbol.owner;
+      Preconditions.checkNotNull(owner, "Symbol.owner should only be null for modules!");
+      Symbol.MethodSymbol enclosingMethod = null;
+      if (owner.getKind().equals(ElementKind.METHOD)
+          || owner.getKind().equals(ElementKind.CONSTRUCTOR)) {
+        enclosingMethod = (Symbol.MethodSymbol) owner; // Potentially null!
+      }
       Symbol.ClassSymbol enclosingClass = ASTHelpers.enclosingClass(classSymbol);
-      // enclosingSymbol can be null in weird cases like for array methods
+      // enclosingClass can be null in weird cases like for array methods
       if (enclosingClass != null) {
-        CacheRecord recordForEnclosing = get(enclosingClass, config);
+        ClassCacheRecord recordForEnclosing = get(enclosingClass, config);
         record =
-            new CacheRecord(
+            new ClassCacheRecord(
                 recordForEnclosing.outermostClassSymbol,
                 (recordForEnclosing.isNullnessAnnotated
+                        || (enclosingMethod != null
+                            && recordForEnclosing.isMethodNullnessAnnotated(enclosingMethod))
                         || ASTHelpers.hasDirectAnnotationWithSimpleName(
                             classSymbol, NullabilityUtil.NULLMARKED_SIMPLE_NAME))
                     && !shouldTreatAsUnannotated(classSymbol, config));
@@ -160,9 +181,9 @@ public final class ClassAnnotationInfo {
     }
     if (record == null) {
       // We are already at the outermost class (we can find), so let's create a record for it
-      record = new CacheRecord(classSymbol, isAnnotatedTopLevelClass(classSymbol, config));
+      record = new ClassCacheRecord(classSymbol, isAnnotatedTopLevelClass(classSymbol, config));
     }
-    cache.put(classSymbol, record);
+    classCache.put(classSymbol, record);
     return record;
   }
 
@@ -205,13 +226,29 @@ public final class ClassAnnotationInfo {
    * <p>The class being referenced by the record is not represented by this object, but rather the
    * key used to retrieve it.
    */
-  private static final class CacheRecord {
+  private static final class ClassCacheRecord {
     public final Symbol.ClassSymbol outermostClassSymbol;
     public final boolean isNullnessAnnotated;
+    public final Map<Symbol.MethodSymbol, Boolean> methodNullnessCache;
 
-    public CacheRecord(Symbol.ClassSymbol outermostClassSymbol, boolean isAnnotated) {
+    public ClassCacheRecord(Symbol.ClassSymbol outermostClassSymbol, boolean isAnnotated) {
       this.outermostClassSymbol = outermostClassSymbol;
       this.isNullnessAnnotated = isAnnotated;
+      this.methodNullnessCache = new HashMap<>();
+    }
+
+    public boolean isMethodNullnessAnnotated(Symbol.MethodSymbol methodSymbol) {
+      methodNullnessCache.computeIfAbsent(
+          methodSymbol,
+          m -> {
+            if (this.isNullnessAnnotated) {
+              // ToDo: check for @NullUnmarked
+              return true;
+            } else {
+              return ASTHelpers.hasDirectAnnotationWithSimpleName(m, NULLMARKED_SIMPLE_NAME);
+            }
+          });
+      return methodNullnessCache.get(methodSymbol);
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -118,10 +118,16 @@ public final class CodeAnnotationInfo {
    *     otherwise
    */
   public boolean isSymbolUnannotated(Symbol symbol, Config config) {
-    final ClassCacheRecord classCacheRecord =
-        get(castToNonNull(ASTHelpers.enclosingClass(symbol)), config);
+    Symbol.ClassSymbol classSymbol;
+    if (symbol instanceof Symbol.ClassSymbol) {
+      classSymbol = (Symbol.ClassSymbol) symbol;
+    } else {
+      classSymbol = castToNonNull(ASTHelpers.enclosingClass(symbol));
+    }
+    final ClassCacheRecord classCacheRecord = get(classSymbol, config);
     boolean inAnnotatedClass = classCacheRecord.isNullnessAnnotated;
-    if (symbol.getKind().equals(ElementKind.METHOD)) {
+    if (symbol.getKind().equals(ElementKind.METHOD)
+        || symbol.getKind().equals(ElementKind.CONSTRUCTOR)) {
       return !classCacheRecord.isMethodNullnessAnnotated((Symbol.MethodSymbol) symbol);
     } else {
       return !inAnnotatedClass;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -572,8 +572,7 @@ public class NullAway extends BugChecker
         if (ASTHelpers.hasDirectAnnotationWithSimpleName(
             methodSymbol, NullabilityUtil.NULLMARKED_SIMPLE_NAME)) {
           // We still care here if this is a transition between @NullUnmarked and @NullMarked code,
-          // within
-          // partially marked code, see checks below for markedMethodInUnmarkedContext.
+          // within partially marked code, see checks below for markedMethodInUnmarkedContext.
           if (!codeAnnotationInfo.isClassNullAnnotated(methodSymbol.enclClass(), config)) {
             markedMethodInUnmarkedContext = true;
           }
@@ -582,8 +581,7 @@ public class NullAway extends BugChecker
     }
     if (markedMethodInUnmarkedContext) {
       // If this is a @NullMarked method of a @NullUnmarked local or anonymous class, we need to set
-      // its environment
-      // mapping, since we skipped it during matchClass.
+      // its environment mapping, since we skipped it during matchClass.
       TreePath pathToEnclosingClass =
           ASTHelpers.findPathFromEnclosingNodeToTopLevel(state.getPath(), ClassTree.class);
       ClassTree enclosingClass = (ClassTree) pathToEnclosingClass.getLeaf();

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -205,7 +205,7 @@ public class NullAway extends BugChecker
   private NullMarking nullMarkingForTopLevelClass = NullMarking.FULLY_MARKED;
 
   /**
-   * We store the ClassAnnotationInfo object in a field for convenience; it is initialized in {@link
+   * We store the CodeAnnotationInfo object in a field for convenience; it is initialized in {@link
    * #matchClass(ClassTree, VisitorState)}
    */
   // suppress initialization warning rather than casting everywhere; we know matchClass() will
@@ -870,7 +870,7 @@ public class NullAway extends BugChecker
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
     final boolean isOverriddenMethodAnnotated =
-        !classAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
+        !codeAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
     Nullness overriddenMethodReturnNullness =
         Nullness.NULLABLE; // Permissive default for unannotated code.
     if (isOverriddenMethodAnnotated && !Nullness.hasNullableAnnotation(overriddenMethod, config)) {
@@ -883,7 +883,7 @@ public class NullAway extends BugChecker
     // overriding method better not return nullable
     if (overriddenMethodReturnNullness.equals(Nullness.NONNULL)) {
       final boolean isOverridingMethodAnnotated =
-          !classAnnotationInfo.isSymbolUnannotated(overridingMethod, config);
+          !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config);
       // Note that, for the overriding method, the permissive default is non-null.
       Nullness overridingMethodReturnNullness = Nullness.NONNULL;
       if (isOverridingMethodAnnotated && Nullness.hasNullableAnnotation(overridingMethod, config)) {
@@ -1325,7 +1325,7 @@ public class NullAway extends BugChecker
 
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
-    // Ensure classAnnotationInfo is initialized here since it requires access to the Context,
+    // Ensure codeAnnotationInfo is initialized here since it requires access to the Context,
     // which is not available in the constructor
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(state.context);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -313,8 +313,7 @@ public class NullAway extends BugChecker
     TreePath path = state.getPath();
     Tree currentTree = path.getLeaf();
     // Find the closest class or method symbol, since those are the only ones we have code
-    // annotation info
-    // for.
+    // annotation info for.
     // For the purposes of determining whether we are inside annotated code or not, when matching
     // a class its enclosing class is itself (otherwise we might not process initialization for
     // top-level classes in general, or @NullMarked inner classes), same for the enclosing method of
@@ -1005,11 +1004,9 @@ public class NullAway extends BugChecker
       final Symbol.ClassSymbol enclClassSymbol = enclosingClassSymbol(enclosingBlockPath);
 
       // Checking for initialization is only meaningful if the full class is null-annotated, which
-      // might not be
-      // the case with @NullMarked methods inside @NullUnmarked classes (note that, in those cases,
-      // we won't even have a
-      // populated class2Entities map). We skip this check if we are not inside a
-      // @NullMarked/annotated *class*:
+      // might not be the case with @NullMarked methods inside @NullUnmarked classes (note that,
+      // in those cases, we won't even have a populated class2Entities map). We skip this check if
+      // we are not inside a @NullMarked/annotated *class*:
       if (nullMarkingForTopLevelClass == NullMarking.PARTIALLY_MARKED
           && !codeAnnotationInfo.isClassNullAnnotated(enclClassSymbol, config)) {
         return false;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1518,8 +1518,7 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
 
-    final boolean isMethodAnnotated =
-        !codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
+    final boolean isMethodAnnotated = !codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
     // If argumentPositionNullness[i] == null, parameter i is unannotated
     Nullness[] argumentPositionNullness = new Nullness[formalParams.size()];
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -211,7 +211,7 @@ public class NullAway extends BugChecker
   // suppress initialization warning rather than casting everywhere; we know matchClass() will
   // always be called before the field gets dereferenced
   @SuppressWarnings("NullAway.Init")
-  private ClassAnnotationInfo classAnnotationInfo;
+  private CodeAnnotationInfo codeAnnotationInfo;
 
   private final Config config;
 
@@ -291,7 +291,7 @@ public class NullAway extends BugChecker
 
   private boolean isMethodUnannotated(MethodInvocationNode invocationNode) {
     return invocationNode == null
-        || classAnnotationInfo.isSymbolUnannotated(
+        || codeAnnotationInfo.isSymbolUnannotated(
             ASTHelpers.getSymbol(invocationNode.getTree()), config);
   }
 
@@ -327,7 +327,7 @@ public class NullAway extends BugChecker
       return false;
     }
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(enclosingClass);
-    return classAnnotationInfo.isClassNullAnnotated(classSymbol, config);
+    return codeAnnotationInfo.isClassNullAnnotated(classSymbol, config);
   }
 
   @Override
@@ -623,7 +623,7 @@ public class NullAway extends BugChecker
         (memberReferenceTree != null)
             && ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
     final boolean isOverriddenMethodAnnotated =
-        !classAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
+        !codeAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
 
     // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
     // null, parameter i is treated as unannotated.
@@ -736,7 +736,7 @@ public class NullAway extends BugChecker
       // support)
       return Description.NO_MATCH;
     }
-    if (classAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
+    if (codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
         || Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return Description.NO_MATCH;
     }
@@ -764,7 +764,7 @@ public class NullAway extends BugChecker
     // (like Rx nullability) run dataflow analysis
     updateEnvironmentMapping(tree, state);
     handler.onMatchLambdaExpression(this, tree, state, funcInterfaceMethod);
-    if (classAnnotationInfo.isSymbolUnannotated(funcInterfaceMethod, config)) {
+    if (codeAnnotationInfo.isSymbolUnannotated(funcInterfaceMethod, config)) {
       return Description.NO_MATCH;
     }
     Description description =
@@ -1267,8 +1267,8 @@ public class NullAway extends BugChecker
   public Description matchClass(ClassTree tree, VisitorState state) {
     // Ensure classAnnotationInfo is initialized here since it requires access to the Context,
     // which is not available in the constructor
-    if (classAnnotationInfo == null) {
-      classAnnotationInfo = ClassAnnotationInfo.instance(state.context);
+    if (codeAnnotationInfo == null) {
+      codeAnnotationInfo = CodeAnnotationInfo.instance(state.context);
     }
     // Check if the class is excluded according to the filter
     // if so, set the flag to match within the class to false
@@ -1459,7 +1459,7 @@ public class NullAway extends BugChecker
     }
 
     final boolean isMethodAnnotated =
-        !classAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
+        !codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
     // If argumentPositionNullness[i] == null, parameter i is unannotated
     Nullness[] argumentPositionNullness = new Nullness[formalParams.size()];
 
@@ -2040,7 +2040,7 @@ public class NullAway extends BugChecker
     if (config.isExcludedClass(className)) {
       return true;
     }
-    if (!classAnnotationInfo.isClassNullAnnotated(classSymbol, config)) {
+    if (!codeAnnotationInfo.isClassNullAnnotated(classSymbol, config)) {
       return true;
     }
     // check annotations
@@ -2163,7 +2163,7 @@ public class NullAway extends BugChecker
   private boolean mayBeNullMethodCall(
       VisitorState state, ExpressionTree expr, Symbol.MethodSymbol exprSymbol) {
     boolean exprMayBeNull = true;
-    if (classAnnotationInfo.isSymbolUnannotated(exprSymbol, config)) {
+    if (codeAnnotationInfo.isSymbolUnannotated(exprSymbol, config)) {
       exprMayBeNull = false;
     }
     if (!Nullness.hasNullableAnnotation(exprSymbol, config)) {
@@ -2190,7 +2190,7 @@ public class NullAway extends BugChecker
 
   private boolean mayBeNullFieldAccess(VisitorState state, ExpressionTree expr, Symbol exprSymbol) {
     boolean exprMayBeNull = true;
-    if (!NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, classAnnotationInfo)) {
+    if (!NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo)) {
       exprMayBeNull = false;
     }
     exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, state, exprMayBeNull);

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -296,12 +296,12 @@ public class NullabilityUtil {
    * @throws NullPointerException if {@code symbol} is null
    */
   public static boolean mayBeNullFieldFromType(
-      Symbol symbol, Config config, ClassAnnotationInfo classAnnotationInfo) {
+      Symbol symbol, Config config, CodeAnnotationInfo codeAnnotationInfo) {
     Preconditions.checkNotNull(
         symbol, "mayBeNullFieldFromType should never be called with a null symbol");
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()
-            || classAnnotationInfo.isSymbolUnannotated(symbol, config))
+            || codeAnnotationInfo.isSymbolUnannotated(symbol, config))
         && Nullness.hasNullableAnnotation(symbol, config);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -31,7 +31,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.TypeTag;
-import com.uber.nullaway.ClassAnnotationInfo;
+import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
@@ -728,13 +728,13 @@ public class AccessPathNullnessPropagation
     return updateRegularStore(nullness, input, updates);
   }
 
-  @Nullable private ClassAnnotationInfo classAnnotationInfo;
+  @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private ClassAnnotationInfo getClassAnnotationInfo(VisitorState state) {
-    if (classAnnotationInfo == null) {
-      classAnnotationInfo = ClassAnnotationInfo.instance(state.context);
+  private CodeAnnotationInfo getClassAnnotationInfo(VisitorState state) {
+    if (codeAnnotationInfo == null) {
+      codeAnnotationInfo = CodeAnnotationInfo.instance(state.context);
     }
-    return classAnnotationInfo;
+    return codeAnnotationInfo;
   }
 
   private void setReceiverNonnull(

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -720,7 +720,7 @@ public class AccessPathNullnessPropagation
     Symbol symbol = ASTHelpers.getSymbol(fieldAccessNode.getTree());
     setReceiverNonnull(updates, fieldAccessNode.getReceiver(), symbol);
     Nullness nullness = NULLABLE;
-    if (!NullabilityUtil.mayBeNullFieldFromType(symbol, config, getClassAnnotationInfo(state))) {
+    if (!NullabilityUtil.mayBeNullFieldFromType(symbol, config, getCodeAnnotationInfo(state))) {
       nullness = NONNULL;
     } else {
       nullness = input.getRegularStore().valueOfField(fieldAccessNode, nullness, apContext);
@@ -730,7 +730,7 @@ public class AccessPathNullnessPropagation
 
   @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private CodeAnnotationInfo getClassAnnotationInfo(VisitorState state) {
+  private CodeAnnotationInfo getCodeAnnotationInfo(VisitorState state) {
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(state.context);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -9,7 +9,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
-import com.uber.nullaway.ClassAnnotationInfo;
+import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
@@ -78,7 +78,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Context context,
       Types types,
       Config config,
-      ClassAnnotationInfo classAnnotationInfo) {
+      CodeAnnotationInfo codeAnnotationInfo) {
     // include nullness info for locals from enclosing environment
     EnclosingEnvironmentNullness environmentNullness =
         EnclosingEnvironmentNullness.instance(context);
@@ -94,7 +94,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         fiMethodSymbol.getParameters();
     // If fiArgumentPositionNullness[i] == null, parameter position i is unannotated
     Nullness[] fiArgumentPositionNullness = new Nullness[fiMethodParameters.size()];
-    final boolean isFIAnnotated = !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config);
+    final boolean isFIAnnotated = !codeAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config);
     if (isFIAnnotated) {
       for (int i = 0; i < fiMethodParameters.size(); i++) {
         fiArgumentPositionNullness[i] =
@@ -127,12 +127,12 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     return result.build();
   }
 
-  @Nullable private ClassAnnotationInfo classAnnotationInfo;
+  @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private ClassAnnotationInfo getClassAnnotationInfo(Context context) {
-    if (classAnnotationInfo == null) {
-      classAnnotationInfo = ClassAnnotationInfo.instance(context);
+  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+    if (codeAnnotationInfo == null) {
+      codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }
-    return classAnnotationInfo;
+    return codeAnnotationInfo;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -45,7 +45,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
           context,
           types,
           config,
-          getClassAnnotationInfo(context));
+          getCodeAnnotationInfo(context));
     } else {
       return methodInitialStore(
           (UnderlyingAST.CFGMethod) underlyingAST, parameters, handler, context, config);
@@ -129,7 +129,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
 
   @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+  private CodeAnnotationInfo getCodeAnnotationInfo(Context context) {
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -38,7 +38,7 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
-import com.uber.nullaway.ClassAnnotationInfo;
+import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.LibraryModels;
 import com.uber.nullaway.LibraryModels.MethodRef;
@@ -171,13 +171,13 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     return newPositions.stream().findAny().orElse(previousArgumentPosition);
   }
 
-  @Nullable private ClassAnnotationInfo classAnnotationInfo;
+  @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private ClassAnnotationInfo getClassAnnotationInfo(Context context) {
-    if (classAnnotationInfo == null) {
-      classAnnotationInfo = ClassAnnotationInfo.instance(context);
+  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+    if (codeAnnotationInfo == null) {
+      codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }
-    return classAnnotationInfo;
+    return codeAnnotationInfo;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -133,7 +133,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       // and any of its overriding implementations.
       // see https://github.com/uber/NullAway/issues/445 for why this is needed.
       boolean isMethodAnnotated =
-          !getClassAnnotationInfo(state.context).isSymbolUnannotated(methodSymbol, this.config);
+          !getCodeAnnotationInfo(state.context).isSymbolUnannotated(methodSymbol, this.config);
       if (optLibraryModels.hasNullableReturn(methodSymbol, state.getTypes(), !isMethodAnnotated)
           || !optLibraryModels.nullImpliesNullParameters(methodSymbol).isEmpty()) {
         // These mean the method might be null, depending on dataflow and arguments. We force
@@ -173,7 +173,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
   @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+  private CodeAnnotationInfo getCodeAnnotationInfo(Context context) {
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }
@@ -193,7 +193,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(node.getTree());
     Preconditions.checkNotNull(callee);
     boolean isMethodAnnotated =
-        !getClassAnnotationInfo(context).isSymbolUnannotated(callee, this.config);
+        !getCodeAnnotationInfo(context).isSymbolUnannotated(callee, this.config);
     setUnconditionalArgumentNullness(bothUpdates, node.getArguments(), callee, context, apContext);
     setConditionalArgumentNullness(
         thenUpdates, elseUpdates, node.getArguments(), callee, context, apContext);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -52,7 +52,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
     if (expr.getKind().equals(Tree.Kind.METHOD_INVOCATION)) {
       Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol((MethodInvocationTree) expr);
-      CodeAnnotationInfo codeAnnotationInfo = getClassAnnotationInfo(state.context);
+      CodeAnnotationInfo codeAnnotationInfo = getCodeAnnotationInfo(state.context);
       if (codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config)) {
         // with the generated-as-unannotated option enabled, we want to ignore
         // annotations in generated code
@@ -69,7 +69,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+  private CodeAnnotationInfo getCodeAnnotationInfo(Context context) {
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }
@@ -129,7 +129,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(node.getTree());
-    CodeAnnotationInfo codeAnnotationInfo = getClassAnnotationInfo(context);
+    CodeAnnotationInfo codeAnnotationInfo = getCodeAnnotationInfo(context);
     // with the generated-as-unannotated option enabled, we want to ignore
     // annotations in generated code
     if (config.treatGeneratedAsUnannotated()

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
-import com.uber.nullaway.ClassAnnotationInfo;
+import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
@@ -52,12 +52,12 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       NullAway analysis, ExpressionTree expr, VisitorState state, boolean exprMayBeNull) {
     if (expr.getKind().equals(Tree.Kind.METHOD_INVOCATION)) {
       Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol((MethodInvocationTree) expr);
-      ClassAnnotationInfo classAnnotationInfo = getClassAnnotationInfo(state.context);
-      if (classAnnotationInfo.isSymbolUnannotated(methodSymbol, config)) {
+      CodeAnnotationInfo codeAnnotationInfo = getClassAnnotationInfo(state.context);
+      if (codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config)) {
         // with the generated-as-unannotated option enabled, we want to ignore
         // annotations in generated code
         if (config.treatGeneratedAsUnannotated()
-            && classAnnotationInfo.isGenerated(methodSymbol, config)) {
+            && codeAnnotationInfo.isGenerated(methodSymbol, config)) {
           return exprMayBeNull;
         } else {
           return Nullness.hasNullableAnnotation(methodSymbol, config) || exprMayBeNull;
@@ -67,13 +67,13 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
     return exprMayBeNull;
   }
 
-  @Nullable private ClassAnnotationInfo classAnnotationInfo;
+  @Nullable private CodeAnnotationInfo codeAnnotationInfo;
 
-  private ClassAnnotationInfo getClassAnnotationInfo(Context context) {
-    if (classAnnotationInfo == null) {
-      classAnnotationInfo = ClassAnnotationInfo.instance(context);
+  private CodeAnnotationInfo getClassAnnotationInfo(Context context) {
+    if (codeAnnotationInfo == null) {
+      codeAnnotationInfo = CodeAnnotationInfo.instance(context);
     }
-    return classAnnotationInfo;
+    return codeAnnotationInfo;
   }
 
   @Override
@@ -129,14 +129,14 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
       AccessPathNullnessPropagation.Updates elseUpdates,
       AccessPathNullnessPropagation.Updates bothUpdates) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(node.getTree());
-    ClassAnnotationInfo classAnnotationInfo = getClassAnnotationInfo(context);
+    CodeAnnotationInfo codeAnnotationInfo = getClassAnnotationInfo(context);
     // with the generated-as-unannotated option enabled, we want to ignore
     // annotations in generated code
     if (config.treatGeneratedAsUnannotated()
-        && classAnnotationInfo.isGenerated(methodSymbol, config)) {
+        && codeAnnotationInfo.isGenerated(methodSymbol, config)) {
       return NullnessHint.UNKNOWN;
     }
-    if (classAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
+    if (codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config)
         && Nullness.hasNullableAnnotation(methodSymbol, config)) {
       return NullnessHint.HINT_NULLABLE;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -240,7 +240,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -268,7 +268,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -278,7 +278,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Bar {",
             "  public static void bar1() {",
             "    // No report, unannotated caller!",
@@ -299,7 +299,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -309,7 +309,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static Runnable runFoo() {",
@@ -336,7 +336,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static IConsumer getConsumer() {",
@@ -367,7 +367,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -377,7 +377,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static Object bar() {",
@@ -401,7 +401,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.example.thirdparty;",
-            "import com.uber.nullaway.testdata.annotations.jspecify.future.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
             "public class Test {",
             "  @NullMarked",
             "  public static Object test() {",
@@ -525,6 +525,41 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "    Outer.Inner.foo(null);",
             "    Outer.unchecked(null);",
             "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void bytecodeNullMarkedMethodLevel() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.example.jspecify.unannotatedpackage.Methods;",
+            "public class Test {",
+            "  public static void test(Object o) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Methods.foo(null);",
+            "    Methods.unchecked(null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void bytecodeNullMarkedMethodLevelOverriding() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.example.jspecify.unannotatedpackage.Methods;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class Test extends Methods.ExtendMe {",
+            "  @Nullable",
+            "  // BUG: Diagnostic contains: method returns @Nullable, but superclass method",
+            "  public Object foo(@Nullable Object o) { return o; }",
+            "  @Nullable",
+            "  public Object unchecked(@Nullable Object o) { return o; }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -417,8 +417,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "  }",
             // This currently causes a crash, because updateEnvironmentMapping() is only called when
             // analyzing the class (which we don't do here, since Test$Foo is unmarked), but used
-            // within
-            // analysis of the null-marked method Test$Foo.foo(...).
+            // within analysis of the null-marked method Test$Foo.foo(...).
             "  public static Object test2() {",
             "    class Foo {",
             "      private Object o;", // No init checking, since Test$2Foo is unmarked.

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -415,9 +415,6 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "    }",
             "    return new Foo();",
             "  }",
-            // This currently causes a crash, because updateEnvironmentMapping() is only called when
-            // analyzing the class (which we don't do here, since Test$Foo is unmarked), but used
-            // within analysis of the null-marked method Test$Foo.foo(...).
             "  public static Object test2() {",
             "    class Foo {",
             "      private Object o;", // No init checking, since Test$2Foo is unmarked.
@@ -425,6 +422,17 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "      @NullMarked",
             "      public String foo(String s) {",
             "        return s;",
+            "      }",
+            "    }",
+            "    return new Foo();",
+            "  }",
+            "  public static Object test3() {",
+            "    class Foo {",
+            "      private Object o;", // No init checking, since Test$2Foo is unmarked.
+            "      public Foo() { }",
+            "      @NullMarked",
+            "      public String foo() {",
+            "        return o.toString();",
             "      }",
             "    }",
             "    return new Foo();",

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2022 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.testdata.annotations.jspecify.future;
+
+// Note:
+// Copied from
+// https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/nullness/NullMarked.java
+// used for testing JSpecify features (such as @NullMarked on methods), which aren't part of
+// JSpecify v0.2.0.
+// This annotation should be deleted and its references replaced with
+// org.jspecify.nullness.NullMarked once
+// JSpecify v0.3.0 is out.
+// This test resource is not redistributed with NullAway.
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated element and the code transitively <a
+ * href="https://docs.oracle.com/en/java/javase/18/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosedElements()">enclosed</a>
+ * within it is <b>null-marked code</b>: type usages are generally considered to exclude {@code
+ * null} as a value unless specified otherwise (special cases to be covered below). Using this
+ * annotation avoids the need to write {@link NonNull @NonNull} many times throughout your code.
+ *
+ * <p><b>WARNING:</b> This annotation is under development, and <i>any</i> aspect of its naming,
+ * location, or design may change before 1.0. <b>Do not release libraries using this annotation at
+ * this time.</b>
+ */
+@Documented
+@Target({TYPE, METHOD, CONSTRUCTOR, PACKAGE, MODULE})
+@Retention(RUNTIME)
+public @interface NullMarked {}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
@@ -25,7 +25,6 @@ package com.uber.nullaway.testdata.annotations.jspecify.future;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -46,6 +45,6 @@ import java.lang.annotation.Target;
  * this time.</b>
  */
 @Documented
-@Target({TYPE, METHOD, CONSTRUCTOR, PACKAGE, MODULE})
+@Target({TYPE, METHOD, CONSTRUCTOR, PACKAGE})
 @Retention(RUNTIME)
 public @interface NullMarked {}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/annotations/jspecify/future/NullMarked.java
@@ -15,14 +15,12 @@
  */
 package com.uber.nullaway.testdata.annotations.jspecify.future;
 
-// Note:
-// Copied from
+// Note: Copied from
 // https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/nullness/NullMarked.java
 // used for testing JSpecify features (such as @NullMarked on methods), which aren't part of
 // JSpecify v0.2.0.
 // This annotation should be deleted and its references replaced with
-// org.jspecify.nullness.NullMarked once
-// JSpecify v0.3.0 is out.
+// org.jspecify.nullness.NullMarked once JSpecify v0.3.0 is out.
 // This test resource is not redistributed with NullAway.
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;

--- a/test-java-lib/src/main/java/com/example/jspecify/future/annotations/NullMarked.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/future/annotations/NullMarked.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.uber.nullaway.testdata.annotations.jspecify.future;
+package com.example.jspecify.future.annotations;
 
 // Note: Copied from
 // https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/nullness/NullMarked.java

--- a/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
@@ -1,0 +1,23 @@
+package com.example.jspecify.unannotatedpackage;
+
+// Needed for annotating methods, should be removed and replaced with the standard
+// JSpecify @NullMarked annotation once v0.3.0 is out.
+import com.example.jspecify.future.annotations.NullMarked;
+
+public class Methods {
+  @NullMarked
+  public static void foo(Object o) {}
+
+  public static void unchecked(Object o) {}
+
+  public static class ExtendMe {
+    @NullMarked
+    public Object foo(Object o) {
+      return o;
+    }
+
+    public Object unchecked(Object o) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This adds support for adding `@NullMarked` to methods, in addition to classes, 
which will be supported by the version of `@NullMarked` shipping with JSpecify 0.3.0.

Some relevant changes needed to accomplish this:

- We rename `ClassAnnotationInfo` to `CodeAnnotationInfo`. It still operates as a cache 
over classes and their annotations, but now each cache entry has a map with information 
about the null-markedness of its methods.
- We add a `checkForMethodNullMarkedness(...)` call to the beginning of `matchMethod(...)`, 
before we check for `withinAnnotatedCode(...)`. If we detect a `@NullMarked` annotation 
here, while otherwise looking at unmarked code, we switch our scan of the current top-level 
class to our slower `PARTIALLY_MARKED` scan mode.
- We add comprehensive tests to  `NullAwayJSpecifyTests.java` and make fixes in various 
places accordingly. An important change to note is that we need to sometimes compute 
`EnclosingEnvironmentNullness` information for anonymous or local classes that are 
otherwise unmarked but have a `@NullMarked` method, and we must do this inside
`checkForMethodNullMarkedness(...)` (since we don't know about the marked methods 
while processing `matchClass(...)`)