### PR TITLE
Optimizations for parameter nullness handler / overriding

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1503,12 +1503,6 @@ public class NullAway extends BugChecker
         handler.onOverrideMethodInvocationParametersNullability(
             state.context, methodSymbol, isMethodAnnotated, argumentPositionNullness);
 
-    //    ImmutableSet<Integer> nonNullPositions =
-    //        argumentPositionNullness.entrySet().stream()
-    //            .filter(e -> e.getValue().equals(Nullness.NONNULL))
-    //            .map(e -> e.getKey())
-    //            .collect(ImmutableSet.toImmutableSet());
-
     // now actually check the arguments
     // NOTE: the case of an invocation on a possibly-null reference
     // is handled by matchMemberSelect()
@@ -1549,8 +1543,6 @@ public class NullAway extends BugChecker
                 errorMessage, actual, buildDescription(actual), state, formalParams.get(argPos)));
       }
     }
-    //    for (int argPos : nonNullPositions) {
-    //    }
     // Check for @NonNull being passed to castToNonNull (if configured)
     return checkCastToNonNullTakesNullable(tree, state, methodSymbol, actualParams);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1503,16 +1503,20 @@ public class NullAway extends BugChecker
         handler.onOverrideMethodInvocationParametersNullability(
             state.context, methodSymbol, isMethodAnnotated, argumentPositionNullness);
 
-    ImmutableSet<Integer> nonNullPositions =
-        argumentPositionNullness.entrySet().stream()
-            .filter(e -> e.getValue().equals(Nullness.NONNULL))
-            .map(e -> e.getKey())
-            .collect(ImmutableSet.toImmutableSet());
+    //    ImmutableSet<Integer> nonNullPositions =
+    //        argumentPositionNullness.entrySet().stream()
+    //            .filter(e -> e.getValue().equals(Nullness.NONNULL))
+    //            .map(e -> e.getKey())
+    //            .collect(ImmutableSet.toImmutableSet());
 
     // now actually check the arguments
     // NOTE: the case of an invocation on a possibly-null reference
     // is handled by matchMemberSelect()
-    for (int argPos : nonNullPositions) {
+    for (Map.Entry<Integer, Nullness> entry : argumentPositionNullness.entrySet()) {
+      if (!entry.getValue().equals(Nullness.NONNULL)) {
+        continue;
+      }
+      int argPos = entry.getKey();
       ExpressionTree actual = null;
       boolean mayActualBeNull = false;
       if (argPos == formalParams.size() - 1 && methodSymbol.isVarArgs()) {
@@ -1545,6 +1549,8 @@ public class NullAway extends BugChecker
                 errorMessage, actual, buildDescription(actual), state, formalParams.get(argPos)));
       }
     }
+    //    for (int argPos : nonNullPositions) {
+    //    }
     // Check for @NonNull being passed to castToNonNull (if configured)
     return checkCastToNonNullTakesNullable(tree, state, methodSymbol, actualParams);
   }


### PR DESCRIPTION
Mostly (?) addresses #645.

Since this code seems to be performance critical, we should consider shifting our representation of parameter nullability from a `Map<Integer,Nullness>` to an `ArrayList<Nullness>`.  But that is a more intrusive change.  These changes seems be enough to address the performance regression from #639 (to be confirmed with a full run of perf regression tests).

