### PR TITLE
Switch parameter overriding handler to use `Nullness[]`

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -673,8 +673,7 @@ public class NullAway extends BugChecker
     final int startParam = unboundMemberRef ? 1 : 0;
 
     for (int i = 0; i < superParamSymbols.size(); i++) {
-      if (overriddenMethodArgNullnessMap[i] == null // unannotated
-          || Nullness.NONNULL.equals(overriddenMethodArgNullnessMap[i])) {
+      if (!Objects.equals(overriddenMethodArgNullnessMap[i], Nullness.NULLABLE)) {
         // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridding a @NonNull arg.
         continue;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -625,7 +625,8 @@ public class NullAway extends BugChecker
     final boolean isOverriddenMethodAnnotated =
         !classAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
 
-    // Get argument nullability for the overridden method:
+    // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
+    // null, parameter i is treated as unannotated.
     Nullness[] overriddenMethodArgNullnessMap = new Nullness[superParamSymbols.size()];
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
@@ -672,7 +673,7 @@ public class NullAway extends BugChecker
     final int startParam = unboundMemberRef ? 1 : 0;
 
     for (int i = 0; i < superParamSymbols.size(); i++) {
-      if (overriddenMethodArgNullnessMap[i] == null
+      if (overriddenMethodArgNullnessMap[i] == null // unannotated
           || Nullness.NONNULL.equals(overriddenMethodArgNullnessMap[i])) {
         // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridding a @NonNull arg.
@@ -1460,6 +1461,7 @@ public class NullAway extends BugChecker
 
     final boolean isMethodAnnotated =
         !classAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
+    // If argumentPositionNullness[i] == null, parameter i is unannotated
     Nullness[] argumentPositionNullness = new Nullness[formalParams.size()];
 
     if (isMethodAnnotated) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -96,6 +96,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -625,18 +626,17 @@ public class NullAway extends BugChecker
         !classAnnotationInfo.isSymbolUnannotated(overriddenMethod, config);
 
     // Get argument nullability for the overridden method:
-    Map<Integer, Nullness> overriddenMethodArgNullnessMap = new LinkedHashMap<>();
+    Nullness[] overriddenMethodArgNullnessMap = new Nullness[superParamSymbols.size()];
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
     // (otherwise, whether we acknowledge @Nullable in unannotated code or not depends on the
     // -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations flag and its handler).
     if (isOverriddenMethodAnnotated) {
       for (int i = 0; i < superParamSymbols.size(); i++) {
-        overriddenMethodArgNullnessMap.put(
-            i,
+        overriddenMethodArgNullnessMap[i] =
             Nullness.paramHasNullableAnnotation(overriddenMethod, i, config)
                 ? Nullness.NULLABLE
-                : Nullness.NONNULL);
+                : Nullness.NONNULL;
       }
     }
 
@@ -652,10 +652,7 @@ public class NullAway extends BugChecker
     // @NonNull, as this parameter will be used as a method receiver inside the generated lambda.
     // e.g. String::length is implemented as (@NonNull s -> s.length()) when used as a
     // SomeFunc<String> and thus incompatible with, for example, SomeFunc.apply(@Nullable T).
-    if (unboundMemberRef
-        && overriddenMethodArgNullnessMap
-            .getOrDefault(0, Nullness.NONNULL)
-            .equals(Nullness.NULLABLE)) {
+    if (unboundMemberRef && Objects.equals(overriddenMethodArgNullnessMap[0], Nullness.NULLABLE)) {
       String message =
           "unbound instance method reference cannot be used, as first parameter of "
               + "functional interface method "
@@ -675,9 +672,8 @@ public class NullAway extends BugChecker
     final int startParam = unboundMemberRef ? 1 : 0;
 
     for (int i = 0; i < superParamSymbols.size(); i++) {
-      if (overriddenMethodArgNullnessMap
-          .getOrDefault(i, Nullness.NONNULL)
-          .equals(Nullness.NONNULL)) {
+      if (overriddenMethodArgNullnessMap[i] == null
+          || Nullness.NONNULL.equals(overriddenMethodArgNullnessMap[i])) {
         // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridding a @NonNull arg.
         continue;
@@ -1464,7 +1460,7 @@ public class NullAway extends BugChecker
 
     final boolean isMethodAnnotated =
         !classAnnotationInfo.isSymbolUnannotated(methodSymbol, config);
-    Map<Integer, Nullness> argumentPositionNullness = new LinkedHashMap<>();
+    Nullness[] argumentPositionNullness = new Nullness[formalParams.size()];
 
     if (isMethodAnnotated) {
       // compute which arguments are @NonNull
@@ -1475,7 +1471,7 @@ public class NullAway extends BugChecker
           if (unboxingCheck != Description.NO_MATCH) {
             return unboxingCheck;
           } else {
-            argumentPositionNullness.put(i, Nullness.NONNULL);
+            argumentPositionNullness[i] = Nullness.NONNULL;
           }
         } else if (ASTHelpers.isSameType(
             param.type, Suppliers.JAVA_LANG_VOID_TYPE.get(state), state)) {
@@ -1485,15 +1481,14 @@ public class NullAway extends BugChecker
           // JSpecify semantics.
           // See the suppression in https://github.com/uber/NullAway/pull/608 for an example of why
           // this is needed.
-          argumentPositionNullness.put(i, Nullness.NULLABLE);
+          argumentPositionNullness[i] = Nullness.NULLABLE;
         } else {
           // we need to call paramHasNullableAnnotation here since the invoked method may be defined
           // in a class file
-          argumentPositionNullness.put(
-              i,
+          argumentPositionNullness[i] =
               Nullness.paramHasNullableAnnotation(methodSymbol, i, config)
                   ? Nullness.NULLABLE
-                  : Nullness.NONNULL);
+                  : Nullness.NONNULL;
         }
       }
     }
@@ -1506,11 +1501,10 @@ public class NullAway extends BugChecker
     // now actually check the arguments
     // NOTE: the case of an invocation on a possibly-null reference
     // is handled by matchMemberSelect()
-    for (Map.Entry<Integer, Nullness> entry : argumentPositionNullness.entrySet()) {
-      if (!entry.getValue().equals(Nullness.NONNULL)) {
+    for (int argPos = 0; argPos < argumentPositionNullness.length; argPos++) {
+      if (!Objects.equals(Nullness.NONNULL, argumentPositionNullness[argPos])) {
         continue;
       }
-      int argPos = entry.getKey();
       ExpressionTree actual = null;
       boolean mayActualBeNull = false;
       if (argPos == formalParams.size() - 1 && methodSymbol.isVarArgs()) {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -14,9 +14,7 @@ import com.uber.nullaway.Config;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.handlers.Handler;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.lang.model.element.Element;
@@ -94,13 +92,12 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     Symbol.MethodSymbol fiMethodSymbol = NullabilityUtil.getFunctionalInterfaceMethod(code, types);
     com.sun.tools.javac.util.List<Symbol.VarSymbol> fiMethodParameters =
         fiMethodSymbol.getParameters();
-    Map<Integer, Nullness> fiArgumentPositionNullness = new LinkedHashMap<>();
+    Nullness[] fiArgumentPositionNullness = new Nullness[fiMethodParameters.size()];
     final boolean isFIAnnotated = !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config);
     if (isFIAnnotated) {
       for (int i = 0; i < fiMethodParameters.size(); i++) {
-        fiArgumentPositionNullness.put(
-            i,
-            Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config) ? NULLABLE : NONNULL);
+        fiArgumentPositionNullness[i] =
+            Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config) ? NULLABLE : NONNULL;
       }
     }
     fiArgumentPositionNullness =
@@ -121,7 +118,10 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         // treat as non-null
         assumed = NONNULL;
       } else {
-        assumed = fiArgumentPositionNullness.getOrDefault(i, NONNULL);
+        assumed = fiArgumentPositionNullness[i];
+        if (assumed == null) {
+          assumed = NONNULL;
+        }
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -92,6 +92,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     Symbol.MethodSymbol fiMethodSymbol = NullabilityUtil.getFunctionalInterfaceMethod(code, types);
     com.sun.tools.javac.util.List<Symbol.VarSymbol> fiMethodParameters =
         fiMethodSymbol.getParameters();
+    // If fiArgumentPositionNullness[i] == null, parameter position i is unannotated
     Nullness[] fiArgumentPositionNullness = new Nullness[fiMethodParameters.size()];
     final boolean isFIAnnotated = !classAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config);
     if (isFIAnnotated) {
@@ -118,10 +119,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         // treat as non-null
         assumed = NONNULL;
       } else {
-        assumed = fiArgumentPositionNullness[i];
-        if (assumed == null) {
-          assumed = NONNULL;
-        }
+        assumed = fiArgumentPositionNullness[i] == null ? NONNULL : fiArgumentPositionNullness[i];
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -43,7 +43,6 @@ import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -119,11 +118,11 @@ public abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  public Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness) {
+      Nullness[] argumentPositionNullness) {
     // NoOp
     return argumentPositionNullness;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -44,7 +44,6 @@ import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -137,11 +136,11 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  public Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness) {
+      Nullness[] argumentPositionNullness) {
     for (Handler h : handlers) {
       argumentPositionNullness =
           h.onOverrideMethodInvocationParametersNullability(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -183,7 +183,8 @@ public interface Handler {
    *     multiple times within the same handler chain.
    * @param argumentPositionNullness Nullness info for each argument position as computed by
    *     upstream handlers and/or the base analysis. Some entries may be {@code null}, indicating
-   *     upstream analysis and handlers model the parameter as unannotated.
+   *     upstream handlers and the base analysis consider the parameter to be nullness-unknown,
+   *     usually since the parameter is from unannotated code.
    * @return The updated nullness info for each argument position, as computed by the current
    *     handler.
    */

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -44,7 +44,6 @@ import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
@@ -187,11 +186,11 @@ public interface Handler {
    *     be incomplete/sparse at this point).
    * @return The updated argument position to nullness map, as computed by the current handler.
    */
-  Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness);
+      Nullness[] argumentPositionNullness);
 
   /**
    * Called when the Dataflow analysis generates the initial NullnessStore for a method or lambda.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -181,10 +181,11 @@ public interface Handler {
    * @param isAnnotated A boolean flag indicating whether the called method is considered to be
    *     within isAnnotated or unannotated code, used to avoid querying for this information
    *     multiple times within the same handler chain.
-   * @param argumentPositionNullness The argument position to nullness map computed by upstream
-   *     handlers and/or the base analysis (though information from the base analysis is allowed to
-   *     be incomplete/sparse at this point).
-   * @return The updated argument position to nullness map, as computed by the current handler.
+   * @param argumentPositionNullness Nullness info for each argument position as computed by
+   *     upstream handlers and/or the base analysis. Some entries may be {@code null}, indicating
+   *     upstream analysis and handlers model the parameter as unannotated.
+   * @return The updated nullness info for each argument position, as computed by the current
+   *     handler.
    */
   Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -124,11 +124,11 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  public Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness) {
+      Nullness[] argumentPositionNullness) {
     if (isAnnotated) {
       // We currently do not load JarInfer models for code marked as annotated.
       // This is unlikely to change, as the behavior of JarInfer on arguments is to explicitly mark
@@ -167,7 +167,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
         // Skip 'this' param for non-static methods
         int nonNullPosition = annotationEntry.getKey() - (methodSymbol.isStatic() ? 0 : 1);
         jiNonNullParams.add(nonNullPosition);
-        argumentPositionNullness.put(nonNullPosition, Nullness.NONNULL);
+        argumentPositionNullness[nonNullPosition] = Nullness.NONNULL;
       }
     }
     if (!jiNonNullParams.isEmpty()) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -79,11 +79,11 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  public Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness) {
+      Nullness[] argumentPositionNullness) {
     OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(context);
     ImmutableSet<Integer> nullableParamsFromModel =
         optimizedLibraryModels.explicitlyNullableParameters(methodSymbol);
@@ -93,7 +93,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     Set<Integer> allPositions = new HashSet<>();
     for (Integer nullParam : nullableParamsFromModel) {
       allPositions.add(nullParam);
-      argumentPositionNullness.put(nullParam, NULLABLE);
+      argumentPositionNullness[nullParam] = NULLABLE;
     }
     for (Integer nonNullParam : nonNullParamsFromModel) {
       if (!allPositions.add(nonNullParam)) {
@@ -103,7 +103,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 "Library models give conflicting nullability for the following parameter of method %s: %s",
                 methodSymbol.getQualifiedName().toString(), nonNullParam.toString()));
       }
-      argumentPositionNullness.put(nonNullParam, NONNULL);
+      argumentPositionNullness[nonNullParam] = NONNULL;
     }
     return argumentPositionNullness;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -36,7 +36,6 @@ import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
 
@@ -78,11 +77,11 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public Map<Integer, Nullness> onOverrideMethodInvocationParametersNullability(
+  public Nullness[] onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      Map<Integer, Nullness> argumentPositionNullness) {
+      Nullness[] argumentPositionNullness) {
     if (isAnnotated) {
       // We ignore isAnnotated code here, since annotations in code considered isAnnotated are
       // already handled
@@ -91,9 +90,9 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
     }
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
       if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
-        argumentPositionNullness.put(i, Nullness.NONNULL);
+        argumentPositionNullness[i] = Nullness.NONNULL;
       } else if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
-        argumentPositionNullness.put(i, Nullness.NULLABLE);
+        argumentPositionNullness[i] = Nullness.NULLABLE;
       }
     }
     return argumentPositionNullness;


### PR DESCRIPTION
The performance improvement from this change is very small at best, and it doesn't seem to fully remove the recent performance regression.  But, this change clearly makes the code more efficient in the common case, and I think a bit easier to read as well.  So we should keep it.  Any remaining performance regression (#645) is probably just due to doing more checking than we were doing before (to fix bugs), so we can tolerate it.

Fixes #645 