### PR TITLE
Add Gradle versions plugin and update some "safe" dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ buildscript {
 }
 plugins {
   id "com.github.sherter.google-java-format" version "0.9"
-  id "net.ltgt.errorprone" version "2.0.1" apply false
+  id "net.ltgt.errorprone" version "2.0.2" apply false
   id "com.github.johnrengelman.shadow" version "6.1.0" apply false
   id "com.github.kt3k.coveralls" version "2.12.0" apply false
-  id "me.champeau.jmh" version "0.6.6" apply false
+  id "me.champeau.jmh" version "0.6.7" apply false
   id "com.github.ben-manes.versions" version "0.42.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ plugins {
   id "com.github.johnrengelman.shadow" version "6.1.0" apply false
   id "com.github.kt3k.coveralls" version "2.12.0" apply false
   id "me.champeau.jmh" version "0.6.6" apply false
+  id "com.github.ben-manes.versions" version "0.42.0"
 }
 
 repositories {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -96,7 +96,7 @@ def support = [
 ]
 
 def test = [
-    junit4                  : "junit:junit:4.12",
+    junit4                  : "junit:junit:4.13.2",
     junit5Jupiter           : ["org.junit.jupiter:junit-jupiter-api:5.0.2","org.apiguardian:apiguardian-api:1.0.0"],
     jetbrainsAnnotations    : "org.jetbrains:annotations:13.0",
     inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
@@ -106,7 +106,7 @@ def test = [
     rxjava2                 : "io.reactivex.rxjava2:rxjava:2.1.2",
     commonsLang3            : "org.apache.commons:commons-lang3:3.8.1",
     commonsLang             : "commons-lang:commons-lang:2.6",
-    lombok                  : "org.projectlombok:lombok:1.18.22",
+    lombok                  : "org.projectlombok:lombok:1.18.24",
     springBeans             : "org.springframework:spring-beans:5.3.7",
     springContext           : "org.springframework:spring-context:5.3.7",
     grpcCore                : "io.grpc:grpc-core:1.15.1", // Should upgrade, but this matches our guava version

--- a/nullaway/src/test/java/com/uber/nullaway/DummyOptionsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/DummyOptionsConfigTest.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.InvocationTargetException;


### PR DESCRIPTION
With the versions plugin, we can run `./gradlew dependencyUpdates` to see which of our dependencies are not the latest version.  Many of these dependencies we may not want to update; e.g., they may be test dependencies against specific artifact versions containing certain annotations.  But it's still good to be able to generate a report.

I also updated a couple of dependencies that are "safe;" they only impact testing code, not anything that ships with NullAway or that NullAway depends on after deployment.