### PR TITLE
[JSpecify] Support @NullUnmarked.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1327,10 +1327,12 @@ public class NullAway extends BugChecker
   }
 
   /**
-   * Returns true iff classSymbol has a direct @NullMarked or @NullUnmarked annotation which differs
-   * from the {@link NullMarking} of the top-level class, meaning the compilation unit is itself
-   * partially marked, and we need to switch to our slower mode for detecting whether we are in
-   * unannotated code.
+   * Check if an inner class's annotation means this Compilation Unit is partially annotated.
+   *
+   * <p>Returns true iff classSymbol has a direct @NullMarked or @NullUnmarked annotation which
+   * differs from the {@link NullMarking} of the top-level class, meaning the compilation unit is
+   * itself partially marked, and we need to switch to our slower mode for detecting whether we are
+   * in unannotated code.
    *
    * @param classSymbol a ClassSymbol representing an inner class within the current compilation
    *     unit.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -559,7 +559,10 @@ public class NullAway extends BugChecker
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
     switch (nullMarkingForTopLevelClass) {
       case FULLY_MARKED:
-        // TODO: Handle @NullUnmarked
+        if (ASTHelpers.hasDirectAnnotationWithSimpleName(
+            methodSymbol, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME)) {
+          nullMarkingForTopLevelClass = NullMarking.PARTIALLY_MARKED;
+        }
         break;
       case FULLY_UNMARKED:
         if (ASTHelpers.hasDirectAnnotationWithSimpleName(
@@ -1364,11 +1367,15 @@ public class NullAway extends BugChecker
       EnclosingEnvironmentNullness.instance(state.context).clear();
     } else {
       // handle the case where the top-class is unannotated, but there is a @NullMarked annotation
-      // on a nested class
-      // TODO handle @NullUnmarked once it is finalized
+      // on a nested class, or, conversely the top-level is annotated but there is a @NullUnmarked
+      // annotation on a nested class.
       if (nullMarkingForTopLevelClass == NullMarking.FULLY_UNMARKED
           && ASTHelpers.hasDirectAnnotationWithSimpleName(
               classSymbol, NullabilityUtil.NULLMARKED_SIMPLE_NAME)) {
+        nullMarkingForTopLevelClass = NullMarking.PARTIALLY_MARKED;
+      } else if (nullMarkingForTopLevelClass == NullMarking.FULLY_MARKED
+          && ASTHelpers.hasDirectAnnotationWithSimpleName(
+              classSymbol, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME)) {
         nullMarkingForTopLevelClass = NullMarking.PARTIALLY_MARKED;
       }
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -58,6 +58,7 @@ import org.checkerframework.nullaway.javacutil.AnnotationUtils;
 /** Helpful utility methods for nullability analysis. */
 public class NullabilityUtil {
   public static final String NULLMARKED_SIMPLE_NAME = "NullMarked";
+  public static final String NULLUNMARKED_SIMPLE_NAME = "NullUnmarked";
 
   private static final Supplier<Type> MAP_TYPE_SUPPLIER = Suppliers.typeFromString("java.util.Map");
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -676,10 +676,11 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "  }",
             "}")
         .addSourceLines(
-            "Test.java",
+            "Test2.java", // Note: Safe to have same-name files in recent Error Prone, but breaks EP
+                          // 2.4.0
             "package com.example.thirdparty.marked;",
             "import com.uber.foo.Foo;",
-            "public class Test {",
+            "public class Test2 {",
             "  public static Object test(Object o) {",
             "    // No errors, because Foo is @NullUnmarked",
             "    Foo.takeNonNull(null);",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -563,4 +563,380 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void nullUnmarkedPackageLevel() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "package-info.java",
+            "@NullUnmarked package com.uber.unmarked;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;")
+        .addSourceLines(
+            "MarkedBecauseAnnotatedFlag.java",
+            "package com.uber.marked;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class MarkedBecauseAnnotatedFlag {",
+            "  public static String nullSafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    if (o1 != null) {",
+            "      return o1.toString();",
+            "    }",
+            "    return s;",
+            "  }",
+            "  @Nullable",
+            "  public static String nullRet() {",
+            "    return null;",
+            "  }",
+            "  public static String unsafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable",
+            "    return o1.toString();",
+            "  }",
+            "}")
+        .addSourceLines(
+            "UnmarkedBecausePackageDirectAnnotation.java",
+            "package com.uber.unmarked;",
+            "import com.uber.marked.MarkedBecauseAnnotatedFlag;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class UnmarkedBecausePackageDirectAnnotation {",
+            "  public static String directlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    // No error: unannotated",
+            "    return o1.toString();",
+            "  }",
+            "  @Nullable",
+            "  public static String nullRet() {",
+            "    return null;",
+            "  }",
+            "  public static String indirectlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    // No error: unannotated",
+            "    return (o1 == null ? MarkedBecauseAnnotatedFlag.nullRet() : o1.toString());",
+            "  }",
+            "}")
+        .addSourceLines(
+            "MarkedImplicitly.java",
+            "package com.uber.unmarked.bar;",
+            "// Note: this package is annotated, because packages do not enclose each other for the purposes",
+            "// of @NullMarked/@NullUnmarked, see https://jspecify.dev/docs/spec#null-marked-scope",
+            "import com.uber.marked.MarkedBecauseAnnotatedFlag;",
+            "import com.uber.unmarked.UnmarkedBecausePackageDirectAnnotation;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class MarkedImplicitly {",
+            "  public static String directlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable",
+            "    return o1.toString();",
+            "  }",
+            "  public static String indirectlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression from method",
+            "    return (o1 == null ? MarkedBecauseAnnotatedFlag.nullRet() : o1.toString());",
+            "  }",
+            "  public static String indirectlyUnsafeStringOrDefaultCallingUnmarked(@Nullable Object o1, String s) {",
+            "    // No error: nullRet() is unannotated",
+            "    return (o1 == null ? UnmarkedBecausePackageDirectAnnotation.nullRet() : o1.toString());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedClassLevel() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "package-info.java",
+            "@NullMarked package com.example.thirdparty.marked;",
+            "import com.example.jspecify.future.annotations.NullMarked;")
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber.foo;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "import org.jspecify.nullness.Nullable;",
+            "@NullUnmarked",
+            "public class Foo {",
+            "  @Nullable",
+            "  public static String nullRet() {",
+            "    return null;",
+            "  }",
+            "  public static String takeNonNull(Object o) {",
+            "    return o.toString();",
+            "  }",
+            "  public static String takeNullable(@Nullable Object o) {",
+            "    return o.toString();",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.foo.Foo;",
+            "public class Test {",
+            "  public static Object test(Object o) {",
+            "    // No errors, because Foo is @NullUnmarked",
+            "    Foo.takeNonNull(null);",
+            "    return Foo.nullRet();",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.example.thirdparty.marked;",
+            "import com.uber.foo.Foo;",
+            "public class Test {",
+            "  public static Object test(Object o) {",
+            "    // No errors, because Foo is @NullUnmarked",
+            "    Foo.takeNonNull(null);",
+            "    return Foo.nullRet();",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedClassLevelOuter() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Bar.java",
+            "package com.uber.foo;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "import org.jspecify.nullness.Nullable;",
+            "@NullUnmarked",
+            "public class Bar {",
+            "  public static class Foo {",
+            "    @Nullable",
+            "    public static String nullRet() {",
+            "      return null;",
+            "    }",
+            "    public static String takeNonNull(Object o) {",
+            "      return o.toString();",
+            "    }",
+            "    public static String takeNullable(@Nullable Object o) {",
+            "      // No errors, because Foo is @NullUnmarked",
+            "      return o.toString();",
+            "    }",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.foo.Bar;",
+            "public class Test {",
+            "  public static Object test(Object o) {",
+            "    // No errors, because Foo is @NullUnmarked",
+            "    Bar.Foo.takeNonNull(null);",
+            "    return Bar.Foo.nullRet();",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedMarkedClassLevelInner() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Bar.java",
+            "package com.uber.foo;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class Bar {",
+            "  @NullUnmarked",
+            "  public static class Foo {",
+            "    @Nullable",
+            "    public static String nullRet() {",
+            "      return null;",
+            "    }",
+            "    public static String takeNonNull(Object o) {",
+            "      return o.toString();",
+            "    }",
+            "    public static String takeNullable(@Nullable Object o) {",
+            "      // No errors, because Foo is @NullUnmarked",
+            "      return o.toString();",
+            "    }",
+            "  }",
+            "  // In marked outer class Bar",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.foo.Bar;",
+            "public class Test {",
+            "  public static Object test(Object o) {",
+            "    // No errors, because Foo is @NullUnmarked",
+            "    Bar.Foo.takeNonNull(null);",
+            "    return Bar.Foo.nullRet();",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedClassLevelDeep() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Bar.java",
+            "package com.uber.foo;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class Bar {",
+            "  @NullUnmarked",
+            "  public static class Foo {",
+            "    @NullMarked",
+            "    public static class Deep {",
+            "      @Nullable",
+            "      public static String nullRet() {",
+            "        return null;",
+            "      }",
+            "      public static String takeNonNull(Object o) {",
+            "        return o.toString();",
+            "      }",
+            "      public static String takeNullable(@Nullable Object o) {",
+            "        // BUG: Diagnostic contains: dereferenced expression o is @Nullable",
+            "        return o.toString();",
+            "      }",
+            "    }",
+            "    // In unmarked inner class Foo",
+            "    public static String sanity() {",
+            "      // No errors, because Foo is @NullUnmarked,",
+            "      return null;",
+            "    }",
+            "  }",
+            "  // In marked outer class Bar",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.foo.Bar;",
+            "public class Test {",
+            "  public static void test(Object o) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'Bar.Foo.Deep.nullRet()'",
+            "    Bar.Foo.Deep.takeNonNull(Bar.Foo.Deep.nullRet());",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedMethodLevel() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "import org.jspecify.nullness.Nullable;",
+            "public class Foo {",
+            "  @NullUnmarked",
+            "  @Nullable",
+            "  public static String callee(@Nullable Object o) {",
+            "    // No error, since this code is unannotated",
+            "    return o.toString();",
+            "  }",
+            "  public static String caller() {",
+            "    // No error, since callee is unannotated",
+            "    return callee(null);",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedOuterMethodLevelWithLocalClass() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Bar.java",
+            "package com.example.thirdparty;",
+            "import com.example.jspecify.future.annotations.NullMarked;",
+            "import com.example.jspecify.future.annotations.NullUnmarked;",
+            "@NullMarked",
+            "public class Bar {",
+            "  public static String takeNonNull(Object o) {",
+            "    return o.toString();",
+            "  }",
+            "  @NullUnmarked",
+            "  public static Object bar1() {",
+            "    class Baz {",
+            "      public void baz() {",
+            "        // No error, unmarked code",
+            "        Bar.takeNonNull(null);",
+            "      }",
+            "    }",
+            "    Baz b = new Baz();",
+            "    b.baz();",
+            "    return b;",
+            "  }",
+            "  @NullUnmarked",
+            "  public static Object bar2() {",
+            "    @NullMarked",
+            "    class Baz {",
+            "      public void baz() {",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        Bar.takeNonNull(null);",
+            "      }",
+            "    }",
+            "    Baz b = new Baz();",
+            "    b.baz();",
+            "    return b;",
+            "  }",
+            "  @NullUnmarked",
+            "  public static Object bar3() {",
+            "    class Baz {",
+            "      @NullMarked",
+            "      public void baz() {",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        Bar.takeNonNull(null);",
+            "      }",
+            "    }",
+            "    Baz b = new Baz();",
+            "    b.baz();",
+            "    return b;",
+            "  }",
+            "  public static String sanity() {",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void bytecodeNullUnmarkedMethodLevel() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.example.jspecify.unannotatedpackage.Methods;",
+            "public class Test {",
+            "  public static void test(Object o) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Methods.Marked.foo(null);",
+            "    Methods.Marked.unchecked(null);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -675,9 +675,9 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "    return null;",
             "  }",
             "}")
+        // Note: Safe to have same-name files in recent Error Prone, but breaks EP 2.4.0
         .addSourceLines(
-            "Test2.java", // Note: Safe to have same-name files in recent Error Prone, but breaks EP
-                          // 2.4.0
+            "Test2.java",
             "package com.example.thirdparty.marked;",
             "import com.uber.foo.Foo;",
             "public class Test2 {",

--- a/test-java-lib/src/main/java/com/example/jspecify/future/annotations/NullUnmarked.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/future/annotations/NullUnmarked.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.jspecify.future.annotations;
+
+// Note: Copied from
+// https://github.com/jspecify/jspecify/blob/main/src/main/java/org/jspecify/nullness/NullUnmarked.java
+// as it isn't part of JSpecify v0.2.0.
+// This annotation should be deleted and its references replaced with
+// org.jspecify.nullness.NullUnmarked once JSpecify v0.3.0 is out.
+// This test resource is not redistributed with NullAway.
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated element and the code transitively {@linkplain
+ * javax.lang.model.element.Element#getEnclosedElements() enclosed} within it is <b>null-unmarked
+ * code</b>: there, type usages generally have <b>unspecified nullness</b> unless explicitly
+ * annotated otherwise.
+ *
+ * <p>This annotation's purpose is to ease migration of a large existing codebase to null-marked
+ * status. It makes it possible to "flip the default" for new code added to a class or package even
+ * before that class or package has been fully migrated. Since new code is the most important code
+ * to analyze, this is strongly recommended as a temporary measure whenever necessary. However, once
+ * a codebase has been fully migrated it would be appropriate to ban use of this annotation.
+ *
+ * <p>For a guided introduction to JSpecify nullness annotations, please see the <a
+ * href="http://jspecify.org/docs/user-guide">User Guide</a>.
+ *
+ * <p><b>Warning:</b> These annotations are under development, and <b>any</b> aspect of their
+ * naming, locations, or design is subject to change until the JSpecify 1.0 release. Moreover,
+ * supporting analysis tools will track with these changes on varying schedules. Releasing a library
+ * using these annotations in its API is <b>strongly discouraged</b> at this time.
+ *
+ * <h2>Null-marked and null-unmarked code</h2>
+ *
+ * <p>{@link NullMarked} and this annotation work as a pair to include and exclude sections of code
+ * from null-marked status.
+ *
+ * <p>Code is considered null-marked if the most narrowly enclosing element annotated with either of
+ * these two annotations is annotated with {@code @NullMarked}.
+ *
+ * <p>Otherwise it is considered null-unmarked. This can happen in two ways: either it is more
+ * narrowly enclosed by a {@code @NullUnmarked}-annotated element than by any
+ * {@code @NullMarked}-annotated element, or neither annotation is present on any enclosing element.
+ * No distinction is made between these cases.
+ *
+ * <h2>Unspecified nullness</h2>
+ *
+ * <p>An unannotated type usage in null-unmarked code has <b>unspecified nullness</b>. There is
+ * <i>some</i> correct way to annotate it, but that information is missing; the usage conveys <b>no
+ * information</b> about whether it includes or excludes {@code null} as a value. Only type usages
+ * within null-unmarked code may have unspecified nullness. (<a
+ * href="https://bit.ly/3ppb8ZC">Why?</a>)
+ *
+ * <p>Unspecified nullness is (will be) explained comprehensively in the <a
+ * href="http://jspecify.org/docs/user-guide">User Guide</a>.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD, CONSTRUCTOR, PACKAGE})
+public @interface NullUnmarked {}

--- a/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
@@ -1,8 +1,9 @@
 package com.example.jspecify.unannotatedpackage;
 
 // Needed for annotating methods, should be removed and replaced with the standard
-// JSpecify @NullMarked annotation once v0.3.0 is out.
+// JSpecify @NullMarked/@NullUnmarked annotations once v0.3.0 is out.
 import com.example.jspecify.future.annotations.NullMarked;
+import com.example.jspecify.future.annotations.NullUnmarked;
 
 public class Methods {
   @NullMarked
@@ -19,5 +20,13 @@ public class Methods {
     public Object unchecked(Object o) {
       return null;
     }
+  }
+
+  @NullMarked
+  public static class Marked {
+    public static void foo(Object o) {}
+
+    @NullUnmarked
+    public static void unchecked(Object o) {}
   }
 }


### PR DESCRIPTION
This PR adds support for JSpecify 0.3.0's `@NullUnmarked` annotation in the following scopes:

- Packages
- Classes
- Methods

We do not yet support the module scope, since we still retain JDK 8 compatibility in NullAway.

Most of this PR is comprised of test cases for `@NullUnmarked` and its interactions with `@NullMarked` and out existing annotated/unannotated code flags. Unfortunately, the matrix of possible interactions is far too large for the test suite to be exhaustive.
