### PR TITLE
Fix crash when querying null-markedness of $primitive.class expressions.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -112,6 +112,22 @@ public final class CodeAnnotationInfo {
   }
 
   /**
+   * Check if the symbol represents the .class field of a primitive type.
+   *
+   * <p>e.g. int.class, boolean.class, void.class, etc.
+   *
+   * @param symbol symbol for entity
+   * @return true iff this symbol represents t.class for a primitive type t.
+   */
+  private boolean isClassFieldOfPrimitiveType(Symbol symbol) {
+    return symbol.name.contentEquals("class")
+        && symbol.owner != null
+        && symbol.owner.getKind().equals(ElementKind.CLASS)
+        && symbol.owner.getQualifiedName().equals(symbol.owner.getSimpleName())
+        && symbol.owner.enclClass() == null;
+  }
+
+  /**
    * Check if a symbol comes from unannotated code.
    *
    * @param symbol symbol for entity
@@ -123,11 +139,8 @@ public final class CodeAnnotationInfo {
     Symbol.ClassSymbol classSymbol;
     if (symbol instanceof Symbol.ClassSymbol) {
       classSymbol = (Symbol.ClassSymbol) symbol;
-    } else if (symbol.name.contentEquals("class")
-        && symbol.owner.getKind().equals(ElementKind.CLASS)
-        && symbol.owner.getQualifiedName().equals(symbol.owner.getSimpleName())
-        && symbol.owner.enclClass() == null) {
-      // As an especial case, int.class, boolean.class, etc, cause ASTHelpers.enclosingClass(...) to
+    } else if (isClassFieldOfPrimitiveType(symbol)) {
+      // As a special case, int.class, boolean.class, etc, cause ASTHelpers.enclosingClass(...) to
       // return null, even though int/boolean/etc. are technically ClassSymbols. We consider this
       // class "field" of primitive types to be always unannotated. (In the future, we could check
       // here for whether java.lang is in the annotated packages, but if it is, I suspect we will

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -123,6 +123,18 @@ public final class CodeAnnotationInfo {
     Symbol.ClassSymbol classSymbol;
     if (symbol instanceof Symbol.ClassSymbol) {
       classSymbol = (Symbol.ClassSymbol) symbol;
+    } else if (symbol.name.contentEquals("class")
+        && symbol.owner.getKind().equals(ElementKind.CLASS)
+        && symbol.owner.getQualifiedName().equals(symbol.owner.getSimpleName())
+        && symbol.owner.enclClass() == null) {
+      // As an especial case, int.class, boolean.class, etc, cause ASTHelpers.enclosingClass(...) to
+      // return null,
+      // even though int/boolean/etc are technically ClassSymbols. We consider this class "field" of
+      // primitive
+      // types to be always unannotated (in the future, we could check here for whether java.lang is
+      // in the annotated
+      // packages, but if it is, I suspect we will have weirder problems than this)
+      return true;
     } else {
       classSymbol = castToNonNull(ASTHelpers.enclosingClass(symbol));
     }

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -119,7 +119,7 @@ public final class CodeAnnotationInfo {
    * @param symbol symbol for entity
    * @return true iff this symbol represents t.class for a primitive type t.
    */
-  private boolean isClassFieldOfPrimitiveType(Symbol symbol) {
+  private static boolean isClassFieldOfPrimitiveType(Symbol symbol) {
     return symbol.name.contentEquals("class")
         && symbol.owner != null
         && symbol.owner.getKind().equals(ElementKind.CLASS)

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -128,12 +128,10 @@ public final class CodeAnnotationInfo {
         && symbol.owner.getQualifiedName().equals(symbol.owner.getSimpleName())
         && symbol.owner.enclClass() == null) {
       // As an especial case, int.class, boolean.class, etc, cause ASTHelpers.enclosingClass(...) to
-      // return null,
-      // even though int/boolean/etc are technically ClassSymbols. We consider this class "field" of
-      // primitive
-      // types to be always unannotated (in the future, we could check here for whether java.lang is
-      // in the annotated
-      // packages, but if it is, I suspect we will have weirder problems than this)
+      // return null, even though int/boolean/etc. are technically ClassSymbols. We consider this
+      // class "field" of primitive types to be always unannotated. (In the future, we could check
+      // here for whether java.lang is in the annotated packages, but if it is, I suspect we will
+      // have weirder problems than this)
       return true;
     } else {
       classSymbol = castToNonNull(ASTHelpers.enclosingClass(symbol));


### PR DESCRIPTION
NullAway 0.10.0 introduces a crash when performing dataflow and encountering expressions of the form `${primitive}.class` (e.g. `int.class`, `boolean.class`, `void.class`).

These expressions look to dataflow and AST analysis like standard field accesses, but calling `ASTHelpers.enclosingClass(symbol)` on the symbol representing e.g. `boolean.class`, returns `null`. 

This is despite `symbol.owner` for these expressions being a non-null `ClassSymbol`. What happens there is that the class symbol for int/boolean/etc is one for which `encClass()` returns `null` rather than itself, which is the behavior for "real" classes. 

Before 0.10.0, we were  skipping this kind of expressions via `NullabilityUtil.mayBeNullFieldFromType(...)`, but after #652, we have a new path through handlers that might attempt to query them for null-markedness.

We _could_ skip these fields by partitioning `NullabilityUtil.mayBeNullFieldFromType(...)` into two different methods performing two separate checks:

- One checking for `symbol.getSimpleName().toString().equals("class") || symbol.isEnum()` and aborting `visitFieldAccess(...)` early, without worrying about `handler.onDataflowVisitFieldAccess(...)`
- One checking for `!codeAnnotationInfo.isSymbolUnannotated(symbol, config) && Nullness.hasNullableAnnotation(symbol, config)` and combined with the results from any handler.

That said, a potentially more robust approach (and the one this PR takes), requiring less careful maintenance of invariants, is to add handling of `${primitive}.class` directly into  `CodeAnnotationInfo::isSymbolUnannotated`. This should prevent a similar bug from being re-introduced through a different checking path, which is important given the difficultly of debugging dataflow issues.

This PR also contains a small unrelated test case for static import that appeared to be related during triage of this bug, but ultimately turned out not to be. It remains a useful test to have.