### PR TITLE
Build and test against Error Prone 2.15.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.14.0
+            epVersion: 2.15.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.14.0
+            epVersion: 2.15.0
           - os: windows-latest
             java: 11
-            epVersion: 2.14.0
+            epVersion: 2.15.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.14.0
+            epVersion: 2.15.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +70,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.14.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.15.0' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
   publish_snapshot:

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ subprojects { project ->
             check("MutablePublicArray", CheckSeverity.OFF)
             // this check is too noisy
             check("StringSplitter", CheckSeverity.OFF)
+            // https://github.com/google/error-prone/issues/3366
+            check("CanIgnoreReturnValueSuggester", CheckSeverity.OFF)
             check("WildcardImport", CheckSeverity.ERROR)
             check("MissingBraces", CheckSeverity.ERROR)
             check("TypeToString", CheckSeverity.ERROR)

--- a/build.gradle
+++ b/build.gradle
@@ -64,19 +64,22 @@ subprojects { project ->
             "-Xlint:unchecked",
             "-Werror"
         ]
-        options.errorprone {
-            // disable warnings in generated code; AutoValue code fails UnnecessaryParentheses check
-            disableWarningsInGeneratedCode = true
-            // Triggers for generated Android code (R.java)
-            check("MutablePublicArray", CheckSeverity.OFF)
-            // this check is too noisy
-            check("StringSplitter", CheckSeverity.OFF)
-            // https://github.com/google/error-prone/issues/3366
-            check("CanIgnoreReturnValueSuggester", CheckSeverity.OFF)
-            check("WildcardImport", CheckSeverity.ERROR)
-            check("MissingBraces", CheckSeverity.ERROR)
-            check("TypeToString", CheckSeverity.ERROR)
-            check("SymbolToString", CheckSeverity.ERROR)
+        if (JavaVersion.current().isJava9Compatible()) {
+            options.errorprone {
+                // disable warnings in generated code; AutoValue code fails UnnecessaryParentheses check
+                disableWarningsInGeneratedCode = true
+                // this check is too noisy
+                check("StringSplitter", CheckSeverity.OFF)
+                // https://github.com/google/error-prone/issues/3366
+                check("CanIgnoreReturnValueSuggester", CheckSeverity.OFF)
+                check("WildcardImport", CheckSeverity.ERROR)
+                check("MissingBraces", CheckSeverity.ERROR)
+                check("TypeToString", CheckSeverity.ERROR)
+                check("SymbolToString", CheckSeverity.ERROR)
+            }
+        } else {
+            // disable Error Prone checking of our code on JDK 8, as more recent versions don't run on JDK 8
+            options.errorprone.enabled = false
         }
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.4.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.14.0"
+def latestErrorProneVersion = "2.15.0"
 // Default to using latest tested Error Prone version, except on Java 8, where 2.10.0 is the last version
 // that works
 def defaultErrorProneVersion =  JavaVersion.current() >= JavaVersion.VERSION_11 ? latestErrorProneVersion : "2.10.0"


### PR DESCRIPTION
EP 2.15.0 has a check enabled by default that we want to disable (see https://github.com/google/error-prone/issues/3366).  We cannot just disable this check with the existing config, since it does not exist in version 2.10.0, the latest version that works with JDK 8.  Rather than adding conditional config around this one check, this PR disables compiling our code with Error Prone checks on JDK 8.  We still check all our code with Error Prone on JDK 11+, and we are still running our own tests on JDK 8 (for now; see #634).

Beyond the config changes, no code changes were required.