### PR TITLE
PreconditionsHandler reflects Guava Preconditions exception types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/PreconditionsHandler.java
@@ -19,7 +19,8 @@ public class PreconditionsHandler extends BaseNoOpHandler {
   @Nullable private Name preconditionsClass;
   @Nullable private Name checkArgumentMethod;
   @Nullable private Name checkStateMethod;
-  @Nullable TypeMirror preconditionErrorType;
+  @Nullable TypeMirror preconditionCheckArgumentErrorType;
+  @Nullable TypeMirror preconditionCheckStateErrorType;
 
   @Override
   public MethodInvocationNode onCFGBuildPhase1AfterVisitMethodInvocation(
@@ -31,13 +32,18 @@ public class PreconditionsHandler extends BaseNoOpHandler {
       preconditionsClass = callee.name.table.fromString(PRECONDITIONS_CLASS_NAME);
       checkArgumentMethod = callee.name.table.fromString(CHECK_ARGUMENT_METHOD_NAME);
       checkStateMethod = callee.name.table.fromString(CHECK_STATE_METHOD_NAME);
-      preconditionErrorType = phase.classToErrorType(IllegalArgumentException.class);
+      preconditionCheckArgumentErrorType = phase.classToErrorType(IllegalArgumentException.class);
+      preconditionCheckStateErrorType = phase.classToErrorType(IllegalStateException.class);
     }
-    Preconditions.checkNotNull(preconditionErrorType);
+    Preconditions.checkNotNull(preconditionCheckArgumentErrorType);
+    Preconditions.checkNotNull(preconditionCheckStateErrorType);
     if (callee.enclClass().getQualifiedName().equals(preconditionsClass)
-        && (callee.name.equals(checkArgumentMethod) || callee.name.equals(checkStateMethod))
-        && callee.getParameters().size() > 0) {
-      phase.insertThrowOnFalse(originalNode.getArgument(0), preconditionErrorType);
+        && !callee.getParameters().isEmpty()) {
+      if (callee.name.equals(checkArgumentMethod)) {
+        phase.insertThrowOnFalse(originalNode.getArgument(0), preconditionCheckArgumentErrorType);
+      } else if (callee.name.equals(checkStateMethod)) {
+        phase.insertThrowOnFalse(originalNode.getArgument(0), preconditionCheckStateErrorType);
+      }
     }
     return originalNode;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayPreconditionTests.java
@@ -222,4 +222,52 @@ public class NullAwayPreconditionTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void checkArgumentCatchException() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    try {",
+            "      Preconditions.checkArgument(a != null);",
+            "    } catch (IllegalArgumentException e) {}",
+            "    // BUG: Diagnostic contains: dereferenced expression a is @Nullable",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void checkStateCatchException() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.google.common.base.Preconditions;",
+            "class Test {",
+            "  private void foo(@Nullable Object a) {",
+            "    try {",
+            "      Preconditions.checkState(a != null);",
+            "    } catch (IllegalStateException e) {}",
+            "    // BUG: Diagnostic contains: dereferenced expression a is @Nullable",
+            "    a.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Note that this shouldn't impact analysis as the throw statement is added after the preconditions method invocation, thus we cannot be confident the method invocation doesn't throw _other_ types of exceptions. This is meant to ensure the code follows [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)

This was an oddity that I noticed while investigating options for #667. I understand if you'd prefer not to merge the change given that it doesn't have an impact on the result, I just thought I'd write something down while it was on my mind.
