### PR TITLE
checkerframework 3.26.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.24.0",
+    checkerFramework       : "3.26.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -676,8 +676,8 @@ public class AccessPathNullnessPropagation
   }
 
   private static boolean hasNonNullConstantValue(LocalVariableNode node) {
-    if (node.getElement() instanceof VariableElement) {
-      VariableElement element = (VariableElement) node.getElement();
+    VariableElement element = node.getElement();
+    if (element != null) {
       return (element.getConstantValue() != null);
     }
     return false;


### PR DESCRIPTION
Updates NullAway to use recently released [checkerframework 3.26.0](https://github.com/typetools/checker-framework/releases/tag/checker-framework-3.26.0) to resolve ABI breaks in checkerframework.

Closes https://github.com/uber/NullAway/issues/670