### PR TITLE
fix #676 Fix a NPE using CheckOptionalEmptiness=true

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -348,7 +348,7 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
         if (elements.size() == 1) {
           // We only care for single method call chains (e.g. this.foo(), not this.f.bar())
           Element element = elements.get(0).getJavaElement();
-          if (!element.getKind().equals(ElementKind.METHOD)) {
+          if (!ElementKind.METHOD.equals(element.getKind())) {
             // We are only looking for method APs
             continue;
           }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayOptionalEmptinessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayOptionalEmptinessTests.java
@@ -505,4 +505,32 @@ public class NullAwayOptionalEmptinessTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void optionalOfMapResultTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Map;",
+            "import java.util.Optional;",
+            "class Test {",
+            "  private Optional<String> f(Map<String, String> map1, Map<String, String> map2) {",
+            "    Optional<String> opt = Optional.ofNullable(map1.get(\"key\"));",
+            "    if (!opt.isPresent()) {",
+            "      return Optional.empty();",
+            "    }",
+            "    return map2.entrySet().stream()",
+            "      .filter(entry -> entry.getValue().equals(opt.get()))",
+            "      .map(Map.Entry::getKey)",
+            "      .findFirst();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This adds a minimal reproducer test case for the failure, which I've verified reproduces the NPE on both Java 11 and Java 17. I've also included a minimal bugfix for the issue, however I suspect we should approach it slightly differently in order to prevent similar regressions in the future.

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [X] A description about what and why you are contributing, even if it's trivial.

  - [X] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [X] If applicable, unit tests.
