### PR TITLE
Add serialization version

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -74,7 +74,6 @@ public class Serializer {
     try (Writer fileWriter =
         Files.newBufferedWriter(versionOutputPath.toFile().toPath(), Charset.defaultCharset())) {
       fileWriter.write(SERIALIZATION_VERSION + "");
-      fileWriter.flush();
     } catch (IOException exception) {
       throw new RuntimeException("Could not serialize output version", exception);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -52,7 +52,7 @@ public class Serializer {
    * Version for all serialized outputs. Outputs formats may change overtime, this version is
    * serialized to keep track of changes.
    */
-  private static final int SERIALIZATION_VERSION = 1;
+  public static final int SERIALIZATION_VERSION = 1;
 
   public Serializer(FixSerializationConfig config) {
     String outputDirectory = config.outputDirectory;

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -34,6 +34,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.annotation.Nullable;
 
 /**
  * Serializer class where all generated files in Fix Serialization package is created through APIs
@@ -68,7 +69,7 @@ public class Serializer {
    *
    * @param outputDirectory Path to root directory for all serialized outputs.
    */
-  private void serializeVersion(String outputDirectory) {
+  private void serializeVersion(@Nullable String outputDirectory) {
     Path versionOutputPath = Paths.get(outputDirectory).resolve("serialization_version.txt");
     try (Writer fileWriter =
         Files.newBufferedWriter(versionOutputPath.toFile().toPath(), Charset.defaultCharset())) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -1659,7 +1659,7 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
       Preconditions.checkArgument(Integer.parseInt(lines.get(0)) == SERIALIZATION_VERSION);
     } catch (IOException e) {
       throw new RuntimeException(
-          "Could not ready serialization version at path: " + serializationVersionPath, e);
+          "Could not read serialization version at path: " + serializationVersionPath, e);
     }
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -1653,7 +1653,7 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
     Path serializationVersionPath = root.resolve("serialization_version.txt");
     try {
       List<String> lines = Files.readAllLines(serializationVersionPath);
-      // Check it contains only one line.
+      // Check if it contains only one line.
       Preconditions.checkArgument(lines.size() == 1);
       // Check the serialized version.
       Preconditions.checkArgument(Integer.parseInt(lines.get(0)) == SERIALIZATION_VERSION);

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.FixSerializationConfig;
+import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 import com.uber.nullaway.fixserialization.out.FieldInitializationInfo;
 import com.uber.nullaway.fixserialization.out.SuggestedNullableFixInfo;
@@ -66,8 +67,6 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
   private static final String ERROR_FILE_HEADER = ErrorInfo.header();
   private static final String FIELD_INIT_FILE_NAME = "field_init.tsv";
   private static final String FIELD_INIT_HEADER = FieldInitializationInfo.header();
-
-  private static final int SERIALIZATION_VERSION = 1;
 
   public NullAwaySerializationTest() {
     this.fixDisplayFactory =
@@ -1656,7 +1655,8 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
       // Check if it contains only one line.
       Preconditions.checkArgument(lines.size() == 1);
       // Check the serialized version.
-      Preconditions.checkArgument(Integer.parseInt(lines.get(0)) == SERIALIZATION_VERSION);
+      Preconditions.checkArgument(
+          Integer.parseInt(lines.get(0)) == Serializer.SERIALIZATION_VERSION);
     } catch (IOException e) {
       throw new RuntimeException(
           "Could not read serialization version at path: " + serializationVersionPath, e);


### PR DESCRIPTION
Adds a version for all outputs of serialization features. Format of serialized outputs may change over time. This version serialization helps users to keep track of changes or maintain compatibility with previous versions of outputs.

If `SerializeFixMetadata` is activated, a file with name `serialization_version.txt` will be created under the root directory for all serialization outputs containing the version as string.


