### PR TITLE
Field region computation bug fix

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMemberInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/ClassAndMemberInfo.java
@@ -86,7 +86,7 @@ public class ClassAndMemberInfo {
         // Node is not enclosed by any method, can be a field declaration or enclosed by it.
         Symbol sym = ASTHelpers.getSymbol(path.getLeaf());
         Symbol.VarSymbol fieldSymbol = null;
-        if (sym != null && sym.getKind().isField()) {
+        if (sym != null && sym.getKind().isField() && sym.isEnclosedBy(classSymbol)) {
           // Directly on a field declaration.
           fieldSymbol = (Symbol.VarSymbol) sym;
         } else {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -1686,11 +1686,14 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
             "   // BUG: Diagnostic contains: dereferenced expression b2 is @Nullable",
             "   Object baz2 = b2.foo;",
             "   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field",
-            "   Object baz3 = b1.c.val;",
+            "   Object baz3 = b1.nonnullC.val;",
+            "   // BUG: Diagnostic contains: dereferenced expression b1.nullableC is @Nullable",
+            "   @Nullable Object baz4 = b1.nullableC.val;",
             "}",
             "class B {",
             "   @Nullable Object foo;",
-            "   C c = new C();",
+            "   C nonnullC = new C();",
+            "   @Nullable C nullableC = new C();",
             "}",
             "class C {",
             "   @Nullable Object val;",
@@ -1733,7 +1736,12 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "DEREFERENCE_NULLABLE",
                 "dereferenced expression b2 is @Nullable",
                 "com.uber.A",
-                "baz2"))
+                "baz2"),
+            new ErrorDisplay(
+                "DEREFERENCE_NULLABLE",
+                "dereferenced expression b1.nullableC is @Nullable",
+                "com.uber.A",
+                "baz4"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -1662,4 +1662,67 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
           "Could not read serialization version at path: " + serializationVersionPath, e);
     }
   }
+
+  @Test
+  public void fieldRegionComputationForInnerClassTest() {
+    SerializationTestHelper<ErrorDisplay> tester = new SerializationTestHelper<>(root);
+    tester
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SerializeFixMetadata=true",
+                "-XepOpt:NullAway:FixSerializationConfigPath=" + configPath))
+        .addSourceLines(
+            "com/uber/A.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class A {",
+            "   Other other1 = new Other();",
+            "   @Nullable Other other2 = null;",
+            "   public void bar(){",
+            "      class Foo {;",
+            "          // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field",
+            "          Object baz1 = other1.foo;",
+            "          // BUG: Diagnostic contains: dereferenced expression other2 is @Nullable",
+            "          Object baz2 = other2.foo;",
+            "      }",
+            "   }",
+            "}",
+            "class Other {",
+            "   @Nullable Object foo;",
+            "}")
+        .setExpectedOutputs(
+            new ErrorDisplay(
+                "ASSIGN_FIELD_NULLABLE",
+                "assigning @Nullable expression to @NonNull field",
+                "com.uber.A$1Foo",
+                "baz1",
+                "FIELD",
+                "com.uber.A$1Foo",
+                "null",
+                "baz1",
+                "null",
+                "com/uber/A.java"),
+            new ErrorDisplay(
+                "ASSIGN_FIELD_NULLABLE",
+                "assigning @Nullable expression to @NonNull field",
+                "com.uber.A$1Foo",
+                "baz2",
+                "FIELD",
+                "com.uber.A$1Foo",
+                "null",
+                "baz2",
+                "null",
+                "com/uber/A.java"),
+            new ErrorDisplay(
+                "DEREFERENCE_NULLABLE",
+                "dereferenced expression other2 is @Nullable",
+                "com.uber.A$1Foo",
+                "baz2"))
+        .setFactory(errorDisplayFactory)
+        .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwaySerializationTest.java
@@ -1679,15 +1679,21 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "public class A {",
-            "   Other other1 = new Other();",
-            "   @Nullable Other other2 = null;",
+            "   B b1 = new B();",
+            "   @Nullable B b2 = null;",
             "   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field",
-            "   Object baz1 = other1.foo;",
-            "   // BUG: Diagnostic contains: dereferenced expression other2 is @Nullable",
-            "   Object baz2 = other2.foo;",
+            "   Object baz1 = b1.foo;",
+            "   // BUG: Diagnostic contains: dereferenced expression b2 is @Nullable",
+            "   Object baz2 = b2.foo;",
+            "   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field",
+            "   Object baz3 = b1.c.val;",
             "}",
-            "class Other {",
+            "class B {",
             "   @Nullable Object foo;",
+            "   C c = new C();",
+            "}",
+            "class C {",
+            "   @Nullable Object val;",
             "}")
         .setExpectedOutputs(
             new ErrorDisplay(
@@ -1713,8 +1719,19 @@ public class NullAwaySerializationTest extends NullAwayTestsBase {
                 "null",
                 "com/uber/A.java"),
             new ErrorDisplay(
+                "ASSIGN_FIELD_NULLABLE",
+                "assigning @Nullable expression to @NonNull field",
+                "com.uber.A",
+                "baz3",
+                "FIELD",
+                "com.uber.A",
+                "null",
+                "baz3",
+                "null",
+                "com/uber/A.java"),
+            new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression other2 is @Nullable",
+                "dereferenced expression b2 is @Nullable",
                 "com.uber.A",
                 "baz2"))
         .setFactory(errorDisplayFactory)


### PR DESCRIPTION
This PR fixes a bug in field region computations. The bug is in the computation of region for fields initialized through chain of  member selects. Please see the example below:

```java
class C{
  @Nullable Object val;
}
class B{
   C c = new C();
}
class A {
    B b = new B();
    Object f = b.c.val;
}
```

For expression `Object f = b.c.val;` which causes an `ASSIGN_NULLABLE` error (`val` is `@Nullable`) the computed region is `null`. This PR resolves this bug by correctly computing the region and setting `f` as the region where the error is reported.