### PR TITLE
Update to JSpecify 0.3-alpha-2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,7 +75,7 @@ def build = [
     checkerDataflow         : "org.checkerframework:dataflow-nullaway:${versions.checkerFramework}",
     guava                   : "com.google.guava:guava:24.1.1-jre",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
-    jspecify                : "org.jspecify:jspecify:0.3.0-alpha-1",
+    jspecify                : "org.jspecify:jspecify:0.3.0-alpha-2",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
     commonsIO               : "commons-io:commons-io:2.11.0",
     wala                    : ["com.ibm.wala:com.ibm.wala.util:${versions.wala}",

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -67,7 +67,7 @@ public final class CodeAnnotationInfo {
   /**
    * Checks if a symbol comes from an annotated package, as determined by either configuration flags
    * (e.g. {@code -XepOpt:NullAway::AnnotatedPackages}) or package level annotations (e.g. {@code
-   * org.jspecify.nullness.NullMarked}).
+   * org.jspecify.annotations.NullMarked}).
    *
    * @param outermostClassSymbol symbol for class (must be an outermost class)
    * @param config NullAway config

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -196,7 +196,7 @@ public class NullAway extends BugChecker
     FULLY_UNMARKED,
     /**
      * class has a mix of annotatedness, depending on presence of {@link
-     * org.jspecify.nullness.NullMarked} annotations
+     * org.jspecify.annotations.NullMarked} annotations
      */
     PARTIALLY_MARKED
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -565,7 +565,7 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "import java.util.Map;",
             "import java.util.function.Function;",
             // Need JSpecify (vs javax) for annotating generics
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "   Object testComputeIfAbsent(String key, Function<String, Object> f, Map<String, Object> m){",
             "     m.computeIfAbsent(key, f);",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -12,7 +12,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class NonNullTypeParam<E> {}",
             "    static class NullableTypeParam<E extends @Nullable Object> {}",
@@ -32,7 +32,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class NonNullTypeParam<E> {}",
             "    static class NullableTypeParam<E extends @Nullable Object> {}",
@@ -62,7 +62,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class MixedTypeParam<E1, E2 extends @Nullable Object, E3 extends @Nullable Object, E4> {}",
             "    // BUG: Diagnostic contains: Generic type parameter",
@@ -82,7 +82,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class NonNullTypeParam<E> {}",
             "    static class NullableTypeParam<E extends @Nullable Object> {}",
@@ -101,7 +101,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static interface NonNullTypeParamInterface<E>{}",
             "    static interface NullableTypeParamInterface<E extends @Nullable Object>{}",
@@ -118,7 +118,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class NonNullTypeParam<E> {}",
             "    static class NullableTypeParam<E extends @Nullable Object> {}",
@@ -141,7 +141,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "    static class NonNullTypeParam<E> {}",
             "    static class NullableTypeParam<E extends @Nullable Object> {}",
@@ -163,7 +163,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
             "Test.java",
             "package com.uber;",
             "import lombok.NonNull;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             " static class NonNullTypeParam<E> {}",
             " static class DifferentAnnotTypeParam1<E extends @NonNull Object> {}",
@@ -187,7 +187,7 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "  static class NonNullTypeParam<E> { }",
             "  static void instOf(Object o) {",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyTests.java
@@ -11,11 +11,11 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "package-info.java",
             "@NullMarked package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;")
+            "import org.jspecify.annotations.NullMarked;")
         .addSourceLines(
             "ThirdPartyAnnotatedUtils.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class ThirdPartyAnnotatedUtils {",
             "  public static String toStringOrDefault(@Nullable Object o1, String s) {",
             "    if (o1 != null) {",
@@ -48,11 +48,11 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "package-info.java",
             "@NullMarked package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;")
+            "import org.jspecify.annotations.NullMarked;")
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Foo {",
             "  public static String foo(String s) {",
             "    return s;",
@@ -71,7 +71,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "public class Foo {",
             "  public static String foo(String s) {",
@@ -97,7 +97,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "public class Foo {",
             "  public static String foo(String s) {",
@@ -117,8 +117,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "public class Bar {",
             "  public static class Foo {",
@@ -146,8 +146,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static class Foo {",
@@ -177,8 +177,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static class Foo {",
@@ -206,8 +206,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Test {",
             "  public static Object test() {",
             "    Object x = null;",
@@ -240,7 +240,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -268,7 +268,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -278,7 +278,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Bar {",
             "  public static void bar1() {",
             "    // No report, unannotated caller!",
@@ -299,7 +299,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -309,7 +309,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static Runnable runFoo() {",
@@ -336,7 +336,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static IConsumer getConsumer() {",
@@ -367,7 +367,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Foo {",
             "  @NullMarked",
             "  public static String foo(String s) {",
@@ -377,7 +377,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Bar {",
             "  @NullMarked",
             "  public static Object bar() {",
@@ -401,7 +401,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "public class Test {",
             "  @NullMarked",
             "  public static Object test() {",
@@ -452,11 +452,11 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "package-info.java",
             "@NullMarked package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;")
+            "import org.jspecify.annotations.NullMarked;")
         .addSourceLines(
             "Foo.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Foo {",
             "  public static String foo(String s) {",
             "    return s;",
@@ -553,7 +553,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "Test.java",
             "package com.uber;",
             "import com.example.jspecify.unannotatedpackage.Methods;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Test extends Methods.ExtendMe {",
             "  @Nullable",
             "  // BUG: Diagnostic contains: method returns @Nullable, but superclass method",
@@ -570,11 +570,11 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "package-info.java",
             "@NullUnmarked package com.uber.unmarked;",
-            "import org.jspecify.nullness.NullUnmarked;")
+            "import org.jspecify.annotations.NullUnmarked;")
         .addSourceLines(
             "MarkedBecauseAnnotatedFlag.java",
             "package com.uber.marked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class MarkedBecauseAnnotatedFlag {",
             "  public static String nullSafeStringOrDefault(@Nullable Object o1, String s) {",
             "    if (o1 != null) {",
@@ -595,7 +595,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "UnmarkedBecausePackageDirectAnnotation.java",
             "package com.uber.unmarked;",
             "import com.uber.marked.MarkedBecauseAnnotatedFlag;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class UnmarkedBecausePackageDirectAnnotation {",
             "  public static String directlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
             "    // No error: unannotated",
@@ -617,7 +617,7 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "// of @NullMarked/@NullUnmarked, see https://jspecify.dev/docs/spec#null-marked-scope",
             "import com.uber.marked.MarkedBecauseAnnotatedFlag;",
             "import com.uber.unmarked.UnmarkedBecausePackageDirectAnnotation;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class MarkedImplicitly {",
             "  public static String directlyUnsafeStringOrDefault(@Nullable Object o1, String s) {",
             "    // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable",
@@ -641,12 +641,12 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "package-info.java",
             "@NullMarked package com.example.thirdparty.marked;",
-            "import org.jspecify.nullness.NullMarked;")
+            "import org.jspecify.annotations.NullMarked;")
         .addSourceLines(
             "Foo.java",
             "package com.uber.foo;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "@NullUnmarked",
             "public class Foo {",
             "  @Nullable",
@@ -700,8 +700,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.uber.foo;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "@NullUnmarked",
             "public class Bar {",
             "  public static class Foo {",
@@ -742,8 +742,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.uber.foo;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Bar {",
             "  @NullUnmarked",
             "  public static class Foo {",
@@ -789,9 +789,9 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.uber.foo;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Bar {",
             "  @NullUnmarked",
             "  public static class Foo {",
@@ -844,8 +844,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "public class Foo {",
             "  @NullUnmarked",
             "  @Nullable",
@@ -871,8 +871,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Bar.java",
             "package com.example.thirdparty;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.NullUnmarked;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.NullUnmarked;",
             "@NullMarked",
             "public class Bar {",
             "  public static String takeNonNull(Object o) {",
@@ -953,9 +953,9 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.NullUnmarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "import org.jspecify.annotations.Nullable;",
             "@NullUnmarked",
             "public class Foo {",
             "  // No initialization warning, Foo is unmarked",
@@ -999,8 +999,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "StaticMethods.java",
             "package com.uber;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
             "public final class StaticMethods {",
             "  private StaticMethods() {}",
             "  @NullMarked",
@@ -1028,8 +1028,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
             "import static com.uber.StaticMethods.nullableCallee;",
             "import static com.uber.StaticMethods.unmarkedCallee;",
             "import static com.uber.StaticMethods.unmarkedNullableCallee;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
             "@NullMarked",
             "public class Test {",
             "  public Object getNewObject() {",
@@ -1062,8 +1062,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
             "import java.lang.reflect.Field;",
             "@NullMarked",
             "public class Test {",
@@ -1104,8 +1104,8 @@ public class NullAwayJSpecifyTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.NullMarked;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
             "import java.lang.reflect.Field;",
             "@NullMarked",
             "public class Test {",

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTypeUseAnnotationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTypeUseAnnotationTests.java
@@ -9,7 +9,7 @@ public class NullAwayTypeUseAnnotationTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "import java.util.function.Supplier;",
             "public class Test {",
             "  public static <R> @Nullable Supplier<@Nullable R> getNullableSupplierOfNullable() {",

--- a/test-java-lib/src/main/java/com/example/jspecify/annotatedpackage/Utils.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/annotatedpackage/Utils.java
@@ -1,6 +1,6 @@
 package com.example.jspecify.annotatedpackage;
 
-import org.jspecify.nullness.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class Utils {
 

--- a/test-java-lib/src/main/java/com/example/jspecify/annotatedpackage/package-info.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/annotatedpackage/package-info.java
@@ -1,4 +1,4 @@
 @NullMarked
 package com.example.jspecify.annotatedpackage;
 
-import org.jspecify.nullness.NullMarked;
+import org.jspecify.annotations.NullMarked;

--- a/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Methods.java
@@ -1,7 +1,7 @@
 package com.example.jspecify.unannotatedpackage;
 
-import org.jspecify.nullness.NullMarked;
-import org.jspecify.nullness.NullUnmarked;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
 
 public class Methods {
   @NullMarked

--- a/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Outer.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/Outer.java
@@ -1,6 +1,6 @@
 package com.example.jspecify.unannotatedpackage;
 
-import org.jspecify.nullness.NullMarked;
+import org.jspecify.annotations.NullMarked;
 
 public class Outer {
   @NullMarked

--- a/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/TopLevel.java
+++ b/test-java-lib/src/main/java/com/example/jspecify/unannotatedpackage/TopLevel.java
@@ -1,6 +1,6 @@
 package com.example.jspecify.unannotatedpackage;
 
-import org.jspecify.nullness.NullMarked;
+import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class TopLevel {


### PR DESCRIPTION
Change all occurrences of `org.jspecify.nullness` to `org.jspecify.annotations` to match the new package structure.  Note that this change only impacts test code; the main NullAway code does not (yet) have any JSpecify dependence.