### PR TITLE
Fix logic for @Nullable annotation on type parameter

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -280,9 +280,12 @@ public class NullabilityUtil {
           (t) ->
               // location is a list of TypePathEntry objects, indicating whether the annotation is
               // on an array, inner type, wildcard, or type argument. If it's empty, then the
-              // annotation
-              // is directly on the return type.
+              // annotation is directly on the return type.
               t.position.type.equals(TargetType.METHOD_RETURN) && t.position.location.isEmpty());
+    } else if (symbol instanceof Symbol.VarSymbol) {
+      // again, we only want annotations directly on the type, so we check that location is empty
+      // (see comment above)
+      return rawTypeAttributes.filter((t) -> t.position.location.isEmpty());
     }
     return rawTypeAttributes;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -284,7 +284,7 @@ public class NullabilityUtil {
           (t) -> t.position.type.equals(TargetType.METHOD_RETURN) && isDirectTypeUseAnnotation(t));
     } else {
       // filter for annotations directly on the type
-      return rawTypeAttributes.filter((t) -> isDirectTypeUseAnnotation(t));
+      return rawTypeAttributes.filter(NullabilityUtil::isDirectTypeUseAnnotation);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -272,22 +272,27 @@ public class NullabilityUtil {
                         && t.position.parameter_index == paramInd));
   }
 
+  /**
+   * Gets the type use annotations on a symbol, ignoring annotations on components of the type (type
+   * arguments, wildcards, etc.)
+   */
   private static Stream<? extends AnnotationMirror> getTypeUseAnnotations(Symbol symbol) {
     Stream<Attribute.TypeCompound> rawTypeAttributes = symbol.getRawTypeAttributes().stream();
     if (symbol instanceof Symbol.MethodSymbol) {
-      // for methods, we want the type-use annotations on the return type
+      // for methods, we want annotations on the return type
       return rawTypeAttributes.filter(
-          (t) ->
-              // location is a list of TypePathEntry objects, indicating whether the annotation is
-              // on an array, inner type, wildcard, or type argument. If it's empty, then the
-              // annotation is directly on the return type.
-              t.position.type.equals(TargetType.METHOD_RETURN) && t.position.location.isEmpty());
-    } else if (symbol instanceof Symbol.VarSymbol) {
-      // again, we only want annotations directly on the type, so we check that location is empty
-      // (see comment above)
-      return rawTypeAttributes.filter((t) -> t.position.location.isEmpty());
+          (t) -> t.position.type.equals(TargetType.METHOD_RETURN) && isDirectTypeUseAnnotation(t));
+    } else {
+      // filter for annotations directly on the type
+      return rawTypeAttributes.filter((t) -> isDirectTypeUseAnnotation(t));
     }
-    return rawTypeAttributes;
+  }
+
+  private static boolean isDirectTypeUseAnnotation(Attribute.TypeCompound t) {
+    // location is a list of TypePathEntry objects, indicating whether the annotation is
+    // on an array, inner type, wildcard, or type argument. If it's empty, then the
+    // annotation is directly on the type.
+    return t.position.location.isEmpty();
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -960,4 +960,34 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void annotationAppliedToTypeParameter() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "class TypeArgumentAnnotation {",
+            "  List<@Nullable String> fSafe = new ArrayList<>();",
+            "  @Nullable List<String> fUnsafe = new ArrayList<>();",
+            "  void useParamSafe(List<@Nullable String> list) {",
+            "    list.hashCode();",
+            "  }",
+            "  void useParamUnsafe(@Nullable List<String> list) {",
+            "    // BUG: Diagnostic contains: dereferenced",
+            "    list.hashCode();",
+            "  }",
+            "  void useFieldSafe() {",
+            "    fSafe.hashCode();",
+            "  }",
+            "  void useFieldUnsafe() {",
+            "    // BUG: Diagnostic contains: dereferenced",
+            "    fUnsafe.hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
We had logic to not consider type use annotations on type parameters when they appeared in return types, but not parameter types or field types.

Fixes #701 