### PR TITLE
Update to Error Prone 2.18.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.17.0
+            epVersion: 2.18.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.17.0
+            epVersion: 2.18.0
           - os: windows-latest
             java: 11
-            epVersion: 2.17.0
+            epVersion: 2.18.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.17.0
+            epVersion: 2.18.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +70,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.17.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.18.0' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
   publish_snapshot:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.16
+            epVersion: 2.17.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.16
+            epVersion: 2.17.0
           - os: windows-latest
             java: 11
-            epVersion: 2.16
+            epVersion: 2.17.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.16
+            epVersion: 2.17.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +70,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.16' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.17.0' && github.repository == 'uber/NullAway'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
   publish_snapshot:

--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,10 @@ subprojects { project ->
                 check("MissingBraces", CheckSeverity.ERROR)
                 check("TypeToString", CheckSeverity.ERROR)
                 check("SymbolToString", CheckSeverity.ERROR)
-                // for doing auto-patching
-//                errorproneArgs.addAll("-XepPatchChecks:MissingSummary", "-XepPatchLocation:IN_PLACE")
+                // To enable auto-patching, uncomment the line below, replace [CheckerName] with
+                // the checker(s) you want to apply patches for (comma-separated), and above, disable
+                // "-Werror"
+//                errorproneArgs.addAll("-XepPatchChecks:[CheckerName]", "-XepPatchLocation:IN_PLACE")
             }
         } else {
             // Disable Error Prone checks on JDK 8, as more recent Error Prone versions don't run on JDK 8

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,8 @@ subprojects { project ->
                 check("MissingBraces", CheckSeverity.ERROR)
                 check("TypeToString", CheckSeverity.ERROR)
                 check("SymbolToString", CheckSeverity.ERROR)
+                // for doing auto-patching
+//                errorproneArgs.addAll("-XepPatchChecks:MissingSummary", "-XepPatchLocation:IN_PLACE")
             }
         } else {
             // Disable Error Prone checks on JDK 8, as more recent Error Prone versions don't run on JDK 8

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.4.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.16"
+def latestErrorProneVersion = "2.17.0"
 // Default to using latest tested Error Prone version, except on Java 8, where 2.10.0 is the last version
 // that works
 def defaultErrorProneVersion =  JavaVersion.current() >= JavaVersion.VERSION_11 ? latestErrorProneVersion : "2.10.0"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.4.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.17.0"
+def latestErrorProneVersion = "2.18.0"
 // Default to using latest tested Error Prone version, except on Java 8, where 2.10.0 is the last version
 // that works
 def defaultErrorProneVersion =  JavaVersion.current() >= JavaVersion.VERSION_11 ? latestErrorProneVersion : "2.10.0"

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor deps.apt.autoService
     compileOnly deps.build.jsr305Annotations
     compileOnly deps.test.jetbrainsAnnotations
+    compileOnly deps.apt.javaxInject
 
 
     compileOnly deps.build.errorProneCheckApi

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -278,7 +278,7 @@ public class NullAway extends BugChecker
     moduleElementClass = null;
   }
 
-  @Inject
+  @Inject // For future Error Prone versions in which checkers are loaded using Guice
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2447,50 +2447,46 @@ public class NullAway extends BugChecker
           ImmutableSet.copyOf(staticInitializerMethods));
     }
 
-    /**
-     * @return symbol for class
-     */
+    /** Returns symbol for class. */
     abstract Symbol.ClassSymbol classSymbol();
 
     /**
-     * @return <code>@NonNull</code> instance fields that are not directly initialized at
-     *     declaration
+     * Returns <code>@NonNull</code> instance fields that are not directly initialized at
+     * declaration.
      */
     abstract ImmutableSet<Symbol> nonnullInstanceFields();
 
     /**
-     * @return <code>@NonNull</code> static fields that are not directly initialized at declaration
+     * Returns <code>@NonNull</code> static fields that are not directly initialized at declaration.
      */
     abstract ImmutableSet<Symbol> nonnullStaticFields();
 
     /**
-     * @return the list of instance initializer blocks (e.g. blocks of the form `class X { { //Code
-     *     } } ), in the order in which they appear in the class
+     * Returns the list of instance initializer blocks (e.g. blocks of the form `class X { { //Code
+     * } } ), in the order in which they appear in the class.
      */
     abstract ImmutableList<BlockTree> instanceInitializerBlocks();
 
     /**
-     * @return the list of static initializer blocks (e.g. blocks of the form `class X { static {
-     *     //Code } } ), in the order in which they appear in the class
+     * Returns the list of static initializer blocks (e.g. blocks of the form `class X { static {
+     * //Code } } ), in the order in which they appear in the class.
      */
     abstract ImmutableList<BlockTree> staticInitializerBlocks();
 
-    /**
-     * @return the list of constructor
-     */
+    /** Returns constructors in the class. */
     abstract ImmutableSet<MethodTree> constructors();
 
     /**
-     * @return the list of non-static (instance) initializer methods. This includes methods
-     *     annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers
-     *     or annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations
+     * Returns the list of non-static (instance) initializer methods. This includes methods
+     * annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers or
+     * annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations.
      */
     abstract ImmutableSet<MethodTree> instanceInitializerMethods();
 
     /**
-     * @return the list of static initializer methods. This includes static methods
-     *     annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers
-     *     or annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations
+     * Returns the list of static initializer methods. This includes static methods
+     * annotated @Initializer, as well as those specified by -XepOpt:NullAway:KnownInitializers or
+     * annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations.
      */
     abstract ImmutableSet<MethodTree> staticInitializerMethods();
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -277,9 +277,10 @@ public class NullAway extends BugChecker
     moduleElementClass = null;
   }
 
-  @SuppressWarnings(
-      "InjectOnBugCheckers") // not sure of severity, and don't want to take another dependence to
-                             // fix this
+  // Suppressing InjectOnBugCheckers warning since I am not sure of severity, and don't want to take
+  // another dependence to pull in the javax.inject.Inject annotation to fix this.  See
+  // https://github.com/google/error-prone/issues/3706
+  @SuppressWarnings("InjectOnBugCheckers")
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -104,6 +104,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -277,10 +278,7 @@ public class NullAway extends BugChecker
     moduleElementClass = null;
   }
 
-  // Suppressing InjectOnBugCheckers warning since I am not sure of severity, and don't want to take
-  // another dependence to pull in the javax.inject.Inject annotation to fix this.  See
-  // https://github.com/google/error-prone/issues/3706
-  @SuppressWarnings("InjectOnBugCheckers")
+  @Inject
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -277,6 +277,9 @@ public class NullAway extends BugChecker
     moduleElementClass = null;
   }
 
+  @SuppressWarnings(
+      "InjectOnBugCheckers") // not sure of severity, and don't want to take another dependence to
+                             // fix this
   public NullAway(ErrorProneFlags flags) {
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);


### PR DESCRIPTION
Fixed some minor Javadoc warnings reported by the new version.  Also, adds an `@Inject` annotation on the main `NullAway` constructor, for compatibility with future versions of Error Prone that load checkers via Guice.