### PR TITLE
Don't do checks for type casts and parameterized trees in unannotated code

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -655,6 +655,9 @@ public class NullAway extends BugChecker
 
   @Override
   public Description matchTypeCast(TypeCastTree tree, VisitorState state) {
+    if (!withinAnnotatedCode(state)) {
+      return Description.NO_MATCH;
+    }
     Type castExprType = ASTHelpers.getType(tree);
     if (castExprType != null && castExprType.isPrimitive()) {
       // casting to a primitive type performs unboxing
@@ -665,6 +668,9 @@ public class NullAway extends BugChecker
 
   @Override
   public Description matchParameterizedType(ParameterizedTypeTree tree, VisitorState state) {
+    if (!withinAnnotatedCode(state)) {
+      return Description.NO_MATCH;
+    }
     GenericsChecks.checkInstantiationForParameterizedTypedTree(tree, state, this, config);
     return Description.NO_MATCH;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -960,4 +960,35 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void issue711() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
+                "-XepOpt:NullAway:AssertsEnabled=true",
+                "-XepOpt:NullAway:ExhaustiveOverride=true",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.function.Consumer;",
+            "import org.junit.Assert;",
+            "class Test {",
+            "  static class SomeStore<A,B> {}",
+            "  static class SomeData {}",
+            "  private void verifyCountZero(SomeStore<String, SomeData> store) {",
+            "    verifyData(store, (count) -> Assert.assertEquals(0, (long) count));",
+            "  }",
+            "  private void verifyData(SomeStore<String, SomeData> store, Consumer<Long> assertFunction) {",
+            // I don't think the body of verifyData has much to do with the issue
+            // "assertFunction.accept(StreamSupport.stream(store.findDataByCondition().spliterator(),
+            // true).count());",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCoreTests.java
@@ -960,35 +960,4 @@ public class NullAwayCoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
-
-  @Test
-  public void issue711() {
-    makeTestHelperWithArgs(
-            Arrays.asList(
-                "-d",
-                temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
-                "-XepOpt:NullAway:AssertsEnabled=true",
-                "-XepOpt:NullAway:ExhaustiveOverride=true",
-                "-XepOpt:NullAway:CheckOptionalEmptiness=true",
-                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
-        .addSourceLines(
-            "Test.java",
-            "package com.uber;",
-            "import java.util.function.Consumer;",
-            "import org.junit.Assert;",
-            "class Test {",
-            "  static class SomeStore<A,B> {}",
-            "  static class SomeData {}",
-            "  private void verifyCountZero(SomeStore<String, SomeData> store) {",
-            "    verifyData(store, (count) -> Assert.assertEquals(0, (long) count));",
-            "  }",
-            "  private void verifyData(SomeStore<String, SomeData> store, Consumer<Long> assertFunction) {",
-            // I don't think the body of verifyData has much to do with the issue
-            // "assertFunction.accept(StreamSupport.stream(store.findDataByCondition().spliterator(),
-            // true).count());",
-            "  }",
-            "}")
-        .doTest();
-  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -198,6 +198,23 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** check that we don't report errors on invalid instantiations in unannotated code */
+  @Test
+  public void instantiationInUnannotatedCode() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.other;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class NonNullTypeParam<E> { }",
+            "  static void instOf(Object o) {",
+            "    Object p = (NonNullTypeParam<@Nullable String>) o;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayUnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayUnannotatedTests.java
@@ -208,4 +208,30 @@ public class NullAwayUnannotatedTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  /**
+   * Ensure we don't crash for a type cast in unannotated code. See
+   * https://github.com/uber/NullAway/issues/711
+   */
+  @Test
+  public void typeCastInUnannotatedCode() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.other"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.function.Consumer;",
+            "import org.junit.Assert;",
+            "class Test {",
+            "  private void verifyCountZero() {",
+            "    verifyData((count) -> Assert.assertEquals(0, (long) count));",
+            "  }",
+            "  private void verifyData(Consumer<Long> assertFunction) {",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #711 