### PR TITLE
add Throwable.getCause to nullableReturns

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -620,6 +620,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         new ImmutableSet.Builder<MethodRef>()
             .add(methodRef("com.sun.source.tree.CompilationUnitTree", "getPackageName()"))
             .add(methodRef("java.lang.Throwable", "getMessage()"))
+            .add(methodRef("java.lang.Throwable", "getLocalizedMessage()"))
+            .add(methodRef("java.lang.Throwable", "getCause()"))
             .add(methodRef("java.lang.ref.Reference", "get()"))
             .add(methodRef("java.lang.ref.PhantomReference", "get()"))
             .add(methodRef("java.lang.ref.SoftReference", "get()"))

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayNativeModels.java
@@ -58,6 +58,10 @@ public class NullAwayNativeModels {
     Exception e = new RuntimeException();
     // BUG: Diagnostic contains: dereferenced expression
     e.getMessage().hashCode();
+    // BUG: Diagnostic contains: dereferenced expression
+    e.getLocalizedMessage().hashCode();
+    // BUG: Diagnostic contains: dereferenced expression
+    e.getCause().toString();
   }
 
   // we will add bug annotations when we have full support for maps


### PR DESCRIPTION
reasoning:
- in its default implementation `getLocalizedMessage()` calls `getMessage()`, so should be treated in the same way
- not every throwable was created with a cause, so `getCause()` will often return `null`, as indicated by its javadoc