### PR TITLE
Avoid redundant Map lookups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ plugins {
   id "net.ltgt.errorprone" version "3.0.1" apply false
   id "com.github.johnrengelman.shadow" version "6.1.0" apply false
   id "com.github.kt3k.coveralls" version "2.12.0" apply false
-  id "me.champeau.jmh" version "0.6.7" apply false
+  id "me.champeau.jmh" version "0.6.8" apply false
   id "com.github.ben-manes.versions" version "0.42.0"
 }
 

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -292,7 +292,7 @@ public final class CodeAnnotationInfo {
     }
 
     public boolean isMethodNullnessAnnotated(Symbol.MethodSymbol methodSymbol) {
-      methodNullnessCache.computeIfAbsent(
+      return methodNullnessCache.computeIfAbsent(
           methodSymbol,
           m -> {
             if (ASTHelpers.hasDirectAnnotationWithSimpleName(
@@ -305,7 +305,6 @@ public final class CodeAnnotationInfo {
                   m, NullabilityUtil.NULLMARKED_SIMPLE_NAME);
             }
           });
-      return methodNullnessCache.get(methodSymbol);
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2411,6 +2411,7 @@ public class NullAway extends BugChecker
    * @return computed nullness for e, if any, else Nullable
    */
   public Nullness getComputedNullness(ExpressionTree e) {
+    // TODO: use Map.getOrDefault after https://github.com/uber/NullAway/issues/723
     Nullness nullness = computedNullnessMap.get(e);
     return nullness != null ? nullness : Nullness.NULLABLE;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/SerializationService.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/SerializationService.java
@@ -36,6 +36,7 @@ import com.uber.nullaway.Nullness;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 import com.uber.nullaway.fixserialization.out.SuggestedNullableFixInfo;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -68,8 +69,10 @@ public class SerializationService {
     // escape existing backslashes
     str = str.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"));
     // escape special characters
-    for (Character key : escapes.keySet()) {
-      str = str.replaceAll(String.valueOf(key), Matcher.quoteReplacement("\\" + escapes.get(key)));
+    for (Map.Entry<Character, Character> entry : escapes.entrySet()) {
+      str =
+          str.replaceAll(
+              String.valueOf(entry.getKey()), Matcher.quoteReplacement("\\" + entry.getValue()));
     }
     return str;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -342,17 +342,12 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   private void cacheAnnotation(String methodSig, Integer argNum, String annotation) {
     // TODO: handle inner classes properly
     String className = methodSig.split(":")[0].replace('$', '.');
-    if (!argAnnotCache.containsKey(className)) {
-      argAnnotCache.put(className, new LinkedHashMap<>());
-    }
-    Map<String, Map<Integer, Set<String>>> cacheForClass = argAnnotCache.get(className);
-    if (!cacheForClass.containsKey(methodSig)) {
-      cacheForClass.put(methodSig, new LinkedHashMap<>());
-    }
-    Map<Integer, Set<String>> cacheForMethod = cacheForClass.get(methodSig);
-    if (!cacheForMethod.containsKey(argNum)) {
-      cacheForMethod.put(argNum, new LinkedHashSet<>());
-    }
-    cacheForMethod.get(argNum).add(annotation);
+    Map<String, Map<Integer, Set<String>>> cacheForClass =
+        argAnnotCache.computeIfAbsent(className, s -> new LinkedHashMap<>());
+    Map<Integer, Set<String>> cacheForMethod =
+        cacheForClass.computeIfAbsent(methodSig, s -> new LinkedHashMap<>());
+    Set<String> cacheForArgument =
+        cacheForMethod.computeIfAbsent(argNum, s -> new LinkedHashSet<>());
+    cacheForArgument.add(annotation);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -984,11 +984,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       Map<Name, Map<MethodRef, T>> nameMapping = new LinkedHashMap<>();
       for (MethodRef ref : refs) {
         Name methodName = names.fromString(ref.methodName);
-        Map<MethodRef, T> mapForName = nameMapping.get(methodName);
-        if (mapForName == null) {
-          mapForName = new LinkedHashMap<>();
-          nameMapping.put(methodName, mapForName);
-        }
+        Map<MethodRef, T> mapForName =
+            nameMapping.computeIfAbsent(methodName, k -> new LinkedHashMap<>());
         mapForName.put(ref, getValForRef.apply(ref));
       }
       return new NameIndexedMap<>(nameMapping);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -325,10 +325,10 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
       MemberReferenceTree tree,
       VisitorState state,
       Symbol.MethodSymbol methodSymbol) {
-    if (mapToFilterMap.containsKey(tree) && ((JCTree.JCMemberReference) tree).kind.isUnbound()) {
+    MaplikeToFilterInstanceRecord callInstanceRecord = mapToFilterMap.get(tree);
+    if (callInstanceRecord != null && ((JCTree.JCMemberReference) tree).kind.isUnbound()) {
       // Unbound method reference, check if we know the corresponding path to be NonNull from the
       // previous filter.
-      MaplikeToFilterInstanceRecord callInstanceRecord = mapToFilterMap.get(tree);
       Tree filterTree = callInstanceRecord.getFilter();
       if (!(filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree)) {
         throw new IllegalStateException(
@@ -421,9 +421,9 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
       return nullnessBuilder;
     }
     assert (tree instanceof MethodTree || tree instanceof LambdaExpressionTree);
-    if (mapToFilterMap.containsKey(tree)) {
+    MaplikeToFilterInstanceRecord callInstanceRecord = mapToFilterMap.get(tree);
+    if (callInstanceRecord != null) {
       // Plug Nullness info from filter method into entry to map method.
-      MaplikeToFilterInstanceRecord callInstanceRecord = mapToFilterMap.get(tree);
       Tree filterTree = callInstanceRecord.getFilter();
       assert (filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree);
       MaplikeMethodRecord mapMR = callInstanceRecord.getMaplikeMethodRecord();
@@ -459,16 +459,14 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
   @Override
   public void onDataflowVisitReturn(
       ReturnTree tree, NullnessStore thenStore, NullnessStore elseStore) {
-    if (returnToEnclosingMethodOrLambda.containsKey(tree)) {
-      Tree filterTree = returnToEnclosingMethodOrLambda.get(tree);
+    Tree filterTree = returnToEnclosingMethodOrLambda.get(tree);
+    if (filterTree != null) {
       assert (filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree);
       ExpressionTree retExpression = tree.getExpression();
       if (canBooleanExpressionEvalToTrue(retExpression)) {
-        if (filterToNSMap.containsKey(filterTree)) {
-          filterToNSMap.put(filterTree, filterToNSMap.get(filterTree).leastUpperBound(thenStore));
-        } else {
-          filterToNSMap.put(filterTree, thenStore);
-        }
+        filterToNSMap.compute(
+            filterTree,
+            (key, value) -> value == null ? thenStore : value.leastUpperBound(thenStore));
       }
     }
   }
@@ -476,8 +474,8 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
   @Override
   public void onDataflowVisitLambdaResultExpression(
       ExpressionTree tree, NullnessStore thenStore, NullnessStore elseStore) {
-    if (expressionBodyToFilterLambda.containsKey(tree)) {
-      LambdaExpressionTree filterTree = expressionBodyToFilterLambda.get(tree);
+    LambdaExpressionTree filterTree = expressionBodyToFilterLambda.get(tree);
+    if (filterTree != null) {
       if (canBooleanExpressionEvalToTrue(tree)) {
         filterToNSMap.put(filterTree, thenStore);
       }


### PR DESCRIPTION
while reading through the code i noticed a few redundant map lookups

i've only adjusted the places where it was clear the map never stores null values and where `get` immediately followed a `containsKey`

according to running the JMH benchmarks locally this safes a few cycles and often makes the code clearer imo