### PR TITLE
Add support for external init annotations in constructors

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -157,6 +157,9 @@ public interface Config {
    * Checks if annotation marks an "external-init class," i.e., a class where some external
    * framework initializes object fields after invoking the zero-argument constructor.
    *
+   * <p>Note that this annotation can be on the class itself, or on the zero-arguments constructor,
+   * but will be ignored anywhere else.
+   *
    * @param annotationName fully-qualified annotation name
    * @return true if classes with the annotation are external-init
    */

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1761,7 +1761,8 @@ public class NullAway extends BugChecker
       } else if (constructorInitInfo == null) {
         // report it on the field, except in the case where the class is externalInit and
         // we have no initializer methods
-        if (!(isExternalInit(classSymbol) && entities.instanceInitializerMethods().isEmpty())) {
+        if (!(symbolHasExternalInitAnnotation(classSymbol)
+            && entities.instanceInitializerMethods().isEmpty())) {
           errorBuilder.reportInitErrorOnField(
               uninitField, state, buildDescription(getTreesInstance(state).getTree(uninitField)));
         }
@@ -1868,12 +1869,14 @@ public class NullAway extends BugChecker
     SetMultimap<MethodTree, Symbol> result = LinkedHashMultimap.create();
     Set<Symbol> nonnullInstanceFields = entities.nonnullInstanceFields();
     Trees trees = getTreesInstance(state);
-    boolean isExternalInit = isExternalInit(entities.classSymbol());
+    boolean isExternalInitClass = symbolHasExternalInitAnnotation(entities.classSymbol());
     for (MethodTree constructor : entities.constructors()) {
       if (constructorInvokesAnother(constructor, state)) {
         continue;
       }
-      if (constructor.getParameters().size() == 0 && isExternalInit) {
+      if (constructor.getParameters().size() == 0
+          && (isExternalInitClass
+              || symbolHasExternalInitAnnotation(ASTHelpers.getSymbol(constructor)))) {
         // external framework initializes fields in this case
         continue;
       }
@@ -1888,8 +1891,8 @@ public class NullAway extends BugChecker
     return result;
   }
 
-  private boolean isExternalInit(Symbol.ClassSymbol classSymbol) {
-    return StreamSupport.stream(NullabilityUtil.getAllAnnotations(classSymbol).spliterator(), false)
+  private boolean symbolHasExternalInitAnnotation(Symbol symbol) {
+    return StreamSupport.stream(NullabilityUtil.getAllAnnotations(symbol).spliterator(), false)
         .map((anno) -> anno.getAnnotationType().toString())
         .anyMatch(config::isExternalInitClassAnnotation);
   }


### PR DESCRIPTION
NullAway has existing support for `-XepOpt:NullAway:ExternalInitAnnotations=...` as configuration option.
Before this PR, that option allows listing a set of class-level annotations with the following semantics:

> A list of annotations for classes that are "externally initialized." Tools like the [Cassandra Object Mapper](https://docs.datastax.com/en/developer/java-driver/3.2/manual/object_mapper/) do their own field initialization of objects with a certain annotation (like [@Table](https://docs.datastax.com/en/drivers/java/3.2/com/datastax/driver/mapping/annotations/Table.html)), after invoking the zero-argument constructor. For any class annotated with an external-init annotation, we don't check that the zero-arg constructor initializes all non-null fields.

This PR extends that configuration option to also allow annotations that are added directly to the zero-arguments
constructor of such an externally initialized class. The reason for this is that it's often desired to document why
the empty constructor exists, and doing so at the declaration site for the constructor makes code more readable than
doing so at the class declaration level.

The canonical example here is GSON serialization, which requires classes to have a private zero-arguments constructor
which is called for deserialization, in addition to their normal initializing constructors.

As a follow up to this PR landing, we will update the Wiki docs accordingly.