### PR TITLE
Support isInstanceOf(...) as implying non-null in assertion libraries.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
@@ -62,7 +62,7 @@ public class AssertionHandler extends BaseNoOpHandler {
 
     // Look for statements of the form: assertThat(A).isNotNull()
     // A will not be NULL after this statement.
-    if (methodNameUtil.isMethodIsNotNull(callee)) {
+    if (methodNameUtil.isMethodIsNotNull(callee) || methodNameUtil.isMethodIsInstanceOf(callee)) {
       Node receiver = node.getTarget().getReceiver();
       if (receiver instanceof MethodInvocationNode) {
         MethodInvocationNode receiver_method = (MethodInvocationNode) receiver;
@@ -80,10 +80,13 @@ public class AssertionHandler extends BaseNoOpHandler {
     // Look for statements of the form:
     //    * assertThat(A, is(not(nullValue())))
     //    * assertThat(A, is(notNullValue()))
+    //    * assertThat(A, isInstanceOf(...)))
     if (methodNameUtil.isMethodHamcrestAssertThat(callee)
         || methodNameUtil.isMethodJunitAssertThat(callee)) {
       List<Node> args = node.getArguments();
-      if (args.size() == 2 && methodNameUtil.isMatcherIsNotNull(args.get(1))) {
+      if (args.size() == 2
+          && (methodNameUtil.isMatcherIsNotNull(args.get(1))
+              || methodNameUtil.isMatcherIsInstanceOf(args.get(1)))) {
         AccessPath ap = AccessPath.getAccessPathForNode(args.get(0), state, apContext);
         if (ap != null) {
           bothUpdates.set(ap, NONNULL);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
@@ -60,7 +60,8 @@ public class AssertionHandler extends BaseNoOpHandler {
       methodNameUtil.initializeMethodNames(callee.name.table);
     }
 
-    // Look for statements of the form: assertThat(A).isNotNull()
+    // Look for statements of the form: assertThat(A).isNotNull() or
+    // assertThat(A).isInstanceOf(Foo.class)
     // A will not be NULL after this statement.
     if (methodNameUtil.isMethodIsNotNull(callee) || methodNameUtil.isMethodIsInstanceOf(callee)) {
       Node receiver = node.getTarget().getReceiver();
@@ -80,7 +81,8 @@ public class AssertionHandler extends BaseNoOpHandler {
     // Look for statements of the form:
     //    * assertThat(A, is(not(nullValue())))
     //    * assertThat(A, is(notNullValue()))
-    //    * assertThat(A, isInstanceOf(...)))
+    //    * assertThat(A, is(instanceOf(Foo.class)))
+    //    * assertThat(A, isA(Foo.class))
     if (methodNameUtil.isMethodHamcrestAssertThat(callee)
         || methodNameUtil.isMethodJunitAssertThat(callee)) {
       List<Node> args = node.getArguments();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
@@ -261,7 +261,7 @@ class MethodNameUtil {
       // All overloads of `is` method have exactly one argument.
       Node inner = ((MethodInvocationNode) node).getArgument(0);
       return matchesMatcherMethod(inner, instanceOfMatcher, matchersClass)
-          || matchesMatcherMethod(inner, isMatcher, coreMatchersClass);
+          || matchesMatcherMethod(inner, instanceOfMatcher, coreMatchersClass);
     }
     return (matchesMatcherMethod(node, isAMatcher, matchersClass)
         || matchesMatcherMethod(node, isAMatcher, coreMatchersClass));

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAssertionLibsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAssertionLibsTests.java
@@ -234,6 +234,34 @@ public class NullAwayAssertionLibsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void supportHamcrestAssertThatIsInstanceOf() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static org.hamcrest.MatcherAssert.assertThat;",
+            "import static org.hamcrest.CoreMatchers.*;",
+            "import org.hamcrest.core.IsNull;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b) {",
+            "    assertThat(a, is(instanceOf(Object.class)));",
+            "    a.toString();",
+            "    assertThat(b, isA(Object.class));",
+            "    b.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void supportJunitAssertThatIsNotNull_Object() {
     makeTestHelperWithArgs(
             Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAssertionLibsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAssertionLibsTests.java
@@ -76,6 +76,31 @@ public class NullAwayAssertionLibsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void supportTruthAssertThatIsInstanceOf() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "class Test {",
+            "  private void foo(@Nullable Object o) {",
+            "    // inInstanceOf => isNotNull!",
+            "    assertThat(o).isInstanceOf(Object.class);",
+            "    o.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void doNotSupportTruthAssertThatWhenDisabled() {
     makeTestHelperWithArgs(
             Arrays.asList(
@@ -236,6 +261,33 @@ public class NullAwayAssertionLibsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void supportJunitAssertThatIsInstanceOf() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static org.junit.Assert.assertThat;",
+            "import static org.hamcrest.Matchers.*;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b) {",
+            "    assertThat(a, is(instanceOf(Object.class)));",
+            "    a.toString();",
+            "    assertThat(b, isA(Object.class));",
+            "    b.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void doNotSupportJunitAssertThatWhenDisabled() {
     makeTestHelperWithArgs(
             Arrays.asList(
@@ -326,6 +378,32 @@ public class NullAwayAssertionLibsTests extends NullAwayTestsBase {
             "  private void foo(Map<String,Object> m) {",
             "    assertThat(m.get(\"foo\")).isNotNull();",
             "    m.get(\"foo\").toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void supportAssertJAssertThatIsInstanceOf() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.lang.Object;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "import static org.assertj.core.api.Assertions.assertThat;",
+            "class Test {",
+            "  private void foo(@Nullable Object a, @Nullable Object b) {",
+            "    assertThat(a).isInstanceOf(Object.class);",
+            "    a.toString();",
+            "    assertThat(b).isInstanceOfAny(String.class, Exception.class);",
+            "    b.toString();",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
Generally speaking, all these libraries implement the assertion by calling `Class.isInstance`, which
will return `false` whenever the argument is `null`. Similar to the `instanceof` operator:
https://docs.oracle.com/javase/1.5.0/docs/api/java/lang/Class.html#isInstance(java.lang.Object)

Given this, we can avoid some redundant assertions by adding knowledge about these calls directly
in `AssertionsHandler`.
