### PR TITLE
Refactoring in symbol serialization 

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway.fixserialization;
 
+import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
@@ -193,6 +194,28 @@ public class Serializer {
       // In this case, we still would like to continue the serialization instead of returning null
       // and not serializing anything.
       return path;
+    }
+  }
+
+  /**
+   * Serializes the given {@link Symbol} to a string.
+   *
+   * @param symbol The symbol to serialize.
+   * @return The serialized symbol.
+   */
+  public static String serializeSymbol(@Nullable Symbol symbol) {
+    if (symbol == null) {
+      return "null";
+    }
+    switch (symbol.getKind()) {
+      case FIELD:
+      case PARAMETER:
+        return symbol.name.toString();
+      case METHOD:
+      case CONSTRUCTOR:
+        return symbol.toString();
+      default:
+        return symbol.flatName().toString();
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.fixserialization.adapters;
 import static com.uber.nullaway.fixserialization.out.ErrorInfo.EMPTY_NONNULL_TARGET_LOCATION_STRING;
 
 import com.uber.nullaway.fixserialization.SerializationService;
+import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 
@@ -53,10 +54,8 @@ public class SerializationV1Adapter implements SerializationAdapter {
         "\t",
         errorInfo.getErrorMessage().getMessageType().toString(),
         SerializationService.escapeSpecialCharacters(errorInfo.getErrorMessage().getMessage()),
-        (errorInfo.getRegionClass() != null
-            ? errorInfo.getRegionClass().flatName().toString()
-            : "null"),
-        (errorInfo.getRegionMember() != null ? errorInfo.getRegionMember().toString() : "null"),
+        Serializer.serializeSymbol(errorInfo.getRegionClass()),
+        Serializer.serializeSymbol(errorInfo.getRegionMember()),
         (errorInfo.getNonnullTarget() != null
             ? SymbolLocation.createLocationFromSymbol(errorInfo.getNonnullTarget())
                 .tabSeparatedToString()

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.fixserialization.adapters;
 import static com.uber.nullaway.fixserialization.out.ErrorInfo.EMPTY_NONNULL_TARGET_LOCATION_STRING;
 
 import com.uber.nullaway.fixserialization.SerializationService;
+import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 
@@ -66,10 +67,8 @@ public class SerializationV2Adapter implements SerializationAdapter {
         "\t",
         errorInfo.getErrorMessage().getMessageType().toString(),
         SerializationService.escapeSpecialCharacters(errorInfo.getErrorMessage().getMessage()),
-        (errorInfo.getRegionClass() != null
-            ? errorInfo.getRegionClass().flatName().toString()
-            : "null"),
-        (errorInfo.getRegionMember() != null ? errorInfo.getRegionMember().toString() : "null"),
+        Serializer.serializeSymbol(errorInfo.getRegionClass()),
+        Serializer.serializeSymbol(errorInfo.getRegionMember()),
         String.valueOf(errorInfo.getOffset()),
         errorInfo.getPath() != null ? errorInfo.getPath().toString() : "null",
         (errorInfo.getNonnullTarget() != null

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.Serializer;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting class fields. */
@@ -41,9 +42,9 @@ public class FieldLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
+        Serializer.serializeSymbol(enclosingClass),
         "null",
-        variableSymbol.toString(),
+        Serializer.serializeSymbol(variableSymbol),
         "null",
         path != null ? path.toString() : "null");
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.Serializer;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting methods. */
@@ -41,8 +42,8 @@ public class MethodLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
-        enclosingMethod.toString(),
+        Serializer.serializeSymbol(enclosingClass),
+        Serializer.serializeSymbol(enclosingMethod),
         "null",
         "null",
         path != null ? path.toString() : "null");

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.location;
 
 import com.google.common.base.Preconditions;
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.Serializer;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting a method parameter. */
@@ -62,9 +63,9 @@ public class MethodParameterLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
-        enclosingMethod.toString(),
-        paramSymbol.toString(),
+        Serializer.serializeSymbol(enclosingClass),
+        Serializer.serializeSymbol(enclosingMethod),
+        Serializer.serializeSymbol(paramSymbol),
         String.valueOf(index),
         path != null ? path.toString() : "null");
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.fixserialization.out;
 
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 
 /**
@@ -49,7 +50,7 @@ public class FieldInitializationInfo {
   public String tabSeparatedToString() {
     return initializerMethodLocation.tabSeparatedToString()
         + '\t'
-        + field.getSimpleName().toString();
+        + Serializer.serializeSymbol(field);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.out;
 
 import com.sun.source.util.TreePath;
 import com.uber.nullaway.ErrorMessage;
+import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import java.util.Objects;
 
@@ -75,10 +76,8 @@ public class SuggestedNullableFixInfo {
         symbolLocation.tabSeparatedToString(),
         errorMessage.getMessageType().toString(),
         "nullable",
-        (classAndMemberInfo.getClazz() == null ? "null" : classAndMemberInfo.getClazz().flatName()),
-        (classAndMemberInfo.getMember() == null
-            ? "null"
-            : classAndMemberInfo.getMember().toString()));
+        Serializer.serializeSymbol(classAndMemberInfo.getClazz()),
+        Serializer.serializeSymbol(classAndMemberInfo.getMember()));
   }
 
   /** Finds the class and member of program point where triggered this type change. */


### PR DESCRIPTION
This PR refactors the serialization logic to call a `static` method in `Serializer` to convert a `Symbol` to its corresponding `String` representation. This PR prepare the update on serialization service for #735.