### PR TITLE
Refactoring tabSeparatedToString logic to prepare for serialization version 3.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -77,7 +77,9 @@ public class Serializer {
     if (enclosing) {
       suggestedNullableFixInfo.initEnclosing();
     }
-    appendToFile(suggestedNullableFixInfo.tabSeparatedToString(), suggestedFixesOutputPath);
+    appendToFile(
+        suggestedNullableFixInfo.tabSeparatedToString(serializationAdapter),
+        suggestedFixesOutputPath);
   }
 
   /**
@@ -91,7 +93,7 @@ public class Serializer {
   }
 
   public void serializeFieldInitializationInfo(FieldInitializationInfo info) {
-    appendToFile(info.tabSeparatedToString(), fieldInitializationOutputPath);
+    appendToFile(info.tabSeparatedToString(serializationAdapter), fieldInitializationOutputPath);
   }
 
   /** Cleared the content of the file if exists and writes the header in the first line. */
@@ -201,9 +203,10 @@ public class Serializer {
    * Serializes the given {@link Symbol} to a string.
    *
    * @param symbol The symbol to serialize.
+   * @param adapter adapter used to serialize symbols.
    * @return The serialized symbol.
    */
-  public static String serializeSymbol(@Nullable Symbol symbol) {
+  public static String serializeSymbol(@Nullable Symbol symbol, SerializationAdapter adapter) {
     if (symbol == null) {
       return "null";
     }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -216,7 +216,7 @@ public class Serializer {
         return symbol.name.toString();
       case METHOD:
       case CONSTRUCTOR:
-        return symbol.toString();
+        return adapter.serializeMethodSignature((Symbol.MethodSymbol) symbol);
       default:
         return symbol.flatName().toString();
     }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationAdapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationAdapter.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway.fixserialization.adapters;
 
+import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.out.ErrorInfo;
 
 /**
@@ -62,4 +63,12 @@ public interface SerializationAdapter {
    * @return Supporting serialization version number.
    */
   int getSerializationVersion();
+
+  /**
+   * Serializes the signature of the given {@link Symbol.MethodSymbol} to a string.
+   *
+   * @param methodSymbol The method symbol to serialize.
+   * @return The serialized method symbol.
+   */
+  String serializeMethodSignature(Symbol.MethodSymbol methodSymbol);
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
@@ -54,11 +54,11 @@ public class SerializationV1Adapter implements SerializationAdapter {
         "\t",
         errorInfo.getErrorMessage().getMessageType().toString(),
         SerializationService.escapeSpecialCharacters(errorInfo.getErrorMessage().getMessage()),
-        Serializer.serializeSymbol(errorInfo.getRegionClass()),
-        Serializer.serializeSymbol(errorInfo.getRegionMember()),
+        Serializer.serializeSymbol(errorInfo.getRegionClass(), this),
+        Serializer.serializeSymbol(errorInfo.getRegionMember(), this),
         (errorInfo.getNonnullTarget() != null
             ? SymbolLocation.createLocationFromSymbol(errorInfo.getNonnullTarget())
-                .tabSeparatedToString()
+                .tabSeparatedToString(this)
             : EMPTY_NONNULL_TARGET_LOCATION_STRING));
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV1Adapter.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.adapters;
 
 import static com.uber.nullaway.fixserialization.out.ErrorInfo.EMPTY_NONNULL_TARGET_LOCATION_STRING;
 
+import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.SerializationService;
 import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
@@ -65,5 +66,10 @@ public class SerializationV1Adapter implements SerializationAdapter {
   @Override
   public int getSerializationVersion() {
     return 1;
+  }
+
+  @Override
+  public String serializeMethodSignature(Symbol.MethodSymbol methodSymbol) {
+    return methodSymbol.toString();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.adapters;
 
 import static com.uber.nullaway.fixserialization.out.ErrorInfo.EMPTY_NONNULL_TARGET_LOCATION_STRING;
 
+import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.SerializationService;
 import com.uber.nullaway.fixserialization.Serializer;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
@@ -80,5 +81,10 @@ public class SerializationV2Adapter implements SerializationAdapter {
   @Override
   public int getSerializationVersion() {
     return 2;
+  }
+
+  @Override
+  public String serializeMethodSignature(Symbol.MethodSymbol methodSymbol) {
+    return methodSymbol.toString();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV2Adapter.java
@@ -67,13 +67,13 @@ public class SerializationV2Adapter implements SerializationAdapter {
         "\t",
         errorInfo.getErrorMessage().getMessageType().toString(),
         SerializationService.escapeSpecialCharacters(errorInfo.getErrorMessage().getMessage()),
-        Serializer.serializeSymbol(errorInfo.getRegionClass()),
-        Serializer.serializeSymbol(errorInfo.getRegionMember()),
+        Serializer.serializeSymbol(errorInfo.getRegionClass(), this),
+        Serializer.serializeSymbol(errorInfo.getRegionMember(), this),
         String.valueOf(errorInfo.getOffset()),
         errorInfo.getPath() != null ? errorInfo.getPath().toString() : "null",
         (errorInfo.getNonnullTarget() != null
             ? SymbolLocation.createLocationFromSymbol(errorInfo.getNonnullTarget())
-                .tabSeparatedToString()
+                .tabSeparatedToString(this)
             : EMPTY_NONNULL_TARGET_LOCATION_STRING));
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/FieldLocation.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.Serializer;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting class fields. */
@@ -38,13 +39,13 @@ public class FieldLocation extends AbstractSymbolLocation {
   }
 
   @Override
-  public String tabSeparatedToString() {
+  public String tabSeparatedToString(SerializationAdapter adapter) {
     return String.join(
         "\t",
         type.toString(),
-        Serializer.serializeSymbol(enclosingClass),
+        Serializer.serializeSymbol(enclosingClass, adapter),
         "null",
-        Serializer.serializeSymbol(variableSymbol),
+        Serializer.serializeSymbol(variableSymbol, adapter),
         "null",
         path != null ? path.toString() : "null");
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodLocation.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.Serializer;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting methods. */
@@ -38,12 +39,12 @@ public class MethodLocation extends AbstractSymbolLocation {
   }
 
   @Override
-  public String tabSeparatedToString() {
+  public String tabSeparatedToString(SerializationAdapter adapter) {
     return String.join(
         "\t",
         type.toString(),
-        Serializer.serializeSymbol(enclosingClass),
-        Serializer.serializeSymbol(enclosingMethod),
+        Serializer.serializeSymbol(enclosingClass, adapter),
+        Serializer.serializeSymbol(enclosingMethod, adapter),
         "null",
         "null",
         path != null ? path.toString() : "null");

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/MethodParameterLocation.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.fixserialization.location;
 import com.google.common.base.Preconditions;
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.Serializer;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import javax.lang.model.element.ElementKind;
 
 /** subtype of {@link AbstractSymbolLocation} targeting a method parameter. */
@@ -59,13 +60,13 @@ public class MethodParameterLocation extends AbstractSymbolLocation {
   }
 
   @Override
-  public String tabSeparatedToString() {
+  public String tabSeparatedToString(SerializationAdapter adapter) {
     return String.join(
         "\t",
         type.toString(),
-        Serializer.serializeSymbol(enclosingClass),
-        Serializer.serializeSymbol(enclosingMethod),
-        Serializer.serializeSymbol(paramSymbol),
+        Serializer.serializeSymbol(enclosingClass, adapter),
+        Serializer.serializeSymbol(enclosingMethod, adapter),
+        Serializer.serializeSymbol(paramSymbol, adapter),
         String.valueOf(index),
         path != null ? path.toString() : "null");
   }

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/SymbolLocation.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway.fixserialization.location;
 
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 
 /** Provides method for symbol locations. */
 public interface SymbolLocation {
@@ -32,9 +33,10 @@ public interface SymbolLocation {
    * of the element, symbol of the containing class, symbol of the enclosing method, symbol of the
    * variable, index of the element and uri to containing file.
    *
+   * @param adapter adapter used to serialize symbols.
    * @return string representation of contents in a line seperated by tabs.
    */
-  String tabSeparatedToString();
+  String tabSeparatedToString(SerializationAdapter adapter);
 
   /**
    * Creates header of an output file containing all {@link SymbolLocation} written in string which

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/FieldInitializationInfo.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.fixserialization.out;
 
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.fixserialization.Serializer;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 
 /**
@@ -45,12 +46,13 @@ public class FieldInitializationInfo {
   /**
    * Returns string representation of content of an object.
    *
+   * @param adapter adapter used to serialize symbols.
    * @return string representation of contents of an object in a line seperated by tabs.
    */
-  public String tabSeparatedToString() {
-    return initializerMethodLocation.tabSeparatedToString()
+  public String tabSeparatedToString(SerializationAdapter adapter) {
+    return initializerMethodLocation.tabSeparatedToString(adapter)
         + '\t'
-        + Serializer.serializeSymbol(field);
+        + Serializer.serializeSymbol(field, adapter);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/out/SuggestedNullableFixInfo.java
@@ -25,6 +25,7 @@ package com.uber.nullaway.fixserialization.out;
 import com.sun.source.util.TreePath;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.fixserialization.Serializer;
+import com.uber.nullaway.fixserialization.adapters.SerializationAdapter;
 import com.uber.nullaway.fixserialization.location.SymbolLocation;
 import java.util.Objects;
 
@@ -68,16 +69,17 @@ public class SuggestedNullableFixInfo {
   /**
    * returns string representation of content of an object.
    *
+   * @param adapter adapter used to serialize symbols.
    * @return string representation of contents of an object in a line separated by tabs.
    */
-  public String tabSeparatedToString() {
+  public String tabSeparatedToString(SerializationAdapter adapter) {
     return String.join(
         "\t",
-        symbolLocation.tabSeparatedToString(),
+        symbolLocation.tabSeparatedToString(adapter),
         errorMessage.getMessageType().toString(),
         "nullable",
-        Serializer.serializeSymbol(classAndMemberInfo.getClazz()),
-        Serializer.serializeSymbol(classAndMemberInfo.getMember()));
+        Serializer.serializeSymbol(classAndMemberInfo.getClazz(), adapter),
+        Serializer.serializeSymbol(classAndMemberInfo.getMember(), adapter));
   }
 
   /** Finds the class and member of program point where triggered this type change. */


### PR DESCRIPTION
This PR is merely refactoring which prepares serialization logic for version `v3` implemented in #735.

Changes in this PR

- Uses adapter to serialize method signatures. 
- Adds `SerializationAdapter` to `tabSeparatedToString` methods for symbol serialization.
- Adds `SerializationAdapter` to `serializeSymbol` static method for symbol serialization.