### PR TITLE
refactor to directly return `mayBeNullFieldAccess`

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2265,19 +2265,15 @@ public class NullAway extends BugChecker
           throw new IllegalStateException(
               "unexpected null symbol for dereference expression " + state.getSourceForNode(expr));
         }
-        exprMayBeNull = mayBeNullFieldAccess(state, expr, exprSymbol);
-        break;
+        return mayBeNullFieldAccess(state, expr, exprSymbol);
       case IDENTIFIER:
         if (exprSymbol == null) {
           throw new IllegalStateException(
               "unexpected null symbol for identifier " + state.getSourceForNode(expr));
         }
-        if (exprSymbol.getKind().equals(ElementKind.FIELD)) {
-          // Special case: mayBeNullFieldAccess runs handler.onOverrideMayBeNullExpr before
-          // dataflow.
+        if (exprSymbol.getKind() == ElementKind.FIELD) {
           return mayBeNullFieldAccess(state, expr, exprSymbol);
         } else {
-          // Check handler.onOverrideMayBeNullExpr before dataflow.
           exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, true);
           return exprMayBeNull ? nullnessFromDataflow(state, expr) : false;
         }


### PR DESCRIPTION
the method already calls `onOverrideMayBeNullExpr` and `nullnessFromDataflow` so there is no point to break out of the switch to call the former again

see also other usage of `mayBeNullFieldAccess` a few lines below

also remove comments that just restated the obvious