### PR TITLE
Remove URI serialization for classes coming from .class files from fix serialization code

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/AbstractSymbolLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/location/AbstractSymbolLocation.java
@@ -53,15 +53,7 @@ public abstract class AbstractSymbolLocation implements SymbolLocation {
             + ".");
     this.type = type;
     this.enclosingClass = castToNonNull(ASTHelpers.enclosingClass(target));
-    // We currently serialize the URI for the classfile if the URI for the sourcefile is not
-    // available, but only if said URI corresponds to a "file:" or "jimfs:" scheme (i.e. not
-    // "jar:"). It's likely that this is no longer needed and should be removed as a follow up:
-    // https://github.com/uber/NullAway/issues/716 Leaving this workaround up temporarily for the
-    // sake of experiments with version `1.3.6-alpha-N` of the auto-annotator.
-    URI pathInURI =
-        enclosingClass.sourcefile != null
-            ? enclosingClass.sourcefile.toUri()
-            : (enclosingClass.classfile != null ? enclosingClass.classfile.toUri() : null);
+    URI pathInURI = enclosingClass.sourcefile != null ? enclosingClass.sourcefile.toUri() : null;
     this.path = Serializer.pathToSourceFileFromURI(pathInURI);
   }
 }


### PR DESCRIPTION
This PR partially resolves #716 by removing URI serialization for classes coming from `.class` files in all serializations.

In Annotator all serialized paths in downstream dependencies analysis phase, are neglected and retrieved from internal data structure of Annotator. Please see [Github](https://github.com/ucr-riple/NullAwayAnnotator/blob/4587c9821f4ccd152c1e6853a0cd10df5bcf277d/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactEvaluator.java#L85)

I tested Annotator with a local snapshot of NullAway with latest changes in this PR and I did not see any problem.

#716 is partially resolved since it requires updating path constructions in tests as well, which I will work on it on a separate PR.