### PR TITLE
refactor: streamline mayBeNullExpr flow

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2278,6 +2278,7 @@ public class NullAway extends BugChecker
           exprMayBeNull =
               NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo);
         } else {
+          // rely on dataflow analysis for local variables
           exprMayBeNull = true;
         }
         break;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2197,18 +2197,13 @@ public class NullAway extends BugChecker
       // obviously not null
       return false;
     }
-    if (expr.getKind() == Tree.Kind.NULL_LITERAL) {
-      // obviously null, so same as for above literals we return early without consulting handlers
-      return true;
-    }
-    // the logic here is to avoid doing dataflow analysis whenever possible
-    Symbol exprSymbol = ASTHelpers.getSymbol(expr);
-    boolean exprMayBeNull;
+    // return early for expressions that no handler overrides and will not need dataflow analysis
     switch (expr.getKind()) {
+      case NULL_LITERAL:
+        // obviously null
+        return true;
       case ARRAY_ACCESS:
         // unsound!  we cannot check for nullness of array contents yet
-        exprMayBeNull = false;
-        break;
       case NEW_CLASS:
       case NEW_ARRAY:
         // for string concatenation, auto-boxing
@@ -2258,29 +2253,34 @@ public class NullAway extends BugChecker
       case RIGHT_SHIFT:
       case UNSIGNED_RIGHT_SHIFT:
         // clearly not null
-        exprMayBeNull = false;
+        return false;
+      default:
         break;
+    }
+    // the logic here is to avoid doing dataflow analysis whenever possible
+    Symbol exprSymbol = ASTHelpers.getSymbol(expr);
+    boolean exprMayBeNull;
+    switch (expr.getKind()) {
       case MEMBER_SELECT:
         if (exprSymbol == null) {
           throw new IllegalStateException(
               "unexpected null symbol for dereference expression " + state.getSourceForNode(expr));
         }
-        exprMayBeNull = mayBeNullFieldAccess(state, expr, exprSymbol);
+        exprMayBeNull =
+            NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo);
         break;
       case IDENTIFIER:
         if (exprSymbol == null) {
           throw new IllegalStateException(
               "unexpected null symbol for identifier " + state.getSourceForNode(expr));
         }
-        if (exprSymbol.getKind().equals(ElementKind.FIELD)) {
-          // Special case: mayBeNullFieldAccess runs handler.onOverrideMayBeNullExpr before
-          // dataflow.
-          return mayBeNullFieldAccess(state, expr, exprSymbol);
+        if (exprSymbol.getKind() == ElementKind.FIELD) {
+          exprMayBeNull =
+              NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo);
         } else {
-          // Check handler.onOverrideMayBeNullExpr before dataflow.
-          exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, true);
-          return exprMayBeNull ? nullnessFromDataflow(state, expr) : false;
+          exprMayBeNull = true;
         }
+        break;
       case METHOD_INVOCATION:
         if (!(exprSymbol instanceof Symbol.MethodSymbol)) {
           throw new IllegalStateException(
@@ -2289,36 +2289,30 @@ public class NullAway extends BugChecker
                   + " for method invocation "
                   + state.getSourceForNode(expr));
         }
-        // Special case: mayBeNullMethodCall runs handler.onOverrideMayBeNullExpr before dataflow.
-        return mayBeNullMethodCall(state, expr, (Symbol.MethodSymbol) exprSymbol);
+        exprMayBeNull = mayBeNullMethodCall((Symbol.MethodSymbol) exprSymbol);
+        break;
       case CONDITIONAL_EXPRESSION:
       case ASSIGNMENT:
-        exprMayBeNull = nullnessFromDataflow(state, expr);
+        exprMayBeNull = true;
         break;
       default:
         // match switch expressions by comparing strings, so the code compiles on JDK versions < 12
         if (expr.getKind().name().equals("SWITCH_EXPRESSION")) {
-          exprMayBeNull = nullnessFromDataflow(state, expr);
+          exprMayBeNull = true;
         } else {
           throw new RuntimeException(
               "whoops, better handle " + expr.getKind() + " " + state.getSourceForNode(expr));
         }
     }
     exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, exprMayBeNull);
-    return exprMayBeNull;
+    return exprMayBeNull && nullnessFromDataflow(state, expr);
   }
 
-  private boolean mayBeNullMethodCall(
-      VisitorState state, ExpressionTree expr, Symbol.MethodSymbol exprSymbol) {
-    boolean exprMayBeNull = true;
+  private boolean mayBeNullMethodCall(Symbol.MethodSymbol exprSymbol) {
     if (codeAnnotationInfo.isSymbolUnannotated(exprSymbol, config)) {
-      exprMayBeNull = false;
+      return false;
     }
-    if (!Nullness.hasNullableAnnotation(exprSymbol, config)) {
-      exprMayBeNull = false;
-    }
-    exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, exprMayBeNull);
-    return exprMayBeNull ? nullnessFromDataflow(state, expr) : false;
+    return Nullness.hasNullableAnnotation(exprSymbol, config);
   }
 
   public boolean nullnessFromDataflow(VisitorState state, ExpressionTree expr) {
@@ -2334,15 +2328,6 @@ public class NullAway extends BugChecker
 
   public AccessPathNullnessAnalysis getNullnessAnalysis(VisitorState state) {
     return AccessPathNullnessAnalysis.instance(state, nonAnnotatedMethod, config, this.handler);
-  }
-
-  private boolean mayBeNullFieldAccess(VisitorState state, ExpressionTree expr, Symbol exprSymbol) {
-    boolean exprMayBeNull = true;
-    if (!NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo)) {
-      exprMayBeNull = false;
-    }
-    exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, exprMayBeNull);
-    return exprMayBeNull ? nullnessFromDataflow(state, expr) : false;
   }
 
   private Description matchDereference(


### PR DESCRIPTION
```
the uniform flow is now:
- return early for obvious expression types
- determine initial exprMayBeNull through simple checks
- apply handler overrides in single place
- finally run dataflow if exprMayBeNull is true in single place
```

idea from discussion on other PR

open questions:

a) why are no tests failing when we return early from the switch for some expressions?
(this is giving performance benefits because we are not redundantly calling the handler chain or dataflow analysis)

-> no handler ever overrides those expression types and dataflow analysis does not matter for them?

b) why are no tests failing because we change the order of "dataflow" and "handler overrides" in some methods, even though they state the order difference is intentional and important there

-> order should be uniform with dataflow running last