### PR TITLE
refactor LibraryModelsHandler.onOverrideMayBeNullExpr

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -142,10 +142,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     boolean isMethodUnannotated =
         getCodeAnnotationInfo(state.context).isSymbolUnannotated(methodSymbol, this.config);
     if (exprMayBeNull) {
-      if (optLibraryModels.hasNonNullReturn(methodSymbol, state.getTypes(), isMethodUnannotated)) {
-        return false;
-      }
-      return true;
+      // This is the only case in which we may switch the result from @Nullable to @NonNull:
+      return !optLibraryModels.hasNonNullReturn(
+          methodSymbol, state.getTypes(), isMethodUnannotated);
     }
     if (optLibraryModels.hasNullableReturn(methodSymbol, state.getTypes(), isMethodUnannotated)) {
       return true;


### PR DESCRIPTION
this does a similar refactoring as in https://github.com/uber/NullAway/pull/747

i held back on putting this up for review because i was assuming the removal of `analysis.nullnessFromDataflow(state, expr)` could be controversial

we can use this review to figure our what kind of tests are missing that would make clear why `nullnessFromDataflow` was being called inside a handler