### PR TITLE
Fix CI on Windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,15 +36,15 @@ jobs:
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v3
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-      - name: 'Set up JDK 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
           distribution: 'temurin'
       - name: Build and test using Java 8 and Error Prone ${{ matrix.epVersion }}
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,11 +36,12 @@ jobs:
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v3
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 17 on Windows'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+        if: matrix.os == 'windows-latest'
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
       - name: Build and test using Java 8 and Error Prone ${{ matrix.epVersion }}
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
@@ -53,7 +58,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -q javaToolchains
+          arguments: verGJF build
         if: matrix.java == '11'
       - name: Build and test using Java 17 and Error Prone ${{ matrix.epVersion }}
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: verGJF build
+          arguments: -q javaToolchains
         if: matrix.java == '11'
       - name: Build and test using Java 17 and Error Prone ${{ matrix.epVersion }}
         env:


### PR DESCRIPTION
Looks like JDK 17 is no longer pre-installed on Windows.  Even though we don't run our tests on JDK 17 on Windows, we need it to be available, as it gets used via Gradle toolchains for certain build steps.  With this change, we unconditionally install JDK 17 on Windows.