### PR TITLE
Upgrade maven publish plugin to 0.21.0 and restore publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.21.0'
         // This restriction is needed due to our mix of Android and Java modules;
         // without it, the build fails with a weird error.
         // See https://stackoverflow.com/questions/70217853/how-to-include-android-project-in-a-gradle-multi-project-build

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=uber
 POM_DEVELOPER_NAME=Uber Technologies
 POM_DEVELOPER_URL=https://uber.com
+
+# Publishing configuration for vanniktech/gradle-maven-publish-plugin
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -107,7 +107,7 @@ publishing {
    }
 
     afterEvaluate {
-        // Below is a series of hacks needed to get publication to work with 
+        // Below is a series of hacks needed to get publication to work with
         // gradle-maven-publish-plugin >= 0.15.0 (itself needed after the upgrade to Gradle 8.0.2).
         // Not sure why e.g. publishShadowPublicationToMavenCentralRepository must depend on signMavenPublication
         // (rather than just signShadowPublication)
@@ -121,6 +121,10 @@ publishing {
         }
         project.tasks.named('publishShadowPublicationToMavenCentralRepository').configure {
             dependsOn 'signMavenPublication'
+        }
+        project.tasks.named('publishShadowPublicationToMavenLocal').configure {
+            dependsOn 'javaSourcesJar'
+            dependsOn 'simpleJavadocJar'
         }
     }
 }

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -21,6 +21,11 @@ dependencies {
     }
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 jar {
     manifest {
         attributes(
@@ -40,6 +45,7 @@ shadowJar {
 }
 shadowJar.dependsOn jar
 assemble.dependsOn shadowJar
+
 
 // We disable the default maven publications to make sure only
 // our custom shadow publication is used. Since we use the empty
@@ -67,8 +73,8 @@ publishing {
             // Since we are skipping the default maven publication, we append the `:sources` and
             // `:javadoc` artifacts here. They are also required for Maven Central validation.
             afterEvaluate {
-                artifact project.sourcesJar
-                artifact project.javadocsJar
+                artifact project.javaSourcesJar
+                artifact project.javadocJar
             }
             // The shadow publication does not auto-configure the pom.xml file for us, so we need to
             // set it up manually. We use the opportunity to change the name and description from
@@ -97,6 +103,24 @@ publishing {
                     url = project.property('POM_SCM_URL')
                 }
             }
+        }
+   }
+
+    afterEvaluate {
+        // Below is a series of hacks needed to get publication to work with 
+        // gradle-maven-publish-plugin >= 0.15.0 (itself needed after the upgrade to Gradle 8.0.2).
+        // Not sure why e.g. publishShadowPublicationToMavenCentralRepository must depend on signMavenPublication
+        // (rather than just signShadowPublication)
+        project.tasks.named('generateMetadataFileForMavenPublication').configure {
+            dependsOn 'javaSourcesJar'
+            dependsOn 'simpleJavadocJar'
+        }
+        project.tasks.named('signShadowPublication').configure {
+            dependsOn 'sourcesJar'
+            dependsOn 'simpleJavadocJar'
+        }
+        project.tasks.named('publishShadowPublicationToMavenCentralRepository').configure {
+            dependsOn 'signMavenPublication'
         }
     }
 }

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -123,7 +123,7 @@ publishing {
             dependsOn 'signMavenPublication'
         }
         project.tasks.named('publishShadowPublicationToMavenLocal').configure {
-            dependsOn 'javaSourcesJar'
+            dependsOn 'sourcesJar'
             dependsOn 'simpleJavadocJar'
         }
     }


### PR DESCRIPTION
Without this change, the recent Gradle upgrade (#743) resulted in the following error while trying to publish to maven central:

```
> Task :jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository' (type 'PublishToMavenRepository').
  - Gradle detected a problem with the following location: '/Users/lazaro/Uber/NullAway/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-0.10.11.jar.asc'.
    
    Reason: Task ':jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository' uses this output of task ':jar-infer:jar-infer-cli:signMavenPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':jar-infer:jar-infer-cli:signMavenPublication' as an input of ':jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository'.
      2. Declare an explicit dependency on ':jar-infer:jar-infer-cli:signMavenPublication' from ':jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository' using Task#dependsOn.
      3. Declare an explicit dependency on ':jar-infer:jar-infer-cli:signMavenPublication' from ':jar-infer:jar-infer-cli:publishShadowPublicationToLocalRepository' using Task#mustRunAfter.
```

This change fixes that issue and also upgrades `com.vanniktech:gradle-maven-publish-plugin` to 0.21.0, the latest compatible version (versions from 0.23.0 onwards don't seem to be compatible with JDK8, and 0.22.0 gives a separate error).

Long term, we need to update the CI testing flow for publishing we added in #768 to also cover jar signing workflows.