### PR TITLE
Fix Publish Snapshot CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -103,7 +103,7 @@ jobs:
       - name: 'Publish'
         uses: gradle/gradle-build-action@v2
         env:
-          ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         with:
           arguments: clean publish --no-daemon --no-parallel


### PR DESCRIPTION
The name of these two configuration options was changed in newer versions of `gradle-maven-publish-plugin`.

Without this change, #773 breaks our snapshot publishing GitHub Actions CI workflow.