### PR TITLE
Add step to create release on GitHub

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,3 +31,4 @@ Releasing
  8. `git commit -am "Prepare next development version."`
  9. `git push && git push --tags`
  10. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 11. Go to [this page](https://github.com/uber/NullAway/releases/new) to create a new release on GitHub, using the release notes from `CHANGELOG.md`.


### PR DESCRIPTION
Users look for GitHub Releases these days (and can be easily notified of such releases), so we should support them.  I created a release for 0.10.11:

https://github.com/uber/NullAway/releases/tag/v0.10.11

The GitHub Release page has a nice feature for generating release notes from commits, so eventually we may want to deprecate `CHANGELOG.md`.
