### PR TITLE
Set concurrency for JMH benchmarking workflow

### DIFF
--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -5,6 +5,9 @@ on:
   issue_comment: # This workflow triggers when a comment is created
     types: [created]
 
+# Only allow one instance of JMH benchmarking to be running at any given time
+concurrency: all
+
 jobs:
   benchmarking:
     # Only run this job if a comment on a pull request contains '/benchmark' and is a PR on the uber/NullAway repository


### PR DESCRIPTION
We should only allow one benchmarking workflow to be running at any given time, since we only have one VM allocated for it.