### PR TITLE
Disable daemon when running benchmarks

### DIFF
--- a/.github/workflows/run_main_benchmarks.sh
+++ b/.github/workflows/run_main_benchmarks.sh
@@ -6,4 +6,4 @@ cd main/
 git clone git@github.com:Uber/NullAway.git
 cd NullAway/
 
-./gradlew jmh
+./gradlew jmh --no-daemon

--- a/.github/workflows/run_pr_benchmarks.sh
+++ b/.github/workflows/run_pr_benchmarks.sh
@@ -6,4 +6,4 @@ cd pr/
 git clone --branch $BRANCH_NAME --single-branch git@github.com:$REPO_NAME.git NullAway
 cd NullAway/
 
-./gradlew jmh
+./gradlew jmh --no-daemon


### PR DESCRIPTION
This might reduce the noise a bit when running benchmarks (since old daemon processes won't be running).