### PR TITLE
Improve auto-fixing of unnecessary castToNonNull calls

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -33,6 +33,7 @@ import static com.uber.nullaway.NullAway.OPTIONAL_CHECK_NAME;
 import static com.uber.nullaway.NullAway.getTreesInstance;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -342,9 +343,15 @@ public class ErrorBuilder {
     // castToNonNull(...) invocation to be replaced by it. Fortunately, state.getPath()
     // should be currently pointing at said call.
     Tree currTree = state.getPath().getLeaf();
-    assert currTree.getKind() == Tree.Kind.METHOD_INVOCATION;
+    Preconditions.checkArgument(
+        currTree.getKind() == Tree.Kind.METHOD_INVOCATION,
+        String.format("Expected castToNonNull invocation expression, found:\n%s", currTree));
     final MethodInvocationTree invTree = (MethodInvocationTree) currTree;
-    assert invTree.getArguments().contains(suggestTree);
+    Preconditions.checkArgument(
+        invTree.getArguments().contains(suggestTree),
+        String.format(
+            "Method invocation tree %s does not contain the expression %s as an argument being cast",
+            invTree, suggestTree));
     // Remove the call to castToNonNull:
     final SuggestedFix fix =
         SuggestedFix.builder().replace(invTree, suggestTree.toString()).build();

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -133,7 +133,7 @@ public class ErrorBuilder {
     }
 
     if (config.suggestSuppressions() && suggestTree != null) {
-      builder = addSuggestedSuppression(errorMessage, suggestTree, builder);
+      builder = addSuggestedSuppression(errorMessage, suggestTree, builder, state);
     }
 
     if (config.serializationIsActive()) {
@@ -187,7 +187,10 @@ public class ErrorBuilder {
   }
 
   private Description.Builder addSuggestedSuppression(
-      ErrorMessage errorMessage, Tree suggestTree, Description.Builder builder) {
+      ErrorMessage errorMessage,
+      Tree suggestTree,
+      Description.Builder builder,
+      VisitorState state) {
     switch (errorMessage.messageType) {
       case DEREFERENCE_NULLABLE:
       case RETURN_NULLABLE:
@@ -201,7 +204,7 @@ public class ErrorBuilder {
         }
         break;
       case CAST_TO_NONNULL_ARG_NONNULL:
-        builder = removeCastToNonNullFix(suggestTree, builder);
+        builder = removeCastToNonNullFix(suggestTree, builder, state);
         break;
       case WRONG_OVERRIDE_RETURN:
         builder = addSuppressWarningsFix(suggestTree, builder, suppressionName);
@@ -334,20 +337,17 @@ public class ErrorBuilder {
   }
 
   private Description.Builder removeCastToNonNullFix(
-      Tree suggestTree, Description.Builder builder) {
-    assert suggestTree.getKind() == Tree.Kind.METHOD_INVOCATION;
-    final MethodInvocationTree invTree = (MethodInvocationTree) suggestTree;
-    final Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invTree);
-    final String qualifiedName =
-        ASTHelpers.enclosingClass(methodSymbol) + "." + methodSymbol.getSimpleName().toString();
-    if (!qualifiedName.equals(config.getCastToNonNullMethod())) {
-      throw new RuntimeException("suggestTree should point to the castToNonNull invocation.");
-    }
+      Tree suggestTree, Description.Builder builder, VisitorState state) {
+    // Note: Here suggestTree refers to the argument being cast. We need to find the
+    // castToNonNull(...) invocation to be replaced by it. Fortunately, state.getPath()
+    // should be currently pointing at said call.
+    Tree currTree = state.getPath().getLeaf();
+    assert currTree.getKind() == Tree.Kind.METHOD_INVOCATION;
+    final MethodInvocationTree invTree = (MethodInvocationTree) currTree;
+    assert invTree.getArguments().contains(suggestTree);
     // Remove the call to castToNonNull:
     final SuggestedFix fix =
-        SuggestedFix.builder()
-            .replace(suggestTree, invTree.getArguments().get(0).toString())
-            .build();
+        SuggestedFix.builder().replace(invTree, suggestTree.toString()).build();
     return builder.addFix(fix);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1712,7 +1712,9 @@ public class NullAway extends BugChecker
                 + "at the invocation site, but which are known not to be null at runtime.";
         return errorBuilder.createErrorDescription(
             new ErrorMessage(MessageTypes.CAST_TO_NONNULL_ARG_NONNULL, message),
-            tree,
+            // The Tree passed as suggestTree is the expression being cast
+            // to avoid recomputing the arg index:
+            actual,
             buildDescription(tree),
             state,
             null);

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -38,7 +38,7 @@ public class NullAwayAutoSuggestTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  public ErrorProneFlags flags;
+  private ErrorProneFlags flags;
 
   @Before
   public void setup() {


### PR DESCRIPTION
In particular, this allows removing unnecessary casts where the castToNonNull method is specified by a library model, rather than a CLI argument.