### PR TITLE
Update to Error Prone 2.21.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: 2.21.1
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: 2.21.1
           - os: windows-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: 2.21.1
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.21.0
+            epVersion: 2.21.1
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.21.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.21.1' && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,6 @@ on:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
-env:
-  EP_LATEST_SUPPORTED: 2.21.0
-  EP_OLDEST_SUPPORTED: 2.4.0
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }} with Error Prone ${{ matrix.epVersion }}"
@@ -18,22 +15,22 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: ${{ env.EP_OLDEST_SUPPORTED }}
+            epVersion: 2.4.0
           - os: ubuntu-latest
             java: 17
-            epVersion: ${{ env.EP_OLDEST_SUPPORTED }}
+            epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
+            epVersion: 2.21.0
           - os: ubuntu-latest
             java: 11
-            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
+            epVersion: 2.21.0
           - os: windows-latest
             java: 11
-            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
+            epVersion: 2.21.0
           - os: ubuntu-latest
             java: 17
-            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
+            epVersion: 2.21.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,7 +61,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == env.EP_LATEST_SUPPORTED && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.21.0' && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == "$EP_LATEST_SUPPORTED" && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == $EP_LATEST_SUPPORTED && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,9 @@ on:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
+env:
+  EP_LATEST_SUPPORTED: 2.21.0
+  EP_OLDEST_SUPPORTED: 2.4.0
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }} with Error Prone ${{ matrix.epVersion }}"
@@ -15,22 +18,22 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.4.0
+            epVersion: "$EP_OLDEST_SUPPORTED"
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.4.0
+            epVersion: "$EP_OLDEST_SUPPORTED"
           - os: macos-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: windows-latest
             java: 11
-            epVersion: 2.21.0
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.21.0
+            epVersion: "$EP_LATEST_SUPPORTED"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +64,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.21.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == "$EP_LATEST_SUPPORTED" && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,22 +18,22 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: env.EP_OLDEST_SUPPORTED
+            epVersion: "$EP_OLDEST_SUPPORTED"
           - os: ubuntu-latest
             java: 17
-            epVersion: env.EP_OLDEST_SUPPORTED
+            epVersion: "$EP_OLDEST_SUPPORTED"
           - os: macos-latest
             java: 11
-            epVersion: env.EP_LATEST_SUPPORTED
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: ubuntu-latest
             java: 11
-            epVersion: env.EP_LATEST_SUPPORTED
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: windows-latest
             java: 11
-            epVersion: env.EP_LATEST_SUPPORTED
+            epVersion: "$EP_LATEST_SUPPORTED"
           - os: ubuntu-latest
             java: 17
-            epVersion: env.EP_LATEST_SUPPORTED
+            epVersion: "$EP_LATEST_SUPPORTED"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,22 +18,22 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: "$EP_OLDEST_SUPPORTED"
+            epVersion: ${{ env.EP_OLDEST_SUPPORTED }}
           - os: ubuntu-latest
             java: 17
-            epVersion: "$EP_OLDEST_SUPPORTED"
+            epVersion: ${{ env.EP_OLDEST_SUPPORTED }}
           - os: macos-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
           - os: ubuntu-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
           - os: windows-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
           - os: ubuntu-latest
             java: 17
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: ${{ env.EP_LATEST_SUPPORTED }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,22 +18,22 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: "$EP_OLDEST_SUPPORTED"
+            epVersion: env.EP_OLDEST_SUPPORTED
           - os: ubuntu-latest
             java: 17
-            epVersion: "$EP_OLDEST_SUPPORTED"
+            epVersion: env.EP_OLDEST_SUPPORTED
           - os: macos-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: env.EP_LATEST_SUPPORTED
           - os: ubuntu-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: env.EP_LATEST_SUPPORTED
           - os: windows-latest
             java: 11
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: env.EP_LATEST_SUPPORTED
           - os: ubuntu-latest
             java: 17
-            epVersion: "$EP_LATEST_SUPPORTED"
+            epVersion: env.EP_LATEST_SUPPORTED
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,7 +64,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == $EP_LATEST_SUPPORTED && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == env.EP_LATEST_SUPPORTED && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.4.0
           - os: macos-latest
             java: 11
-            epVersion: 2.20.0
+            epVersion: 2.21.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.20.0
+            epVersion: 2.21.0
           - os: windows-latest
             java: 11
-            epVersion: 2.20.0
+            epVersion: 2.21.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.20.0
+            epVersion: 2.21.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
         with:
           arguments: coveralls
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.20.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.21.0' && github.repository == 'uber/NullAway'
       - name: Test publishToMavenLocal flow
         env:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.4.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.21.0"
+def latestErrorProneVersion = "2.21.1"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.4.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.20.0"
+def latestErrorProneVersion = "2.21.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/nullaway/src/main/java/com/uber/nullaway/ASTHelpersBackports.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ASTHelpersBackports.java
@@ -32,6 +32,7 @@ public class ASTHelpersBackports {
    * https://github.com/google/error-prone/blame/a1318e4b0da4347dff7508108835d77c470a7198/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1148
    * TODO: delete this method and switch to ASTHelpers once we can require Error Prone 2.20.0
    */
+  @SuppressWarnings("ASTHelpersSuggestions")
   public static List<Symbol> getEnclosedElements(Symbol symbol) {
     return symbol.getEnclosedElements();
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -56,22 +56,18 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
 
   private Optional<Type> tbaseType;
 
+  /**
+   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
+   * processed, before any other handler methods
+   */
+  @Initializer
   @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (tbaseType == null) {
-      init(state);
+      tbaseType =
+          Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
     }
-  }
-
-  /**
-   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
-   * processed by {@link #onMatchTopLevelClass(NullAway, ClassTree, VisitorState,
-   * Symbol.ClassSymbol)}
-   */
-  @Initializer
-  private void init(VisitorState state) {
-    tbaseType = Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -23,7 +23,6 @@ package com.uber.nullaway.handlers;
 
 import static com.uber.nullaway.ASTHelpersBackports.getEnclosedElements;
 
-import com.google.common.base.Preconditions;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
@@ -33,6 +32,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
+import com.uber.nullaway.annotations.Initializer;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import java.util.Objects;
@@ -54,15 +54,24 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
 
   private static final Supplier<Type> TBASE_TYPE_SUPPLIER = Suppliers.typeFromString(TBASE_NAME);
 
-  @Nullable private Optional<Type> tbaseType;
+  private Optional<Type> tbaseType;
 
   @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (tbaseType == null) {
-      tbaseType =
-          Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
+      init(state);
     }
+  }
+
+  /**
+   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
+   * processed by {@link #onMatchTopLevelClass(NullAway, ClassTree, VisitorState,
+   * Symbol.ClassSymbol)}
+   */
+  @Initializer
+  private void init(VisitorState state) {
+    tbaseType = Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
   }
 
   @Override
@@ -173,7 +182,6 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
   }
 
   private boolean thriftIsSetCall(Symbol.MethodSymbol symbol, Types types) {
-    Preconditions.checkNotNull(tbaseType);
     // noinspection ConstantConditions
     return tbaseType.isPresent()
         && symbol.getSimpleName().toString().startsWith("isSet")

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
@@ -24,7 +24,6 @@ package com.uber.nullaway.handlers;
 import static com.uber.nullaway.ASTHelpersBackports.getEnclosedElements;
 import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
@@ -37,6 +36,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
+import com.uber.nullaway.annotations.Initializer;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import java.util.ArrayList;
@@ -61,20 +61,29 @@ public class GrpcHandler extends BaseNoOpHandler {
   private static final Supplier<Type> GRPC_METADATA_KEY_TYPE_SUPPLIER =
       Suppliers.typeFromString(GRPC_METADATA_KEY_TNAME);
 
-  @Nullable private Optional<Type> grpcMetadataType;
-  @Nullable private Optional<Type> grpcKeyType;
+  private Optional<Type> grpcMetadataType;
+  private Optional<Type> grpcKeyType;
 
   @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (grpcMetadataType == null || grpcKeyType == null) {
-      grpcMetadataType =
-          Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state))
-              .map(state.getTypes()::erasure);
-      grpcKeyType =
-          Optional.ofNullable(GRPC_METADATA_KEY_TYPE_SUPPLIER.get(state))
-              .map(state.getTypes()::erasure);
+      init(state);
     }
+  }
+
+  /**
+   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
+   * processed by {@link #onMatchTopLevelClass(NullAway, ClassTree, VisitorState,
+   * Symbol.ClassSymbol)}
+   */
+  @Initializer
+  private void init(VisitorState state) {
+    grpcMetadataType =
+        Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
+    grpcKeyType =
+        Optional.ofNullable(GRPC_METADATA_KEY_TYPE_SUPPLIER.get(state))
+            .map(state.getTypes()::erasure);
   }
 
   @Override
@@ -135,8 +144,6 @@ public class GrpcHandler extends BaseNoOpHandler {
   }
 
   private boolean grpcIsMetadataContainsKeyCall(Symbol.MethodSymbol symbol, Types types) {
-    Preconditions.checkNotNull(grpcMetadataType);
-    Preconditions.checkNotNull(grpcKeyType);
     // noinspection ConstantConditions
     return grpcMetadataType.isPresent()
         && grpcKeyType.isPresent()
@@ -149,8 +156,6 @@ public class GrpcHandler extends BaseNoOpHandler {
   }
 
   private boolean grpcIsMetadataGetCall(Symbol.MethodSymbol symbol, Types types) {
-    Preconditions.checkNotNull(grpcMetadataType);
-    Preconditions.checkNotNull(grpcKeyType);
     // noinspection ConstantConditions
     return grpcMetadataType.isPresent()
         && grpcKeyType.isPresent()

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
@@ -64,26 +64,22 @@ public class GrpcHandler extends BaseNoOpHandler {
   private Optional<Type> grpcMetadataType;
   private Optional<Type> grpcKeyType;
 
+  /**
+   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
+   * processed, before any other handler methods
+   */
+  @Initializer
   @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     if (grpcMetadataType == null || grpcKeyType == null) {
-      init(state);
+      grpcMetadataType =
+          Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state))
+              .map(state.getTypes()::erasure);
+      grpcKeyType =
+          Optional.ofNullable(GRPC_METADATA_KEY_TYPE_SUPPLIER.get(state))
+              .map(state.getTypes()::erasure);
     }
-  }
-
-  /**
-   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
-   * processed by {@link #onMatchTopLevelClass(NullAway, ClassTree, VisitorState,
-   * Symbol.ClassSymbol)}
-   */
-  @Initializer
-  private void init(VisitorState state) {
-    grpcMetadataType =
-        Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);
-    grpcKeyType =
-        Optional.ofNullable(GRPC_METADATA_KEY_TYPE_SUPPLIER.get(state))
-            .map(state.getTypes()::erasure);
   }
 
   @Override

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -34,8 +34,6 @@ tasks.withType(JavaCompile) {
   if (!name.toLowerCase().contains("test")) {
     options.errorprone {
       check("NullAway", CheckSeverity.ERROR)
-      // Issue in Error Prone 2.21.0: https://github.com/google/error-prone/issues/4040
-      check("NotJavadoc", CheckSeverity.OFF)
       option("NullAway:AnnotatedPackages", "com.uber")
       option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -34,6 +34,8 @@ tasks.withType(JavaCompile) {
   if (!name.toLowerCase().contains("test")) {
     options.errorprone {
       check("NullAway", CheckSeverity.ERROR)
+      // Issue in Error Prone 2.21.0: https://github.com/google/error-prone/issues/4040
+      check("NotJavadoc", CheckSeverity.OFF)
       option("NullAway:AnnotatedPackages", "com.uber")
       option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
     }


### PR DESCRIPTION
Mostly straightforward.  Error Prone has a new [NullableOptional](https://errorprone.info/bugpattern/NullableOptional) check that warned on a couple instances in our code base.  I changed these cases to use an `@Initializer` method which I think better captures what is going on.  Will update the required CI checks before landing.