### PR TITLE
Update to WALA 1.6.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.1",
+    wala                   : "1.6.2",
     commonscli             : "1.4",
     autoValue              : "1.9",
     autoService            : "1.0.1",

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -228,7 +228,7 @@ public class DefinitelyDerefedParamsDriver {
     } else if (!new File(inPath).exists()) {
       return;
     }
-    AnalysisScope scope = AnalysisScopeReader.instance.makePrimordialScope(null);
+    AnalysisScope scope = AnalysisScopeReader.instance.makeBasePrimordialScope(null);
     scope.setExclusions(
         new FileOfClasses(
             new ByteArrayInputStream(DEFAULT_EXCLUSIONS.getBytes(StandardCharsets.UTF_8))));


### PR DESCRIPTION
We use a [new WALA feature](https://github.com/wala/WALA/pull/1286) to only include the `java.base` module in the `AnalysisScope` used for JarInfer.  JarInfer does not require all JDK standard library modules to be part of the analysis scope, just enough to make a valid class hierarchy, and `java.base` suffices.  This should speed up runs of JarInfer, and in particular it speeds up our JarInfer regression tests.