### PR TITLE
Avoid suggesting castToNonNull fixes in certain cases

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -204,7 +204,7 @@ public class ErrorBuilder {
           builder = addCastToNonNullFix(suggestTree, builder);
         } else {
           // When there is a castToNonNull method, suggestTree is set to the expression to be
-          // casted, which is not suppressible.  For simplicity, we just always recompute the
+          // casted, which is not suppressible. For simplicity, we just always recompute the
           // suppressible node here.
           Tree suppressibleNode = suppressibleNode(state.getPath());
           if (suppressibleNode != null) {

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -203,6 +203,9 @@ public class ErrorBuilder {
         if (config.getCastToNonNullMethod() != null && canBeCastToNonNull(suggestTree)) {
           builder = addCastToNonNullFix(suggestTree, builder);
         } else {
+          // When there is a castToNonNull method, suggestTree is set to the expression to be
+          // casted, which is not suppressible.  For simplicity, we just always recompute the
+          // suppressible node here.
           Tree suppressibleNode = suppressibleNode(state.getPath());
           if (suppressibleNode != null) {
             builder = addSuppressWarningsFix(suppressibleNode, builder, suppressionName);

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -203,8 +203,10 @@ public class ErrorBuilder {
         if (config.getCastToNonNullMethod() != null && canBeCastToNonNull(suggestTree)) {
           builder = addCastToNonNullFix(suggestTree, builder);
         } else {
-          builder =
-              addSuppressWarningsFix(suppressibleNode(state.getPath()), builder, suppressionName);
+          Tree suppressibleNode = suppressibleNode(state.getPath());
+          if (suppressibleNode != null) {
+            builder = addSuppressWarningsFix(suppressibleNode, builder, suppressionName);
+          }
         }
         break;
       case CAST_TO_NONNULL_ARG_NONNULL:
@@ -343,7 +345,8 @@ public class ErrorBuilder {
         // make the parameter @NonNull and add casts at call sites, but that is beyond the scope of
         // our suggested fixes
         Symbol symbol = ASTHelpers.getSymbol(tree);
-        return !(symbol.getKind().equals(ElementKind.PARAMETER)
+        return !(symbol != null
+            && symbol.getKind().equals(ElementKind.PARAMETER)
             && hasNullableAnnotation(symbol, config));
       default:
         return true;

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -395,8 +395,8 @@ public class ErrorBuilder {
   }
 
   /**
-   * Reports initialization errors where a constructor fails to guarantee non-fields are initialized
-   * along all paths at exit points.
+   * Reports initialization errors where a constructor fails to guarantee non-null fields are
+   * initialized along all paths at exit points.
    *
    * @param methodSymbol Constructor symbol.
    * @param message Error message.

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -198,7 +198,7 @@ public class ErrorBuilder {
       case PASS_NULLABLE:
       case ASSIGN_FIELD_NULLABLE:
       case SWITCH_EXPRESSION_NULLABLE:
-        if (config.getCastToNonNullMethod() != null) {
+        if (config.getCastToNonNullMethod() != null && canBeCastToNonNull(suggestTree, state)) {
           builder = addCastToNonNullFix(suggestTree, builder);
         } else {
           builder = addSuppressWarningsFix(suggestTree, builder, suppressionName);
@@ -318,6 +318,25 @@ public class ErrorBuilder {
         .filter(ErrorBuilder::canHaveSuppressWarningsAnnotation)
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * Checks if it would be appropriate to wrap {@code tree} in a {@code castToNonNull} call. There
+   * are two cases where this method returns {@code false}:
+   *
+   * <ol>
+   *   <li>{@code tree} represents the {@code null} literal
+   *   <li>{@code tree} represents a {@code @Nullable} formal parameter of the enclosing method
+   * </ol>
+   */
+  private boolean canBeCastToNonNull(Tree tree, VisitorState state) {
+    switch (tree.getKind()) {
+      case NULL_LITERAL:
+        return false;
+      case IDENTIFIER:
+      default:
+        return true;
+    }
   }
 
   private Description.Builder addCastToNonNullFix(Tree suggestTree, Description.Builder builder) {

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -134,10 +134,15 @@ public class NullAwayAutoSuggestTest {
             "  void test3() {",
             "    f = null;",
             "  }",
+            "  @Nullable Object m() { return null; }",
+            "  Object shouldAddCast() {",
+            "    return m();",
+            "  }",
             "}")
         .addOutputLines(
             "out/Test.java",
             "package com.uber;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
             "import javax.annotation.Nullable;",
             "class Test {",
             "  Object f = new Object();",
@@ -149,6 +154,10 @@ public class NullAwayAutoSuggestTest {
             "  }",
             "  @SuppressWarnings(\"NullAway\") void test3() {",
             "    f = null;",
+            "  }",
+            "  @Nullable Object m() { return null; }",
+            "  Object shouldAddCast() {",
+            "    return castToNonNull(m());",
             "  }",
             "}")
         .doTest();
@@ -244,6 +253,70 @@ public class NullAwayAutoSuggestTest {
             "  @SuppressWarnings(\"NullAway\") void test() throws Exception {",
             "    takesNonNull(execute(Test::doReturnNullable));",
             "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suggestInitSuppressionOnConstructor() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object f;",
+            "  Object g;",
+            "  Test() {}",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object f;",
+            "  Object g;",
+            "  @SuppressWarnings(\"NullAway.Init\") Test() {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suggestInitSuppressionOnField() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object f;",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @SuppressWarnings(\"NullAway.Init\") Object f;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void updateExtantSuppressWarnings() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @SuppressWarnings(\"unused\") Object f;",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @SuppressWarnings({\"unused\",\"NullAway.Init\"}) Object f;",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -92,7 +92,8 @@ public class NullAwayAutoSuggestTest {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "class Test {",
-            "  Object test1(@Nullable Object o) {",
+            "  @Nullable Object o;",
+            "  Object test1() {",
             "    return o;",
             "  }",
             "}")
@@ -102,8 +103,39 @@ public class NullAwayAutoSuggestTest {
             "import static com.uber.nullaway.testdata.Util.castToNonNull;",
             "import javax.annotation.Nullable;",
             "class Test {",
-            "  Object test1(@Nullable Object o) {",
+            "  @Nullable Object o;",
+            "  Object test1() {",
             "    return castToNonNull(o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suppressInsteadOfCastToNonNull() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  Object test1(@Nullable Object o) {",
+            "    return o;",
+            "  }",
+            "  Object test2() {",
+            "    return null;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @SuppressWarnings(\"NullAway\") Object test1(@Nullable Object o) {",
+            "    return o;",
+            "  }",
+            "  @SuppressWarnings(\"NullAway\") Object test2() {",
+            "    return null;",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -24,6 +24,7 @@ package com.uber.nullaway;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.ErrorProneFlags;
+import com.sun.source.tree.Tree;
 import com.uber.nullaway.testlibrarymodels.TestLibraryModels;
 import java.io.IOException;
 import org.junit.Before;
@@ -111,6 +112,10 @@ public class NullAwayAutoSuggestTest {
         .doTest();
   }
 
+  /**
+   * Test for cases where we heuristically decide not to wrap an expression in castToNonNull; see
+   * {@link ErrorBuilder#canBeCastToNonNull(Tree)}
+   */
   @Test
   public void suppressInsteadOfCastToNonNull() throws IOException {
     makeTestHelper()
@@ -119,11 +124,15 @@ public class NullAwayAutoSuggestTest {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "class Test {",
+            "  Object f = new Object();",
             "  Object test1(@Nullable Object o) {",
             "    return o;",
             "  }",
             "  Object test2() {",
             "    return null;",
+            "  }",
+            "  void test3() {",
+            "    f = null;",
             "  }",
             "}")
         .addOutputLines(
@@ -131,11 +140,15 @@ public class NullAwayAutoSuggestTest {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "class Test {",
+            "  Object f = new Object();",
             "  @SuppressWarnings(\"NullAway\") Object test1(@Nullable Object o) {",
             "    return o;",
             "  }",
             "  @SuppressWarnings(\"NullAway\") Object test2() {",
             "    return null;",
+            "  }",
+            "  @SuppressWarnings(\"NullAway\") void test3() {",
+            "    f = null;",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
We avoid suggesting a `castToNonNull` fix if either (1) the expression is the `null` literal (i.e., don't suggest `castToNonNull(null)`), or (2) the expression is a `@Nullable` parameter (see code comments for justification).  In these cases, we suggest a `@SuppressWarnings` annotation instead.

Here we also add some tests to improve coverage of the `ErrorBuilder` class.