### PR TITLE
Enable contract checking when building NullAway

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -171,6 +171,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
         option("NullAway:CastToNonNullMethod", "com.uber.nullaway.NullabilityUtil.castToNonNull")
         option("NullAway:CheckOptionalEmptiness")
         option("NullAway:AcknowledgeRestrictiveAnnotations")
+        option("NullAway:CheckContracts")
     }
     // Make sure the jar has already been built
     dependsOn 'jar'


### PR DESCRIPTION
I think we only have one `@Contract` annotation in the NullAway code base right now, but anyway this will give us a bit more test coverage of contract checking.