### PR TITLE
Allow library models to define custom stream classes.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -22,9 +22,11 @@
 
 package com.uber.nullaway;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.handlers.stream.StreamTypeRecord;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -130,7 +132,23 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods();
 
   /**
-   * representation of a method as a qualified class name + a signature for the method
+   * Get a list of custom stream library specifications.
+   *
+   * <p>This allows users to define filter/map/other methods for APIs which behave similarly to Java
+   * 8 streams or ReactiveX streams, so that NullAway is able to understand nullability invariants
+   * across stream API calls. See {@see com.uber.nullaway.handlers.stream.StreamModelBuilder} for
+   * details on how to construct these {@see com.uber.nullaway.handlers.stream.StreamTypeRecord}
+   * specs. A full example is available at {@see
+   * com.uber.nullaway.testlibrarymodels.TestLibraryModels}.
+   *
+   * @return A list of StreamTypeRecord specs (usually generated using StreamModelBuilder).
+   */
+  default ImmutableList<StreamTypeRecord> customStreamNullabilitySpecs() {
+    return ImmutableList.of();
+  }
+
+  /**
+   * Representation of a method as a qualified class name + a signature for the method
    *
    * <p>The formatting of a method signature should match the result of calling {@link
    * Symbol.MethodSymbol#toString()} on the corresponding symbol. See {@link

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -136,9 +136,9 @@ public interface LibraryModels {
    *
    * <p>This allows users to define filter/map/other methods for APIs which behave similarly to Java
    * 8 streams or ReactiveX streams, so that NullAway is able to understand nullability invariants
-   * across stream API calls. See {@see com.uber.nullaway.handlers.stream.StreamModelBuilder} for
-   * details on how to construct these {@see com.uber.nullaway.handlers.stream.StreamTypeRecord}
-   * specs. A full example is available at {@see
+   * across stream API calls. See {@link com.uber.nullaway.handlers.stream.StreamModelBuilder} for
+   * details on how to construct these {@link com.uber.nullaway.handlers.stream.StreamTypeRecord}
+   * specs. A full example is available at {@link
    * com.uber.nullaway.testlibrarymodels.TestLibraryModels}.
    *
    * @return A list of StreamTypeRecord specs (usually generated using StreamModelBuilder).

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -57,9 +57,11 @@ public class Handlers {
       handlerListBuilder.add(new AssertionHandler(methodNameUtil));
     }
     handlerListBuilder.add(new GuavaAssertionsHandler());
-    handlerListBuilder.add(new LibraryModelsHandler(config));
+    LibraryModelsHandler libraryModelsHandler = new LibraryModelsHandler(config);
+    handlerListBuilder.add(libraryModelsHandler);
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getRxStreamNullabilityPropagator());
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator());
+    handlerListBuilder.add(libraryModelsHandler.getStreamNullabilityPropagatorFromModels());
     handlerListBuilder.add(new ContractHandler(config));
     handlerListBuilder.add(new ApacheThriftIsSetHandler());
     handlerListBuilder.add(new GrpcHandler());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -61,7 +61,9 @@ public class Handlers {
     handlerListBuilder.add(libraryModelsHandler);
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getRxStreamNullabilityPropagator());
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator());
-    handlerListBuilder.add(libraryModelsHandler.getStreamNullabilityPropagatorFromModels());
+    handlerListBuilder.add(
+        StreamNullabilityPropagatorFactory.fromSpecs(
+            libraryModelsHandler.getStreamNullabilitySpecs()));
     handlerListBuilder.add(new ContractHandler(config));
     handlerListBuilder.add(new ApacheThriftIsSetHandler());
     handlerListBuilder.add(new GrpcHandler());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -27,6 +27,7 @@ import static com.uber.nullaway.Nullness.NONNULL;
 import static com.uber.nullaway.Nullness.NULLABLE;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.errorprone.VisitorState;
@@ -46,6 +47,7 @@ import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
+import com.uber.nullaway.handlers.stream.StreamTypeRecord;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -289,6 +291,21 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         accessPathsAtIndexes(requiredNonNullParameters, arguments, state, apContext)) {
       bothUpdates.set(accessPath, NONNULL);
     }
+  }
+
+  /**
+   * Generate a StreamNullabilityPropagator handler based on all the stream specifications loaded
+   * from any of our library models.
+   *
+   * <p>This handler must be registered in Handlers.java separatedly from the LibraryModelsHandler
+   * itself.
+   */
+  public StreamNullabilityPropagator getStreamNullabilityPropagatorFromModels() {
+    // Note: Currently, OptimizedLibraryModels doesn't carry the information about stream type
+    // records,
+    // it is not clear what it means to "optimize" lookup for those and they get access only once:
+    // here.
+    return new StreamNullabilityPropagator(libraryModels.customStreamNullabilitySpecs());
   }
 
   private static LibraryModels loadLibraryModels(Config config) {
@@ -827,6 +844,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
     private final ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods;
 
+    private final ImmutableList<StreamTypeRecord> customStreamNullabilitySpecs;
+
     public CombinedLibraryModels(Iterable<LibraryModels> models, Config config) {
       this.config = config;
       ImmutableSetMultimap.Builder<MethodRef, Integer> failIfNullParametersBuilder =
@@ -845,6 +864,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       ImmutableSet.Builder<MethodRef> nonNullReturnsBuilder = new ImmutableSet.Builder<>();
       ImmutableSetMultimap.Builder<MethodRef, Integer> castToNonNullMethodsBuilder =
           new ImmutableSetMultimap.Builder<>();
+      ImmutableList.Builder<StreamTypeRecord> customStreamNullabilitySpecsBuilder =
+          new ImmutableList.Builder<>();
       for (LibraryModels libraryModels : models) {
         for (Map.Entry<MethodRef, Integer> entry : libraryModels.failIfNullParameters().entries()) {
           if (shouldSkipModel(entry.getKey())) {
@@ -904,6 +925,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
           }
           castToNonNullMethodsBuilder.put(entry);
         }
+        for (StreamTypeRecord streamTypeRecord : libraryModels.customStreamNullabilitySpecs()) {
+          customStreamNullabilitySpecsBuilder.add(streamTypeRecord);
+        }
       }
       failIfNullParameters = failIfNullParametersBuilder.build();
       explicitlyNullableParameters = explicitlyNullableParametersBuilder.build();
@@ -914,6 +938,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       nullableReturns = nullableReturnsBuilder.build();
       nonNullReturns = nonNullReturnsBuilder.build();
       castToNonNullMethods = castToNonNullMethodsBuilder.build();
+      customStreamNullabilitySpecs = customStreamNullabilitySpecsBuilder.build();
     }
 
     private boolean shouldSkipModel(MethodRef key) {
@@ -963,6 +988,11 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
       return castToNonNullMethods;
+    }
+
+    @Override
+    public ImmutableList<StreamTypeRecord> customStreamNullabilitySpecs() {
+      return customStreamNullabilitySpecs;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -294,18 +294,22 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   /**
-   * Generate a StreamNullabilityPropagator handler based on all the stream specifications loaded
-   * from any of our library models.
+   * Get all the stream specifications loaded from any of our library models.
    *
-   * <p>This handler must be registered in Handlers.java separatedly from the LibraryModelsHandler
-   * itself.
+   * <p>This is used in Handlers.java to create a StreamNullabilityPropagator handler, which gets
+   * registered independently of this LibraryModelsHandler itself.
+   *
+   * <p>LibraryModelsHandler is responsible from reading the library models for stream specs, but
+   * beyond that, checking of the specs falls under the responsibility of the generated
+   * StreamNullabilityPropagator handler.
+   *
+   * @return The list of all stream specifications loaded from any of our library models.
    */
-  public StreamNullabilityPropagator getStreamNullabilityPropagatorFromModels() {
+  public ImmutableList<StreamTypeRecord> getStreamNullabilitySpecs() {
     // Note: Currently, OptimizedLibraryModels doesn't carry the information about stream type
-    // records,
-    // it is not clear what it means to "optimize" lookup for those and they get access only once:
-    // here.
-    return new StreamNullabilityPropagator(libraryModels.customStreamNullabilitySpecs());
+    // records, it is not clear what it means to "optimize" lookup for those and they get accessed
+    // only once by calling this method during handler setup in Handlers.java.
+    return libraryModels.customStreamNullabilitySpecs();
   }
 
   private static LibraryModels loadLibraryModels(Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
@@ -29,6 +29,8 @@ import com.uber.nullaway.handlers.stream.StreamModelBuilder;
 import com.uber.nullaway.handlers.stream.StreamTypeRecord;
 
 public class StreamNullabilityPropagatorFactory {
+
+  /** Returns a handler for the standard Java 8 stream APIs. */
   public static StreamNullabilityPropagator getJavaStreamNullabilityPropagator() {
     ImmutableList<StreamTypeRecord> streamModels =
         StreamModelBuilder.start()
@@ -78,6 +80,7 @@ public class StreamNullabilityPropagatorFactory {
     return new StreamNullabilityPropagator(streamModels);
   }
 
+  /** Returns a handler for io.reactivex.* stream APIs */
   public static StreamNullabilityPropagator getRxStreamNullabilityPropagator() {
     ImmutableList<StreamTypeRecord> rxModels =
         StreamModelBuilder.start()
@@ -136,5 +139,20 @@ public class StreamNullabilityPropagatorFactory {
             .end();
 
     return new StreamNullabilityPropagator(rxModels);
+  }
+
+  /**
+   * Create a new StreamNullabilityPropagator from a list of StreamTypeRecord specs.
+   *
+   * <p>This is used to create a new StreamNullabilityPropagator based on stream API specs provided
+   * by library models.
+   *
+   * @param streamNullabilitySpecs the list of StreamTypeRecord objects defining one or more stream
+   *     APIs (from {@link StreamModelBuilder}).
+   * @return A handler corresponding to the stream APIs defined by the given specs.
+   */
+  public static StreamNullabilityPropagator fromSpecs(
+      ImmutableList<StreamTypeRecord> streamNullabilitySpecs) {
+    return new StreamNullabilityPropagator(streamNullabilitySpecs);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/stream/StreamModelBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/stream/StreamModelBuilder.java
@@ -92,6 +92,12 @@ public class StreamModelBuilder {
     return this;
   }
 
+  /**
+   * Add a stream type to our models based on the type's fully qualified name.
+   *
+   * @param fullyQualifiedName the FQN of the class/interface in our stream-based API.
+   * @return This builder (for chaining).
+   */
   public StreamModelBuilder addStreamTypeFromName(String fullyQualifiedName) {
     return this.addStreamType(new DescendantOf(Suppliers.typeFromString(fullyQualifiedName)));
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/stream/StreamModelBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/stream/StreamModelBuilder.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.predicates.TypePredicate;
+import com.google.errorprone.predicates.type.DescendantOf;
+import com.google.errorprone.suppliers.Suppliers;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -88,6 +90,10 @@ public class StreamModelBuilder {
     this.tp = tp;
     initializeBuilders();
     return this;
+  }
+
+  public StreamModelBuilder addStreamTypeFromName(String fullyQualifiedName) {
+    return this.addStreamType(new DescendantOf(Suppliers.typeFromString(fullyQualifiedName)));
   }
 
   private void initializeBuilders() {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayStreamSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayStreamSupportNegativeCases.java
@@ -24,6 +24,7 @@ package com.uber.nullaway.testdata;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.uber.nullaway.testdata.unannotated.CustomStream;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.DoubleStream;
@@ -286,6 +287,19 @@ public class NullAwayStreamSupportNegativeCases {
 
   private void filterThenForEachOrdered(Stream<NullableContainer<String>> stream) {
     stream.filter(s -> s.get() != null).forEachOrdered(s -> System.out.println(s.get().length()));
+  }
+
+  // CustomStream is modeled in TestLibraryModels
+  private CustomStream<Integer> filterThenMapLambdasCustomStream(CustomStream<String> stream) {
+    return stream.filter(s -> s != null).map(s -> s.length());
+  }
+
+  private CustomStream<Integer> filterThenMapMethodRefsCustomStream(
+      CustomStream<NullableContainer<String>> stream) {
+    return stream
+        .filter(c -> c.get() != null && perhaps())
+        .map(NullableContainer::get)
+        .map(String::length);
   }
 
   private static class CheckFinalBeforeStream<T> {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayStreamSupportNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayStreamSupportNegativeCases.java
@@ -294,6 +294,13 @@ public class NullAwayStreamSupportNegativeCases {
     return stream.filter(s -> s != null).map(s -> s.length());
   }
 
+  private CustomStream<Integer> filterThenMapNullableContainerLambdasCustomStream(
+            CustomStream<NullableContainer<String>> stream) {
+        return stream
+                .filter(c -> c.get() != null)
+                .map(c -> c.get().length());
+    }
+
   private CustomStream<Integer> filterThenMapMethodRefsCustomStream(
       CustomStream<NullableContainer<String>> stream) {
     return stream

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/CustomStream.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/CustomStream.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.testdata.unannotated;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A class representing a custom implementation of java.util.stream.Stream to test the ability to
+ * define stream handler specs through library models.
+ */
+public class CustomStream<T> {
+
+  private CustomStream() {}
+
+  public CustomStream<T> filter(Predicate<? super T> predicate) {
+    throw new UnsupportedOperationException();
+  }
+
+  public <R> CustomStream<R> map(Function<? super T, ? extends R> mapper) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/CustomStreamWithoutModel.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/unannotated/CustomStreamWithoutModel.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.testdata.unannotated;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A copy of {@link CustomStream} but for which our test library models have no spec/model, to test that errors still
+ * get reported in the absence of a model.
+ */
+public class CustomStreamWithoutModel<T> {
+
+    private CustomStreamWithoutModel() {}
+
+    public CustomStreamWithoutModel<T> filter(Predicate<? super T> predicate) {
+        throw new UnsupportedOperationException();
+    }
+
+    public <R> CustomStreamWithoutModel<R> map(Function<? super T, ? extends R> mapper) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -18,9 +18,12 @@ package com.uber.nullaway.testlibrarymodels;
 import static com.uber.nullaway.LibraryModels.MethodRef.methodRef;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.uber.nullaway.LibraryModels;
+import com.uber.nullaway.handlers.stream.StreamModelBuilder;
+import com.uber.nullaway.handlers.stream.StreamTypeRecord;
 
 @AutoService(LibraryModels.class)
 public class TestLibraryModels implements LibraryModels {
@@ -86,5 +89,37 @@ public class TestLibraryModels implements LibraryModels {
                 "com.uber.nullaway.testdata.Util", "<T>castToNonNull(java.lang.String,T,int)"),
             1)
         .build();
+  }
+
+  @Override
+  public ImmutableList<StreamTypeRecord> customStreamNullabilitySpecs() {
+    // Identical to the default model for java.util.stream.Stream, but with the original type
+    // renamed
+    return StreamModelBuilder.start()
+        .addStreamTypeFromName("com.uber.unannotated.CustomStreamA")
+        .withFilterMethodFromSignature("filter(java.util.function.Predicate<? super T>)")
+        .withMapMethodFromSignature(
+            "<R>map(java.util.function.Function<? super T,? extends R>)",
+            "apply",
+            ImmutableSet.of(0))
+        .withMapMethodFromSignature(
+            "mapToInt(java.util.function.ToIntFunction<? super T>)",
+            "applyAsInt",
+            ImmutableSet.of(0))
+        .withMapMethodFromSignature(
+            "mapToLong(java.util.function.ToLongFunction<? super T>)",
+            "applyAsLong",
+            ImmutableSet.of(0))
+        .withMapMethodFromSignature(
+            "mapToDouble(java.util.function.ToDoubleFunction<? super T>)",
+            "applyAsDouble",
+            ImmutableSet.of(0))
+        .withMapMethodFromSignature(
+            "forEach(java.util.function.Consumer<? super T>)", "accept", ImmutableSet.of(0))
+        .withMapMethodFromSignature(
+            "forEachOrdered(java.util.function.Consumer<? super T>)", "accept", ImmutableSet.of(0))
+        .withMapMethodAllFromName("flatMap", "apply", ImmutableSet.of(0))
+        .withPassthroughMethodFromSignature("distinct()")
+        .end();
   }
 }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -96,7 +96,7 @@ public class TestLibraryModels implements LibraryModels {
     // Identical to the default model for java.util.stream.Stream, but with the original type
     // renamed
     return StreamModelBuilder.start()
-        .addStreamTypeFromName("com.uber.unannotated.CustomStreamA")
+        .addStreamTypeFromName("com.uber.nullaway.testdata.unannotated.CustomStream")
         .withFilterMethodFromSignature("filter(java.util.function.Predicate<? super T>)")
         .withMapMethodFromSignature(
             "<R>map(java.util.function.Function<? super T,? extends R>)",


### PR DESCRIPTION
This is needed to support both fully custom stream libraries, as well as backports/shadowed versions
of existing stream libraries.