### PR TITLE
Use Spotless to enforce consistent formatting for Gradle build scripts

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -16,30 +16,30 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id 'java-library'
-  id 'nullaway.jacoco-conventions'
+    id 'java-library'
+    id 'nullaway.jacoco-conventions'
 }
 
 dependencies {
 }
 
 test {
-  maxHeapSize = "1024m"
-  // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
-  jvmArgs += [
-          "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-          "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-          "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-          "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-          // Accessed by Lombok tests
-          "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
-  ]
+    maxHeapSize = "1024m"
+    // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
+    jvmArgs += [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    ]
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,13 @@ subprojects { project ->
             java {
                 googleJavaFormat()
             }
+            groovyGradle {
+                target '**/*.gradle'
+                greclipse()
+                indentWithSpaces(4)
+                trimTrailingWhitespace()
+                endWithNewline()
+            }
         }
     }
 }
@@ -120,6 +127,9 @@ spotless {
 }
 spotlessPredeclare {
     java { googleJavaFormat('1.17.0') }
+    groovyGradle {
+        greclipse()
+    }
 }
 ////////////////////////////////////////////////////////////////////////
 //

--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -35,18 +35,18 @@ test {
     maxHeapSize = "1024m"
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Accessed by Lombok tests
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
     ]
 }
 

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -34,9 +34,7 @@ java {
 
 jar {
     manifest {
-        attributes(
-        'Main-Class': 'com.uber.nullaway.jarinfer.JarInfer'
-        )
+        attributes('Main-Class': 'com.uber.nullaway.jarinfer.JarInfer')
     }
     // add this classifier so that the output file for the jar task differs from
     // the output file for the shadowJar task (otherwise they overwrite each other's
@@ -46,7 +44,9 @@ jar {
 
 shadowJar {
     mergeServiceFiles()
-    configurations = [project.configurations.runtimeClasspath]
+    configurations = [
+        project.configurations.runtimeClasspath
+    ]
     archiveClassifier = ""
 }
 shadowJar.dependsOn jar
@@ -110,7 +110,7 @@ publishing {
                 }
             }
         }
-   }
+    }
 
     afterEvaluate {
         // Below is a series of hacks needed to get publication to work with

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -51,18 +51,18 @@ test {
     maxHeapSize = "1024m"
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Accessed by Lombok tests
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
     ]
     dependsOn ':jar-infer:test-android-lib-jarinfer:bundleReleaseAar'
 }

--- a/jar-infer/nullaway-integration-test/build.gradle
+++ b/jar-infer/nullaway-integration-test/build.gradle
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 plugins {
-  id "java-library"
-  id "nullaway.jacoco-conventions"
+    id "java-library"
+    id "nullaway.jacoco-conventions"
 }
 
 dependencies {
-     testImplementation deps.test.junit4
-     testImplementation(deps.build.errorProneTestHelpers) {
+    testImplementation deps.test.junit4
+    testImplementation(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
-     testImplementation project(":nullaway")
-     testImplementation project(":jar-infer:test-java-lib-jarinfer")
-    
+    testImplementation project(":nullaway")
+    testImplementation project(":jar-infer:test-java-lib-jarinfer")
 }
 
 
@@ -33,15 +32,15 @@ test {
     maxHeapSize = "1024m"
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
     ]
 }

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 evaluationDependsOn(":jar-infer:jar-infer-cli")
@@ -28,7 +28,7 @@ jar {
                 'Created-By'     : "Gradle ${gradle.gradleVersion}",
                 'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
                 'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
-        )
+                )
     }
 }
 
@@ -36,7 +36,12 @@ jar.doLast {
     javaexec {
         classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-${VERSION_NAME}.jar")
         main = "com.uber.nullaway.jarinfer.JarInfer"
-        args = ["-i", jar.archiveFile.get(), "-o", "${jar.destinationDirectory.get()}/${astubxPath}"]
+        args = [
+            "-i",
+            jar.archiveFile.get(),
+            "-o",
+            "${jar.destinationDirectory.get()}/${astubxPath}"
+        ]
     }
     exec {
         workingDir "./build/libs"

--- a/jdk17-unit-tests/build.gradle
+++ b/jdk17-unit-tests/build.gradle
@@ -47,19 +47,18 @@ test {
     maxHeapSize = "1024m"
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Expose a module path for tests as a JVM property.
-            // Used by com.uber.nullaway.jdk17.NullAwayModuleInfoTests
-            "-Dtest.module.path=${configurations.testModulePath.asPath}"
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Expose a module path for tests as a JVM property.
+        // Used by com.uber.nullaway.jdk17.NullAwayModuleInfoTests
+        "-Dtest.module.path=${configurations.testModulePath.asPath}"
     ]
 }
-

--- a/jmh/build.gradle
+++ b/jmh/build.gradle
@@ -105,13 +105,13 @@ def nullawayReleaseProcessorpath = configurations.nullawayReleaseProcessors.asPa
 
 // Extra JVM arguments to expose relevant paths for compiling benchmarks
 def extraJVMArgs = [
-        "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
-        "-Dnullaway.caffeine.classpath=$caffeineClasspath",
-        "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()}",
-        "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
-        "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
-        "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
-        "-Dnullaway.nullawayRelease.processorpath=$nullawayReleaseProcessorpath",
+    "-Dnullaway.caffeine.sources=${caffeineSourceDir.get()}",
+    "-Dnullaway.caffeine.classpath=$caffeineClasspath",
+    "-Dnullaway.autodispose.sources=${autodisposeSourceDir.get()}",
+    "-Dnullaway.autodispose.classpath=$autodisposeClasspath",
+    "-Dnullaway.nullawayRelease.sources=${nullawayReleaseSourceDir.get()}",
+    "-Dnullaway.nullawayRelease.classpath=$nullawayReleaseClasspath",
+    "-Dnullaway.nullawayRelease.processorpath=$nullawayReleaseProcessorpath",
 ]
 
 jmh {
@@ -134,16 +134,15 @@ tasks.named('test') {
     jvmArgs extraJVMArgs
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
     ]
 }
-

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -16,8 +16,8 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id 'java-library'
-  id 'nullaway.jacoco-conventions'
+    id 'java-library'
+    id 'nullaway.jacoco-conventions'
 }
 
 configurations {
@@ -79,18 +79,18 @@ test {
     maxHeapSize = "1024m"
     // to expose necessary JDK types on JDK 16+; see https://errorprone.info/docs/installation#java-9-and-newer
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Accessed by Lombok tests
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
     ]
     if (deps.versions.errorProneApi == "2.4.0" && JavaVersion.current() >= JavaVersion.VERSION_17) {
         // This test does not pass on JDK 17 with Error Prone 2.4.0 due to a Mockito incompatibility.  Skip it (the

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -39,7 +39,7 @@ android {
     lintOptions {
         abortOnError false
     }
-    
+
     DomainObjectSet<BaseVariant> variants = getApplicationVariants() // or getLibraryVariants() in libraries
     variants.addAll(getTestVariants())
     variants.addAll(getUnitTestVariants())
@@ -51,17 +51,17 @@ android {
             }
         }
     }
-    
+
     // If you want to disable NullAway in just tests, you can do the below
-//    DomainObjectSet<BaseVariant> testVariants = getTestVariants()
-//    testVariants.addAll(getUnitTestVariants())
-//    testVariants.configureEach { variant ->
-//        variant.getJavaCompileProvider().configure {
-//            options.errorprone {
-//                check("NullAway", CheckSeverity.OFF)
-//            }
-//        }
-//    }
+    //    DomainObjectSet<BaseVariant> testVariants = getTestVariants()
+    //    testVariants.addAll(getUnitTestVariants())
+    //    testVariants.configureEach { variant ->
+    //        variant.getJavaCompileProvider().configure {
+    //            options.errorprone {
+    //                check("NullAway", CheckSeverity.OFF)
+    //            }
+    //        }
+    //    }
 }
 
 dependencies {
@@ -70,7 +70,6 @@ dependencies {
     annotationProcessor project(path: ":sample-library-model")
 
     testImplementation deps.test.junit4
-
 }
 
 spotless {

--- a/sample-library-model/build.gradle
+++ b/sample-library-model/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 dependencies {
@@ -29,10 +29,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  if (!name.toLowerCase().contains("test")) {
-    options.errorprone {
-      check("NullAway", CheckSeverity.ERROR)
-      option("NullAway:AnnotatedPackages", "com.uber")
+    if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+            check("NullAway", CheckSeverity.ERROR)
+            option("NullAway:AnnotatedPackages", "com.uber")
+        }
     }
-  }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 dependencies {
@@ -29,10 +29,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  if (!name.toLowerCase().contains("test")) {
-    options.errorprone {
-      check("NullAway", CheckSeverity.ERROR)
-      option("NullAway:AnnotatedPackages", "com.uber")
+    if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+            check("NullAway", CheckSeverity.ERROR)
+            option("NullAway:AnnotatedPackages", "com.uber")
+        }
     }
-  }
-} 
+}

--- a/test-java-lib-lombok/build.gradle
+++ b/test-java-lib-lombok/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 dependencies {
@@ -31,14 +31,16 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  if (!name.toLowerCase().contains("test")) {
-    options.errorprone {
-      check("NullAway", CheckSeverity.ERROR)
-      option("NullAway:AnnotatedPackages", "com.uber")
-      option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
+    if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+            check("NullAway", CheckSeverity.ERROR)
+            option("NullAway:AnnotatedPackages", "com.uber")
+            option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
+        }
     }
-  }
-  // We need to fork on JDK 16+ since Lombok accesses internal compiler APIs
-  options.fork = true
-  options.forkOptions.jvmArgs += ["--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"]
+    // We need to fork on JDK 16+ since Lombok accesses internal compiler APIs
+    options.fork = true
+    options.forkOptions.jvmArgs += [
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
+    ]
 }

--- a/test-java-lib/build.gradle
+++ b/test-java-lib/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 dependencies {
@@ -30,11 +30,11 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  if (!name.toLowerCase().contains("test")) {
-    options.errorprone {
-      check("NullAway", CheckSeverity.ERROR)
-      option("NullAway:AnnotatedPackages", "com.uber")
-      option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
+    if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+            check("NullAway", CheckSeverity.ERROR)
+            option("NullAway:AnnotatedPackages", "com.uber")
+            option("NullAway:UnannotatedSubPackages", "com.uber.lib.unannotated")
+        }
     }
-  }
 }

--- a/test-library-models/build.gradle
+++ b/test-library-models/build.gradle
@@ -17,7 +17,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id "java-library"
+    id "java-library"
 }
 
 dependencies {
@@ -29,10 +29,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  if (!name.toLowerCase().contains("test")) {
-    options.errorprone {
-      check("NullAway", CheckSeverity.ERROR)
-      option("NullAway:AnnotatedPackages", "com.uber")
+    if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+            check("NullAway", CheckSeverity.ERROR)
+            option("NullAway:AnnotatedPackages", "com.uber")
+        }
     }
-  }
 }


### PR DESCRIPTION
I used 4-space indentation to be consistent with what most of our scripts were already doing.  The only changes here are enabling the Gradle script formatting checks and the corresponding needed reformatting.