### PR TITLE
Bump gradle maven publish plugin from 0.21.0 to 0.25.3

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,7 +32,7 @@ Releasing
  3. Update the `README.md` with the new version.
  4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  5. `git tag -a vX.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 6. `./gradlew clean publish --no-daemon --no-parallel`
+ 6. `./gradlew clean publish`
  7. Update the `gradle.properties` to the next SNAPSHOT version.
  8. `git commit -am "Prepare next development version."`
  9. `git push && git push --tags`

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.21.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.3'
         // This restriction is needed due to our mix of Android and Java modules;
         // without it, the build fails with a weird error.
         // See https://stackoverflow.com/questions/70217853/how-to-include-android-project-in-a-gradle-multi-project-build

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -79,7 +79,7 @@ publishing {
             // Since we are skipping the default maven publication, we append the `:sources` and
             // `:javadoc` artifacts here. They are also required for Maven Central validation.
             afterEvaluate {
-                artifact project.javaSourcesJar
+                artifact project.sourcesJar
                 artifact project.javadocJar
             }
             // The shadow publication does not auto-configure the pom.xml file for us, so we need to
@@ -118,7 +118,7 @@ publishing {
         // Not sure why e.g. publishShadowPublicationToMavenCentralRepository must depend on signMavenPublication
         // (rather than just signShadowPublication)
         project.tasks.named('generateMetadataFileForMavenPublication').configure {
-            dependsOn 'javaSourcesJar'
+            dependsOn 'sourcesJar'
             dependsOn 'simpleJavadocJar'
         }
         if (project.tasks.findByName('signShadowPublication')) {

--- a/jar-infer/test-java-lib-jarinfer/build.gradle
+++ b/jar-infer/test-java-lib-jarinfer/build.gradle
@@ -34,7 +34,7 @@ jar {
 
 jar.doLast {
     javaexec {
-        classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli-${VERSION_NAME}.jar")
+        classpath = files("${rootProject.projectDir}/jar-infer/jar-infer-cli/build/libs/jar-infer-cli.jar")
         main = "com.uber.nullaway.jarinfer.JarInfer"
         args = ["-i", jar.archiveFile.get(), "-o", "${jar.destinationDirectory.get()}/${astubxPath}"]
     }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -24,6 +24,8 @@ configurations {
     nullawayJar
 }
 
+// we set the group and version properties so the nullawayJar configuration
+// below resolves to the jar corresponding to the current NullAway source code
 group = property("GROUP")
 version = property("VERSION_NAME")
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -24,6 +24,9 @@ configurations {
     nullawayJar
 }
 
+group = property("GROUP")
+version = property("VERSION_NAME")
+
 dependencies {
     compileOnly project(":annotations")
     compileOnly deps.apt.autoValueAnnot

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -24,11 +24,6 @@ configurations {
     nullawayJar
 }
 
-// we set the group and version properties so the nullawayJar configuration
-// below resolves to the jar corresponding to the current NullAway source code
-group = property("GROUP")
-version = property("VERSION_NAME")
-
 dependencies {
     compileOnly project(":annotations")
     compileOnly deps.apt.autoValueAnnot
@@ -70,9 +65,6 @@ dependencies {
     testImplementation deps.test.mockitoInline
     testImplementation deps.test.javaxAnnotationApi
     testImplementation deps.test.assertJ
-
-    // This ends up being resolved to the NullAway jar under nullaway/build/libs
-    nullawayJar "com.uber.nullaway:nullaway:$VERSION_NAME"
 }
 
 javadoc {
@@ -165,11 +157,12 @@ tasks.register('buildWithNullAway', JavaCompile) {
     source = sourceSets.main.java
     classpath = sourceSets.main.compileClasspath
     destinationDirectory = file("$buildDir/ignoredClasses")
-    def nullawayDeps = configurations.nullawayJar.asCollection()
     options.annotationProcessorPath = files(
             configurations.errorprone.asCollection(),
             sourceSets.main.annotationProcessorPath,
-            nullawayDeps)
+            // This refers to the NullAway jar built from the current source
+            jar.archiveFile.get(),
+            sourceSets.main.compileClasspath)
     options.errorprone.enabled = true
     options.errorprone {
         option("NullAway:AnnotatedPackages", "com.uber,org.checkerframework.nullaway")
@@ -183,9 +176,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
     // Check that the NullAway jar actually exists (without this,
     // Gradle will run the compilation even if the jar doesn't exist)
     doFirst {
-        nullawayDeps.forEach { f ->
-            assert f.exists()
-        }
+        assert jar.archiveFile.get().getAsFile().exists()
     }
 }
 


### PR DESCRIPTION
[Changelog for plugin](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/cf02bca4185083bfc5d258e81e82939b5b2451a8/CHANGELOG.md)

We have to do some renaming as the `javaSourcesJar` configuration is now just `sourcesJar`.  Also, the `:nullaway:buildWithNullAway` previously used a hacky way to refer to the current NullAway jar that broke with this upgrade.  Here we clean things up to refer to the current jar more directly.

The plugin has better integration with Sonatype and will close the staging repository after all artifacts are uploaded.  There is an option to automatically release as well, but I haven't enabled that for now (it makes testing of release uploads difficult), so you still need to go to https://oss.sonatype.org to finalize the release.  Relatedly, apparently we don't need `--no-daemon` and `--no-parallel` flags anymore when cutting a release; updated the release docs accordingly.

I tested locally and confirmed that the exact same number of files get included in the jar-infer-cli shadow jar, and that cutting a real release successfully uploads to Maven Central.