### PR TITLE
Ensure castToNonNull insertion/removal suggested fixes do not remove comments

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -199,7 +199,7 @@ public class ErrorBuilder {
       case ASSIGN_FIELD_NULLABLE:
       case SWITCH_EXPRESSION_NULLABLE:
         if (config.getCastToNonNullMethod() != null) {
-          builder = addCastToNonNullFix(suggestTree, builder);
+          builder = addCastToNonNullFix(suggestTree, builder, state);
         } else {
           builder = addSuppressWarningsFix(suggestTree, builder, suppressionName);
         }
@@ -320,7 +320,8 @@ public class ErrorBuilder {
         .orElse(null);
   }
 
-  private Description.Builder addCastToNonNullFix(Tree suggestTree, Description.Builder builder) {
+  private Description.Builder addCastToNonNullFix(
+      Tree suggestTree, Description.Builder builder, VisitorState state) {
     final String fullMethodName = config.getCastToNonNullMethod();
     if (fullMethodName == null) {
       throw new IllegalStateException("cast-to-non-null method not set");
@@ -328,7 +329,7 @@ public class ErrorBuilder {
     // Add a call to castToNonNull around suggestTree:
     final String[] parts = fullMethodName.split("\\.");
     final String shortMethodName = parts[parts.length - 1];
-    final String replacement = shortMethodName + "(" + suggestTree.toString() + ")";
+    final String replacement = shortMethodName + "(" + state.getSourceForNode(suggestTree) + ")";
     final SuggestedFix fix =
         SuggestedFix.builder()
             .replace(suggestTree, replacement)
@@ -354,7 +355,7 @@ public class ErrorBuilder {
             invTree, suggestTree));
     // Remove the call to castToNonNull:
     final SuggestedFix fix =
-        SuggestedFix.builder().replace(invTree, suggestTree.toString()).build();
+        SuggestedFix.builder().replace(invTree, state.getSourceForNode(suggestTree)).build();
     return builder.addFix(fix);
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -292,18 +292,25 @@ public class NullAwayAutoSuggestTest {
   }
 
   @Test
-  public void suggestCastToNonNullMultiLine() throws IOException {
+  public void suggestCastToNonNullPreserveComments() throws IOException {
     makeTestHelper()
         .addInputLines(
             "Test.java",
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "class Test {",
+            "  Object x = new Object();",
             "  static class Foo { @Nullable Object getObj() { return null; } }",
             "  Object test1(Foo f) {",
             "    return f",
             "           // comment that should not be deleted",
             "           .getObj();",
+            "  }",
+            "  void test2(Foo f) {",
+            "    x = f.getObj(); // comment that should not be deleted",
+            "  }",
+            "  Object test3(Foo f) {",
+            "    return f./* keep this comment */getObj();",
             "  }",
             "}")
         .addOutputLines(
@@ -313,11 +320,18 @@ public class NullAwayAutoSuggestTest {
             "",
             "import javax.annotation.Nullable;",
             "class Test {",
+            "  Object x = new Object();",
             "  static class Foo { @Nullable Object getObj() { return null; } }",
             "  Object test1(Foo f) {",
             "    return castToNonNull(f",
             "           // comment that should not be deleted",
             "           .getObj());",
+            "  }",
+            "  void test2(Foo f) {",
+            "    x = castToNonNull(f.getObj()); // comment that should not be deleted",
+            "  }",
+            "  Object test3(Foo f) {",
+            "    return castToNonNull(f./* keep this comment */getObj());",
             "  }",
             "}")
         .doTest(TEXT_MATCH);

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -22,6 +22,8 @@
 
 package com.uber.nullaway;
 
+import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
+
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.ErrorProneFlags;
 import com.uber.nullaway.testlibrarymodels.TestLibraryModels;
@@ -162,6 +164,38 @@ public class NullAwayAutoSuggestTest {
   }
 
   @Test
+  public void removeUnnecessaryCastToNonNullMultiLine() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  static class Foo { Object getObj() { return new Object(); } }",
+            "  Object test1(Foo f) {",
+            "    return castToNonNull(f",
+            "                         // comment that should not be deleted",
+            "                         .getObj());",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "class Test {",
+            "  static class Foo { Object getObj() { return new Object(); } }",
+            "  Object test1(Foo f) {",
+            "    return f",
+            "        // comment that should not be deleted",
+            "        .getObj();",
+            "  }",
+            "}")
+        .doTest(TEXT_MATCH);
+  }
+
+  @Test
   public void suggestSuppressionOnMethodRef() throws IOException {
     makeTestHelper()
         .addInputLines(
@@ -222,6 +256,7 @@ public class NullAwayAutoSuggestTest {
             "out/Test.java",
             "package com.uber;",
             "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "",
             "import javax.annotation.Nullable;",
             "class Test {",
             "  static class Foo { @Nullable Object getObj() { return null; } }",
@@ -231,6 +266,6 @@ public class NullAwayAutoSuggestTest {
             "           .getObj());",
             "  }",
             "}")
-        .doTest();
+        .doTest(TEXT_MATCH);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayAutoSuggestTest.java
@@ -202,4 +202,35 @@ public class NullAwayAutoSuggestTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void suggestCastToNonNullMultiLine() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  static class Foo { @Nullable Object getObj() { return null; } }",
+            "  Object test1(Foo f) {",
+            "    return f",
+            "           // comment that should not be deleted",
+            "           .getObj();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  static class Foo { @Nullable Object getObj() { return null; } }",
+            "  Object test1(Foo f) {",
+            "    return castToNonNull(f",
+            "           // comment that should not be deleted",
+            "           .getObj());",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
We now preserve the original source code of the AST node for which we are adding or removing a cast, ensuring that comments within the node are preserved.