### PR TITLE
Remove unnecessary compile dependence for jar-infer-cli

### DIFF
--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -17,8 +17,6 @@ repositories {
 dependencies {
     implementation deps.build.commonscli
     implementation deps.build.guava
-    compileOnly deps.build.errorProneCheckApi
-
     implementation project(":jar-infer:jar-infer-lib")
 
     testImplementation deps.test.junit4


### PR DESCRIPTION
Everything works without this