### PR TITLE
Remove ASM-related hack in build config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.3'
-        // This restriction is needed due to our mix of Android and Java modules;
-        // without it, the build fails with a weird error.
-        // See https://stackoverflow.com/questions/70217853/how-to-include-android-project-in-a-gradle-multi-project-build
-        classpath('org.ow2.asm:asm') {
-            version {
-                strictly '9.2'
-            }
-        }
     }
 }
 plugins {


### PR DESCRIPTION
I'm guessing this was necessary for building on Java 8, but now everything works without it.