### PR TITLE
Ignore code coverage for method executed non-deterministically in tests

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/annotations/JacocoIgnoreGenerated.java
+++ b/nullaway/src/main/java/com/uber/nullaway/annotations/JacocoIgnoreGenerated.java
@@ -1,0 +1,14 @@
+package com.uber.nullaway.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate to Jacoco that code coverage of a method or constructor should be ignored.
+ * Jacoco requires such annotations to have "Generated" in their name.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface JacocoIgnoreGenerated {}

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -35,6 +35,7 @@ import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.uber.nullaway.NullabilityUtil;
+import com.uber.nullaway.annotations.JacocoIgnoreGenerated;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -648,7 +649,14 @@ public final class AccessPath implements MapKey {
       return iteratorVarElement;
     }
 
+    /**
+     * We ignore this method for code coverage since there is non-determinism somewhere deep in a
+     * Map implementation such that, depending on how AccessPaths get bucketed in the Map (which
+     * depends on non-deterministic hash codes), sometimes this method is called and sometimes it is
+     * not.
+     */
     @Override
+    @JacocoIgnoreGenerated
     public boolean equals(Object o) {
       if (this == o) {
         return true;


### PR DESCRIPTION
Fixes #828 (hopefully)

There is some non-determinism in whether `com.uber.nullaway.dataflow.AccessPath.IteratorContentsKey#equals` runs or not during tests (see the code comment).  The non-determinism will be hard for us to fix, so instead, add an annotation that tells JaCoCo to ignore coverage of this method (which is low risk as it's an `equals()` method that I don't expect will change).