### PR TITLE
Build NullAway with JSpecify mode enabled

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -168,6 +168,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
         option("NullAway:CheckOptionalEmptiness")
         option("NullAway:AcknowledgeRestrictiveAnnotations")
         option("NullAway:CheckContracts")
+        option("NullAway:JSpecifyMode")
     }
     // Make sure the jar has already been built
     dependsOn 'jar'

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.lang.model.type.ExecutableType;
 
 /** Methods for performing checks related to generic types and nullability. */
 public final class GenericsChecks {
@@ -737,8 +738,9 @@ public final class GenericsChecks {
   private static Nullness getGenericMethodReturnTypeNullness(
       Symbol.MethodSymbol method, Type enclosingType, VisitorState state, Config config) {
     Type overriddenMethodType = state.getTypes().memberType(enclosingType, method);
-    if (!(overriddenMethodType instanceof Type.MethodType)) {
-      throw new RuntimeException("expected method type but instead got " + overriddenMethodType);
+    if (!(overriddenMethodType instanceof ExecutableType)) {
+      throw new RuntimeException(
+          "expected ExecutableType but instead got " + overriddenMethodType.getClass());
     }
     return getTypeNullness(overriddenMethodType.getReturnType(), config);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -738,10 +738,10 @@ public final class GenericsChecks {
   private static Nullness getGenericMethodReturnTypeNullness(
       Symbol.MethodSymbol method, Type enclosingType, VisitorState state, Config config) {
     Type overriddenMethodType = state.getTypes().memberType(enclosingType, method);
-    if (!(overriddenMethodType instanceof ExecutableType)) {
-      throw new RuntimeException(
-          "expected ExecutableType but instead got " + overriddenMethodType.getClass());
-    }
+    verify(
+        overriddenMethodType instanceof ExecutableType,
+        "expected ExecutableType but instead got %s",
+        overriddenMethodType.getClass());
     return getTypeNullness(overriddenMethodType.getReturnType(), config);
   }
 


### PR DESCRIPTION
This will give us a bit better test coverage as we continue to implement JSpecify.  With one small fix to an assertion check, now NullAway can build itself in JSpecify mode without crashing!