### PR TITLE
JSpecify: adding com.google.common to annotated packages in build.gradle

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -152,7 +152,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
             sourceSets.main.compileClasspath)
     options.errorprone.enabled = true
     options.errorprone {
-        option("NullAway:AnnotatedPackages", "com.uber,org.checkerframework.nullaway")
+        option("NullAway:AnnotatedPackages", "com.uber,org.checkerframework.nullaway,com.google.common")
         option("NullAway:CastToNonNullMethod", "com.uber.nullaway.NullabilityUtil.castToNonNull")
         option("NullAway:CheckOptionalEmptiness")
         option("NullAway:AcknowledgeRestrictiveAnnotations")


### PR DESCRIPTION
Based on the fixes made in #856  , we should no longer get that exception after adding com.google.common in the annotated packages when running in JSpecify mode. 

