### PR TITLE
JSpecify: handling the return of a diamond operator anonymous object method caller 

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -784,7 +784,7 @@ public final class GenericsChecks {
       MethodInvocationTree tree,
       VisitorState state,
       Config config) {
-    if (!(tree.getMethodSelect() instanceof MemberSelectTree)) {
+    if (!(tree.getMethodSelect() instanceof MemberSelectTree) || invokedMethodSymbol.isStatic()) {
       return Nullness.NONNULL;
     }
     Type methodReceiverType =
@@ -834,7 +834,7 @@ public final class GenericsChecks {
       MethodInvocationTree tree,
       VisitorState state,
       Config config) {
-    if (!(tree.getMethodSelect() instanceof MemberSelectTree)) {
+    if (!(tree.getMethodSelect() instanceof MemberSelectTree) || invokedMethodSymbol.isStatic()) {
       return Nullness.NONNULL;
     }
     Type enclosingType =

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -784,17 +784,17 @@ public final class GenericsChecks {
       MethodInvocationTree tree,
       VisitorState state,
       Config config) {
-    if (!(tree.getMethodSelect() instanceof MemberSelectTree)
-        || invokedMethodSymbol.isStatic()
-        || null
-            == getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state)) {
+    if (!(tree.getMethodSelect() instanceof MemberSelectTree) || invokedMethodSymbol.isStatic()) {
       return Nullness.NONNULL;
     }
     Type methodReceiverType =
-        castToNonNull(
-            getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state));
-    return getGenericMethodReturnTypeNullness(
-        invokedMethodSymbol, methodReceiverType, state, config);
+        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state);
+    if (null == methodReceiverType) {
+      return Nullness.NONNULL;
+    } else {
+      return getGenericMethodReturnTypeNullness(
+          invokedMethodSymbol, castToNonNull(methodReceiverType), state, config);
+    }
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -787,6 +787,18 @@ public final class GenericsChecks {
     if (!(tree.getMethodSelect() instanceof MemberSelectTree) || invokedMethodSymbol.isStatic()) {
       return Nullness.NONNULL;
     }
+    Tree expressionTree = ((MemberSelectTree) tree.getMethodSelect()).getExpression();
+    if (expressionTree instanceof NewClassTree
+        && ((NewClassTree) expressionTree).getIdentifier() instanceof ParameterizedTypeTree) {
+      ParameterizedTypeTree paramTypedTree =
+          (ParameterizedTypeTree) ((NewClassTree) expressionTree).getIdentifier();
+      // The case of having a diamond operator
+      if (paramTypedTree.getTypeArguments().isEmpty()) {
+        // bail out
+        // TODO: support diamond operators
+        return Nullness.NONNULL;
+      }
+    }
     Type methodReceiverType =
         castToNonNull(
             getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state));

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -789,7 +789,7 @@ public final class GenericsChecks {
     }
     Type methodReceiverType =
         getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state);
-    if (null == methodReceiverType) {
+    if (methodReceiverType == null) {
       return Nullness.NONNULL;
     } else {
       return getGenericMethodReturnTypeNullness(

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -793,7 +793,7 @@ public final class GenericsChecks {
       return Nullness.NONNULL;
     } else {
       return getGenericMethodReturnTypeNullness(
-          invokedMethodSymbol, castToNonNull(methodReceiverType), state, config);
+          invokedMethodSymbol, methodReceiverType, state, config);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/GenericsChecks.java
@@ -784,20 +784,11 @@ public final class GenericsChecks {
       MethodInvocationTree tree,
       VisitorState state,
       Config config) {
-    if (!(tree.getMethodSelect() instanceof MemberSelectTree) || invokedMethodSymbol.isStatic()) {
+    if (!(tree.getMethodSelect() instanceof MemberSelectTree)
+        || invokedMethodSymbol.isStatic()
+        || null
+            == getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state)) {
       return Nullness.NONNULL;
-    }
-    Tree expressionTree = ((MemberSelectTree) tree.getMethodSelect()).getExpression();
-    if (expressionTree instanceof NewClassTree
-        && ((NewClassTree) expressionTree).getIdentifier() instanceof ParameterizedTypeTree) {
-      ParameterizedTypeTree paramTypedTree =
-          (ParameterizedTypeTree) ((NewClassTree) expressionTree).getIdentifier();
-      // The case of having a diamond operator
-      if (paramTypedTree.getTypeArguments().isEmpty()) {
-        // bail out
-        // TODO: support diamond operators
-        return Nullness.NONNULL;
-      }
     }
     Type methodReceiverType =
         castToNonNull(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1494,6 +1494,34 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void testForStaticMethodCallAsAParam() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class A<T> {",
+            "   public static <T> A<T> returnA(){",
+            "     return new A<T>();",
+            "   }",
+            "   public static <T> A<T> returnAWithParam(Object o){",
+            "     return new A<T>();",
+            "   }",
+            "  }",
+            "  static void func(A<Object> a){",
+            "  }",
+            "  static void testNegative() {",
+            "   func(A.returnA());",
+            "  }",
+            "  static void testNegative2() {",
+            "   func(A.returnAWithParam(new Object()));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1522,6 +1522,24 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void testForDiamondOperatorReturnedAsAMethodCaller() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class B<T>{",
+            "   String build(){return \"x\";}",
+            "  }",
+            "  static String testNegative() {",
+            "   return new B<>().build();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
In reference to the [exception](https://github.com/uber/NullAway/issues/791#issuecomment-1803020173) mentioned in the discussion for #791 . 

Adding the test case to reproduce the same issue:

```java
class Test {
    static class B<T>{
        String build(){return "x";}
    }
    static String testNegative() {
        //We were getting the aforementioned mentioned exception when we tried to do this
        return new B<>().build();
    }
}
```
All unit tests have passed for the changes that were made for this.