### PR TITLE
Model Apache Flink's RichFunction.open as an @Initializer method

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -130,7 +130,11 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "androidx.fragment.app.Fragment.onActivityCreated",
           "androidx.fragment.app.Fragment.onViewCreated",
           // Multidex app
-          "android.support.multidex.Application.onCreate");
+          "android.support.multidex.Application.onCreate",
+          // Apache Flink
+          // See docs:
+          // https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/api/common/functions/RichFunction.html#open-org.apache.flink.api.common.functions.OpenContext-
+          "org.apache.flink.api.common.functions.RichFunction.open");
 
   static final ImmutableSet<String> DEFAULT_INITIALIZER_ANNOT =
       ImmutableSet.of(


### PR DESCRIPTION
From the [docs](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/api/common/functions/RichFunction.html#open-org.apache.flink.api.common.functions.OpenContext-) here: `open(...)` should always be called before other methods,
such as `filter(...)`, so it fits our definition of an `@Initializer` method.
