### PR TITLE
Fix assertion check for structure of enhanced-for loop over a Map keySet

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -650,9 +650,11 @@ public class AccessPathNullnessPropagation
     Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(invocationTree);
     if (symbol != null && symbol.getSimpleName().contentEquals(methodName)) {
       // NOTE: previously we checked if symbol.owner.type was a subtype of the containing type.
-      // However, symbol.owner.type refers to the static type at the call site, which might be a
-      // supertype of the containing type with some Java compilers.  Instead, we check if the type
-      // of the receiver at the invocation is a subtype of the containing type.  See
+      // However, symbol.owner.type refers to the static type at the call site, in which the target
+      // class/interface might be a supertype of the containing type with some Java compilers.
+      // Instead, we now check if the static type of the receiver at the invocation is a subtype of
+      // the containing type (as this guarantees a method in the containing type or one of its
+      // subtypes will be invoked, assuming such a method exists).  See
       // https://github.com/uber/NullAway/issues/866.
       return ASTHelpers.isSubtype(
           ASTHelpers.getReceiverType(invocationTree), containingTypeSupplier.get(state), state);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -637,10 +637,12 @@ public class AccessPathNullnessPropagation
       MethodInvocationNode invocationNode,
       Supplier<Type> containingTypeSupplier,
       String methodName) {
-    Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(invocationNode.getTree());
+    MethodInvocationTree invocationTree = invocationNode.getTree();
+    Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(invocationTree);
     return symbol != null
         && symbol.getSimpleName().contentEquals(methodName)
-        && ASTHelpers.isSubtype(symbol.owner.type, containingTypeSupplier.get(state), state);
+        && ASTHelpers.isSubtype(
+            ASTHelpers.getReceiverType(invocationTree), containingTypeSupplier.get(state), state);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -25,6 +25,7 @@ import static javax.lang.model.element.ElementKind.EXCEPTION_PARAMETER;
 import static org.checkerframework.nullaway.javacutil.TreeUtils.elementFromDeclaration;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.VerifyException;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
@@ -578,7 +579,7 @@ public class AccessPathNullnessPropagation
         if (mapWithIteratorContentsKey != null) {
           // put sanity check here to minimize perf impact
           if (!isCallToMethod(rhsInv, SET_TYPE_SUPPLIER, "iterator")) {
-            throw new RuntimeException(
+            throw new VerifyException(
                 "expected call to iterator(), instead saw "
                     + state.getSourceForNode(rhsInv.getTree()));
           }
@@ -603,7 +604,7 @@ public class AccessPathNullnessPropagation
         if (mapGetPath != null) {
           // put sanity check here to minimize perf impact
           if (!isCallToMethod(methodInv, ITERATOR_TYPE_SUPPLIER, "next")) {
-            throw new RuntimeException(
+            throw new VerifyException(
                 "expected call to next(), instead saw "
                     + state.getSourceForNode(methodInv.getTree()));
           }


### PR DESCRIPTION
Fixes #866 

Before, we would check that an enhanced-for loop includes a call to `Set.iterator()` on the result of calling `Map.keySet()`.  However, it is possible and legal that statically, the target of this call is instead `Collection.iterator()`.  So, we change our check to test the receiver type passed into the call (which must still be a `Set`).  Also, opportunistically switch a couple of places we were throwing `RuntimeException` around this check to throw the more meaningful `VerifyException`.  Unfortunately, we have not found a way to add a test in open-source to reproduce the failure from #866 but we have confirmed this change fixes the problem.