### PR TITLE
Update to Checker Framework 3.41.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
+        mavenLocal()
     }
 
     // For some reason, spotless complains when applied to the jar-infer folder itself, even

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-        mavenLocal()
     }
 
     // For some reason, spotless complains when applied to the jar-infer folder itself, even

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.39.0",
+    checkerFramework       : "3.40.1-SNAPSHOT",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.40.1-SNAPSHOT",
+    checkerFramework       : "3.41.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.


### PR DESCRIPTION
Just to stay up to date.  [Benchmarking results](https://github.com/uber/NullAway/pull/873#issuecomment-1839420450) show no overhead regression, and possibly a very slight improvement.