### PR TITLE
Extend library models to mark fields as nullable

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -132,6 +132,13 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods();
 
   /**
+   * Get the set of library fields that may be null.
+   *
+   * @return set of library fields that may be null
+   */
+  ImmutableSet<FieldRef> nullableFields();
+
+  /**
    * Get a list of custom stream library specifications.
    *
    * <p>This allows users to define filter/map/other methods for APIs which behave similarly to Java
@@ -240,6 +247,60 @@ public interface LibraryModels {
           + '\''
           + ", fullMethodSig='"
           + fullMethodSig
+          + '\''
+          + '}';
+    }
+  }
+
+  /** Representation of a field as a qualified class name + a field name */
+  final class FieldRef {
+
+    public final String enclosingClass;
+
+    public final String fieldName;
+
+    private FieldRef(String enclosingClass, String fieldName) {
+      this.enclosingClass = enclosingClass;
+      this.fieldName = fieldName;
+    }
+
+    /**
+     * Construct a field reference.
+     *
+     * @param enclosingClass containing flat name class
+     * @param fieldName field name
+     * @return corresponding {@link FieldRef}
+     */
+    public static FieldRef fieldRef(String enclosingClass, String fieldName) {
+      return new FieldRef(enclosingClass, fieldName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FieldRef fieldRef = (FieldRef) o;
+      return Objects.equals(enclosingClass, fieldRef.enclosingClass)
+          && Objects.equals(fieldName, fieldRef.fieldName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(enclosingClass, fieldName);
+    }
+
+    @Override
+    public String toString() {
+      return "FieldRef{"
+          + "enclosingClass='"
+          + enclosingClass
+          + '\''
+          + ", field name='"
+          + fieldName
           + '\''
           + '}';
     }

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -133,9 +133,9 @@ public interface LibraryModels {
 
   /**
    * Get the set of library fields that may be null. This is mostly used to index the impact of
-   * making fields nullable on downstream dependencies.
+   * making fields <code>@Nullable</code> on downstream dependencies.
    *
-   * @return set of library fields that may be null
+   * @return set of library fields that may be <code>null</code>.
    */
   ImmutableSet<FieldRef> nullableFields();
 

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -132,7 +132,8 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods();
 
   /**
-   * Get the set of library fields that may be null.
+   * Get the set of library fields that may be null. This is mostly used to index the impact of
+   * making fields nullable on downstream dependencies.
    *
    * @return set of library fields that may be null
    */

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -254,56 +255,15 @@ public interface LibraryModels {
   }
 
   /** Representation of a field as a qualified class name + a field name */
-  final class FieldRef {
+  @AutoValue
+  abstract class FieldRef {
 
-    public final String enclosingClass;
+    public abstract String getEnclosingClassName();
 
-    public final String fieldName;
+    public abstract String getFieldName();
 
-    private FieldRef(String enclosingClass, String fieldName) {
-      this.enclosingClass = enclosingClass;
-      this.fieldName = fieldName;
-    }
-
-    /**
-     * Construct a field reference.
-     *
-     * @param enclosingClass containing flat name class
-     * @param fieldName field name
-     * @return corresponding {@link FieldRef}
-     */
     public static FieldRef fieldRef(String enclosingClass, String fieldName) {
-      return new FieldRef(enclosingClass, fieldName);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      FieldRef fieldRef = (FieldRef) o;
-      return Objects.equals(enclosingClass, fieldRef.enclosingClass)
-          && Objects.equals(fieldName, fieldRef.fieldName);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(enclosingClass, fieldName);
-    }
-
-    @Override
-    public String toString() {
-      return "FieldRef{"
-          + "enclosingClass='"
-          + enclosingClass
-          + '\''
-          + ", field name='"
-          + fieldName
-          + '\''
-          + '}';
+      return new AutoValue_LibraryModels_FieldRef(enclosingClass, fieldName);
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -486,7 +486,10 @@ public class NullAway extends BugChecker
       return Description.NO_MATCH;
     }
 
-    if (Nullness.hasNullableAnnotation(assigned, config)) {
+    if (Nullness.hasNullableAnnotation(assigned, config)
+        || handler
+            .onOverrideFieldNullability(assigned, Nullness.NONNULL)
+            .equals(Nullness.NULLABLE)) {
       // field already annotated
       return Description.NO_MATCH;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -487,9 +487,7 @@ public class NullAway extends BugChecker
     }
 
     if (Nullness.hasNullableAnnotation(assigned, config)
-        || handler
-            .onOverrideFieldNullability(assigned, Nullness.NONNULL)
-            .equals(Nullness.NULLABLE)) {
+        || handler.onOverrideFieldNullability(assigned)) {
       // field already annotated
       return Description.NO_MATCH;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -119,6 +119,12 @@ public abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
+  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
+    // NoOp
+    return fieldNullness;
+  }
+
+  @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
       VisitorState state,
       Symbol.MethodSymbol methodSymbol,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -119,9 +119,9 @@ public abstract class BaseNoOpHandler implements Handler {
   }
 
   @Override
-  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
+  public boolean onOverrideFieldNullability(Symbol field) {
     // NoOp
-    return fieldNullness;
+    return false;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -136,11 +136,15 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
+  public boolean onOverrideFieldNullability(Symbol field) {
     for (Handler h : handlers) {
-      fieldNullness = h.onOverrideFieldNullability(field, fieldNullness);
+      if (h.onOverrideFieldNullability(field)) {
+        // If any handler determines that the field is @Nullable, we should acknowledge that and
+        // treat it as such.
+        return true;
+      }
     }
-    return fieldNullness;
+    return false;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -136,6 +136,14 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
+    for (Handler h : handlers) {
+      fieldNullness = h.onOverrideFieldNullability(field, fieldNullness);
+    }
+    return fieldNullness;
+  }
+
+  @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
       VisitorState state,
       Symbol.MethodSymbol methodSymbol,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -174,6 +174,15 @@ public interface Handler {
       Nullness returnNullness);
 
   /**
+   * Called to potentially override the nullability of a field which is not annotated as @Nullable.
+   *
+   * @param field The symbol for the field in question.
+   * @param fieldNullness field Nullness computed by upstream handlers or NullAway core.
+   * @return Updated field nullability computed by this handler.
+   */
+  Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness);
+
+  /**
    * Called after the analysis determines the nullability of a method's arguments, allowing handlers
    * to override.
    *

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -175,12 +175,13 @@ public interface Handler {
 
   /**
    * Called to potentially override the nullability of a field which is not annotated as @Nullable.
+   * If the field is decided to be @Nullable by this handler, the field should be treated
+   * as @Nullable anyway.
    *
    * @param field The symbol for the field in question.
-   * @param fieldNullness field Nullness computed by upstream handlers or NullAway core.
-   * @return Updated field nullability computed by this handler.
+   * @return true if the field should be treated as @Nullable, false otherwise.
    */
-  Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness);
+  boolean onOverrideFieldNullability(Symbol field);
 
   /**
    * Called after the analysis determines the nullability of a method's arguments, allowing handlers

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -90,7 +90,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       AccessPath.AccessPathContext apContext,
       AccessPathNullnessPropagation.SubNodeValues inputs,
       AccessPathNullnessPropagation.Updates updates) {
-    return isNullableFieldInLibraryModel(symbol)
+    return isNullableFieldInLibraryModels(symbol)
         ? NullnessHint.HINT_NULLABLE
         : NullnessHint.UNKNOWN;
   }
@@ -147,7 +147,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       @Nullable Symbol exprSymbol,
       VisitorState state,
       boolean exprMayBeNull) {
-    if (isNullableFieldInLibraryModel(exprSymbol)) {
+    if (isNullableFieldInLibraryModels(exprSymbol)) {
       return true;
     }
     if (!(expr.getKind() == Tree.Kind.METHOD_INVOCATION
@@ -257,7 +257,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
    * @param symbol The symbol to check.
    * @return True if the symbol is a field that is marked as nullable in any of our library models.
    */
-  private boolean isNullableFieldInLibraryModel(@Nullable Symbol symbol) {
+  private boolean isNullableFieldInLibraryModels(@Nullable Symbol symbol) {
     if (symbol instanceof Symbol.VarSymbol && symbol.getKind().isField()) {
       Symbol.VarSymbol varSymbol = (Symbol.VarSymbol) symbol;
       Symbol.ClassSymbol classSymbol = varSymbol.enclClass();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -266,13 +266,13 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         return false;
       }
       String fieldName = varSymbol.getSimpleName().toString();
-      String enclosingClass = classSymbol.flatName().toString();
+      String enclosingClassName = classSymbol.flatName().toString();
       // check presence
       return libraryModels.nullableFields().stream()
           .anyMatch(
               fieldRef ->
                   fieldRef.fieldName.equals(fieldName)
-                      && fieldRef.enclosingClass.equals(enclosingClass));
+                      && fieldRef.enclosingClass.equals(enclosingClassName));
     }
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway.handlers;
 
+import static com.uber.nullaway.LibraryModels.FieldRef.fieldRef;
 import static com.uber.nullaway.LibraryModels.MethodRef.methodRef;
 import static com.uber.nullaway.Nullness.NONNULL;
 import static com.uber.nullaway.Nullness.NULLABLE;
@@ -279,11 +280,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       // check presence. This is a bit inefficient, but it's only used while indexing impact of
       // making fields @Nullable on downstream dependencies. Also, the set of nullable fields is not
       // expected to be large. We can optimize in future if needed.
-      return libraryModels.nullableFields().stream()
-          .anyMatch(
-              fieldRef ->
-                  fieldRef.getFieldName().equals(fieldName)
-                      && fieldRef.getEnclosingClassName().equals(enclosingClassName));
+      return libraryModels.nullableFields().contains(fieldRef(enclosingClassName, fieldName));
     }
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -273,8 +273,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       return libraryModels.nullableFields().stream()
           .anyMatch(
               fieldRef ->
-                  fieldRef.fieldName.equals(fieldName)
-                      && fieldRef.enclosingClass.equals(enclosingClassName));
+                  fieldRef.getFieldName().equals(fieldName)
+                      && fieldRef.getEnclosingClassName().equals(enclosingClassName));
     }
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -82,6 +82,14 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
+  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
+    if (fieldNullness.equals(NONNULL) && isNullableFieldInLibraryModels(field)) {
+      return NULLABLE;
+    }
+    return fieldNullness;
+  }
+
+  @Override
   public NullnessHint onDataflowVisitFieldAccess(
       FieldAccessNode node,
       Symbol symbol,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -82,11 +82,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
   }
 
   @Override
-  public Nullness onOverrideFieldNullability(Symbol field, Nullness fieldNullness) {
-    if (fieldNullness.equals(NONNULL) && isNullableFieldInLibraryModels(field)) {
-      return NULLABLE;
-    }
-    return fieldNullness;
+  public boolean onOverrideFieldNullability(Symbol field) {
+    return isNullableFieldInLibraryModels(field);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -277,9 +277,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       }
       String fieldName = varSymbol.getSimpleName().toString();
       String enclosingClassName = classSymbol.flatName().toString();
-      // check presence. This is a bit inefficient, but it's only used while indexing impact of
-      // making fields @Nullable on downstream dependencies. Also, the set of nullable fields is not
-      // expected to be large. We can optimize in future if needed.
+      // This check could be optimized further in the future if needed
       return libraryModels.nullableFields().contains(fieldRef(enclosingClassName, fieldName));
     }
     return false;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -258,6 +258,10 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
    * @return True if the symbol is a field that is marked as nullable in any of our library models.
    */
   private boolean isNullableFieldInLibraryModels(@Nullable Symbol symbol) {
+    if (libraryModels.nullableFields().isEmpty()) {
+      // no need to do any work if there are no nullable fields.
+      return false;
+    }
     if (symbol instanceof Symbol.VarSymbol && symbol.getKind().isField()) {
       Symbol.VarSymbol varSymbol = (Symbol.VarSymbol) symbol;
       Symbol.ClassSymbol classSymbol = varSymbol.enclClass();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -267,7 +267,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       }
       String fieldName = varSymbol.getSimpleName().toString();
       String enclosingClassName = classSymbol.flatName().toString();
-      // check presence
+      // check presence. This is a bit inefficient, but it's only used while indexing impact of
+      // making fields @Nullable on downstream dependencies. Also, the set of nullable fields is not
+      // expected to be large. We can optimize in future if needed.
       return libraryModels.nullableFields().stream()
           .anyMatch(
               fieldRef ->

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -57,6 +57,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.checkerframework.nullaway.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.Node;
 
@@ -78,6 +79,20 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     super();
     this.config = config;
     libraryModels = loadLibraryModels(config);
+  }
+
+  @Override
+  public NullnessHint onDataflowVisitFieldAccess(
+      FieldAccessNode node,
+      Symbol symbol,
+      Types types,
+      Context context,
+      AccessPath.AccessPathContext apContext,
+      AccessPathNullnessPropagation.SubNodeValues inputs,
+      AccessPathNullnessPropagation.Updates updates) {
+    return isNullableFieldInLibraryModel(symbol)
+        ? NullnessHint.HINT_NULLABLE
+        : NullnessHint.UNKNOWN;
   }
 
   @Override
@@ -132,6 +147,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       @Nullable Symbol exprSymbol,
       VisitorState state,
       boolean exprMayBeNull) {
+    if (isNullableFieldInLibraryModel(exprSymbol)) {
+      return true;
+    }
     if (!(expr.getKind() == Tree.Kind.METHOD_INVOCATION
         && exprSymbol instanceof Symbol.MethodSymbol)) {
       return exprMayBeNull;
@@ -231,6 +249,32 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     } else {
       return NullnessHint.UNKNOWN;
     }
+  }
+
+  /**
+   * Check if the given symbol is a field that is marked as nullable in any of our library models.
+   *
+   * @param symbol The symbol to check.
+   * @return True if the symbol is a field that is marked as nullable in any of our library models.
+   */
+  private boolean isNullableFieldInLibraryModel(@Nullable Symbol symbol) {
+    if (symbol instanceof Symbol.VarSymbol && symbol.getKind().isField()) {
+      Symbol.VarSymbol varSymbol = (Symbol.VarSymbol) symbol;
+      Symbol.ClassSymbol classSymbol = varSymbol.enclClass();
+      if (classSymbol == null) {
+        // e.g. .class expressions
+        return false;
+      }
+      String fieldName = varSymbol.getSimpleName().toString();
+      String enclosingClass = classSymbol.flatName().toString();
+      // check presence
+      return libraryModels.nullableFields().stream()
+          .anyMatch(
+              fieldRef ->
+                  fieldRef.fieldName.equals(fieldName)
+                      && fieldRef.enclosingClass.equals(enclosingClass));
+    }
+    return false;
   }
 
   private void setConditionalArgumentNullness(
@@ -824,6 +868,11 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
       return CAST_TO_NONNULL_METHODS;
     }
+
+    @Override
+    public ImmutableSet<FieldRef> nullableFields() {
+      return ImmutableSet.of();
+    }
   }
 
   private static class CombinedLibraryModels implements LibraryModels {
@@ -845,6 +894,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     private final ImmutableSet<MethodRef> nullableReturns;
 
     private final ImmutableSet<MethodRef> nonNullReturns;
+
+    private final ImmutableSet<FieldRef> nullableFields;
 
     private final ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods;
 
@@ -870,6 +921,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
           new ImmutableSetMultimap.Builder<>();
       ImmutableList.Builder<StreamTypeRecord> customStreamNullabilitySpecsBuilder =
           new ImmutableList.Builder<>();
+      ImmutableSet.Builder<FieldRef> nullableFieldsBuilder = new ImmutableSet.Builder<>();
       for (LibraryModels libraryModels : models) {
         for (Map.Entry<MethodRef, Integer> entry : libraryModels.failIfNullParameters().entries()) {
           if (shouldSkipModel(entry.getKey())) {
@@ -932,6 +984,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
         for (StreamTypeRecord streamTypeRecord : libraryModels.customStreamNullabilitySpecs()) {
           customStreamNullabilitySpecsBuilder.add(streamTypeRecord);
         }
+        for (FieldRef fieldRef : libraryModels.nullableFields()) {
+          nullableFieldsBuilder.add(fieldRef);
+        }
       }
       failIfNullParameters = failIfNullParametersBuilder.build();
       explicitlyNullableParameters = explicitlyNullableParametersBuilder.build();
@@ -943,6 +998,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
       nonNullReturns = nonNullReturnsBuilder.build();
       castToNonNullMethods = castToNonNullMethodsBuilder.build();
       customStreamNullabilitySpecs = customStreamNullabilitySpecsBuilder.build();
+      nullableFields = nullableFieldsBuilder.build();
     }
 
     private boolean shouldSkipModel(MethodRef key) {
@@ -987,6 +1043,11 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
     @Override
     public ImmutableSet<MethodRef> nonNullReturns() {
       return nonNullReturns;
+    }
+
+    @Override
+    public ImmutableSet<FieldRef> nullableFields() {
+      return nullableFields;
     }
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -871,6 +871,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
     @Override
     public ImmutableSet<FieldRef> nullableFields() {
+      // No nullable field by default.
       return ImmutableSet.of();
     }
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
@@ -227,4 +227,34 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void libraryModelsAndOverridingFieldNullability() {
+    makeLibraryModelsTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.UnannotatedWithModels;",
+            "public class Test {",
+            "   UnannotatedWithModels uwm = new UnannotatedWithModels();",
+            "   Object nonnullField = new Object();",
+            "   void assignNullableFromLibraryModelField() {",
+            "      // BUG: Diagnostic contains: assigning @Nullable",
+            "      this.nonnullField = uwm.nullableFieldUnannotated1;",
+            "      // BUG: Diagnostic contains: assigning @Nullable",
+            "      this.nonnullField = uwm.nullableFieldUnannotated2;",
+            "   }",
+            "   void flowTest() {",
+            "      if(uwm.nullableFieldUnannotated1 != null){",
+            "      // no error here, to check that library models only initialize flow store",
+            "      this.nonnullField = uwm.nullableFieldUnannotated1;",
+            "      }",
+            "   }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
@@ -254,6 +254,10 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             "         this.nonnullField = uwm.nullableFieldUnannotated1;",
             "      }",
             "   }",
+            "   String dereferenceTest() {",
+            "      // BUG: Diagnostic contains: dereferenced expression uwm.nullableFieldUnannotated1 is @Nullable",
+            "      return uwm.nullableFieldUnannotated1.toString();",
+            "   }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
@@ -249,9 +249,9 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             "      this.nonnullField = uwm.nullableFieldUnannotated2;",
             "   }",
             "   void flowTest() {",
-            "      if(uwm.nullableFieldUnannotated1 != null){",
-            "      // no error here, to check that library models only initialize flow store",
-            "      this.nonnullField = uwm.nullableFieldUnannotated1;",
+            "      if(uwm.nullableFieldUnannotated1 != null) {",
+            "         // no error here, to check that library models only initialize flow store",
+            "         this.nonnullField = uwm.nullableFieldUnannotated1;",
             "      }",
             "   }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayCustomLibraryModelsTests.java
@@ -250,13 +250,16 @@ public class NullAwayCustomLibraryModelsTests extends NullAwayTestsBase {
             "   }",
             "   void flowTest() {",
             "      if(uwm.nullableFieldUnannotated1 != null) {",
-            "         // no error here, to check that library models only initialize flow store",
+            "         // no error here, to check that library models only initialize  flow store",
             "         this.nonnullField = uwm.nullableFieldUnannotated1;",
             "      }",
             "   }",
             "   String dereferenceTest() {",
             "      // BUG: Diagnostic contains: dereferenced expression uwm.nullableFieldUnannotated1 is @Nullable",
             "      return uwm.nullableFieldUnannotated1.toString();",
+            "   }",
+            "   void assignmentTest() {",
+            "      uwm.nullableFieldUnannotated1 = null;",
             "   }",
             "}")
         .doTest();

--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -71,4 +71,9 @@ public class ExampleLibraryModels implements LibraryModels {
   public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
     return ImmutableSetMultimap.of();
   }
+
+  @Override
+  public ImmutableSet<FieldRef> nullableFields() {
+    return ImmutableSet.of();
+  }
 }

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/UnannotatedWithModels.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/UnannotatedWithModels.java
@@ -2,6 +2,10 @@ package com.uber.lib.unannotated;
 
 public class UnannotatedWithModels {
 
+  public Object nullableFieldUnannotated1;
+
+  public Object nullableFieldUnannotated2;
+
   public Object returnsNullUnannotated() {
     return null;
   }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -15,6 +15,7 @@
  */
 package com.uber.nullaway.testlibrarymodels;
 
+import static com.uber.nullaway.LibraryModels.FieldRef.fieldRef;
 import static com.uber.nullaway.LibraryModels.MethodRef.methodRef;
 
 import com.google.auto.service.AutoService;
@@ -121,5 +122,14 @@ public class TestLibraryModels implements LibraryModels {
         .withMapMethodAllFromName("flatMap", "apply", ImmutableSet.of(0))
         .withPassthroughMethodFromSignature("distinct()")
         .end();
+  }
+
+  @Override
+  public ImmutableSet<FieldRef> nullableFields() {
+    return ImmutableSet.<FieldRef>builder()
+        .add(
+            fieldRef("com.uber.lib.unannotated.UnannotatedWithModels", "nullableFieldUnannotated1"),
+            fieldRef("com.uber.lib.unannotated.UnannotatedWithModels", "nullableFieldUnannotated2"))
+        .build();
   }
 }


### PR DESCRIPTION
This PR extends `LibraryModels` to add support for marking fields `@Nullable`. This feature is required to enable [Annotator](https://github.com/ucr-riple/NullAwayAnnotator) index impact of making fields `@Nullable` on downstream dependencies.

Please note, since this feature is mostly going to be used while indexing impacts on downstream dependencies, this PR does not focus on the optimality of the implementation. Also the working set in iterations is not expected to be large. We can optimize the implementation in a follow up PR if needed.