### PR TITLE
Fix jarinfer cli output determinism

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -213,8 +213,7 @@ public final class BytecodeAnnotator {
   }
 
   /**
-   * Create a zip entry with creation time to 0 to ensure that jars is always have the same
-   * checksum.
+   * Create a zip entry with creation time of 0 to ensure that jars always have the same checksum.
    *
    * @param name of the zip entry.
    * @return the zip entry.

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -212,6 +212,19 @@ public final class BytecodeAnnotator {
     annotateBytecode(is, os, nonnullParams, nullableReturns, javaxNullableDesc, javaxNonnullDesc);
   }
 
+  /**
+   * Create a zip entry with creation time to 0 to ensure that jars is always have the same
+   * checksum.
+   *
+   * @param name of the zip entry.
+   * @return the zip entry.
+   */
+  private static ZipEntry createZipEntry(String name) {
+    ZipEntry entry = new ZipEntry(name);
+    entry.setTime(0);
+    return entry;
+  }
+
   private static void copyAndAnnotateJarEntry(
       JarEntry jarEntry,
       InputStream is,
@@ -224,7 +237,7 @@ public final class BytecodeAnnotator {
       throws IOException {
     String entryName = jarEntry.getName();
     if (entryName.endsWith(".class")) {
-      jarOS.putNextEntry(new ZipEntry(jarEntry.getName()));
+      jarOS.putNextEntry(createZipEntry(jarEntry.getName()));
       annotateBytecode(is, jarOS, nonnullParams, nullableReturns, nullableDesc, nonnullDesc);
     } else if (entryName.equals("META-INF/MANIFEST.MF")) {
       // Read full file
@@ -241,7 +254,7 @@ public final class BytecodeAnnotator {
       if (!manifestText.equals(manifestMinusDigests) && !stripJarSignatures) {
         throw new SignedJarException(SIGNED_JAR_ERROR_MESSAGE);
       }
-      jarOS.putNextEntry(new ZipEntry(jarEntry.getName()));
+      jarOS.putNextEntry(createZipEntry(jarEntry.getName()));
       jarOS.write(manifestMinusDigests.getBytes(UTF_8));
     } else if (entryName.startsWith("META-INF/")
         && (entryName.endsWith(".DSA")
@@ -251,7 +264,7 @@ public final class BytecodeAnnotator {
         throw new SignedJarException(SIGNED_JAR_ERROR_MESSAGE);
       } // the case where stripJarSignatures==true is handled by default by skipping these files
     } else {
-      jarOS.putNextEntry(new ZipEntry(jarEntry.getName()));
+      jarOS.putNextEntry(createZipEntry(jarEntry.getName()));
       jarOS.write(IOUtils.toByteArray(is));
     }
     jarOS.closeEntry();
@@ -329,7 +342,7 @@ public final class BytecodeAnnotator {
     while (zipIterator.hasNext()) {
       ZipEntry zipEntry = zipIterator.next();
       InputStream is = inputZip.getInputStream(zipEntry);
-      zipOS.putNextEntry(new ZipEntry(zipEntry.getName()));
+      zipOS.putNextEntry(createZipEntry(zipEntry.getName()));
       if (zipEntry.getName().equals("classes.jar")) {
         JarInputStream jarIS = new JarInputStream(is);
         JarEntry inputJarEntry = jarIS.getNextJarEntry();


### PR DESCRIPTION
When invoking CLI, jar output sha is not constant. This breaks cacheability in build systems like Buck and Bazel.
Binary investigation (see attached screenshot) of these jars show byte 0xa-0xd in PkZip header is what is changes, and corresponds to file modified date/time (see https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html).
This PR is setting these times to 0 explicilty, so that jar sha remains constant between invokation.

<img width="1073" alt="Screenshot 2023-12-21 at 10 35 42 AM" src="https://github.com/uber/NullAway/assets/52428902/0ac7880e-857a-4484-8f87-2a1d1aa8e8cf">
