### PR TITLE
Revert "Model Lombok-generated equals methods as having a @Nullable p…

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -761,7 +761,10 @@ public class NullAway extends BugChecker
     // Check handlers for any further/overriding nullness information
     overriddenMethodArgNullnessMap =
         handler.onOverrideMethodInvocationParametersNullability(
-            state, overriddenMethod, isOverriddenMethodAnnotated, overriddenMethodArgNullnessMap);
+            state.context,
+            overriddenMethod,
+            isOverriddenMethodAnnotated,
+            overriddenMethodArgNullnessMap);
 
     // If we have an unbound method reference, the first parameter of the overridden method must be
     // @NonNull, as this parameter will be used as a method receiver inside the generated lambda.
@@ -1712,7 +1715,7 @@ public class NullAway extends BugChecker
     // Allow handlers to override the list of non-null argument positions
     argumentPositionNullness =
         handler.onOverrideMethodInvocationParametersNullability(
-            state, methodSymbol, isMethodAnnotated, argumentPositionNullness);
+            state.context, methodSymbol, isMethodAnnotated, argumentPositionNullness);
 
     // now actually check the arguments
     // NOTE: the case of an invocation on a possibly-null reference

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -206,7 +206,7 @@ public class AccessPathNullnessPropagation
   public NullnessStore initialStore(
       UnderlyingAST underlyingAST, List<LocalVariableNode> parameters) {
     return nullnessStoreInitializer.getInitialStore(
-        underlyingAST, parameters, handler, state, config);
+        underlyingAST, parameters, handler, state.context, state.getTypes(), config);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStoreInitializer.java
@@ -1,10 +1,10 @@
 package com.uber.nullaway.dataflow;
 
-import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
@@ -30,7 +30,8 @@ public abstract class NullnessStoreInitializer {
    * @param underlyingAST The AST node being matched.
    * @param parameters list of local variable nodes.
    * @param handler reference to the handler invoked.
-   * @param state the visitor state.
+   * @param context context.
+   * @param types types.
    * @param config config for analysis.
    * @return Initial Nullness store.
    */
@@ -38,7 +39,8 @@ public abstract class NullnessStoreInitializer {
       UnderlyingAST underlyingAST,
       List<LocalVariableNode> parameters,
       Handler handler,
-      VisitorState state,
+      Context context,
+      Types types,
       Config config);
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/BaseNoOpHandler.java
@@ -126,7 +126,7 @@ public abstract class BaseNoOpHandler implements Handler {
 
   @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -149,14 +149,14 @@ class CompositeHandler implements Handler {
 
   @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness) {
     for (Handler h : handlers) {
       argumentPositionNullness =
           h.onOverrideMethodInvocationParametersNullability(
-              state, methodSymbol, isAnnotated, argumentPositionNullness);
+              context, methodSymbol, isAnnotated, argumentPositionNullness);
     }
     return argumentPositionNullness;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -192,7 +192,7 @@ public interface Handler {
    * considered isAnnotated or not. We use a mutable map for performance, but it should not outlive
    * the chain of handler invocations.
    *
-   * @param state The current visitor state.
+   * @param context The current context.
    * @param methodSymbol The method symbol for the method in question.
    * @param isAnnotated A boolean flag indicating whether the called method is considered to be
    *     within isAnnotated or unannotated code, used to avoid querying for this information
@@ -205,7 +205,7 @@ public interface Handler {
    *     handler.
    */
   Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -28,6 +28,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
@@ -121,7 +122,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
 
   @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -103,11 +103,11 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
 
   @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness) {
-    OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(state.context);
+    OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(context);
     ImmutableSet<Integer> nullableParamsFromModel =
         optimizedLibraryModels.explicitlyNullableParameters(methodSymbol);
     ImmutableSet<Integer> nonNullParamsFromModel =

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LombokHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LombokHandler.java
@@ -86,26 +86,4 @@ public class LombokHandler extends BaseNoOpHandler {
     }
     return returnNullness;
   }
-
-  /**
-   * Mark the first argument of Lombok-generated {@code equals} methods as {@code @Nullable}, since
-   * Lombok does not generate the annotation.
-   */
-  @Override
-  public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
-      Symbol.MethodSymbol methodSymbol,
-      boolean isAnnotated,
-      Nullness[] argumentPositionNullness) {
-    if (ASTHelpers.hasAnnotation(methodSymbol, LOMBOK_GENERATED_ANNOTATION_NAME, state)) {
-      // We assume that Lombok-generated equals methods with a single argument override
-      // Object.equals and are not an overload.
-      if (methodSymbol.getSimpleName().contentEquals("equals")
-          && methodSymbol.params().size() == 1) {
-        // The parameter is not annotated with @Nullable, but it should be.
-        argumentPositionNullness[0] = Nullness.NULLABLE;
-      }
-    }
-    return argumentPositionNullness;
-  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -99,7 +99,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   @Override
   public Nullness[] onOverrideMethodInvocationParametersNullability(
-      VisitorState state,
+      Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
       Nullness[] argumentPositionNullness) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractNullnessStoreInitializer.java
@@ -3,11 +3,12 @@ package com.uber.nullaway.handlers.contract;
 import static com.uber.nullaway.Nullness.NONNULL;
 import static com.uber.nullaway.Nullness.NULLABLE;
 
-import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -30,7 +31,8 @@ public class ContractNullnessStoreInitializer extends NullnessStoreInitializer {
       UnderlyingAST underlyingAST,
       List<LocalVariableNode> parameters,
       Handler handler,
-      VisitorState state,
+      Context context,
+      Types types,
       Config config) {
     assert underlyingAST.getKind() == UnderlyingAST.Kind.METHOD;
 
@@ -47,7 +49,7 @@ public class ContractNullnessStoreInitializer extends NullnessStoreInitializer {
     String[] parts = clauses[0].split("->");
     String[] antecedent = parts[0].split(",");
 
-    NullnessStore envStore = getEnvNullnessStoreForClass(classTree, state.context);
+    NullnessStore envStore = getEnvNullnessStoreForClass(classTree, context);
     NullnessStore.Builder result = envStore.toBuilder();
 
     for (int i = 0; i < antecedent.length; ++i) {

--- a/test-java-lib-lombok/src/main/java/com/uber/lombok/UsesDTO.java
+++ b/test-java-lib-lombok/src/main/java/com/uber/lombok/UsesDTO.java
@@ -38,9 +38,4 @@ class UsesDTO {
     s += (ldto.getNullableField() == null ? "" : ldto.getNullableField().toString());
     return s;
   }
-
-  public static boolean callEquals(LombokDTO ldto, @Nullable Object o) {
-    // No error should be reported since equals() parameter should be treated as @Nullable
-    return ldto.equals(o);
-  }
 }


### PR DESCRIPTION
…arameter (#874)"

This reverts commit 5fbee1ff8682762cd2f291070491fe3e476787cf.

It turns out that this change requires a couple of other changes along with it, including #880 and better overall checking of overriding of `equals()` methods.  We want to get a release out soon, so temporarily revert this change; we will restore it after cutting the release.