### PR TITLE
Update to WALA 1.6.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.2",
+    wala                   : "1.6.3",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -51,12 +51,6 @@ test {
     dependsOn ':jar-infer:test-android-lib-jarinfer:bundleReleaseAar'
 }
 
-tasks.named('testJdk21', Test).configure {
-    // Tests fail since WALA does not yet support JDK 21; see https://github.com/uber/NullAway/issues/829
-    // So, disable them
-    onlyIf { false }
-}
-
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }


### PR DESCRIPTION
Fixes #829 

WALA 1.6.3 supports running on JDK 21, so JarInfer now runs on JDK 21 and the tests pass.