### PR TITLE
Update to Error Prone 2.24.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.10.0
           - os: macos-latest
             java: 11
-            epVersion: 2.23.0
+            epVersion: 2.24.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.23.0
+            epVersion: 2.24.0
           - os: windows-latest
             java: 11
-            epVersion: 2.23.0
+            epVersion: 2.24.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.23.0
+            epVersion: 2.24.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -63,7 +63,7 @@ jobs:
         with:
           arguments: codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.23.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.24.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.10.0
           - os: macos-latest
             java: 11
-            epVersion: 2.24.0
+            epVersion: 2.24.1
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.24.0
+            epVersion: 2.24.1
           - os: windows-latest
             java: 11
-            epVersion: 2.24.0
+            epVersion: 2.24.1
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.24.0
+            epVersion: 2.24.1
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -63,7 +63,7 @@ jobs:
         with:
           arguments: codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.24.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.24.1' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.10.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.23.0"
+def latestErrorProneVersion = "2.24.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.10.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.24.0"
+def latestErrorProneVersion = "2.24.1"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion


### PR DESCRIPTION
Just to stay up to date.

A repo owner will have to update the required CI jobs before this can land.