### PR TITLE
Fix crash with raw types in overrides in JSpecify mode

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -3,7 +3,6 @@ package com.uber.nullaway.generics;
 import static com.google.common.base.Verify.verify;
 import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
-import com.google.common.base.Preconditions;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
@@ -772,7 +771,7 @@ public final class GenericsChecks {
     List<Type> overriddenMethodParameterTypes = overriddenMethodType.getParameterTypes();
     // TODO handle varargs; they are not handled for now
     for (int i = 0; i < methodParameters.size(); i++) {
-      Type overridingMethodParameterType = ASTHelpers.getType(methodParameters.get(i));
+      Type overridingMethodParameterType = getTreeType(methodParameters.get(i), state);
       Type overriddenMethodParameterType = overriddenMethodParameterTypes.get(i);
       if (overriddenMethodParameterType != null && overridingMethodParameterType != null) {
         if (!compareNullabilityAnnotations(
@@ -801,11 +800,10 @@ public final class GenericsChecks {
   private static void checkTypeParameterNullnessForOverridingMethodReturnType(
       MethodTree tree, Type overriddenMethodType, NullAway analysis, VisitorState state) {
     Type overriddenMethodReturnType = overriddenMethodType.getReturnType();
-    Type overridingMethodReturnType = ASTHelpers.getType(tree.getReturnType());
-    if (overriddenMethodReturnType == null) {
+    Type overridingMethodReturnType = getTreeType(tree.getReturnType(), state);
+    if (overriddenMethodReturnType == null || overridingMethodReturnType == null) {
       return;
     }
-    Preconditions.checkArgument(overridingMethodReturnType != null);
     if (!compareNullabilityAnnotations(
         overriddenMethodReturnType, overridingMethodReturnType, state)) {
       reportInvalidOverridingMethodReturnTypeError(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1615,6 +1615,26 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void overrideWithRawType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "class Test {",
+            "  interface Foo<T> {}",
+            "  interface Bar<T> {",
+            "    void add(Foo<T> foo);",
+            "  }",
+            "  static class Baz<T> implements Bar<T> {",
+            "    @SuppressWarnings(\"rawtypes\")",
+            "    @Override",
+            "    public void add(Foo foo) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1621,15 +1621,20 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "  interface Foo<T> {}",
             "  interface Bar<T> {",
             "    void add(Foo<T> foo);",
+            "    @Nullable Foo<T> get();",
             "  }",
             "  static class Baz<T> implements Bar<T> {",
             "    @SuppressWarnings(\"rawtypes\")",
             "    @Override",
             "    public void add(Foo foo) {}",
+            "    @SuppressWarnings(\"rawtypes\")",
+            "    @Override",
+            "    public @Nullable Foo get() { return null; }",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
We should skip checking for errors here instead of crashing