### PR TITLE
Add foojay-resolver-convention plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,11 @@ pluginManagement {
     }
 }
 
+plugins {
+    // to automatically pull in relevant JDK toolchains when not present on the local machine
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 include ':annotations'
 include ':nullaway'
 include ':sample-library-model'


### PR DESCRIPTION
See https://github.com/gradle/foojay-toolchains.  With this plugin, if relevant toolchains are not present on the local machine (e.g., for JDK 8 or JDK 21), Gradle will automatically download an appropriate distribution and place it in the local Gradle cache.  This plugin is officially supported by Gradle, so I think it's safe to add.  Without this plugin, new contributors may run into issues running basic commands like `./gradlew compileJava` since it requires multiple JDKs to be installed in order to succeed.