### PR TITLE
Support for extra Futures classes

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/AbstractConfig.java
@@ -103,6 +103,8 @@ public abstract class AbstractConfig implements Config {
 
   protected ImmutableSet<String> skippedLibraryModels;
 
+  protected ImmutableSet<String> extraFuturesClasses;
+
   /** --- JarInfer configs --- */
   protected boolean jarInferEnabled;
 
@@ -297,6 +299,11 @@ public abstract class AbstractConfig implements Config {
   @Override
   public boolean isSkippedLibraryModel(String classDotMethod) {
     return skippedLibraryModels.contains(classDotMethod);
+  }
+
+  @Override
+  public ImmutableSet<String> getExtraFuturesClasses() {
+    return extraFuturesClasses;
   }
 
   @AutoValue

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -263,6 +263,13 @@ public interface Config {
    */
   boolean isSkippedLibraryModel(String classDotMethod);
 
+  /**
+   * Gets the set of classes that should be treated as equivalent to a Guava fluent futures class.
+   *
+   * @see com.uber.nullaway.handlers.temporary.FluentFutureHandler
+   */
+  Set<String> getExtraFuturesClasses();
+
   // --- JarInfer configs ---
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -191,6 +191,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public Set<String> getExtraFuturesClasses() {
+    throw new IllegalStateException(ERROR_MESSAGE);
+  }
+
+  @Override
   public boolean isJarInferEnabled() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -75,6 +75,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
 
   static final String FL_SKIP_LIBRARY_MODELS = EP_FL_NAMESPACE + ":IgnoreLibraryModelsFor";
 
+  static final String FL_EXTRA_FUTURES = EP_FL_NAMESPACE + ":ExtraFuturesClasses";
+
   /** --- JarInfer configs --- */
   static final String FL_JI_ENABLED = EP_FL_NAMESPACE + ":JarInferEnabled";
 
@@ -220,6 +222,8 @@ final class ErrorProneCLIFlagsConfig extends AbstractConfig {
           "Invalid -XepOpt:" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
     }
     skippedLibraryModels = getFlagStringSet(flags, FL_SKIP_LIBRARY_MODELS);
+    extraFuturesClasses = getFlagStringSet(flags, FL_EXTRA_FUTURES);
+
     /* --- JarInfer configs --- */
     jarInferEnabled = flags.getBoolean(FL_JI_ENABLED).orElse(false);
     jarInferUseReturnAnnotations = flags.getBoolean(FL_JI_USE_RETURN).orElse(false);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -80,7 +80,7 @@ public class Handlers {
       handlerListBuilder.add(new ContractCheckHandler(config));
     }
     handlerListBuilder.add(new LombokHandler(config));
-    handlerListBuilder.add(new FluentFutureHandler());
+    handlerListBuilder.add(new FluentFutureHandler(config));
 
     return new CompositeHandler(handlerListBuilder.build());
   }


### PR DESCRIPTION
This allows for a list of classes to be passed in via a command-line argument `-XepOpt:NullAway:ExtraFuturesClasses`.  Such classes will be treated equivalently to built-in Guava Futures classes via the `FluentFutureHandler`.  This is a follow-up to #771.