### PR TITLE
JSpecify test case for generic methods

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericMethodTests.java
@@ -1,0 +1,44 @@
+package com.uber.nullaway;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.util.Arrays;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class NullAwayJSpecifyGenericMethodTests extends NullAwayTestsBase {
+
+  @Test
+  @Ignore("requires generic method support")
+  public void genericMethodAndVoidType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class Foo {",
+            "    <C extends @Nullable Object> void foo(C c, Visitor<C> visitor) {",
+            "      visitor.visit(this, c);",
+            "    }",
+            "  }",
+            "  static abstract class Visitor<C extends @Nullable Object> {",
+            "    abstract void visit(Foo foo, C c);",
+            "  }",
+            "  static class MyVisitor extends Visitor<@Nullable Void> {",
+            "    @Override",
+            "    void visit(Foo foo, @Nullable Void c) {}",
+            "  }",
+            "  static void test(Foo f) {",
+            "    // this is safe",
+            "    f.foo(null, new MyVisitor());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        Arrays.asList(
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber", "-XepOpt:NullAway:JSpecifyMode=true"));
+  }
+}


### PR DESCRIPTION
Based on an internal issue.  When we get to supporting generic methods in JSpecify we want to be able to handle this case.  The test is ignored for now.