### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,6 +68,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./code-coverage-report/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
         if: steps.jacoco_report.outcome == 'success'
       - name: Test publishToMavenLocal flow
         env:


### PR DESCRIPTION
We have upgraded our codecov upload action to v4. However, tokenless uploads are unsupported now (see https://github.com/codecov/codecov-action/issues/1293). This PR fixes the config to give the action a codecov token stored in repository secrets.