### PR TITLE
Fix another JSpecify raw type issue

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1,7 +1,6 @@
 package com.uber.nullaway.generics;
 
 import static com.google.common.base.Verify.verify;
-import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
@@ -687,8 +686,7 @@ public final class GenericsChecks {
       return Nullness.NONNULL;
     }
     Type enclosingType =
-        castToNonNull(
-            getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state));
+        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state);
     return getGenericMethodParameterNullness(
         paramIndex, invokedMethodSymbol, enclosingType, state, config);
   }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1717,6 +1717,27 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void testRawTypeReceiverCast() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class A<T> {",
+            "    void foo(T n) {}",
+            "  }",
+            "  static class B {",
+            "    static <T> void bar(A<T> a) {",
+            "      ((A) a).foo(new Object());",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJSpecifyGenericsTests.java
@@ -1723,8 +1723,6 @@ public class NullAwayJSpecifyGenericsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "package com.uber;",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "  static class A<T> {",
             "    void foo(T n) {}",


### PR DESCRIPTION
We did not handle casting a receiver to a raw type
