### PR TITLE
Fix handling of references to methods of array types and type variables

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2326,7 +2326,7 @@ public class NullAway extends BugChecker
         return true;
       case NEW_CLASS:
       case NEW_ARRAY:
-        // for string concatenation, auto-boxing
+      case ARRAY_TYPE:
       case LAMBDA_EXPRESSION:
         // Lambdas may return null, but the lambda literal itself should not be null
       case MEMBER_REFERENCE:

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2485,7 +2485,8 @@ public class NullAway extends BugChecker
     if (baseExpressionSymbol != null) {
       if (baseExpressionSymbol.type.isPrimitive()
           || baseExpressionSymbol.getKind() == ElementKind.PACKAGE
-          || ElementUtils.isTypeElement(baseExpressionSymbol)) {
+          || ElementUtils.isTypeElement(baseExpressionSymbol)
+          || baseExpressionSymbol.getKind() == ElementKind.TYPE_PARAMETER) {
         // we know we don't have a null dereference here
         return Description.NO_MATCH;
       }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJava8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJava8Tests.java
@@ -30,10 +30,15 @@ public class NullAwayJava8Tests extends NullAwayTestsBase {
             "Test.java",
             "package com.uber;",
             "import org.jspecify.annotations.Nullable;",
+            "import java.util.Arrays;",
             "class Test {",
-            "  public static boolean test(@Nullable String text, java.util.Set<String> s) {",
+            "  public static boolean testPositive(@Nullable String text, java.util.Set<String> s) {",
             "    // BUG: Diagnostic contains: dereferenced expression text is @Nullable",
             "    return s.stream().anyMatch(text::contains);",
+            "  }",
+            "  public static String[] testNegative(Object[] arr) {",
+            "    // also tests we don't crash when the qualifier expression of a method reference is a type",
+            "    return Arrays.stream(arr).map(Object::toString).toArray(String[]::new);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayJava8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayJava8Tests.java
@@ -31,6 +31,7 @@ public class NullAwayJava8Tests extends NullAwayTestsBase {
             "package com.uber;",
             "import org.jspecify.annotations.Nullable;",
             "import java.util.Arrays;",
+            "import java.util.stream.Collectors;",
             "class Test {",
             "  public static boolean testPositive(@Nullable String text, java.util.Set<String> s) {",
             "    // BUG: Diagnostic contains: dereferenced expression text is @Nullable",
@@ -39,6 +40,9 @@ public class NullAwayJava8Tests extends NullAwayTestsBase {
             "  public static String[] testNegative(Object[] arr) {",
             "    // also tests we don't crash when the qualifier expression of a method reference is a type",
             "    return Arrays.stream(arr).map(Object::toString).toArray(String[]::new);",
+            "  }",
+            "  public static <T> boolean testNegativeWithTypeVariable(T[] arr) {",
+            "    return Arrays.stream(arr).map(T::toString).collect(Collectors.toList()).isEmpty();",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
After #920 we check the nullability of the qualifier expression of a method reference.  We weren't correctly handling the cases where that expression was an array type or a type variable
