### PR TITLE
Bump to Checker Framework 3.43.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.40.0",
+    checkerFramework       : "3.43.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.


### PR DESCRIPTION
The previous bug that was preventing us from upgrading (https://github.com/typetools/checker-framework/issues/6396) is fixed in this release.  Benchmarks show no performance regression.