### PR TITLE
Drop Java 8 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,10 +15,10 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.10.0
+            epVersion: 2.14.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.10.0
+            epVersion: 2.14.0
           - os: macos-latest
             java: 11
             epVersion: 2.27.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NullAway is *fast*.  It is built as a plugin to [Error Prone](http://errorprone.
 
 ### Overview
 
-NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.10.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
+NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.14.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
 
 ### Gradle
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,11 +79,11 @@ subprojects { project ->
         }
     }
 
-    // Target JDK 8.  We need to use the older sourceCompatibility / targetCompatibility settings to get
-    // the build to work on JDK 11+.  Once we stop supporting JDK 8, switch to using the javac "release" option
+    // We need to use the older sourceCompatibility / targetCompatibility settings, rather than the newer "release"
+    // option, since we use internal javac APIs, which "release" doesn't allow
     tasks.withType(JavaCompile) {
-        java.sourceCompatibility = "1.8"
-        java.targetCompatibility = "1.8"
+        java.sourceCompatibility = JavaVersion.VERSION_11
+        java.targetCompatibility = JavaVersion.VERSION_11
     }
 
     tasks.withType(Test).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 GROUP=com.uber.nullaway
-VERSION_NAME=0.10.27-SNAPSHOT
+VERSION_NAME=0.11.0-SNAPSHOT
 
 POM_DESCRIPTION=A fast annotation-based null checker for Java
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ import org.gradle.util.VersionNumber
  */
 
 // The oldest version of Error Prone that we support running on
-def oldestErrorProneVersion = "2.10.0"
+def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
 def latestErrorProneVersion = "2.27.1"
 // Default to using latest tested Error Prone version

--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -60,18 +60,18 @@ def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     testClassesDirs = testTask.testClassesDirs
 
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Accessed by Lombok tests
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
     ]
 }
 

--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -18,6 +18,11 @@ plugins {
     id 'nullaway.java-test-conventions'
 }
 
+configurations {
+    // A configuration holding the jars for the oldest supported version of Error Prone, to use with tests
+    errorProneOldest
+}
+
 // We need this separate build target to test newer versions of Guava
 // (e.g. 31+) than that which NullAway currently depends on.
 
@@ -29,29 +34,47 @@ dependencies {
     }
     testImplementation deps.build.jsr305Annotations
     testImplementation "com.google.guava:guava:31.1-jre"
+
+    errorProneOldest deps.build.errorProneCheckApiOld
+    errorProneOldest(deps.build.errorProneTestHelpersOld) {
+        exclude group: "junit", module: "junit"
+    }
 }
 
 // Create a task to test on JDK 8
-def jdk8Test = tasks.register("testJdk8", Test) {
-    onlyIf {
-        // Only if we are using a version of Error Prone compatible with JDK 8
-        deps.versions.errorProneApi == "2.10.0"
-    }
+def epOldestTest = tasks.register("testErrorProneOldest", Test) {
 
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 
-    description = "Runs the test suite on JDK 8"
+    description = "Runs the test suite using the oldest supported version of Error Prone"
     group = LifecycleBasePlugin.VERIFICATION_GROUP
 
     // Copy inputs from normal Test task.
     def testTask = tasks.getByName("test")
-    classpath = testTask.classpath
+    // A bit of a hack: we add the dependencies of the oldest supported Error Prone version to the _beginning_ of the
+    // classpath, so that they are used instead of the latest version.  This exercises the scenario of building
+    // NullAway against the latest supported Error Prone version but then running on the oldest supported version.
+    classpath = configurations.errorProneOldest + testTask.classpath
     testClassesDirs = testTask.testClassesDirs
-    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+
+    jvmArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            // Accessed by Lombok tests
+            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    ]
 }
 
 tasks.named('check').configure {
-    dependsOn(jdk8Test)
+    dependsOn(epOldestTest)
 }

--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -41,7 +41,8 @@ dependencies {
     }
 }
 
-// Create a task to test on JDK 8
+// Create a task to test with the oldest supported version of Error Prone
+// (while still building against the latest supported version)
 def epOldestTest = tasks.register("testErrorProneOldest", Test) {
 
     javaLauncher = javaToolchains.launcherFor {

--- a/jar-infer/jar-infer-cli/build.gradle
+++ b/jar-infer/jar-infer-cli/build.gradle
@@ -4,12 +4,6 @@ plugins {
     id "com.github.johnrengelman.shadow"
 }
 
-// JarInfer requires JDK 11+, due to its dependence on WALA
-tasks.withType(JavaCompile) {
-    java.sourceCompatibility = JavaVersion.VERSION_11
-    java.targetCompatibility = JavaVersion.VERSION_11
-}
-
 repositories {
     mavenCentral()
 }

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -18,12 +18,6 @@ plugins {
     id 'nullaway.java-test-conventions'
 }
 
-// JarInfer requires JDK 11+, due to its dependence on WALA
-tasks.withType(JavaCompile) {
-    java.sourceCompatibility = JavaVersion.VERSION_11
-    java.targetCompatibility = JavaVersion.VERSION_11
-}
-
 repositories {
     mavenCentral()
     // uncomment if you want to use wala.dalvik or wala.scandroid

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -85,21 +85,21 @@ apply plugin: 'com.vanniktech.maven.publish'
 // JDK-internal APIs that are not exposed otherwise.  Since we currently target JDK 8, we do not need to pass the
 // arguments, as encapsulation of JDK internals is not enforced on JDK 8.  In fact, the arguments cause a compiler error
 // when targeting JDK 8.  Leaving commented so we can easily add them back once we target JDK 11.
-//    tasks.withType(JavaCompile).configureEach {
-//        options.compilerArgs += [
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-//                "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
-//        ]
-//    }
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
+    ]
+}
 
 // Create a task to test on JDK 8
 // NOTE: even when we drop JDK 8 support, we will still need a test task similar to this one for testing building

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -105,12 +105,12 @@ tasks.withType(JavaCompile).configureEach {
 // NOTE: even when we drop JDK 8 support, we will still need a test task similar to this one for testing building
 // against a recent JDK and Error Prone version but then running on the oldest supported JDK and Error Prone version,
 // to check for binary compatibility issues.
-def jdk8Test = tasks.register("testJdk8", Test) {
+def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 
-    description = "Runs the test suite on JDK 8"
+    description = "Runs the test suite using the oldest supported version of Error Prone"
     group = LifecycleBasePlugin.VERIFICATION_GROUP
 
     // Copy inputs from normal Test task.
@@ -121,18 +121,26 @@ def jdk8Test = tasks.register("testJdk8", Test) {
     classpath = configurations.errorProneOldest + testTask.classpath
 
     testClassesDirs = testTask.testClassesDirs
-    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
-    filter {
-        // JDK 8 does not support diamonds on anonymous classes
-        excludeTestsMatching "com.uber.nullaway.jspecify.GenericsTests.overrideDiamondAnonymousClass"
-        // tests cannot run on JDK 8 since Mockito version no longer supports it
-        excludeTestsMatching "com.uber.nullaway.SerializationTest.initializationError"
-        excludeTestsMatching "com.uber.nullaway.handlers.contract.ContractUtilsTest.getEmptyAntecedent"
-    }
+
+    jvmArgs += [
+            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            // Accessed by Lombok tests
+            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    ]
+
 }
 
 tasks.named('check').configure {
-    dependsOn(jdk8Test)
+    dependsOn(epOldestTest)
 }
 
 // Create a task to build NullAway with NullAway checking enabled

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -82,9 +82,7 @@ javadoc {
 apply plugin: 'com.vanniktech.maven.publish'
 
 // These --add-exports arguments are required when targeting JDK 11+ since Error Prone and NullAway access a bunch of
-// JDK-internal APIs that are not exposed otherwise.  Since we currently target JDK 8, we do not need to pass the
-// arguments, as encapsulation of JDK internals is not enforced on JDK 8.  In fact, the arguments cause a compiler error
-// when targeting JDK 8.  Leaving commented so we can easily add them back once we target JDK 11.
+// JDK-internal APIs that are not exposed otherwise.
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
@@ -101,10 +99,8 @@ tasks.withType(JavaCompile).configureEach {
     ]
 }
 
-// Create a task to test on JDK 8
-// NOTE: even when we drop JDK 8 support, we will still need a test task similar to this one for testing building
-// against a recent JDK and Error Prone version but then running on the oldest supported JDK and Error Prone version,
-// to check for binary compatibility issues.
+// Create a task to test with the oldest supported version of Error Prone
+// (while still building against the latest supported version)
 def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(11)

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -87,17 +87,17 @@ apply plugin: 'com.vanniktech.maven.publish'
 // when targeting JDK 8.  Leaving commented so we can easily add them back once we target JDK 11.
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.source.tree=ALL-UNNAMED",
     ]
 }
 
@@ -123,20 +123,19 @@ def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     testClassesDirs = testTask.testClassesDirs
 
     jvmArgs += [
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            // Accessed by Lombok tests
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        // Accessed by Lombok tests
+        "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
     ]
-
 }
 
 tasks.named('check').configure {


### PR DESCRIPTION
This PR drops support for running NullAway on a JDK 8 JVM.  After it lands, running NullAway will require JDK 11 or above (like current versions of Error Prone).  There are various cleanups that this change enables, but to keep the PR small, I tried to do close to the minimum.  In particular:

* I updated the minimum supported Error Prone version to 2.14.0, which is ~2 years old.  Depending on what we decide about policy (see #882) we may want to bump this to an even more recent version.
* Update our JDK 8 test tasks to instead just test building with the most recent supported Error Prone version but running on the oldest supported version.  I tested locally that this does still detect binary compatibility issues.
* Remove references to Java 11 in the jarinfer build files, as we now use that version everywhere.

We will have to change the required CI job names before landing this. 

Will do other enabled cleanups in separate PRs.