### PR TITLE
Disable publishing of snapshot builds from CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -81,25 +81,3 @@ jobs:
         if: matrix.java == '11'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
-  publish_snapshot:
-    name: 'Publish snapshot'
-    needs: [build]
-    if: github.event_name == 'push' && github.repository == 'uber/NullAway' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@v4
-      - name: 'Set up JDK 11'
-        uses: actions/setup-java@v4
-        with:
-          java-version: |
-            21
-            11
-          distribution: 'temurin'
-      - name: 'Publish'
-        uses: gradle/gradle-build-action@v3
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        with:
-          arguments: clean publish --no-daemon --no-parallel

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Finally, in the `tasks.withType(JavaCompile)` section, we pass some configuratio
 
 We recommend addressing all the issues that Error Prone reports, particularly those reported as errors (rather than warnings).  But, if you'd like to try out NullAway without running other Error Prone checks, you can use `options.errorprone.disableAllChecks` (equivalent to passing `"-XepDisableAllChecks"` to the compiler, before the NullAway-specific arguments).
 
-Snapshots of the development version are available in [Sonatype's snapshots repository][snapshots].
-
 #### Android
 
 Versions 3.0.0 and later of the Gradle Error Prone Plugin [no longer support Android](https://github.com/tbroyer/gradle-errorprone-plugin/releases/tag/v3.0.0).  So if you're using a recent version of this plugin, you'll need to add some further configuration to run Error Prone and NullAway.  Our [sample app `build.gradle` file](https://github.com/uber/NullAway/blob/master/sample-app/build.gradle) shows one way to do this, but your Android project may require tweaks.  Alternately, 2.x versions of the Gradle Error Prone Plugin still support Android and may still work with your project.
@@ -141,5 +139,3 @@ you create a pull request, you will be asked to sign our [Uber Contributor Licen
 ## License
 
 NullAway is licensed under the MIT license.  See the LICENSE.txt file for more information.
-
- [snapshots]: https://oss.sonatype.org/content/repositories/snapshots/com/uber/nullaway/


### PR DESCRIPTION
NullAway is stable enough now, and easy enough to build, that publishing snapshot builds is less compelling for users (who should not be relying on frequently-changing remote SNAPSHOT versions anyway).  We can think about restoring these builds if there is demand.