### PR TITLE
Update JavaParser to 3.26.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,7 +75,7 @@ def build = [
     errorProneTestHelpersOld: "com.google.errorprone:error_prone_test_helpers:${oldestErrorProneVersion}",
     checkerDataflow         : "org.checkerframework:dataflow-nullaway:${versions.checkerFramework}",
     guava                   : "com.google.guava:guava:30.1-jre",
-    javaparser              : "com.github.javaparser:javaparser-core:3.25.8",
+    javaparser              : "com.github.javaparser:javaparser-core:3.26.0",
     javaxValidation         : "javax.validation:validation-api:2.0.1.Final",
     jspecify                : "org.jspecify:jspecify:0.3.0",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",


### PR DESCRIPTION
This release includes some fixes for bugs that have impacted other projects like the annotator