### PR TITLE
Reenable JMH benchmarking in a safer manner

### DIFF
--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -20,12 +20,15 @@ jobs:
     - name: Checkout repository 
       uses: actions/checkout@v4
 
+    - name: Print repo name
+    - run: echo ${{ github.repository }}
+      
     - name: Set branch name 
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
       run: |
         chmod +x ./.github/workflows/get_repo_details.sh 
-        ./.github/workflows/get_repo_details.sh "${{ secrets.GITHUB_TOKEN }}" "${{ github.event.number }}" "${{ github.event.repository }}"
+        ./.github/workflows/get_repo_details.sh "${{ secrets.GITHUB_TOKEN }}" "${{ github.event.number }}" "${{ github.repository }}"
 
     - id: 'auth'
       name: Authenticating 

--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -11,7 +11,7 @@ concurrency: all
 jobs:
   benchmarking:
     # Only run this job if the label is 'run-benchmarks' and the PR in on the uber/NullAway repository
-    if: github.event.label.name == 'run-benchmarks'
+    if: github.event.label.name == 'run-benchmarks' && github.repository == 'uber/NullAway'
     runs-on: ubuntu-latest 
     permissions: write-all 
 
@@ -20,10 +20,7 @@ jobs:
     - name: Checkout repository 
       uses: actions/checkout@v4
 
-    - name: Print repo name
-      run: echo ${{ github.repository }}
-      
-    - name: Set branch name 
+    - name: Set branch name
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
       run: |

--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Print repo name
-    - run: echo ${{ github.repository }}
+      run: echo ${{ github.repository }}
       
     - name: Set branch name 
       env:

--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -25,7 +25,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
       run: |
         chmod +x ./.github/workflows/get_repo_details.sh 
-        ./.github/workflows/get_repo_details.sh "${{ secrets.GITHUB_TOKEN }}" "${{ github.event.issue.number }}" "${{ github.repository }}"
+        ./.github/workflows/get_repo_details.sh "${{ secrets.GITHUB_TOKEN }}" "${{ github.event.number }}" "${{ github.event.repository }}"
 
     - id: 'auth'
       name: Authenticating 

--- a/.github/workflows/jmh-benchmark.yml
+++ b/.github/workflows/jmh-benchmark.yml
@@ -1,8 +1,8 @@
-# This GitHub Actions workflow runs JMH benchmarks when a new comment is created on a pull request
+# This GitHub Actions workflow runs JMH benchmarks when requested
 name: Run JMH Benchmarks for Pull Request
 
 on:
-  pull_request: # This workflow triggers when a comment is created
+  pull_request: # Trigger when a label is added.  Only contributors have permissions to add labels
     types: [labeled]
 
 # Only allow one instance of JMH benchmarking to be running at any given time
@@ -10,7 +10,7 @@ concurrency: all
 
 jobs:
   benchmarking:
-    # Only run this job if a comment on a pull request contains '/benchmark' and is a PR on the uber/NullAway repository
+    # Only run this job if the label is 'run-benchmarks' and the PR in on the uber/NullAway repository
     if: github.event.label.name == 'run-benchmarks'
     runs-on: ubuntu-latest 
     permissions: write-all 


### PR DESCRIPTION
Fixes #968 

The key difference is now the benchmarking job only starts when the label with the name `run-benchmarks` is added to a PR.  According to [the docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label) only those with triage access to the repository can add or remove a label.  In contrast, anyone can comment on an issue, which made our previous technique for kick-starting the benchmarks unsafe.  Before adding the `run-benchmarks` label, a PR should be reviewed to check for malicious code.

It is impossible to test this workflow without first merging it to the main branch.  However, I did test it using a PR on my fork, and confirmed it could comment back the benchmark results like before:

https://github.com/msridhar/NullAway/pull/12

After merging this PR we'll also have to add some credentials to the main NullAway repo to make this work.  But first we should review, land, and then see that it fails as expected without the credentials.

Compared to [the earlier workflow file](https://github.com/uber/NullAway/blob/87ec10d4f26630d4bb91aefe5ff7c0fc181f030a/.github/workflows/jmh-benchmark.yml), beyond changing to use labeling, I updated the versions of some external GitHub actions we are using.