### PR TITLE
Update to Error Prone 2.28.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,16 @@ jobs:
             epVersion: 2.14.0
           - os: macos-latest
             java: 11
-            epVersion: 2.27.1
+            epVersion: 2.28.0
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.27.1
+            epVersion: 2.28.0
           - os: windows-latest
             java: 11
-            epVersion: 2.27.1
+            epVersion: 2.28.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.27.1
+            epVersion: 2.28.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.27.1' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.28.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.27.1"
+def latestErrorProneVersion = "2.28.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion


### PR DESCRIPTION
To stay up to date.  Required job names need updating before landing