### PR TITLE
Features/944 tidy stream nullability propagator

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -214,21 +214,22 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
     VisitorState state = methodAnalysisContext.state();
     Type receiverType = ASTHelpers.getReceiverType(tree);
     for (StreamTypeRecord streamType : models) {
-      if (streamType.matchesType(receiverType, state)) {
-        // Build observable call chain
-        buildObservableCallChain(tree);
+      if (!streamType.matchesType(receiverType, state)) {
+        continue;
+      }
+      // Build observable call chain
+      buildObservableCallChain(tree);
+      if (methodSymbol.getParameters().length() != 1) {
+        continue;
+      }
 
-        // Dispatch to code handling specific observer methods
-        if (streamType.isFilterMethod(methodSymbol) && methodSymbol.getParameters().length() == 1) {
-          handleFilterMethod(tree, streamType, state);
-        } else if (streamType.isMapMethod(methodSymbol)
-            && methodSymbol.getParameters().length() == 1) {
-          handleMapMethod(tree, streamType, methodSymbol);
-        } else {
-          if (methodSymbol.getParameters().length() == 1) {
-            handleCollectMethod(tree, streamType, methodSymbol);
-          }
-        }
+      // Dispatch to code handling specific observer methods
+      if (streamType.isFilterMethod(methodSymbol)) {
+        handleFilterMethod(tree, streamType, state);
+      } else if (streamType.isMapMethod(methodSymbol)) {
+        handleMapMethod(tree, streamType, methodSymbol);
+      } else {
+        handleCollectMethod(tree, streamType, methodSymbol);
       }
     }
   }


### PR DESCRIPTION
#944 - Tidy function `StreamNullabilityPropagator :: onMatchMethodInvocation`

- As suggested in #944, I have extracted three dedicated utility functions for handling filter/map/collect methods.
- Following that, I have inverted 2 of the if statements to eliminate the multiple levels of nesting 

(the two changes described above can be seen in the 2 different commits)

Fixes #944 