### PR TITLE
JSpecify: Handle @Nullable elements for enhanced-for-loops on arrays

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -508,6 +508,7 @@ public class AccessPathNullnessPropagation
     Node rhs = node.getExpression();
     Nullness value = values(input).valueOfSubNode(rhs);
     Node target = node.getTarget();
+
     if (target instanceof LocalVariableNode
         && !castToNonNull(ASTHelpers.getType(target.getTree())).isPrimitive()) {
       LocalVariableNode localVariableNode = (LocalVariableNode) target;
@@ -793,6 +794,7 @@ public class AccessPathNullnessPropagation
     if (config.isJSpecifyMode()) {
       Symbol arraySymbol;
       boolean isElementNullable = false;
+      // For enhanced-for-loops we get the symbol from the array expression as the node is desugared
       ExpressionTree arrayExpr = node.getArrayExpression();
       if (arrayExpr != null) {
         arraySymbol = ASTHelpers.getSymbol(arrayExpr);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -30,6 +30,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -507,7 +508,6 @@ public class AccessPathNullnessPropagation
     Node rhs = node.getExpression();
     Nullness value = values(input).valueOfSubNode(rhs);
     Node target = node.getTarget();
-
     if (target instanceof LocalVariableNode
         && !castToNonNull(ASTHelpers.getType(target.getTree())).isPrimitive()) {
       LocalVariableNode localVariableNode = (LocalVariableNode) target;
@@ -791,8 +791,14 @@ public class AccessPathNullnessPropagation
     Nullness resultNullness;
     // Unsoundly assume @NonNull, except in JSpecify mode where we check the type
     if (config.isJSpecifyMode()) {
-      Symbol arraySymbol = ASTHelpers.getSymbol(node.getArray().getTree());
+      Symbol arraySymbol;
       boolean isElementNullable = false;
+      ExpressionTree arrayExpr = node.getArrayExpression();
+      if (arrayExpr != null) {
+        arraySymbol = ASTHelpers.getSymbol(arrayExpr);
+      } else {
+        arraySymbol = ASTHelpers.getSymbol(node.getArray().getTree());
+      }
       if (arraySymbol != null) {
         isElementNullable = NullabilityUtil.isArrayElementNullable(arraySymbol, config);
       }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/ArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/ArrayTests.java
@@ -3,7 +3,6 @@ package com.uber.nullaway.jspecify;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ArrayTests extends NullAwayTestsBase {
@@ -492,7 +491,6 @@ public class ArrayTests extends NullAwayTestsBase {
   }
 
   @Test
-  @Ignore("for-each handling needs to be fixed; see https://github.com/uber/NullAway/issues/983")
   public void forEachLoop() {
     makeHelper()
         .addSourceLines(
@@ -506,8 +504,6 @@ public class ArrayTests extends NullAwayTestsBase {
             "      if (s != null) {",
             "        s.toString();",
             "      }",
-            "    }",
-            "    for (String s : fizz) {",
             "      // BUG: Diagnostic contains: dereferenced expression s is @Nullable",
             "      s.toString();",
             "    }",


### PR DESCRIPTION
Currently, enhanced-for-loops do not honor nullability annotations on arrays. 

**Current Behavior**
Both these dereferences work fine.
```
static @Nullable String[] fizz = {"1"}
for (String s: fizz){
     s.toString();
     if (s!=null){
          s.toString();
     }  
}

```
**New Behavior**
The first one throws an error, as expected.
```
static @Nullable String[] fizz = {"1"}
for (String s: fizz){
     // BUG: Diagnostic contains: dereferenced expression s is @Nullable
     s.toString();
     if (s!=null){
          s.toString();
     }  
}

```



Fixes #983 
