### PR TITLE
Add missing @Test annotation

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway.jspecify;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -1765,6 +1766,7 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
   public void boxInteger() {
     makeHelper()
         .addSourceLines(
@@ -1796,6 +1798,6 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   private CompilationTestHelper makeHelperWithoutJSpecifyMode() {
-    return makeTestHelperWithArgs(Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+    return makeTestHelperWithArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"));
   }
 }


### PR DESCRIPTION
And fix another IntelliJ warning related to Arrays.asList called with one arg
