### PR TITLE
JSpecify: fix crashes where declared parameter / return types were raw

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -356,6 +356,10 @@ public final class GenericsChecks {
     }
 
     Type formalReturnType = methodSymbol.getReturnType();
+    if (formalReturnType.isRaw()) {
+      // bail out of any checking involving raw types for now
+      return;
+    }
     Type returnExpressionType = getTreeType(retExpr, state);
     if (formalReturnType != null && returnExpressionType != null) {
       boolean isReturnTypeValid =

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -515,7 +515,6 @@ public final class GenericsChecks {
     }
     for (int i = 0; i < n; i++) {
       Type formalParameter = formalParams.get(i).type;
-      // TODO also check on return types, assignments to locals, assignments to fields, etc.
       if (formalParameter.isRaw()) {
         // bail out of any checking involving raw types for now
         return;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -511,6 +511,11 @@ public final class GenericsChecks {
     }
     for (int i = 0; i < n; i++) {
       Type formalParameter = formalParams.get(i).type;
+      // TODO also check on return types, assignments to locals, assignments to fields, etc.
+      if (formalParameter.isRaw()) {
+        // bail out of any checking involving raw types for now
+        return;
+      }
       Type actualParameter = getTreeType(actualParams.get(i), state);
       if (actualParameter != null) {
         if (!subtypeParameterNullability(formalParameter, actualParameter, state)) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1760,6 +1760,8 @@ public class GenericsTests extends NullAwayTestsBase {
             "    @Nullable A<?> field;",
             "    void m3(A<?> a) {",
             "      field = a;",
+            "      A local = a;",
+            "      local = a;",
             "    }",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1738,19 +1738,27 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void testRawFormalParameterType() {
+  public void pseudoAssignmentWithRawDeclaredTypes() {
     makeHelper()
         .addSourceLines(
             "Test.java",
             "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
             "class Test {",
             "  static class A<T> {",
             "    void foo(T n) {}",
             "  }",
             "  static class B {",
             "    static void bar(A a) {}",
-            "    static void baz(A<?> a) {",
+            "    static void m1(A<?> a) {",
             "      bar(a);",
+            "    }",
+            "    static A m2(A<?> a) {",
+            "      return a;",
+            "    }",
+            "    @Nullable A<?> field;",
+            "    void m3(A<?> a) {",
+            "      field = a;",
             "    }",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1738,6 +1738,26 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void testRawFormalParameterType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "class Test {",
+            "  static class A<T> {",
+            "    void foo(T n) {}",
+            "  }",
+            "  static class B {",
+            "    static void bar(A a) {}",
+            "    static void baz(A<?> a) {",
+            "      bar(a);",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testUseOfUnannotatedCode() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
We were lacking bailouts for these cases