### PR TITLE
Strip annotations from MethodSymbol strings

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -238,10 +238,18 @@ public interface LibraryModels {
     }
 
     public static MethodRef fromSymbol(Symbol.MethodSymbol symbol) {
-      String methodStr = symbol.toString();
+      String methodStr = stripAnnotationsFromMethodSymbolString(symbol.toString());
 
       return new MethodRef(
           symbol.owner.getQualifiedName().toString(), symbol.name.toString(), methodStr);
+    }
+
+    /**
+     * Strip annotations from a method symbol string. The logic is specialized to work for strings
+     * produced by {@link Symbol.MethodSymbol#toString()} and will not work for arbitrary strings.
+     */
+    private static String stripAnnotationsFromMethodSymbolString(String str) {
+      return str.replaceAll("@[^ ]+ ", "");
     }
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -400,13 +400,6 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                     "com.google.common.base.Preconditions",
                     "<T>checkNotNull(T,java.lang.String,java.lang.Object...)"),
                 0)
-            // For JDK 22
-            // TODO check if this is still needed in JDK 23 / subsequent releases
-            .put(
-                methodRef(
-                    "com.google.common.base.Preconditions",
-                    "<T>checkNotNull(T,java.lang.String,java.lang.@org.checkerframework.checker.nullness.qual.Nullable Object...)"),
-                0)
             .put(
                 methodRef(
                     "com.google.common.base.Preconditions",
@@ -522,13 +515,6 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 methodRef(
                     "com.google.common.base.Verify",
                     "<T>verifyNotNull(T,java.lang.String,java.lang.Object...)"),
-                0)
-            // For JDK 22
-            // TODO check if this is still needed in JDK 23 / subsequent releases
-            .put(
-                methodRef(
-                    "com.google.common.base.Verify",
-                    "<T>verifyNotNull(T,java.lang.String,java.lang.@org.checkerframework.checker.nullness.qual.Nullable Object...)"),
                 0)
             .put(methodRef("java.util.Objects", "<T>requireNonNull(T)"), 0)
             .put(methodRef("java.util.Objects", "<T>requireNonNull(T,java.lang.String)"), 0)


### PR DESCRIPTION
Follow up to #992.  This is a better fix for handling type-use annotations that may be present in MethodSymbol strings from JDK 22 forward.