### PR TITLE
Update to WALA 1.6.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.3",
+    wala                   : "1.6.6",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -46,11 +46,6 @@ test {
     dependsOn ':jar-infer:test-android-lib-jarinfer:bundleReleaseAar'
 }
 
-tasks.getByName('testJdk22').configure {
-    // Won't work until WALA supports JDK 22; see https://github.com/wala/WALA/issues/1414
-    onlyIf { false }
-}
-
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }


### PR DESCRIPTION
This allows for JarInfer to run on JDK 22
