### PR TITLE
JSpecify: handle intersection type in one place

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -5,7 +5,6 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import java.util.List;
 import javax.lang.model.type.NullType;
-import javax.lang.model.type.TypeMirror;
 
 /**
  * Visitor that checks for identical nullability annotations at all nesting levels within two types.
@@ -66,14 +65,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   /** Check identical nullability for every type in the intersection */
   private Boolean handleIntersectionType(
       Type.IntersectionClassType intersectionType, Type rhsType) {
-    List<? extends TypeMirror> bounds = intersectionType.getBounds();
-    for (int i = 0; i < bounds.size(); i++) {
-      Type bound = (Type) bounds.get(i);
-      if (!bound.accept(this, rhsType)) {
-        return false;
-      }
-    }
-    return true;
+    return intersectionType.getBounds().stream()
+        .allMatch(type -> ((Type) type).accept(this, rhsType));
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
@@ -37,6 +37,9 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
 
   @Override
   public String visitClassType(Type.ClassType t, Void s) {
+    if (t.isIntersection()) {
+      return prettyIntersectionType((Type.IntersectionClassType) t);
+    }
     StringBuilder sb = new StringBuilder();
     Type enclosingType = t.getEnclosingType();
     if (!ASTHelpers.isSameType(enclosingType, Type.noType, state)) {
@@ -55,6 +58,12 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
       sb.append(">");
     }
     return sb.toString();
+  }
+
+  private String prettyIntersectionType(Type.IntersectionClassType t) {
+    return t.getBounds().stream()
+        .map(type -> ((Type) type).accept(this, null))
+        .collect(joining(" & "));
   }
 
   @Override

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1868,6 +1868,9 @@ public class GenericsTests extends NullAwayTestsBase {
             "    private String getStr() {",
             "        return (relativeServices == null ? \"relativeServices == null\" : relativeServices.size()) + \"\";",
             "    }",
+            "    private String getStr2(boolean b, java.util.List<Object> l) {",
+            "        return (b ? (b ? l.size() : \"hello\") : 3) + \"\";",
+            "    }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1875,7 +1875,32 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  // TODO write an intersection test where nullability of type parameters does not match
+  @Test
+  public void intersectionTypeInvalidAssign() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.io.Serializable;",
+            "public class Test {",
+            "  interface A<T extends @Nullable Object> {}",
+            "  static class B implements A<@Nullable String>, Serializable {}",
+            "  static void test1(Object o) {",
+            "    var x = (A<String> & Serializable) o;",
+            "    // BUG: Diagnostic contains: Cannot assign from type B to type A<String> & Serializable",
+            "    x = new B();",
+            "  }",
+            "  static class C implements A<String>, Serializable {}",
+            "  static void test2(Object o) {",
+            "    var x = (A<@Nullable String> & Serializable) o;",
+            // TODO: this assignment should be an error but we do not compute annotations in the
+            //  type of x correctly
+            "    x = new C();",
+            "  }",
+            "}")
+        .doTest();
+  }
 
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1886,16 +1886,20 @@ public class GenericsTests extends NullAwayTestsBase {
             "public class Test {",
             "  interface A<T extends @Nullable Object> {}",
             "  static class B implements A<@Nullable String>, Serializable {}",
+            "  static class C implements A<String>, Serializable {}",
             "  static void test1(Object o) {",
             "    var x = (A<String> & Serializable) o;",
             "    // BUG: Diagnostic contains: Cannot assign from type B to type A<String> & Serializable",
             "    x = new B();",
+            "    // ok",
+            "    x = new C();",
             "  }",
-            "  static class C implements A<String>, Serializable {}",
             "  static void test2(Object o) {",
             "    var x = (A<@Nullable String> & Serializable) o;",
-            // TODO: this assignment should be an error but we do not compute annotations in the
-            //  type of x correctly
+            // TODO: should _not_ be an error, see https://github.com/uber/NullAway/issues/1022
+            "    // BUG: Diagnostic contains: Cannot assign from type B to type A<String> & Serializable",
+            "    x = new B();",
+            // TODO: _should_ be an error, see https://github.com/uber/NullAway/issues/1022
             "    x = new C();",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1902,6 +1902,7 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
   public void issue1014() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1856,6 +1856,22 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1013() {
+    makeHelper()
+        .addSourceLines(
+            "ServiceExtraInfo.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class ServiceExtraInfo {",
+            "    private java.util.@Nullable List<Object> relativeServices;",
+            "    private String getStr() {",
+            "        return (relativeServices == null ? \"relativeServices == null\" : relativeServices.size()) + \"\";",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1857,7 +1857,7 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void issue1013() {
+  public void intersectionTypeFromConditionalExprInStringConcat() {
     makeHelper()
         .addSourceLines(
             "ServiceExtraInfo.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1875,6 +1875,8 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  // TODO write an intersection test where nullability of type parameters does not match
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
Intersection types may arise, e.g., as part of string concatenation.  We handling of an intersection type for one scenario; broader handling definitely requires more testing and thinking.

Fixes #1013 