### PR TITLE
Add test for #1011

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -222,6 +222,22 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void callMethodTakingJavaUtilFunction() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import com.uber.lib.generics.JavaUtilFunctionMethods;",
+            "class Test {",
+            "  static void testNegative() {",
+            "    JavaUtilFunctionMethods.withFunction(s -> { return null; });",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway.jspecify;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class BytecodeGenericsTests extends NullAwayTestsBase {
@@ -223,6 +224,8 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  @Ignore("Failing due to https://bugs.openjdk.org/browse/JDK-8337795")
+  // TODO Re-enable this test once the JDK bug is fixed, on appropriate JDK versions
   public void callMethodTakingJavaUtilFunction() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -226,6 +226,7 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
   @Test
   @Ignore("Failing due to https://bugs.openjdk.org/browse/JDK-8337795")
   // TODO Re-enable this test once the JDK bug is fixed, on appropriate JDK versions
+  //  See https://github.com/uber/NullAway/issues/1011
   public void callMethodTakingJavaUtilFunction() {
     makeHelper()
         .addSourceLines(

--- a/test-java-lib/src/main/java/com/uber/lib/generics/JavaUtilFunctionMethods.java
+++ b/test-java-lib/src/main/java/com/uber/lib/generics/JavaUtilFunctionMethods.java
@@ -1,0 +1,9 @@
+package com.uber.lib.generics;
+
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+public class JavaUtilFunctionMethods {
+
+  public static void withFunction(Function<String, @Nullable String> f) {}
+}


### PR DESCRIPTION
We can enable the test on appropriate JDK versions once https://github.com/openjdk/jdk/pull/20460 lands.  #1011 
