### PR TITLE
JSpecify: fix for crash with wildcard types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -5,6 +5,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import java.util.List;
 import javax.lang.model.type.NullType;
+import javax.lang.model.type.TypeKind;
 
 /**
  * Visitor that checks for identical nullability annotations at all nesting levels within two types.
@@ -21,6 +22,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   @Override
   public Boolean visitClassType(Type.ClassType lhsType, Type rhsType) {
     if (rhsType instanceof NullType || rhsType.isPrimitive()) {
+      return true;
+    }
+    if (rhsType.getKind().equals(TypeKind.WILDCARD)) {
+      // TODO Handle wildcard types
       return true;
     }
     Types types = state.getTypes();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1856,6 +1856,28 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1014() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.util.function.Function;",
+            "class Test<R> {",
+            "    public interface PropertyFunction<",
+            "            T extends @Nullable Object, R extends @Nullable Object, E extends Exception>",
+            "            extends Function<T, R> {",
+            "        R _apply(T t) throws E;",
+            "    }",
+            "    @Nullable PropertyFunction<? super R, ? extends String, ? super Exception> stringFunc;",
+            "    public void propertyString() {",
+            "        var f = stringFunc;",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
For now we just bail out; wildcard support will come later.

Fixes #1014 