### PR TITLE
JSpecify: add another bailout check for raw types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -32,6 +32,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     if (rhsTypeAsSuper == null) {
       throw new RuntimeException("Did not find supertype of " + rhsType + " matching " + lhsType);
     }
+    // bail out of checking raw types for now
+    if (rhsTypeAsSuper.isRaw()) {
+      return true;
+    }
     List<Type> lhsTypeArguments = lhsType.getTypeArguments();
     List<Type> rhsTypeArguments = rhsTypeAsSuper.getTypeArguments();
     // This is impossible, considering the fact that standard Java subtyping succeeds before

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1856,6 +1856,27 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1019() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "",
+            "public class Test {",
+            "    public static class StringList extends ArrayList {",
+            "    }",
+            "    @SuppressWarnings(\"unchecked\")",
+            "    public static List<String> convert(final StringList stringList) {",
+            "        return stringList;",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
Fixes #1019

