### PR TITLE
Update handling of annotations on varargs argument

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1764,12 +1764,13 @@ public class NullAway extends BugChecker
     // NOTE: the case of an invocation on a possibly-null reference
     // is handled by matchMemberSelect()
     for (int argPos = 0; argPos < argumentPositionNullness.length; argPos++) {
-      if (!Objects.equals(Nullness.NONNULL, argumentPositionNullness[argPos])) {
+      boolean varargPosition = argPos == formalParams.size() - 1 && methodSymbol.isVarArgs();
+      if (!varargPosition && !Objects.equals(Nullness.NONNULL, argumentPositionNullness[argPos])) {
         continue;
       }
       ExpressionTree actual = null;
       boolean mayActualBeNull = false;
-      if (argPos == formalParams.size() - 1 && methodSymbol.isVarArgs()) {
+      if (varargPosition) {
         // Check all vararg actual arguments for nullability
         if (actualParams.size() <= argPos) {
           continue;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1781,8 +1781,8 @@ public class NullAway extends BugChecker
             (Type.ArrayType) formalParams.get(formalParams.size() - 1).type;
         Type actualParameterType = ASTHelpers.getType(actual);
         if (actualParameterType != null
-            && state.getTypes().isAssignable(actualParameterType, varargsArrayType)) {
-          Verify.verify(actualParams.size() == argPos + 1);
+            && state.getTypes().isAssignable(actualParameterType, varargsArrayType)
+            && actualParams.size() == argPos + 1) {
           // If varargs array itself is not @Nullable, cannot pass @Nullable array
           if (!Nullness.varargsParamIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1801,7 +1801,6 @@ public class NullAway extends BugChecker
             }
           }
         }
-
       } else { // not the vararg position
         actual = actualParams.get(argPos);
         mayActualBeNull = mayBeNullExpr(state, actual);
@@ -2513,7 +2512,6 @@ public class NullAway extends BugChecker
         return Description.NO_MATCH;
       }
     }
-    // (baseExpressionSymbol.flags() & Flags.VARARGS) != 0
     if (mayBeNullExpr(state, baseExpression)) {
       String message =
           "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1791,7 +1791,10 @@ public class NullAway extends BugChecker
           if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
-        } else { // varargs are being passed individually
+        } else { 
+          // This is the case were varargs are being passed individually, as 1 or more actual
+          // arguments starting at the position of the var args formal.
+          // If the formal var args accepts `@Nullable`, then there is nothing for us to check.
           if (!argIsNonNull) {
             continue;
           }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2496,6 +2496,7 @@ public class NullAway extends BugChecker
         return Description.NO_MATCH;
       }
     }
+    // (baseExpressionSymbol.flags() & Flags.VARARGS) != 0
     if (mayBeNullExpr(state, baseExpression)) {
       String message =
           "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1792,7 +1792,8 @@ public class NullAway extends BugChecker
           if (!argIsNonNull) {
             continue;
           }
-          // TODO report an error for each violating vararg
+          // TODO report all varargs errors in a single build; this code only reports the first
+          //  error
           for (ExpressionTree arg : actualParams.subList(argPos, actualParams.size())) {
             actual = arg;
             mayActualBeNull = mayBeNullExpr(state, actual);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1784,7 +1784,7 @@ public class NullAway extends BugChecker
             && state.getTypes().isAssignable(actualParameterType, varargsArrayType)
             && actualParams.size() == argPos + 1) {
           // If varargs array itself is not @Nullable, cannot pass @Nullable array
-          if (!Nullness.varargsParamIsNullable(formalParams.get(argPos), config)) {
+          if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
         } else {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1788,7 +1788,6 @@ public class NullAway extends BugChecker
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
         } else {
-          // TODO need to update this check to see if the vararg array contents is @Nullable
           if (!argIsNonNull) {
             continue;
           }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1773,6 +1773,8 @@ public class NullAway extends BugChecker
       boolean mayActualBeNull = false;
       if (varargPosition) {
         // Check all vararg actual arguments for nullability
+         // This is the case where no actual parameter is passed for the var args parameter
+         // (i.e. it defaults to an empty array)
         if (actualParams.size() <= argPos) {
           continue;
         }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1764,12 +1764,12 @@ public class NullAway extends BugChecker
     // NOTE: the case of an invocation on a possibly-null reference
     // is handled by matchMemberSelect()
     for (int argPos = 0; argPos < argumentPositionNullness.length; argPos++) {
-      boolean varargPosition = argPos == formalParams.size() - 1 && methodSymbol.isVarArgs();
-      if (!varargPosition && !Objects.equals(Nullness.NONNULL, argumentPositionNullness[argPos])) {
+      if (!Objects.equals(Nullness.NONNULL, argumentPositionNullness[argPos])) {
         continue;
       }
       ExpressionTree actual = null;
       boolean mayActualBeNull = false;
+      boolean varargPosition = methodSymbol.isVarArgs() && argPos == formalParams.size() - 1;
       if (varargPosition) {
         // Check all vararg actual arguments for nullability
         if (actualParams.size() <= argPos) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1788,6 +1788,7 @@ public class NullAway extends BugChecker
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
         } else {
+          // TODO need to update this check to see if the vararg array contents is @Nullable
           if (!argIsNonNull) {
             continue;
           }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1773,8 +1773,8 @@ public class NullAway extends BugChecker
       boolean mayActualBeNull = false;
       if (varargPosition) {
         // Check all vararg actual arguments for nullability
-         // This is the case where no actual parameter is passed for the var args parameter
-         // (i.e. it defaults to an empty array)
+        // This is the case where no actual parameter is passed for the var args parameter
+        // (i.e. it defaults to an empty array)
         if (actualParams.size() <= argPos) {
           continue;
         }
@@ -1786,12 +1786,13 @@ public class NullAway extends BugChecker
         if (actualParameterType != null
             && state.getTypes().isAssignable(actualParameterType, varargsArrayType)
             && actualParams.size() == argPos + 1) {
-          // This is the case where an array is explicitly passed in the position of the var args parameter
+          // This is the case where an array is explicitly passed in the position of the var args
+          // parameter
           // If varargs array itself is not @Nullable, cannot pass @Nullable array
           if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
-        } else { 
+        } else {
           // This is the case were varargs are being passed individually, as 1 or more actual
           // arguments starting at the position of the var args formal.
           // If the formal var args accepts `@Nullable`, then there is nothing for us to check.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1786,6 +1786,7 @@ public class NullAway extends BugChecker
         if (actualParameterType != null
             && state.getTypes().isAssignable(actualParameterType, varargsArrayType)
             && actualParams.size() == argPos + 1) {
+          // This is the case where an array is explicitly passed in the position of the var args parameter
           // If varargs array itself is not @Nullable, cannot pass @Nullable array
           if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1777,6 +1777,7 @@ public class NullAway extends BugChecker
           continue;
         }
         actual = actualParams.get(argPos);
+        // check if the varargs arguments are being passed as an array
         Type.ArrayType varargsArrayType =
             (Type.ArrayType) formalParams.get(formalParams.size() - 1).type;
         Type actualParameterType = ASTHelpers.getType(actual);
@@ -1787,11 +1788,11 @@ public class NullAway extends BugChecker
           if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
-        } else {
+        } else { // varargs are being passed individually
           if (!argIsNonNull) {
             continue;
           }
-          // TODO report multiple errors for each violating vararg
+          // TODO report an error for each violating vararg
           for (ExpressionTree arg : actualParams.subList(argPos, actualParams.size())) {
             actual = arg;
             mayActualBeNull = mayBeNullExpr(state, actual);
@@ -1801,11 +1802,10 @@ public class NullAway extends BugChecker
           }
         }
 
-      } else {
+      } else { // not the vararg position
         actual = actualParams.get(argPos);
         mayActualBeNull = mayBeNullExpr(state, actual);
       }
-      // make sure we are passing a non-null value
       if (mayActualBeNull) {
         String message =
             "passing @Nullable parameter '"

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -38,6 +38,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import com.sun.tools.javac.code.Type;
@@ -431,6 +432,11 @@ public class NullabilityUtil {
           }
         }
       }
+    }
+    // In JSpecify mode, for varargs symbols we also consider the elements to be @Nullable if there
+    // is a @Nullable declaration annotation on the parameter
+    if (config.isJSpecifyMode() && (arraySymbol.flags() & Flags.VARARGS) != 0) {
+      return Nullness.hasNullableDeclarationAnnotation(arraySymbol, config);
     }
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -433,9 +433,9 @@ public class NullabilityUtil {
         }
       }
     }
-    // In JSpecify mode, for varargs symbols we also consider the elements to be @Nullable if there
-    // is a @Nullable declaration annotation on the parameter
-    if (config.isJSpecifyMode() && (arraySymbol.flags() & Flags.VARARGS) != 0) {
+    // For varargs symbols we also consider the elements to be @Nullable if there is a @Nullable
+    // declaration annotation on the parameter
+    if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
       return Nullness.hasNullableDeclarationAnnotation(arraySymbol, config);
     }
     return false;

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -278,7 +278,7 @@ public class NullabilityUtil {
    * Gets the type use annotations on a symbol, ignoring annotations on components of the type (type
    * arguments, wildcards, etc.)
    */
-  private static Stream<? extends AnnotationMirror> getTypeUseAnnotations(
+  public static Stream<? extends AnnotationMirror> getTypeUseAnnotations(
       Symbol symbol, Config config) {
     Stream<Attribute.TypeCompound> rawTypeAttributes = symbol.getRawTypeAttributes().stream();
     if (symbol instanceof Symbol.MethodSymbol) {

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -268,8 +268,10 @@ public enum Nullness implements AbstractValue<Nullness> {
    * that the argument array passed at a call site can be {@code null}? Syntactically, this would be
    * written as {@code foo(Object @Nullable... args}}
    */
-  public static boolean varargsParamIsNullable(Symbol paramSymbol, Config config) {
-    return hasNullableTypeUseAnnotation(paramSymbol, config);
+  public static boolean varargsArrayIsNullable(Symbol paramSymbol, Config config) {
+    return hasNullableTypeUseAnnotation(paramSymbol, config)
+        || (config.isLegacyAnnotationLocation()
+            && hasNullableDeclarationAnnotation(paramSymbol, config));
   }
 
   private static boolean individualVarargsParamsAreNullable(Symbol paramSymbol, Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -282,7 +282,8 @@ public enum Nullness implements AbstractValue<Nullness> {
         || NullabilityUtil.isArrayElementNullable(paramSymbol, config);
   }
 
-  private static boolean hasNullableDeclarationAnnotation(Symbol symbol, Config config) {
+  /** Checks if the symbol has a {@code @Nullable} declaration annotation */
+  public static boolean hasNullableDeclarationAnnotation(Symbol symbol, Config config) {
     return hasNullableAnnotation(symbol.getRawAttributes().stream(), config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -251,4 +251,13 @@ public enum Nullness implements AbstractValue<Nullness> {
     return hasNonNullAnnotation(
         NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd, config), config);
   }
+
+  /**
+   * Is the varargs parameter {@code paramSymbol} have a {@code @Nullable} annotation indicating
+   * that the argument array passed at a call site can be {@code null}? Syntactically, this would be
+   * written as {@code foo(Object @Nullable... args}}
+   */
+  public static boolean varargsParamIsNullable(Symbol paramSymbol, Config config) {
+    return false;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -258,6 +258,6 @@ public enum Nullness implements AbstractValue<Nullness> {
    * written as {@code foo(Object @Nullable... args}}
    */
   public static boolean varargsParamIsNullable(Symbol paramSymbol, Config config) {
-    return false;
+    return hasNullableAnnotation(paramSymbol, config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -224,7 +224,9 @@ public enum Nullness implements AbstractValue<Nullness> {
     if (isRecordEqualsParam(symbol, paramInd)) {
       return true;
     }
-    if (symbol.isVarArgs() && paramInd == symbol.getParameters().size() - 1) {
+    if (symbol.isVarArgs()
+        && paramInd == symbol.getParameters().size() - 1
+        && !config.isLegacyAnnotationLocation()) {
       return individualVarargsParamsAreNullable(symbol.getParameters().get(paramInd), config);
     } else {
       return hasNullableAnnotation(

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -206,7 +206,7 @@ public enum Nullness implements AbstractValue<Nullness> {
     return hasNullableAnnotation(NullabilityUtil.getAllAnnotations(symbol, config), config);
   }
 
-  public static boolean hasNullableTypeUseAnnotation(Symbol symbol, Config config) {
+  private static boolean hasNullableTypeUseAnnotation(Symbol symbol, Config config) {
     return hasNullableAnnotation(NullabilityUtil.getTypeUseAnnotations(symbol, config), config);
   }
 
@@ -278,7 +278,6 @@ public enum Nullness implements AbstractValue<Nullness> {
 
   private static boolean individualVarargsParamsAreNullable(Symbol paramSymbol, Config config) {
     // declaration annotation,  or type-use annotation on the elements
-    // TODO update and test for legacy mode
     return hasNullableDeclarationAnnotation(paramSymbol, config)
         || NullabilityUtil.isArrayElementNullable(paramSymbol, config);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -206,6 +206,10 @@ public enum Nullness implements AbstractValue<Nullness> {
     return hasNullableAnnotation(NullabilityUtil.getAllAnnotations(symbol, config), config);
   }
 
+  public static boolean hasNullableTypeUseAnnotation(Symbol symbol, Config config) {
+    return hasNullableAnnotation(NullabilityUtil.getTypeUseAnnotations(symbol, config), config);
+  }
+
   /**
    * Does the parameter of {@code symbol} at {@code paramInd} have a {@code @Nullable} declaration
    * or type-use annotation? This method works for methods defined in either source or class files.
@@ -258,6 +262,6 @@ public enum Nullness implements AbstractValue<Nullness> {
    * written as {@code foo(Object @Nullable... args}}
    */
   public static boolean varargsParamIsNullable(Symbol paramSymbol, Config config) {
-    return hasNullableAnnotation(paramSymbol, config);
+    return hasNullableTypeUseAnnotation(paramSymbol, config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -227,7 +227,9 @@ public enum Nullness implements AbstractValue<Nullness> {
     if (symbol.isVarArgs()
         && paramInd == symbol.getParameters().size() - 1
         && !config.isLegacyAnnotationLocation()) {
-      return individualVarargsParamsAreNullable(symbol.getParameters().get(paramInd), config);
+      // individual arguments passed in the varargs positions can be @Nullable if the array element
+      // type of the parameter is @Nullable
+      return NullabilityUtil.isArrayElementNullable(symbol.getParameters().get(paramInd), config);
     } else {
       return hasNullableAnnotation(
           NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd, config), config);
@@ -274,12 +276,6 @@ public enum Nullness implements AbstractValue<Nullness> {
     return hasNullableTypeUseAnnotation(paramSymbol, config)
         || (config.isLegacyAnnotationLocation()
             && hasNullableDeclarationAnnotation(paramSymbol, config));
-  }
-
-  private static boolean individualVarargsParamsAreNullable(Symbol paramSymbol, Config config) {
-    // declaration annotation,  or type-use annotation on the elements
-    return hasNullableDeclarationAnnotation(paramSymbol, config)
-        || NullabilityUtil.isArrayElementNullable(paramSymbol, config);
   }
 
   /** Checks if the symbol has a {@code @Nullable} declaration annotation */

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -68,7 +68,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Symbol paramSymbol = (Symbol) param.getElement();
       Nullness assumed;
       if ((paramSymbol.flags() & Flags.VARARGS) != 0) {
-        assumed = Nullness.varargsParamIsNullable(paramSymbol, config) ? NULLABLE : NONNULL;
+        assumed = Nullness.varargsArrayIsNullable(paramSymbol, config) ? NULLABLE : NONNULL;
       } else {
         assumed = Nullness.hasNullableAnnotation(paramSymbol, config) ? NULLABLE : NONNULL;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -7,6 +7,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
@@ -64,9 +65,13 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     NullnessStore envStore = getEnvNullnessStoreForClass(classTree, context);
     NullnessStore.Builder result = envStore.toBuilder();
     for (LocalVariableNode param : parameters) {
-      Element element = param.getElement();
-      Nullness assumed =
-          Nullness.hasNullableAnnotation((Symbol) element, config) ? NULLABLE : NONNULL;
+      Symbol paramSymbol = (Symbol) param.getElement();
+      Nullness assumed;
+      if ((paramSymbol.flags() & Flags.VARARGS) != 0) {
+        assumed = Nullness.varargsParamIsNullable(paramSymbol, config) ? NULLABLE : NONNULL;
+      } else {
+        assumed = Nullness.hasNullableAnnotation(paramSymbol, config) ? NULLABLE : NONNULL;
+      }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }
     result = handler.onDataflowInitialStore(underlyingAST, parameters, result);

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -36,6 +36,9 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNonNullVarargs(o1);", // Empty var args passed
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    Utilities.takesNonNullVarargs(o1, o4);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNonNullVarargs(o1, x);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -46,6 +46,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "import javax.annotation.Nullable;",
             "public class Utilities {",
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
+            "  // BUG: Diagnostic contains: [NullAway] dereferenced expression others is @Nullable",
             "  String s = o.toString() + \" \" + others.toString();",
             "  return s;",
             " }",

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -62,7 +62,6 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargs(o1, o4);",
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
             "    Object[] x = null;",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    Utilities.takesNullableVarargs(o1, x);",
             "  }",
             "}")
@@ -78,6 +77,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "import org.checkerframework.checker.nullness.qual.Nullable;",
             "public class Utilities {",
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
+            "  // BUG: Diagnostic contains: [NullAway] dereferenced expression others is @Nullable",
             "  String s = o.toString() + \" \" + others.toString();",
             "  for (Object other : others) {",
             "    // no error since we do not reason about array element nullability",
@@ -97,7 +97,6 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargs(o1, o4);",
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
             "    Object[] x = null;",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    Utilities.takesNullableVarargs(o1, x);",
             "  }",
             "}")
@@ -232,10 +231,8 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "import org.checkerframework.checker.nullness.qual.Nullable;",
             "public class Test {",
             "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
             "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
-            "    // BUG: Diagnostic contains: passing @Nullable parameter",
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
             "    // this is fine!",
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
@@ -305,12 +302,9 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "package com.uber;",
             "public class Test {",
             "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
             "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
-            "    // BUG: Diagnostic contains: passing @Nullable parameter",
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
-            "    // this is fine!",
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
             "  }",
             "}")
@@ -333,6 +327,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "public class Utilities {",
             " public static String takesNullableVarargsArray(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
             "  for (Object other : others) {",
             "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
             "  }",
@@ -347,7 +342,6 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
             "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter '(java.lang.Object[]) null' where @NonNull",
             "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
             "  }",
             "}")
@@ -407,9 +401,8 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "  static void takesNullableVarargsArray(Object @Nullable... args) {}",
             "  static void test2(Object o) {",
             "    Object[] x = null;",
-            "    // can pass x as the varargs array itself, but not along with other args",
             "    takesNullableVarargsArray(x);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    // in legacy mode the annotation allows for individual arguments to be nullable",
             "    takesNullableVarargsArray(x, o);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -4,6 +4,10 @@ import com.google.errorprone.CompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
+/**
+ * Tests for handling of varargs annotations with legacy annotation locations enabled. Based on
+ * {@link VarargsTests}, with tests and assertions modified appropriately.
+ */
 public class LegacyVarargsTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -213,7 +213,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArray() {
+  public void typeUseNullableVarargsArray() {
     makeHelper()
         .addSourceLines(
             "Utilities.java",
@@ -246,7 +246,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArrayAndElements() {
+  public void typeUseNullableVarargsArrayAndElements() {
     makeHelper()
         .addSourceLines(
             "Utilities.java",

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -1,0 +1,424 @@
+package com.uber.nullaway;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class LegacyVarargsTests extends NullAwayTestsBase {
+
+  @Test
+  public void testNonNullVarargs() {
+    makeHelper()
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Utilities {",
+            " public static String takesNonNullVarargs(Object o, Object... others) {",
+            "  String s = o.toString() + \" \";",
+            "  for (Object other : others) {",
+            "    s += other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNonNullVarargs(o1, o2, o3);",
+            "    Utilities.takesNonNullVarargs(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    Utilities.takesNonNullVarargs(o1, o4);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNullableVarargs() {
+    makeHelper()
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
+            "  String s = o.toString() + \" \" + others.toString();",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargs(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargs(o1, o4);",
+            "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNullableVarargs(o1, x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullableTypeUseVarargs() {
+    makeHelper()
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
+            "  String s = o.toString() + \" \" + others.toString();",
+            "  for (Object other : others) {",
+            "    // no error since we do not reason about array element nullability",
+            "    s += other.toString();",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargs(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargs(o1, o4);",
+            "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNullableVarargs(o1, x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNonNullVarargsFromHandler() {
+    String generatedAnnot =
+        (Double.parseDouble(System.getProperty("java.specification.version")) >= 11)
+            ? "@javax.annotation.processing.Generated"
+            : "@javax.annotation.Generated";
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Generated.java",
+            "package com.uber;",
+            "import javax.annotation.Nonnull;",
+            generatedAnnot + "(\"foo\")",
+            "public class Generated {",
+            " public static String takesNonNullVarargs(@Nonnull Object o, @Nonnull Object... others) {",
+            "  String s = o.toString() + \" \";",
+            "  for (Object other : others) {",
+            "    s += other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Generated.takesNonNullVarargs(o1, o2, o3);",
+            "    Generated.takesNonNullVarargs(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    Generated.takesNonNullVarargs(o1, o4);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  // This is required for compatibility with kotlinc generated jars
+  // See https://github.com/uber/NullAway/issues/720
+  @Test
+  public void testSkipJetbrainsNotNullOnVarArgsFromThirdPartyJars() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "ThirdParty.java",
+            "package com.uber.nullaway.lib.unannotated;",
+            "import org.jetbrains.annotations.NotNull;",
+            "public class ThirdParty {",
+            " public static String takesNullableVarargs(@NotNull Object o, @NotNull Object... others) {",
+            "  String s = o.toString() + \" \";",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "FirstParty.java",
+            "package com.uber;",
+            "import org.jetbrains.annotations.NotNull;",
+            "public class FirstParty {",
+            " public static String takesNonNullVarargs(@NotNull Object o, @NotNull Object... others) {",
+            "  String s = o.toString() + \" \";",
+            "  for (Object other : others) {",
+            "    s += other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import com.uber.nullaway.lib.unannotated.ThirdParty;",
+            "public class Test {",
+            "  public void testNullableVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    ThirdParty.takesNullableVarargs(o1, o2, o3, o4);",
+            "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
+            "    ThirdParty.takesNullableVarargs(o1, o4);",
+            "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
+            "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.
+            "  }",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    FirstParty.takesNonNullVarargs(o1, o2, o3);",
+            "    FirstParty.takesNonNullVarargs(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    FirstParty.takesNonNullVarargs(o1, o4);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullableVarargsArray() {
+    makeHelper()
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {",
+            "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    // this is fine!",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullableVarargsArrayAndElements() {
+    makeHelper()
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {",
+            "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    // this is fine!",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeUseAndDeclarationBeforeDots() {
+    makeHelper()
+        .addSourceLines(
+            "Nullable.java",
+            "package com.uber;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})",
+            "public @interface Nullable {}")
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {",
+            "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    // this is fine!",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeUseAndDeclarationOnElements() {
+    makeHelper()
+        .addSourceLines(
+            "Nullable.java",
+            "package com.uber;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})",
+            "public @interface Nullable {}")
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, @Nullable Object... others) {",
+            "  String s = o.toString() + \" \";",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(java.lang.Object[]) null' where @NonNull",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeUseAndDeclarationOnBoth() {
+    makeHelper()
+        .addSourceLines(
+            "Nullable.java",
+            "package com.uber;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})",
+            "public @interface Nullable {}")
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {",
+            "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsPassArrayAndOtherArgs() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Test {",
+            "  static void takesVarargs(Object... args) {}",
+            "  static void test(Object o) {",
+            "    Object[] x = new Object[10];",
+            "    takesVarargs(x, o);",
+            "  }",
+            "  static void takesNullableVarargsArray(Object @Nullable... args) {}",
+            "  static void test2(Object o) {",
+            "    Object[] x = null;",
+            "    // can pass x as the varargs array itself, but not along with other args",
+            "    takesNullableVarargsArray(x);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    takesNullableVarargsArray(x, o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        Arrays.asList(
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+            "-XepOpt:NullAway:LegacyAnnotationLocations=true"));
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -44,6 +44,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "public class Utilities {",
+            // TODO a declaration annotation at the top level should apply to the individual
+            // arguments, not the variable itself
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
             "  for (Object other : others) {",

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -212,4 +212,43 @@ public class VarargsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void typeUseBeforeDots() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Nullable.java",
+            "package com.uber;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})",
+            "public @interface Nullable {}")
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "public class Utilities {",
+            " public static String takesNullableVarargs(@Nullable Object @Nullable... others) {",
+            "  String s = \"\";",
+            "  for (Object other : others) {",
+            "    s += other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNullableVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargs(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargs(o1, o4);",
+            "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
+            // SHOULD be an error!
+            "    Utilities.takesNullableVarargs(o1, (java.lang.Object[]) null);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -67,6 +67,36 @@ public class VarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  public void nullableTypeUseVarargs() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
+            "  String s = o.toString() + \" \" + others.toString();",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  public void testNonNullVarargs(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    Utilities.takesNullableVarargs(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
+            "    Utilities.takesNullableVarargs(o1, o4);",
+            "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNullableVarargs(o1, x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   @Test
   public void testNonNullVarargsFromHandler() {
     String generatedAnnot =

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+/** Tests for handling of varargs annotations in NullAway's default mode */
 public class VarargsTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -60,7 +60,7 @@ public class VarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargs(o1, o4);",
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
             "    Object[] x = null;",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    Utilities.takesNullableVarargs(o1, x);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -384,4 +384,30 @@ public class VarargsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  /** testing for no crash */
+  @Test
+  public void varargsPassArrayAndOtherArgs() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Test {",
+            "  static void takesVarargs(Object... args) {}",
+            "  static void test(Object o) {",
+            "    Object[] x = new Object[10];",
+            "    takesVarargs(x, o);",
+            "  }",
+            "  static void takesNullableVarargsArray(Object @Nullable... args) {}",
+            "  static void test2(Object o) {",
+            "    Object[] x = null;",
+            "    // can pass x as the varargs array itself, but not along with other args",
+            "    takesNullableVarargsArray(x);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    takesNullableVarargsArray(x, o);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -46,11 +46,9 @@ public class VarargsTests extends NullAwayTestsBase {
             "public class Utilities {",
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
-            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable", // Shouldn't be an error!
             "  for (Object other : others) {",
             "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
             "  }",
-            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable", // Shouldn't be an error!
             "  for (Object other : others) {",
             "    s += other.toString();", // SHOULD be an error!
             "  }",
@@ -173,6 +171,41 @@ public class VarargsTests extends NullAwayTestsBase {
             "    FirstParty.takesNonNullVarargs(o1);", // Empty var args passed
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    FirstParty.takesNonNullVarargs(o1, o4);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullableVarargsArray() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Utilities.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Utilities {",
+            " public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {",
+            "  String s = o.toString() + \" \";",
+            "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
+            "  for (Object other : others) {",
+            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "  }",
+            "  return s;",
+            " }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class Test {",
+            "  public void testNullableVarargsArray(Object o1, Object o2, Object o3, @Nullable Object o4) {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
+            "    Utilities.takesNullableVarargsArray(o1, o2, o3, o4);",
+            "    Utilities.takesNullableVarargsArray(o1);", // Empty var args passed
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object) null);",
+            "    // this is fine!",
+            "    Utilities.takesNullableVarargsArray(o1, (java.lang.Object[]) null);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -157,7 +157,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);", // SHOULD be an error!
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
+            "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.
             "  }",

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -32,6 +32,9 @@ public class VarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNonNullVarargs(o1);", // Empty var args passed
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    Utilities.takesNonNullVarargs(o1, o4);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNonNullVarargs(o1, x);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -59,7 +59,7 @@ public class VarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
             "    Utilities.takesNullableVarargs(o1, o4);",
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
-            // SHOULD be an error!
+            // TODO SHOULD be an error!
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object[]) null);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -59,8 +59,9 @@ public class VarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNullableVarargs(o1);", // Empty var args passed
             "    Utilities.takesNullableVarargs(o1, o4);",
             "    Utilities.takesNullableVarargs(o1, (java.lang.Object) null);",
-            // TODO SHOULD be an error!
-            "    Utilities.takesNullableVarargs(o1, (java.lang.Object[]) null);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    Utilities.takesNullableVarargs(o1, x);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -45,7 +45,7 @@ public class VarargsTests extends NullAwayTestsBase {
             "import javax.annotation.Nullable;",
             "public class Utilities {",
             // TODO a declaration annotation at the top level should apply to the individual
-            // arguments, not the variable itself
+            //  arguments, not the variable itself
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
             "  for (Object other : others) {",

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -209,7 +209,7 @@ public class VarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArray() {
+  public void typeUseNullableVarargsArray() {
     defaultCompilationHelper
         .addSourceLines(
             "Utilities.java",
@@ -244,7 +244,7 @@ public class VarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArrayAndElements() {
+  public void typeUseNullableVarargsArrayAndElements() {
     defaultCompilationHelper
         .addSourceLines(
             "Utilities.java",

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -44,16 +44,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "package com.uber;",
             "import javax.annotation.Nullable;",
             "public class Utilities {",
-            // TODO a declaration annotation at the top level should apply to the individual
-            //  arguments, not the variable itself
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
-            "  String s = o.toString() + \" \";",
-            "  for (Object other : others) {",
-            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
-            "  }",
-            "  for (Object other : others) {",
-            "    s += other.toString();", // SHOULD be an error!
-            "  }",
+            "  String s = o.toString() + \" \" + others.toString();",
             "  return s;",
             " }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -27,7 +27,7 @@ import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
 import org.junit.Test;
 
-public class ArrayTests extends NullAwayTestsBase {
+public class JSpecifyArrayTests extends NullAwayTestsBase {
 
   @Test
   public void arrayTopLevelAnnotationDereference() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -215,7 +215,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArray() {
+  public void typeUseNullableVarargsArrayAndElements() {
     makeHelper()
         .addSourceLines(
             "Utilities.java",
@@ -250,7 +250,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void nullableVarargsArrayAndElements() {
+  public void typeUseNullableVarargsArrayAndElements() {
     makeHelper()
         .addSourceLines(
             "Utilities.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -56,6 +56,10 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             "public class Utilities {",
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \" + others.toString();",
+            "  for (Object other : others) {",
+            "    // no error here; requires a type-use annotation on the elements",
+            "    s += other.toString();",
+            "  }",
             "  return s;",
             " }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -1,13 +1,15 @@
-package com.uber.nullaway;
+package com.uber.nullaway.jspecify;
 
+import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
 import org.junit.Test;
 
-public class VarargsTests extends NullAwayTestsBase {
+public class JSpecifyVarargsTests extends NullAwayTestsBase {
 
   @Test
   public void testNonNullVarargs() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Utilities.java",
             "package com.uber;",
@@ -38,7 +40,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void testNullableVarargs() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Utilities.java",
             "package com.uber;",
@@ -69,7 +71,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void nullableTypeUseVarargs() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Utilities.java",
             "package com.uber;",
@@ -78,7 +80,7 @@ public class VarargsTests extends NullAwayTestsBase {
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \" + others.toString();",
             "  for (Object other : others) {",
-            "    // no error since we do not reason about array element nullability",
+            "    // BUG: Diagnostic contains: dereferenced expression other is @Nullable",
             "    s += other.toString();",
             "  }",
             "  return s;",
@@ -209,7 +211,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void nullableVarargsArray() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Utilities.java",
             "package com.uber;",
@@ -244,7 +246,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void nullableVarargsArrayAndElements() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Utilities.java",
             "package com.uber;",
@@ -254,7 +256,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "  String s = o.toString() + \" \";",
             "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
             "  for (Object other : others) {",
-            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "    // BUG: Diagnostic contains: dereferenced expression other is @Nullable",
+            "    s += other.toString();",
             "  }",
             "  return s;",
             " }",
@@ -277,7 +280,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void typeUseAndDeclarationBeforeDots() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Nullable.java",
             "package com.uber;",
@@ -317,7 +320,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void typeUseAndDeclarationOnElements() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Nullable.java",
             "package com.uber;",
@@ -332,7 +335,8 @@ public class VarargsTests extends NullAwayTestsBase {
             " public static String takesNullableVarargsArray(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \";",
             "  for (Object other : others) {",
-            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "    // BUG: Diagnostic contains: dereferenced expression other is @Nullable",
+            "    s += other.toString();",
             "  }",
             "  return s;",
             " }",
@@ -354,7 +358,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void typeUseAndDeclarationOnBoth() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Nullable.java",
             "package com.uber;",
@@ -370,7 +374,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "  String s = o.toString() + \" \";",
             "  // BUG: Diagnostic contains: enhanced-for expression others is @Nullable",
             "  for (Object other : others) {",
-            "    s += (other == null) ? \"(null) \" : other.toString() + \" \";",
+            "    // BUG: Diagnostic contains: dereferenced expression other is @Nullable",
+            "    s += other.toString();",
             "  }",
             "  return s;",
             " }",
@@ -391,7 +396,7 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void varargsPassArrayAndOtherArgs() {
-    defaultCompilationHelper
+    makeHelper()
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -412,5 +417,11 @@ public class VarargsTests extends NullAwayTestsBase {
             "  }",
             "}")
         .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        Arrays.asList(
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber", "-XepOpt:NullAway:JSpecifyMode=true"));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -2,9 +2,14 @@ package com.uber.nullaway.jspecify;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
+import com.uber.nullaway.VarargsTests;
 import java.util.Arrays;
 import org.junit.Test;
 
+/**
+ * Tests for handling of varargs annotations in JSpecify mode. Based on {@link VarargsTests}, with
+ * tests and assertions modified appropriately.
+ */
 public class JSpecifyVarargsTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -57,7 +57,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             " public static String takesNullableVarargs(Object o, @Nullable Object... others) {",
             "  String s = o.toString() + \" \" + others.toString();",
             "  for (Object other : others) {",
-            "    // no error here; requires a type-use annotation on the elements",
+            "    // BUG: Diagnostic contains: dereferenced expression other is @Nullable",
             "    s += other.toString();",
             "  }",
             "  return s;",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -38,6 +38,9 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             "    Utilities.takesNonNullVarargs(o1);", // Empty var args passed
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    Utilities.takesNonNullVarargs(o1, o4);",
+            "    Object[] x = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Utilities.takesNonNullVarargs(o1, x);",
             "  }",
             "}")
         .doTest();
@@ -215,7 +218,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void typeUseNullableVarargsArrayAndElements() {
+  public void typeUseNullableVarargsArray() {
     makeHelper()
         .addSourceLines(
             "Utilities.java",


### PR DESCRIPTION
See https://github.com/uber/NullAway/issues/708#issuecomment-2254281582 for an overview, and https://github.com/uber/NullAway/issues/674#issuecomment-2295040745 for all the details of how annotations on the varargs argument are now checked by NullAway.  Reproduced from https://github.com/uber/NullAway/issues/674#issuecomment-2295040745, here are the updated behaviors for different types of annotations on the varargs formal parameter (**Update** the table is slightly tweaked from the previous comment; this table now matches the current thinking / implementation):

| Annotation Type | Annotation Position | Mode | `@Nullable` varargs array | `@Nullable` array elements | `@Nullable` args at calls
------------------|---------------------|------|-----------------------|----------------------|-----------|
| declaration  |   -   |   standard | ❌ | ❌ | ✅
| declaration  |   -   |   legacy | ✅ | ❌ | ✅
| declaration  |   -   |   JSpecify | ❌ | ✅ | ✅
| type use  |  before `...`  |   standard | ✅ | ❌ | ❌
| type use  |   before `...`   |   legacy | ✅ | ❌ | ✅
| type use  |   before `...`   |   JSpecify | ✅ | ❌ | ❌
| type use  |   elements   |   standard | ❌ | ❌ | ✅
| type use  |   elements   |   legacy | ✅ | ❌ | ✅
| type use  |   elements   |   JSpecify | ❌ | ✅ | ✅
| type use  |   both   |   standard | ✅ | ❌ | ✅
| type use  |   both   |   legacy | ✅ | ❌ | ✅
| type use  |   both   |   JSpecify | ✅ | ✅ | ✅
| both  |   before `...`   |   standard | ✅ | ❌ | ❌
| both  |   before `...`   |   legacy | ✅ | ❌ | ✅
| both  |   before `...`   |   JSpecify | ✅ | ❌ | ❌
| both  |   elements   |   standard | ❌ | ❌ | ✅
| both  |   elements   |   legacy | ✅ | ❌ | ✅
| both  |   elements   |   JSpecify | ❌ | ✅ | ✅
| both  |   both   |   standard | ✅ | ❌ | ✅
| both  |   both   |   legacy | ✅ | ❌ | ✅
| both  |   both   |   JSpecify | ✅ | ✅ | ✅

"`@Nullable` varargs array" means that the varargs array is treated as `@Nullable` within the method body, and a `@Nullable` array can be passed at call sites.  "`@Nullable` array elements" means that elements of the varargs array are treated as `@Nullable` within the method body (only relevant in JSpecify mode).  And, "`@Nullable` args at calls" means that individual arguments passed in the varargs position at call sites may be `@Nullable`.

Fixes #674 