### PR TITLE
Partial handling for restrictive annotations on varargs in unannotated code

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1789,7 +1789,8 @@ public class NullAway extends BugChecker
           // This is the case where an array is explicitly passed in the position of the var args
           // parameter
           // If varargs array itself is not @Nullable, cannot pass @Nullable array
-          if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
+          if (isMethodAnnotated
+              && !Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
             mayActualBeNull = mayBeNullExpr(state, actual);
           }
         } else {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1788,10 +1788,16 @@ public class NullAway extends BugChecker
             && actualParams.size() == argPos + 1) {
           // This is the case where an array is explicitly passed in the position of the var args
           // parameter
-          // If varargs array itself is not @Nullable, cannot pass @Nullable array
-          if (isMethodAnnotated
-              && !Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
-            mayActualBeNull = mayBeNullExpr(state, actual);
+          // Only check for a nullable varargs array if the method is annotated or a @NonNull
+          // restrictive annotation is present in legacy mode (as previously the annotation was
+          // applied to both the array itself and the elements)
+          boolean checkForNullableVarargsArray =
+              isMethodAnnotated || (config.isLegacyAnnotationLocation() && argIsNonNull);
+          if (checkForNullableVarargsArray) {
+            // If varargs array itself is not @Nullable, cannot pass @Nullable array
+            if (!Nullness.varargsArrayIsNullable(formalParams.get(argPos), config)) {
+              mayActualBeNull = mayBeNullExpr(state, actual);
+            }
           }
         } else {
           // This is the case were varargs are being passed individually, as 1 or more actual

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -64,6 +64,7 @@ public class NullabilityUtil {
   public static final String NULLUNMARKED_SIMPLE_NAME = "NullUnmarked";
 
   private static final Supplier<Type> MAP_TYPE_SUPPLIER = Suppliers.typeFromString("java.util.Map");
+  private static final String JETBRAINS_NOT_NULL = "org.jetbrains.annotations.NotNull";
 
   private NullabilityUtil() {}
 
@@ -465,5 +466,18 @@ public class NullabilityUtil {
       return Nullness.hasNonNullDeclarationAnnotation(arraySymbol, config);
     }
     return false;
+  }
+
+  /**
+   * Does the given symbol have a JetBrains @NotNull declaration annotation? Useful for workarounds
+   * in light of https://github.com/uber/NullAway/issues/720
+   */
+  public static boolean hasJetBrainsNotNullDeclarationAnnotation(Symbol.VarSymbol varSymbol) {
+    // We explicitly ignore type-use annotations here, looking for @NotNull used as a
+    // declaration annotation, which is why this logic is simpler than e.g.
+    // NullabilityUtil.getAllAnnotationsForParameter.
+    return varSymbol.getAnnotationMirrors().stream()
+        .map(a -> a.getAnnotationType().toString())
+        .anyMatch(annotName -> annotName.equals(JETBRAINS_NOT_NULL));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -442,11 +442,11 @@ public class NullabilityUtil {
   }
 
   /**
-   * Checks if the given array symbol has a {@code @Nullable} annotation for its elements.
+   * Checks if the given array symbol has a {@code @NonNull} annotation for its elements.
    *
    * @param arraySymbol The symbol of the array to check.
    * @param config NullAway configuration.
-   * @return true if the array symbol has a {@code @Nullable} annotation for its elements, false
+   * @return true if the array symbol has a {@code @NonNull} annotation for its elements, false
    *     otherwise
    */
   public static boolean isArrayElementNonNull(Symbol arraySymbol, Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -440,4 +440,30 @@ public class NullabilityUtil {
     }
     return false;
   }
+
+  /**
+   * Checks if the given array symbol has a {@code @Nullable} annotation for its elements.
+   *
+   * @param arraySymbol The symbol of the array to check.
+   * @param config NullAway configuration.
+   * @return true if the array symbol has a {@code @Nullable} annotation for its elements, false
+   *     otherwise
+   */
+  public static boolean isArrayElementNonNull(Symbol arraySymbol, Config config) {
+    for (Attribute.TypeCompound t : arraySymbol.getRawTypeAttributes()) {
+      for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
+        if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
+          if (Nullness.isNonNullAnnotation(t.type.toString(), config)) {
+            return true;
+          }
+        }
+      }
+    }
+    // For varargs symbols we also consider the elements to be @Nullable if there is a @Nullable
+    // declaration annotation on the parameter
+    if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
+      return Nullness.hasNonNullDeclarationAnnotation(arraySymbol, config);
+    }
+    return false;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -459,7 +459,7 @@ public class NullabilityUtil {
         }
       }
     }
-    // For varargs symbols we also consider the elements to be @Nullable if there is a @Nullable
+    // For varargs symbols we also consider the elements to be @NonNull if there is a @NonNull
     // declaration annotation on the parameter
     if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
       return Nullness.hasNonNullDeclarationAnnotation(arraySymbol, config);

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -269,8 +269,8 @@ public enum Nullness implements AbstractValue<Nullness> {
     if (symbol.isVarArgs()
         && paramInd == symbol.getParameters().size() - 1
         && !config.isLegacyAnnotationLocation()) {
-      // individual arguments passed in the varargs positions can be @Nullable if the array element
-      // type of the parameter is @Nullable
+      // individual arguments passed in the varargs positions must be @NonNull if the array element
+      // type of the parameter is @NonNull
       return NullabilityUtil.isArrayElementNonNull(symbol.getParameters().get(paramInd), config);
     } else {
       return hasNonNullAnnotation(

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -175,7 +175,7 @@ public enum Nullness implements AbstractValue<Nullness> {
    * @param annotName annotation name
    * @return true if we treat annotName as a <code>@NonNull</code> annotation, false otherwise
    */
-  private static boolean isNonNullAnnotation(String annotName, Config config) {
+  public static boolean isNonNullAnnotation(String annotName, Config config) {
     return annotName.endsWith(".NonNull")
         || annotName.endsWith(".NotNull")
         || annotName.endsWith(".Nonnull")
@@ -260,11 +260,22 @@ public enum Nullness implements AbstractValue<Nullness> {
   /**
    * Does the parameter of {@code symbol} at {@code paramInd} have a {@code @NonNull} declaration or
    * type-use annotation? This method works for methods defined in either source or class files.
+   *
+   * <p>For a varargs parameter, this method returns true if <em>individual</em> arguments passed in
+   * the varargs positions must be {@code @NonNull}.
    */
   public static boolean paramHasNonNullAnnotation(
       Symbol.MethodSymbol symbol, int paramInd, Config config) {
-    return hasNonNullAnnotation(
-        NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd, config), config);
+    if (symbol.isVarArgs()
+        && paramInd == symbol.getParameters().size() - 1
+        && !config.isLegacyAnnotationLocation()) {
+      // individual arguments passed in the varargs positions can be @Nullable if the array element
+      // type of the parameter is @Nullable
+      return NullabilityUtil.isArrayElementNonNull(symbol.getParameters().get(paramInd), config);
+    } else {
+      return hasNonNullAnnotation(
+          NullabilityUtil.getAllAnnotationsForParameter(symbol, paramInd, config), config);
+    }
   }
 
   /**
@@ -281,5 +292,10 @@ public enum Nullness implements AbstractValue<Nullness> {
   /** Checks if the symbol has a {@code @Nullable} declaration annotation */
   public static boolean hasNullableDeclarationAnnotation(Symbol symbol, Config config) {
     return hasNullableAnnotation(symbol.getRawAttributes().stream(), config);
+  }
+
+  /** Checks if the symbol has a {@code @NonNull} declaration annotation */
+  public static boolean hasNonNullDeclarationAnnotation(Symbol symbol, Config config) {
+    return hasNonNullAnnotation(symbol.getRawAttributes().stream(), config);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -491,6 +491,14 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'y'",
             "    Unannotated.takesVarargsTypeUseOnArray(y);",
             "  }",
+            "  public void testTypeUseOnElements() {",
+            "    Object x = null;",
+            "    Object[] y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Unannotated.takesVarargsTypeUseOnElements(x);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y'",
+            "    Unannotated.takesVarargsTypeUseOnElements(y);",
+            "  }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -200,8 +200,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
-            // TODO should we preserve the old behavior in legacy mode?
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -481,6 +481,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Object[] y = null;",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    Unannotated.takesVarargsDeclaration(x);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y'",
             "    Unannotated.takesVarargsDeclaration(y);",
             "  }",
             "  public void testTypeUseOnArray() {",
@@ -488,8 +489,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    Object[] y = null;",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    Unannotated.takesVarargsTypeUseOnArray(x);",
-            // TODO report an error here; will require some refactoring of restrictive annotation
-            //  handling
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y'",
             "    Unannotated.takesVarargsTypeUseOnArray(y);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -200,7 +200,8 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
+            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
+            // TODO should we preserve the old behavior in legacy mode?
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.
@@ -411,6 +412,28 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             "    takesNullableVarargsArray(x);",
             "    // in legacy mode the annotation allows for individual arguments to be nullable",
             "    takesNullableVarargsArray(x, o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testVarargsNullArrayUnannotated() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Unannotated.java",
+            "package foo.unannotated;",
+            "public class Unannotated {",
+            "  public static void takesVarargs(Object... args) {}",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import foo.unannotated.Unannotated;",
+            "public class Test {",
+            "  public void test() {",
+            "    Object[] x = null;",
+            "    Unannotated.takesVarargs(x);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -485,7 +485,8 @@ public class VarargsTests extends NullAwayTestsBase {
             "    Object x = null;",
             "    Object[] y = null;",
             "    Unannotated.takesVarargsTypeUseOnArray(x);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y'",
+            // TODO report an error here; will require some refactoring of restrictive annotation
+            //  handling
             "    Unannotated.takesVarargsTypeUseOnArray(y);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -420,25 +420,37 @@ public class VarargsTests extends NullAwayTestsBase {
 
   @Test
   public void testVarargsNullArrayUnannotated() {
+    String[] unannotatedSource = {
+      "package foo.unannotated;",
+      "public class Unannotated {",
+      "  public static void takesVarargs(Object... args) {}",
+      "}"
+    };
+    String[] testSource = {
+      "package com.uber;",
+      "import foo.unannotated.Unannotated;",
+      "public class Test {",
+      "  public void test() {",
+      "    Object x = null;",
+      "    Object[] y = null;",
+      "    Unannotated.takesVarargs(x);",
+      "    Unannotated.takesVarargs(y);",
+      "  }",
+      "}"
+    };
+    // test with both restrictive annotations enabled and disabled
     defaultCompilationHelper
-        .addSourceLines(
-            "Unannotated.java",
-            "package foo.unannotated;",
-            "public class Unannotated {",
-            "  public static void takesVarargs(Object... args) {}",
-            "}")
-        .addSourceLines(
-            "Test.java",
-            "package com.uber;",
-            "import foo.unannotated.Unannotated;",
-            "public class Test {",
-            "  public void test() {",
-            "    Object x = null;",
-            "    Object[] y = null;",
-            "    Unannotated.takesVarargs(x);",
-            "    Unannotated.takesVarargs(y);",
-            "  }",
-            "}")
+        .addSourceLines("Unannotated.java", unannotatedSource)
+        .addSourceLines("Test.java", testSource)
+        .doTest();
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines("Unannotated.java", unannotatedSource)
+        .addSourceLines("Test.java", testSource)
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -196,7 +196,7 @@ public class VarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -442,6 +442,10 @@ public class VarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * This test is a WIP for restrictive annotations on varargs. More assertions still need to be
+   * written, and more support needs to be implemented.
+   */
   @Test
   public void testVarargsRestrictive() {
     makeTestHelperWithArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -196,7 +196,7 @@ public class VarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
+            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.
@@ -413,6 +413,28 @@ public class VarargsTests extends NullAwayTestsBase {
             "    takesNullableVarargsArray(x);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    takesNullableVarargsArray(x, o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testVarargsNullArrayUnannotated() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Unannotated.java",
+            "package foo.unannotated;",
+            "public class Unannotated {",
+            "  public static void takesVarargs(Object... args) {}",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import foo.unannotated.Unannotated;",
+            "public class Test {",
+            "  public void test() {",
+            "    Object[] x = null;",
+            "    Unannotated.takesVarargs(x);",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -505,6 +505,13 @@ public class VarargsTests extends NullAwayTestsBase {
             //  handling
             "    Unannotated.takesVarargsTypeUseOnArray(y);",
             "  }",
+            "  public void testTypeUseOnElements() {",
+            "    Object x = null;",
+            "    Object[] y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Unannotated.takesVarargsTypeUseOnElements(x);",
+            "    Unannotated.takesVarargsTypeUseOnElements(y);",
+            "  }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -206,7 +206,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -505,6 +505,13 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             //  handling
             "    Unannotated.takesVarargsTypeUseOnArray(y);",
             "  }",
+            "  public void testTypeUseOnElements() {",
+            "    Object x = null;",
+            "    Object[] y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Unannotated.takesVarargsTypeUseOnElements(x);",
+            "    Unannotated.takesVarargsTypeUseOnElements(y);",
+            "  }",
             "}")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -453,6 +453,62 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * This test is a WIP for restrictive annotations on varargs. More assertions still need to be
+   * written, and more support needs to be implemented.
+   */
+  @Test
+  public void testVarargsRestrictive() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:JSpecifyMode=true",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "NonNull.java",
+            "package com.uber.both;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})",
+            "public @interface NonNull {}")
+        .addSourceLines(
+            "Unannotated.java",
+            "package foo.unannotated;",
+            "public class Unannotated {",
+            "  public static void takesVarargsDeclaration(@javax.annotation.Nonnull Object... args) {}",
+            "  public static void takesVarargsTypeUseOnArray(Object @org.jspecify.annotations.NonNull... args) {}",
+            "  public static void takesVarargsTypeUseOnElements(@org.jspecify.annotations.NonNull Object... args) {}",
+            "  public static void takesVarargsTypeUseOnBoth(@org.jspecify.annotations.NonNull Object @org.jspecify.annotations.NonNull... args) {}",
+            "  public static void takesVarargsBothOnArray(Object @com.uber.both.NonNull... args) {}",
+            "  public static void takesVarargsBothOnElements(@com.uber.both.NonNull Object... args) {}",
+            "  public static void takesVarargsBothOnBoth(@com.uber.both.NonNull Object @com.uber.both.NonNull... args) {}",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import foo.unannotated.Unannotated;",
+            "public class Test {",
+            "  public void testDeclaration() {",
+            "    Object x = null;",
+            "    Object[] y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
+            "    Unannotated.takesVarargsDeclaration(x);",
+            "    Unannotated.takesVarargsDeclaration(y);",
+            "  }",
+            "  public void testTypeUseOnArray() {",
+            "    Object x = null;",
+            "    Object[] y = null;",
+            "    Unannotated.takesVarargsTypeUseOnArray(x);",
+            // TODO report an error here; will require some refactoring of restrictive annotation
+            //  handling
+            "    Unannotated.takesVarargsTypeUseOnArray(y);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -206,7 +206,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             "    ThirdParty.takesNullableVarargs(o1);", // Empty var args passed
             "    ThirdParty.takesNullableVarargs(o1, o4);",
             "    ThirdParty.takesNullableVarargs(o1, (Object) null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object[]) null' where @NonNull",
+            "    // No error: we require a type-use annotation for nullability of the varargs array itself",
             "    ThirdParty.takesNullableVarargs(o1, (Object[]) null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'o4' where @NonNull",
             "    ThirdParty.takesNullableVarargs(o4);", // First arg is not varargs.
@@ -426,6 +426,28 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             "    takesNullableVarargsArray(x);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'x'",
             "    takesNullableVarargsArray(x, o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testVarargsNullArrayUnannotated() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Unannotated.java",
+            "package foo.unannotated;",
+            "public class Unannotated {",
+            "  public static void takesVarargs(Object... args) {}",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import foo.unannotated.Unannotated;",
+            "public class Test {",
+            "  public void test() {",
+            "    Object[] x = null;",
+            "    Unannotated.takesVarargs(x);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
Partially addresses #1027.  Most importantly, handles the case with unannotated methods and _no_ restrictive annotations; we were getting warnings in some cases with the main branch, which impacts backward compatibility.

I started implementing full support for restrictive annotations on varargs parameters and then realized it would take some refactoring (since there can be a restrictive annotation on the varargs array itself or on its contents, and we have no way to express this in the current code structure).  This PR contains some incomplete code towards that change, which I figured does no harm so I left it in for now.  If desired I can remove it and put it in a separate PR.