### PR TITLE
Update to Checker Framework 3.48.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.47.0",
+    checkerFramework       : "3.48.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.43.0",
+    checkerFramework       : "3.47.0",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1060,8 +1060,9 @@ public class CoreTests extends NullAwayTestsBase {
         .addSourceLines(
             "TestCase.java",
             "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
             "public class TestCase {",
-            "    public static String foo(String x) {",
+            "    public static @Nullable String foo(String x) {",
             "        return x.isEmpty() ? null : null;",
             "    }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1053,4 +1053,18 @@ public class CoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void ternaryBothCasesNull() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "TestCase.java",
+            "package com.uber;",
+            "public class TestCase {",
+            "    public static String foo(String x) {",
+            "        return x.isEmpty() ? null : null;",
+            "    }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1054,6 +1054,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** testing for no Checker Framework crash */
   @Test
   public void ternaryBothCasesNull() {
     defaultCompilationHelper


### PR DESCRIPTION
Fixes #1012.  [Benchmarking](https://github.com/uber/NullAway/pull/1030#issuecomment-2389637778) shows any perf difference is within the noise.