### PR TITLE
Create basic unit tests for library model generation

### DIFF
--- a/library-model/library-model-generator/build.gradle
+++ b/library-model/library-model-generator/build.gradle
@@ -23,4 +23,6 @@ dependencies {
     implementation deps.build.javaparser
     compileOnly deps.apt.autoValueAnnot
     annotationProcessor deps.apt.autoValue
+
+    testImplementation deps.test.junit4
 }

--- a/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
+++ b/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
@@ -72,16 +72,26 @@ public class LibraryModelGenerator {
       this.methodRecords = methodRecords;
       this.nullableUpperBounds = nullableUpperBounds;
     }
+
+    @Override
+    public String toString() {
+      return "ModelData{"
+          + "methodRecords="
+          + methodRecords
+          + ", nullableUpperBounds="
+          + nullableUpperBounds
+          + '}';
+    }
   }
 
   /**
    * Parses all the source files within the directory using javaparser.
    *
    * @param inputSourceDirectory Directory containing annotated java source files.
-   * @param outputDirectory Directory to write the astubx file into.
+   * @param outputFile absolute path to the output file.
    */
-  public ModelData generateAstubxForLibraryModels(
-      String inputSourceDirectory, String outputDirectory) {
+  public static ModelData generateAstubxForLibraryModels(
+      String inputSourceDirectory, String outputFile) {
     Map<String, MethodAnnotationsRecord> methodRecords = new LinkedHashMap<>();
     Map<String, Set<Integer>> nullableUpperBounds = new LinkedHashMap<>();
     Path root = dirnameToPath(inputSourceDirectory);
@@ -103,17 +113,17 @@ public class LibraryModelGenerator {
                 throw new RuntimeException(e);
               }
             });
-    writeToAstubx(outputDirectory, modelData);
+    writeToAstubx(outputFile, modelData);
     return modelData;
   }
 
   /**
    * Writes the Nullability annotation information into the output directory as an astubx file.
    *
-   * @param outputPath Output Directory.
+   * @param outputPath path to output astubx file.
    * @param modelData ModelData instance containing the collected annotation information.
    */
-  private void writeToAstubx(String outputPath, ModelData modelData) {
+  private static void writeToAstubx(String outputPath, ModelData modelData) {
     Map<String, MethodAnnotationsRecord> methodRecords = modelData.methodRecords;
     Map<String, Set<Integer>> nullableUpperBounds = modelData.nullableUpperBounds;
     if (methodRecords.isEmpty() && nullableUpperBounds.isEmpty()) {
@@ -140,7 +150,7 @@ public class LibraryModelGenerator {
     }
   }
 
-  public Path dirnameToPath(String dir) {
+  public static Path dirnameToPath(String dir) {
     File f = new File(dir);
     String absoluteDir = f.getAbsolutePath();
     if (absoluteDir.endsWith("/.")) {

--- a/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
+++ b/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
@@ -62,11 +62,15 @@ import java.util.Set;
  */
 public class LibraryModelGenerator {
 
-  public static class ModelData {
+  /**
+   * Data class for storing the annotation information collected from the source files. This is the
+   * information that is stored in the astubx file.
+   */
+  public static class LibraryModelData {
     public final Map<String, MethodAnnotationsRecord> methodRecords;
     public final Map<String, Set<Integer>> nullableUpperBounds;
 
-    public ModelData(
+    public LibraryModelData(
         Map<String, MethodAnnotationsRecord> methodRecords,
         Map<String, Set<Integer>> nullableUpperBounds) {
       this.methodRecords = methodRecords;
@@ -90,12 +94,12 @@ public class LibraryModelGenerator {
    * @param inputSourceDirectory Directory containing annotated java source files.
    * @param outputFile absolute path to the output file.
    */
-  public static ModelData generateAstubxForLibraryModels(
+  public static LibraryModelData generateAstubxForLibraryModels(
       String inputSourceDirectory, String outputFile) {
     Map<String, MethodAnnotationsRecord> methodRecords = new LinkedHashMap<>();
     Map<String, Set<Integer>> nullableUpperBounds = new LinkedHashMap<>();
     Path root = dirnameToPath(inputSourceDirectory);
-    ModelData modelData = new ModelData(methodRecords, nullableUpperBounds);
+    LibraryModelData modelData = new LibraryModelData(methodRecords, nullableUpperBounds);
     AnnotationCollectorCallback ac = new AnnotationCollectorCallback(modelData);
     CollectionStrategy strategy = new ParserCollectionStrategy();
     // Required to include directories that contain a module-info.java, which don't parse by
@@ -123,7 +127,7 @@ public class LibraryModelGenerator {
    * @param outputPath path to output astubx file.
    * @param modelData ModelData instance containing the collected annotation information.
    */
-  private static void writeToAstubx(String outputPath, ModelData modelData) {
+  private static void writeToAstubx(String outputPath, LibraryModelData modelData) {
     Map<String, MethodAnnotationsRecord> methodRecords = modelData.methodRecords;
     Map<String, Set<Integer>> nullableUpperBounds = modelData.nullableUpperBounds;
     if (methodRecords.isEmpty() && nullableUpperBounds.isEmpty()) {
@@ -163,7 +167,7 @@ public class LibraryModelGenerator {
 
     private final AnnotationCollectionVisitor annotationCollectionVisitor;
 
-    public AnnotationCollectorCallback(ModelData modelData) {
+    public AnnotationCollectorCallback(LibraryModelData modelData) {
       this.annotationCollectionVisitor = new AnnotationCollectionVisitor(modelData);
     }
 
@@ -191,7 +195,7 @@ public class LibraryModelGenerator {
     private static final String NULLABLE = "Nullable";
     private static final String JSPECIFY_NULLABLE_IMPORT = "org.jspecify.annotations.Nullable";
 
-    public AnnotationCollectionVisitor(ModelData modelData) {
+    public AnnotationCollectionVisitor(LibraryModelData modelData) {
       this.methodRecords = modelData.methodRecords;
       this.nullableUpperBounds = modelData.nullableUpperBounds;
     }

--- a/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
+++ b/library-model/library-model-generator/src/main/java/com/uber/nullaway/libmodel/LibraryModelGenerator.java
@@ -217,7 +217,11 @@ public class LibraryModelGenerator {
       logic does not currently handle cases where @NullMarked annotations appear on some nested
       classes but not others. It also does not consider annotations within package-info.java or
       module-info.java files.*/
-      parentName += "." + cid.getNameAsString();
+      String oldParentName = parentName;
+      if (!parentName.isEmpty()) {
+        parentName += ".";
+      }
+      parentName += cid.getNameAsString();
       cid.getAnnotations()
           .forEach(
               a -> {
@@ -234,7 +238,7 @@ public class LibraryModelGenerator {
       }
       super.visit(cid, null);
       // We reset the variable that constructs the parent name after visiting all the children.
-      parentName = parentName.substring(0, parentName.lastIndexOf("." + cid.getNameAsString()));
+      parentName = oldParentName;
     }
 
     @Override

--- a/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
+++ b/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
@@ -1,0 +1,52 @@
+package com.uber.nullaway.libmodel;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LibraryModelGeneratorTest {
+
+  /** For input source code files */
+  @Rule public TemporaryFolder inputSourcesFolder = new TemporaryFolder();
+
+  /** For output astubx files */
+  @Rule public TemporaryFolder outputFolder = new TemporaryFolder();
+
+  @Test
+  public void firstTest() throws IOException {
+    String[] lines =
+        new String[] {
+          "import org.jspecify.annotations.NullMarked;",
+          "import org.jspecify.annotations.Nullable;",
+          "@NullMarked",
+          "public class AnnotationExample {",
+          "    @Nullable",
+          "    public String makeUpperCase(String inputString) {",
+          "        if (inputString == null || inputString.isEmpty()) {",
+          "            return null;",
+          "        } else {",
+          "            return inputString.toUpperCase();",
+          "        }",
+          "    }",
+          "}"
+        };
+    // write it to a source file in inputSourcesFolder with the right file name
+    Files.write(
+        inputSourcesFolder.newFile("AnnotationExample.java").toPath(),
+        String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+    // run the generator
+    String astubxOutputPath =
+        Paths.get(outputFolder.getRoot().getAbsolutePath(), "output.astubx").toString();
+    LibraryModelGenerator.ModelData modelData =
+        LibraryModelGenerator.generateAstubxForLibraryModels(
+            inputSourcesFolder.getRoot().getAbsolutePath(), astubxOutputPath);
+    // check that the output file was created
+    Assert.assertTrue("astubx file was not created", Files.exists(Paths.get(astubxOutputPath)));
+    System.err.println(modelData);
+  }
+}

--- a/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
+++ b/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
@@ -1,5 +1,10 @@
 package com.uber.nullaway.libmodel;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -47,6 +52,10 @@ public class LibraryModelGeneratorTest {
             inputSourcesFolder.getRoot().getAbsolutePath(), astubxOutputPath);
     // check that the output file was created
     Assert.assertTrue("astubx file was not created", Files.exists(Paths.get(astubxOutputPath)));
-    System.err.println(modelData);
+    ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
+        ImmutableMap.of(
+            "AnnotationExample:String makeUpperCase(String)",
+            MethodAnnotationsRecord.create(ImmutableSet.of("Nullable"), ImmutableMap.of()));
+    assertThat(modelData.methodRecords, equalTo(expectedMethodRecords));
   }
 }

--- a/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
+++ b/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
@@ -39,6 +39,7 @@ public class LibraryModelGeneratorTest {
     LibraryModelGenerator.LibraryModelData modelData =
         LibraryModelGenerator.generateAstubxForLibraryModels(
             inputSourcesFolder.getRoot().getAbsolutePath(), astubxOutputPath);
+    System.err.println("modelData: " + modelData);
     Assert.assertTrue("astubx file was not created", Files.exists(Paths.get(astubxOutputPath)));
     assertThat(modelData.methodRecords, equalTo(expectedMethodRecords));
     assertThat(modelData.nullableUpperBounds, equalTo(expectedNullableUpperBounds));

--- a/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
+++ b/library-model/library-model-generator/src/test/java/com/uber/nullaway/libmodel/LibraryModelGeneratorTest.java
@@ -36,7 +36,7 @@ public class LibraryModelGeneratorTest {
     // run the generator
     String astubxOutputPath =
         Paths.get(outputFolder.getRoot().getAbsolutePath(), "output.astubx").toString();
-    LibraryModelGenerator.ModelData modelData =
+    LibraryModelGenerator.LibraryModelData modelData =
         LibraryModelGenerator.generateAstubxForLibraryModels(
             inputSourcesFolder.getRoot().getAbsolutePath(), astubxOutputPath);
     Assert.assertTrue("astubx file was not created", Files.exists(Paths.get(astubxOutputPath)));


### PR DESCRIPTION
This is in preparation for #1006.  When working on that PR I realized we really need some unit tests to more easily debug various scenarios (right now all we have are integration tests).  Plus this will make our code coverage reports more useful.  This adds some infrastructure for unit tests and a couple of basic tests; we will add more as we go.  Also fix a couple minor issues in `LibraryModelGenerator`.