### PR TITLE
Add missing source files in android-jarinfer-models-sdk modules

### DIFF
--- a/jar-infer/android-jarinfer-models-sdk29/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
+++ b/jar-infer/android-jarinfer-models-sdk29/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.jarinfer;
+
+public class AndroidJarInferModels {}

--- a/jar-infer/android-jarinfer-models-sdk30/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
+++ b/jar-infer/android-jarinfer-models-sdk30/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.jarinfer;
+
+public class AndroidJarInferModels {}

--- a/jar-infer/android-jarinfer-models-sdk31/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
+++ b/jar-infer/android-jarinfer-models-sdk31/src/main/java/com/uber/nullaway/jarinfer/AndroidJarInferModels.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.jarinfer;
+
+public class AndroidJarInferModels {}


### PR DESCRIPTION
These are copied from the sdk28 module.  These are needed in order for the models to be loaded by the code [here](https://github.com/uber/NullAway/blob/b7756eaa0f28d88e09ad6a52a22d373e4a42ae56/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java#L76-L79).

I am deliberately _not_ adding an integration test to detect this issue right now, though I think we could using the Android sample app.  The issue is that we are currently evolving the astubx format, and I don't want to be forced to re-generate these SDK models `astubx` files each time we make a small change.  I'll open an issue so that we add the integration test once our work on astubx stabilizes and before we cut our next release.