### PR TITLE
Update to Error Prone 2.32.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,18 +19,19 @@ jobs:
           - os: ubuntu-latest
             java: 17
             epVersion: 2.14.0
-          - os: macos-latest
-            java: 11
-            epVersion: 2.30.0
+          # last version of Error Prone that supports Java 11
           - os: ubuntu-latest
             java: 11
-            epVersion: 2.30.0
+            epVersion: 2.31.0
+          - os: macos-latest
+            java: 17
+            epVersion: 2.32.0
           - os: windows-latest
-            java: 11
-            epVersion: 2.30.0
+            java: 17
+            epVersion: 2.32.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.30.0
+            epVersion: 2.32.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +62,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '11' && matrix.epVersion == '2.30.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.32.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -74,6 +75,6 @@ jobs:
           ORG_GRADLE_PROJECT_VERSION_NAME: '0.0.0.1-LOCAL'
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: 'false'
         run: ./gradlew publishToMavenLocal
-        if: matrix.java == '11'
+        if: matrix.java == '17'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.30.0"
+def latestErrorProneVersion = "2.32.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion


### PR DESCRIPTION
Error Prone 2.32.0 requires JDK 17 or higher.  We tweak our CI config accordingly, adding a job testing on the last EP version (2.31.0) that worked with JDK 11.  (We should really tweak our Gradle config to completely divorce the JDK version used to run Gradle from the JDK version for the `test` tasks, but that'll have to wait for a PR.)

A few changes to our required job names will be required before this can land.