### PR TITLE
Various version updates

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,13 +25,13 @@ jobs:
             epVersion: 2.31.0
           - os: macos-latest
             java: 17
-            epVersion: 2.32.0
+            epVersion: 2.33.0
           - os: windows-latest
             java: 17
-            epVersion: 2.32.0
+            epVersion: 2.33.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.32.0
+            epVersion: 2.33.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.32.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.33.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ subprojects { project ->
         project.apply plugin: "com.diffplug.spotless"
         spotless {
             java {
-                googleJavaFormat()
+                googleJavaFormat(deps.versions.googlejavaformat)
             }
         }
     }
@@ -129,7 +129,7 @@ spotless {
     }
 }
 spotlessPredeclare {
-    java { googleJavaFormat('1.19.2') }
+    java { googleJavaFormat(deps.versions.googlejavaformat) }
     groovyGradle {
         greclipse()
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.32.0"
+def latestErrorProneVersion = "2.33.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,6 +53,7 @@ def versions = [
     autoValue              : "1.10.2",
     autoService            : "1.1.1",
     javaparser             : "3.26.2",
+    googlejavaformat       : "1.24.0",
 ]
 
 def apt = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=1541fa36599e12857140465f3c91a97409b4512501c26f9631fb113e392c5bd1
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2366,10 +2366,11 @@ public class NullAway extends BugChecker
       case NEW_CLASS:
       case NEW_ARRAY:
       case ARRAY_TYPE:
+      // Lambdas may return null, but the lambda literal itself should not be null
       case LAMBDA_EXPRESSION:
-        // Lambdas may return null, but the lambda literal itself should not be null
+      // These cannot be null; the compiler would catch it
       case MEMBER_REFERENCE:
-        // These cannot be null; the compiler would catch it
+      // result of compound assignment cannot be null
       case MULTIPLY_ASSIGNMENT:
       case DIVIDE_ASSIGNMENT:
       case REMAINDER_ASSIGNMENT:
@@ -2381,9 +2382,8 @@ public class NullAway extends BugChecker
       case AND_ASSIGNMENT:
       case XOR_ASSIGNMENT:
       case OR_ASSIGNMENT:
-        // result of compound assignment cannot be null
+      // rest are for auto-boxing
       case PLUS:
-        // rest are for auto-boxing
       case MINUS:
       case MULTIPLY:
       case DIVIDE:

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -287,7 +287,7 @@ public final class AccessPath implements MapKey {
             && (receiver.toString().equals("Integer") || receiver.toString().equals("Long"))) {
           return argumentToMapKeySpecifier(arguments.get(0), state, apContext);
         }
-        // Fine to fallthrough:
+      // Fine to fallthrough:
       default:
         // Every other type of expression, including variables, field accesses, new A(...), etc.
         return getAccessPathForNode(argument, state, apContext); // Every AP is a MapKey too
@@ -488,8 +488,8 @@ public final class AccessPath implements MapKey {
                   break;
                 }
               }
-              // Cascade to default, symbol is not a constant field
-              // fall through
+            // Cascade to default, symbol is not a constant field
+            // fall through
             default:
               return null; // Not an AP
           }


### PR DESCRIPTION
Update Gradle, Google Java Format, and Error Prone.

The GJF update tweaks comment indentation for switch statements.  For clarity, we move a couple of these comments to a more appropriate spot.

Will need to update CI job names before landing.