### PR TITLE
Add library model for Apache Commons CollectionUtils.isNotEmpty (#932)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -742,6 +742,16 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
             .put(methodRef("spark.utils.StringUtils", "hasLength(java.lang.String)"), 0)
             .put(methodRef("spark.utils.StringUtils", "hasLength(java.lang.CharSequence)"), 0)
             .put(
+                methodRef(
+                    "org.apache.commons.collections.CollectionUtils",
+                    "isNotEmpty(java.util.Collection)"),
+                0)
+            .put(
+                methodRef(
+                    "org.apache.commons.collections4.CollectionUtils",
+                    "isNotEmpty(java.util.Collection<?>)"),
+                0)
+            .put(
                 methodRef("org.apache.commons.lang.StringUtils", "isNotEmpty(java.lang.String)"), 0)
             .put(
                 methodRef(

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1018,6 +1018,42 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void apacheCollectionsCollectionUtilsIsNotEmpty() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import org.apache.commons.collections.CollectionUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable List<String> s) {",
+            "    if(CollectionUtils.isNotEmpty(s))",
+            "      s.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void apacheCollections4CollectionUtilsIsNotEmpty() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import org.apache.commons.collections4.CollectionUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable List<String> s) {",
+            "    if(CollectionUtils.isNotEmpty(s))",
+            "      s.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void filesIsDirectory() {
     defaultCompilationHelper
         .addSourceLines(


### PR DESCRIPTION
Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] Added library model for Apache Commons CollectionUtils.isNotEmpty

  - [ ] related to issue #932 

  - [ ] `void apacheCollectionsCollectionUtilsIsNotEmpty()` and `void apacheCollectionsCollectionUtilsIsNotEmpty()` tests have been added to `FrameworkTests.java`
