### PR TITLE
Update to latest Error Prone and Error Prone Gradle plugin

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,13 +25,13 @@ jobs:
             epVersion: 2.31.0
           - os: macos-latest
             java: 17
-            epVersion: 2.33.0
+            epVersion: 2.35.1
           - os: windows-latest
             java: 17
-            epVersion: 2.33.0
+            epVersion: 2.35.1
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.33.0
+            epVersion: 2.35.1
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.33.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.35.1' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 }
 plugins {
     id "com.diffplug.spotless" version "6.25.0"
-    id "net.ltgt.errorprone" version "3.1.0" apply false
+    id "net.ltgt.errorprone" version "4.1.0" apply false
     id "com.github.johnrengelman.shadow" version "8.1.1" apply false
     id "me.champeau.jmh" version "0.7.1" apply false
     id "com.github.ben-manes.versions" version "0.51.0"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.33.0"
+def latestErrorProneVersion = "2.35.1"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -24,6 +24,7 @@ configurations {
     // A configuration holding the jars for the oldest supported version of Error Prone, to use with tests
     errorProneOldest
 
+    // To resolve the errorprone dependencies for the buildWithNullAway task
     errorproneExtended {
         extendsFrom errorprone
         canBeResolved = true

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -23,6 +23,11 @@ plugins {
 configurations {
     // A configuration holding the jars for the oldest supported version of Error Prone, to use with tests
     errorProneOldest
+
+    errorproneExtended {
+        extendsFrom errorprone
+        canBeResolved = true
+    }
 }
 
 dependencies {
@@ -152,7 +157,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
     classpath = sourceSets.main.compileClasspath
     destinationDirectory = file("$buildDir/ignoredClasses")
     options.annotationProcessorPath = files(
-            configurations.errorprone.asCollection(),
+            configurations.errorproneExtended.asCollection(),
             sourceSets.main.annotationProcessorPath,
             // This refers to the NullAway jar built from the current source
             jar.archiveFile.get(),

--- a/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
@@ -33,8 +33,8 @@ public class AndroidTest {
   public void coreFragmentSuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/core/Fragment.java")
-        .addSourceFile("android-success/CoreFragment.java")
+        .addSourceFile("testdata/androidstubs/core/Fragment.java")
+        .addSourceFile("testdata/android-success/CoreFragment.java")
         .doTest();
   }
 
@@ -42,8 +42,8 @@ public class AndroidTest {
   public void coreFragmentMissingOnAttachError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/core/Fragment.java")
-        .addSourceFile("android-error/CoreFragmentWithoutOnAttach.java")
+        .addSourceFile("testdata/androidstubs/core/Fragment.java")
+        .addSourceFile("testdata/android-error/CoreFragmentWithoutOnAttach.java")
         .doTest();
   }
 
@@ -51,8 +51,8 @@ public class AndroidTest {
   public void coreFragmentMissingOnCreateError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/core/Fragment.java")
-        .addSourceFile("android-error/CoreFragmentWithoutOnCreate.java")
+        .addSourceFile("testdata/androidstubs/core/Fragment.java")
+        .addSourceFile("testdata/android-error/CoreFragmentWithoutOnCreate.java")
         .doTest();
   }
 
@@ -60,8 +60,8 @@ public class AndroidTest {
   public void coreFragmentMissingOnCreateViewError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/core/Fragment.java")
-        .addSourceFile("android-error/CoreFragmentWithoutOnCreateView.java")
+        .addSourceFile("testdata/androidstubs/core/Fragment.java")
+        .addSourceFile("testdata/android-error/CoreFragmentWithoutOnCreateView.java")
         .doTest();
   }
 
@@ -70,8 +70,8 @@ public class AndroidTest {
   public void androidxFragmentSuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/androidx/Fragment.java")
-        .addSourceFile("android-success/AndroidxFragment.java")
+        .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
+        .addSourceFile("testdata/android-success/AndroidxFragment.java")
         .doTest();
   }
 
@@ -79,8 +79,8 @@ public class AndroidTest {
   public void androidxFragmentMissingOnAttachError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/androidx/Fragment.java")
-        .addSourceFile("android-error/AndroidxFragmentWithoutOnAttach.java")
+        .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
+        .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnAttach.java")
         .doTest();
   }
 
@@ -88,8 +88,8 @@ public class AndroidTest {
   public void androidxFragmentMissingOnCreateError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/androidx/Fragment.java")
-        .addSourceFile("android-error/AndroidxFragmentWithoutOnCreate.java")
+        .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
+        .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnCreate.java")
         .doTest();
   }
 
@@ -97,8 +97,8 @@ public class AndroidTest {
   public void androidxFragmentMissingOnCreateViewError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/androidx/Fragment.java")
-        .addSourceFile("android-error/AndroidxFragmentWithoutOnCreateView.java")
+        .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
+        .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnCreateView.java")
         .doTest();
   }
 
@@ -108,8 +108,8 @@ public class AndroidTest {
   public void supportLibFragmentSuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/supportlib/Fragment.java")
-        .addSourceFile("android-success/SupportLibraryFragment.java")
+        .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
+        .addSourceFile("testdata/android-success/SupportLibraryFragment.java")
         .doTest();
   }
 
@@ -117,8 +117,8 @@ public class AndroidTest {
   public void supportLibFragmentMissingOnAttachError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/supportlib/Fragment.java")
-        .addSourceFile("android-error/SupportLibraryFragmentWithoutOnAttach.java")
+        .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
+        .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnAttach.java")
         .doTest();
   }
 
@@ -126,8 +126,8 @@ public class AndroidTest {
   public void supportLibFragmentMissingOnCreateError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/supportlib/Fragment.java")
-        .addSourceFile("android-error/SupportLibraryFragmentWithoutOnCreate.java")
+        .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
+        .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnCreate.java")
         .doTest();
   }
 
@@ -135,8 +135,8 @@ public class AndroidTest {
   public void supportLibFragmentMissingOnCreateViewError() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/supportlib/Fragment.java")
-        .addSourceFile("android-error/SupportLibraryFragmentWithoutOnCreateView.java")
+        .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
+        .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnCreateView.java")
         .doTest();
   }
 
@@ -146,8 +146,8 @@ public class AndroidTest {
   public void coreActivitySuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/core/Activity.java")
-        .addSourceFile("android-success/CoreActivity.java")
+        .addSourceFile("testdata/androidstubs/core/Activity.java")
+        .addSourceFile("testdata/android-success/CoreActivity.java")
         .doTest();
   }
 
@@ -157,8 +157,8 @@ public class AndroidTest {
   public void supportLibActivitySuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/supportlib/ActivityCompat.java")
-        .addSourceFile("android-success/SupportLibActivityCompat.java")
+        .addSourceFile("testdata/androidstubs/supportlib/ActivityCompat.java")
+        .addSourceFile("testdata/android-success/SupportLibActivityCompat.java")
         .doTest();
   }
 
@@ -168,8 +168,8 @@ public class AndroidTest {
   public void androidxActivitySuccess() {
     initialiseAndroidCoreClasses();
     compilationHelper
-        .addSourceFile("androidstubs/androidx/ActivityCompat.java")
-        .addSourceFile("android-success/AndroidxActivityCompat.java")
+        .addSourceFile("testdata/androidstubs/androidx/ActivityCompat.java")
+        .addSourceFile("testdata/android-success/AndroidxActivityCompat.java")
         .doTest();
   }
 
@@ -177,11 +177,11 @@ public class AndroidTest {
   @SuppressWarnings("CheckReturnValue")
   private void initialiseAndroidCoreClasses() {
     compilationHelper
-        .addSourceFile("androidstubs/core/Context.java")
-        .addSourceFile("androidstubs/core/Bundle.java")
-        .addSourceFile("androidstubs/core/LayoutInflater.java")
-        .addSourceFile("androidstubs/core/PersistableBundle.java")
-        .addSourceFile("androidstubs/core/View.java")
-        .addSourceFile("androidstubs/core/ViewGroup.java");
+        .addSourceFile("testdata/androidstubs/core/Context.java")
+        .addSourceFile("testdata/androidstubs/core/Bundle.java")
+        .addSourceFile("testdata/androidstubs/core/LayoutInflater.java")
+        .addSourceFile("testdata/androidstubs/core/PersistableBundle.java")
+        .addSourceFile("testdata/androidstubs/core/View.java")
+        .addSourceFile("testdata/androidstubs/core/ViewGroup.java");
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -13,7 +13,7 @@ public class ContractsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:CheckContracts=true"))
-        .addSourceFile("CheckContractPositiveCases.java")
+        .addSourceFile("testdata/CheckContractPositiveCases.java")
         .doTest();
   }
 
@@ -25,7 +25,7 @@ public class ContractsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:CheckContracts=true"))
-        .addSourceFile("CheckContractNegativeCases.java")
+        .addSourceFile("testdata/CheckContractNegativeCases.java")
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -33,27 +33,29 @@ public class CoreTests extends NullAwayTestsBase {
 
   @Test
   public void coreNullabilityPositiveCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayPositiveCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayPositiveCases.java").doTest();
   }
 
   @Test
   public void nullabilityAnonymousClass() {
-    defaultCompilationHelper.addSourceFile("NullAwayAnonymousClass.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayAnonymousClass.java").doTest();
   }
 
   @Test
   public void coreNullabilityNegativeCases() {
     defaultCompilationHelper
-        .addSourceFile("NullAwayNegativeCases.java")
-        .addSourceFile("OtherStuff.java")
-        .addSourceFile("TestAnnot.java")
-        .addSourceFile("unannotated/UnannotatedClass.java")
+        .addSourceFile("testdata/NullAwayNegativeCases.java")
+        .addSourceFile("testdata/OtherStuff.java")
+        .addSourceFile("testdata/TestAnnot.java")
+        .addSourceFile("testdata/unannotated/UnannotatedClass.java")
         .doTest();
   }
 
   @Test
   public void assertSupportPositiveCases() {
-    defaultCompilationHelper.addSourceFile("CheckAssertSupportPositiveCases.java").doTest();
+    defaultCompilationHelper
+        .addSourceFile("testdata/CheckAssertSupportPositiveCases.java")
+        .doTest();
   }
 
   @Test
@@ -64,7 +66,7 @@ public class CoreTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:AssertsEnabled=true"))
-        .addSourceFile("CheckAssertSupportNegativeCases.java")
+        .addSourceFile("testdata/CheckAssertSupportNegativeCases.java")
         .doTest();
   }
 
@@ -258,7 +260,7 @@ public class CoreTests extends NullAwayTestsBase {
   @Test
   public void testCastToNonNull() {
     defaultCompilationHelper
-        .addSourceFile("Util.java")
+        .addSourceFile("testdata/Util.java")
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -279,7 +281,7 @@ public class CoreTests extends NullAwayTestsBase {
   @Test
   public void testCastToNonNullExtraArgsWarning() {
     defaultCompilationHelper
-        .addSourceFile("Util.java")
+        .addSourceFile("testdata/Util.java")
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -384,7 +386,7 @@ public class CoreTests extends NullAwayTestsBase {
 
   @Test
   public void testCapturingScopes() {
-    defaultCompilationHelper.addSourceFile("CapturingScopes.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/CapturingScopes.java").doTest();
   }
 
   @Test
@@ -635,7 +637,7 @@ public class CoreTests extends NullAwayTestsBase {
 
   @Test
   public void tryFinallySupport() {
-    defaultCompilationHelper.addSourceFile("NullAwayTryFinallyCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayTryFinallyCases.java").doTest();
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -6,36 +6,40 @@ import org.junit.Test;
 public class FrameworkTests extends NullAwayTestsBase {
   @Test
   public void lombokSupportTesting() {
-    defaultCompilationHelper.addSourceFile("lombok/LombokBuilderInit.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/lombok/LombokBuilderInit.java").doTest();
   }
 
   @Test
   public void coreNullabilityNativeModels() {
     defaultCompilationHelper
-        .addSourceFile("NullAwayNativeModels.java")
-        .addSourceFile("androidstubs/WebView.java")
-        .addSourceFile("androidstubs/TextUtils.java")
+        .addSourceFile("testdata/NullAwayNativeModels.java")
+        .addSourceFile("testdata/androidstubs/WebView.java")
+        .addSourceFile("testdata/androidstubs/TextUtils.java")
         .doTest();
   }
 
   @Test
   public void rxSupportPositiveCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayRxSupportPositiveCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayRxSupportPositiveCases.java").doTest();
   }
 
   @Test
   public void rxSupportNegativeCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayRxSupportNegativeCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayRxSupportNegativeCases.java").doTest();
   }
 
   @Test
   public void streamSupportNegativeCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayStreamSupportNegativeCases.java").doTest();
+    defaultCompilationHelper
+        .addSourceFile("testdata/NullAwayStreamSupportNegativeCases.java")
+        .doTest();
   }
 
   @Test
   public void streamSupportPositiveCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayStreamSupportPositiveCases.java").doTest();
+    defaultCompilationHelper
+        .addSourceFile("testdata/NullAwayStreamSupportPositiveCases.java")
+        .doTest();
   }
 
   @Test
@@ -382,8 +386,8 @@ public class FrameworkTests extends NullAwayTestsBase {
   @Test
   public void springTestAutowiredFieldTest() {
     defaultCompilationHelper
-        .addSourceFile("springboot-annotations/MockBean.java")
-        .addSourceFile("springboot-annotations/SpyBean.java")
+        .addSourceFile("testdata/springboot-annotations/MockBean.java")
+        .addSourceFile("testdata/springboot-annotations/SpyBean.java")
         .addSourceLines(
             "Foo.java",
             "package com.uber;",

--- a/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
@@ -6,27 +6,27 @@ import org.junit.Test;
 public class InitializationTests extends NullAwayTestsBase {
   @Test
   public void initFieldPositiveCases() {
-    defaultCompilationHelper.addSourceFile("CheckFieldInitPositiveCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/CheckFieldInitPositiveCases.java").doTest();
   }
 
   @Test
   public void initFieldNegativeCases() {
-    defaultCompilationHelper.addSourceFile("CheckFieldInitNegativeCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/CheckFieldInitNegativeCases.java").doTest();
   }
 
   @Test
   public void readBeforeInitPositiveCases() {
     defaultCompilationHelper
-        .addSourceFile("ReadBeforeInitPositiveCases.java")
-        .addSourceFile("Util.java")
+        .addSourceFile("testdata/ReadBeforeInitPositiveCases.java")
+        .addSourceFile("testdata/Util.java")
         .doTest();
   }
 
   @Test
   public void readBeforeInitNegativeCases() {
     defaultCompilationHelper
-        .addSourceFile("ReadBeforeInitNegativeCases.java")
-        .addSourceFile("Util.java")
+        .addSourceFile("testdata/ReadBeforeInitNegativeCases.java")
+        .addSourceFile("testdata/Util.java")
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
@@ -5,22 +5,26 @@ import org.junit.Test;
 public class Java8Tests extends NullAwayTestsBase {
   @Test
   public void java8PositiveCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayJava8PositiveCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayJava8PositiveCases.java").doTest();
   }
 
   @Test
   public void java8NegativeCases() {
-    defaultCompilationHelper.addSourceFile("NullAwayJava8NegativeCases.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/NullAwayJava8NegativeCases.java").doTest();
   }
 
   @Test
   public void functionalMethodSuperInterface() {
-    defaultCompilationHelper.addSourceFile("NullAwaySuperFunctionalInterface.java").doTest();
+    defaultCompilationHelper
+        .addSourceFile("testdata/NullAwaySuperFunctionalInterface.java")
+        .doTest();
   }
 
   @Test
   public void functionalMethodOverrideSuperInterface() {
-    defaultCompilationHelper.addSourceFile("NullAwayOverrideFunctionalInterfaces.java").doTest();
+    defaultCompilationHelper
+        .addSourceFile("testdata/NullAwayOverrideFunctionalInterfaces.java")
+        .doTest();
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
@@ -156,7 +156,7 @@ public class ThriftTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
                 "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
                 "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
-        .addSourceFile("Util.java")
+        .addSourceFile("testdata/Util.java")
         .addSourceLines("TBase.java", "package org.apache.thrift;", "public interface TBase {}")
         .addSourceLines(
             "GeneratedClass.java",

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -8,10 +8,10 @@ public class UnannotatedTests extends NullAwayTestsBase {
   @Test
   public void coreNullabilitySkipClass() {
     defaultCompilationHelper
-        .addSourceFile("Shape_Stuff.java")
-        .addSourceFile("excluded/Shape_Stuff2.java")
-        .addSourceFile("AnnotatedClass.java")
-        .addSourceFile("TestAnnot.java")
+        .addSourceFile("testdata/Shape_Stuff.java")
+        .addSourceFile("testdata/excluded/Shape_Stuff2.java")
+        .addSourceFile("testdata/AnnotatedClass.java")
+        .addSourceFile("testdata/TestAnnot.java")
         .doTest();
   }
 
@@ -68,7 +68,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
 
   @Test
   public void coreNullabilitySkipPackage() {
-    defaultCompilationHelper.addSourceFile("unannotated/UnannotatedClass.java").doTest();
+    defaultCompilationHelper.addSourceFile("testdata/unannotated/UnannotatedClass.java").doTest();
   }
 
   @Test


### PR DESCRIPTION
To stay up to date.  Required CI job names will need to be updated.

Due to https://github.com/google/error-prone/commit/097ab7a236003e2b12ae4c5e46937c3fc17a40a2 we need to update our tests to explicitly mention the `testdata/` path.
