### PR TITLE
Refactor serialization adapter retrieval by version

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationAdapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationAdapter.java
@@ -71,4 +71,29 @@ public interface SerializationAdapter {
    * @return The serialized method symbol.
    */
   String serializeMethodSignature(Symbol.MethodSymbol methodSymbol);
+
+  /**
+   * Gets the adapter for the given version number.
+   *
+   * @param version Version number of the adapter.
+   * @return Adapter for the given version.
+   */
+  static SerializationAdapter getAdapterForVersion(int version) {
+    switch (version) {
+      case 1:
+        return new SerializationV1Adapter();
+      case 2:
+        throw new RuntimeException(
+            "Serialization version v2 is skipped and was used for an alpha version of the auto-annotator tool. Please use version 3 instead.");
+      case 3:
+        return new SerializationV3Adapter();
+      default:
+        throw new RuntimeException(
+            "Unrecognized NullAway serialization version: "
+                + version
+                + ". Supported versions: 1 to "
+                + SerializationAdapter.LATEST_VERSION
+                + ".");
+    }
+  }
 }


### PR DESCRIPTION
This PR prepares for #1063 by moving the `initializeAdapter` declaration from `FixSerializationConfig` to `SerializationVersionAdapter`. This change ensures that version-specific serializations are handled directly by `SerializationVersionAdapter`, which will simplify test modifications in #1063.

This transition also aligns with a clearer design, as `SerializationVersionAdapter` should be responsible for computing the appropriate adapter for each new version. This approach will help us maintain version updates within `SerializationVersionAdapter` while keeping `FixSerializationConfig` unchanged.

I'm uncertain if maintaining backward compatibility is necessary in the long term. If it's not needed, we can consider removing it in the future. For now, however, this PR is required to keep #1063 concise.