### PR TITLE
Use type arguments of generic methods to check for generic type parameter's nullability

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1852,7 +1852,7 @@ public class NullAway extends BugChecker
       }
       if (config.isJSpecifyMode()) {
         GenericsChecks.compareGenericTypeParameterNullabilityForCall(
-            formalParams, actualParams, varArgsMethod, this, state);
+            tree, methodSymbol, formalParams, actualParams, varArgsMethod, this, state);
         if (!methodSymbol.getTypeParameters().isEmpty()) {
           GenericsChecks.checkGenericMethodCallTypeArguments(tree, state, this, config, handler);
         }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -592,10 +592,10 @@ public final class GenericsChecks {
   }
 
   /**
-   * Checks that for each parameter p at a call, the type parameter nullability for p's type matches
-   * that of the corresponding formal parameter. If a mismatch is found, report an error.
+   * Checks that for each actual parameter p at a call, the type parameter nullability for p's type
+   * matches that of the corresponding formal parameter. If a mismatch is found, report an error.
    *
-   * @param tree the tree to get substituted types
+   * @param tree the tree corresponding to the method invocation
    * @param methodSymbol symbol for the invoked method
    * @param formalParams the formal parameters
    * @param actualParams the actual parameters

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -105,8 +105,36 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
-  @Ignore("requires generic method support")
   public void genericMethodAndVoidType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  static class Foo {",
+            "    <C extends @Nullable Object> void foo(C c, Visitor<C> visitor) {",
+            "      visitor.visit(this, c);",
+            "    }",
+            "  }",
+            "  static abstract class Visitor<C extends @Nullable Object> {",
+            "    abstract void visit(Foo foo, C c);",
+            "  }",
+            "  static class MyVisitor extends Visitor<@Nullable Void> {",
+            "    @Override",
+            "    void visit(Foo foo, @Nullable Void c) {}",
+            "  }",
+            "  static void test(Foo f) {",
+            "    // this is safe",
+            "    f.<@Nullable Void>foo(null, new MyVisitor());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  @Ignore("requires generic method inference support")
+  public void genericMethodAndVoidTypeWithInference() {
     makeHelper()
         .addSourceLines(
             "Test.java",


### PR DESCRIPTION
  - I have made NullAway to check generic type parameter's nullability using the type arguments passed at the call site (generic methods).

  - The relevant unit test is `void genericMethodAndVoidType() `in the `jspecify/GenericMethodTests.java` file.