### PR TITLE
Enable javac -parameters flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,8 @@ subprojects { project ->
             "-Xlint:deprecation",
             "-Xlint:rawtypes",
             "-Xlint:unchecked",
-            "-Werror"
+            "-Werror",
+            "-parameters",
         ]
         options.errorprone {
             // disable warnings in generated code; AutoValue code fails UnnecessaryParentheses check

--- a/nullaway/src/test/java/com/uber/nullaway/DummyOptionsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/DummyOptionsConfigTest.java
@@ -50,7 +50,7 @@ public class DummyOptionsConfigTest {
       Throwable cause = reflectionException.getCause();
       assertThat(cause, instanceOf(IllegalStateException.class));
       IllegalStateException exception = (IllegalStateException) cause;
-      assertEquals(exception.getMessage(), DummyOptionsConfig.ERROR_MESSAGE);
+      assertEquals(DummyOptionsConfig.ERROR_MESSAGE, exception.getMessage());
     }
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyAndJspecifyModeTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyAndJspecifyModeTest.java
@@ -42,6 +42,6 @@ public class LegacyAndJspecifyModeTest {
 
     Throwable cause = exception.getCause();
     assertThat(cause, instanceOf(IllegalStateException.class));
-    assertEquals(cause.getMessage(), ERROR);
+    assertEquals(ERROR, cause.getMessage());
   }
 }


### PR DESCRIPTION
This enables Error Prone to discover more issues, e.g., we fix a couple of `assertEquals` argument ordering issues.