### PR TITLE
Fix JarInfer parameter indexes for instance methods

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/BytecodeAnnotator.java
@@ -172,11 +172,9 @@ public final class BytecodeAnnotator {
       }
       Set<Integer> params = nonnullParams.get(methodSignature);
       if (params != null) {
-        boolean isStatic = (method.access & Opcodes.ACC_STATIC) != 0;
         for (Integer param : params) {
-          int paramNum = isStatic ? param : param - 1;
           // Add a @Nonnull annotation on this parameter.
-          method.visitParameterAnnotation(paramNum, nonnullDesc, visible);
+          method.visitParameterAnnotation(param, nonnullDesc, visible);
           LOG(
               debug,
               "DEBUG",

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -273,7 +273,8 @@ public class DefinitelyDerefedParamsDriver {
               String sign = "";
               try {
                 // Parameter analysis
-                if (mtd.getNumberOfParameters() > (mtd.isStatic() ? 0 : 1)) {
+                boolean isStatic = mtd.isStatic();
+                if (mtd.getNumberOfParameters() > (isStatic ? 0 : 1)) {
                   // For inferring parameter nullability, our criteria is based on finding
                   // unchecked dereferences of that parameter. We perform a quick bytecode
                   // check and skip methods containing no dereferences (i.e. method calls
@@ -283,6 +284,11 @@ public class DefinitelyDerefedParamsDriver {
                   if (bytecodeHasAnyDereferences(mtd)) {
                     analysisDriver = getAnalysisDriver(mtd, options, cache);
                     Set<Integer> result = analysisDriver.analyze();
+                    if (!isStatic) {
+                      // subtract 1 from each parameter index to account for 'this' parameter
+                      result =
+                          result.stream().map(i -> i - 1).collect(ImmutableSet.toImmutableSet());
+                    }
                     sign = getSignature(mtd);
                     LOG(DEBUG, "DEBUG", "analyzed method: " + sign);
                     if (!result.isEmpty() || DEBUG) {

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -206,7 +206,7 @@ public class JarInferTest {
         "Test",
         ImmutableMap.of(
             "toys.Test:void test(java.lang.String, toys.Foo, toys.Bar)", Sets.newHashSet(0, 2),
-            "toys.Foo:boolean run(java.lang.String)", Sets.newHashSet(1)),
+            "toys.Foo:boolean run(java.lang.String)", Sets.newHashSet(0)),
         "class Foo {",
         "  private String foo;",
         "  public Foo(String str) {",
@@ -267,7 +267,7 @@ public class JarInferTest {
         "toys",
         "Foo",
         ImmutableMap.of(
-            "toys.Foo:void test(java.lang.String, java.lang.String)", Sets.newHashSet(1)),
+            "toys.Foo:void test(java.lang.String, java.lang.String)", Sets.newHashSet(0)),
         "class Foo {",
         "  private String foo;",
         "  public Foo(String str) {",
@@ -305,7 +305,7 @@ public class JarInferTest {
         "Foo",
         ImmutableMap.of(
             "toys.Foo:void test(java.lang.String, java.lang.String, java.lang.String)",
-            Sets.newHashSet(1, 3)),
+            Sets.newHashSet(0, 2)),
         "import com.google.common.base.Preconditions;",
         "import java.util.Objects;",
         "import org.junit.Assert;",
@@ -336,7 +336,7 @@ public class JarInferTest {
         "Foo",
         ImmutableMap.of(
             "toys.Foo:void test(java.lang.String, java.lang.String, java.lang.String)",
-            Sets.newHashSet(1, 2)),
+            Sets.newHashSet(0, 1)),
         "import com.google.common.base.Preconditions;",
         "import java.util.Objects;",
         "import org.junit.Assert;",
@@ -367,7 +367,7 @@ public class JarInferTest {
         "Foo",
         ImmutableMap.of(
             "toys.Foo:void test(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)",
-            Sets.newHashSet(1, 4)),
+            Sets.newHashSet(0, 3)),
         "import com.google.common.base.Preconditions;",
         "import java.util.Objects;",
         "import org.junit.Assert;",
@@ -407,7 +407,7 @@ public class JarInferTest {
         "toys",
         "Foo",
         ImmutableMap.of(
-            "toys.Foo:void test(java.lang.String, java.lang.String)", Sets.newHashSet(1)),
+            "toys.Foo:void test(java.lang.String, java.lang.String)", Sets.newHashSet(0)),
         "import com.google.common.base.Preconditions;",
         "import java.util.Objects;",
         "import org.junit.Assert;",
@@ -449,7 +449,7 @@ public class JarInferTest {
         "generic",
         "TestGeneric",
         ImmutableMap.of(
-            "generic.TestGeneric:java.lang.String foo(java.lang.Object)", Sets.newHashSet(1)),
+            "generic.TestGeneric:java.lang.String foo(java.lang.Object)", Sets.newHashSet(0)),
         "public class TestGeneric<T> {",
         "  public String foo(T t) {",
         "    return t.toString();",

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -122,7 +122,8 @@ public class JarInferIntegrationTest {
    * project which determines which SDK version's models are being tested.
    */
   @Test
-  @Ignore("temporarily ignore while making some astubx format changes")
+  @Ignore(
+      "temporarily ignore while making some astubx format changes; see https://github.com/uber/NullAway/issues/1072")
   public void jarInferAndroidSDKModels() {
     compilationHelper
         .setArgs(

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -4,6 +4,7 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAway;
 import java.util.Arrays;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -121,6 +122,7 @@ public class JarInferIntegrationTest {
    * project which determines which SDK version's models are being tested.
    */
   @Test
+  @Ignore("temporarily ignore while making some astubx format changes")
   public void jarInferAndroidSDKModels() {
     compilationHelper
         .setArgs(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -131,8 +131,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
     for (Map.Entry<Integer, Set<String>> annotationEntry : methodArgAnnotations.entrySet()) {
       if (annotationEntry.getKey() != RETURN
           && annotationEntry.getValue().contains("javax.annotation.Nonnull")) {
-        // Skip 'this' param for non-static methods
-        int nonNullPosition = annotationEntry.getKey() /* - (methodSymbol.isStatic() ? 0 : 1)*/;
+        int nonNullPosition = annotationEntry.getKey();
         jiNonNullParams.add(nonNullPosition);
         argumentPositionNullness[nonNullPosition] = Nullness.NONNULL;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -132,7 +132,7 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
       if (annotationEntry.getKey() != RETURN
           && annotationEntry.getValue().contains("javax.annotation.Nonnull")) {
         // Skip 'this' param for non-static methods
-        int nonNullPosition = annotationEntry.getKey() - (methodSymbol.isStatic() ? 0 : 1);
+        int nonNullPosition = annotationEntry.getKey() /* - (methodSymbol.isStatic() ? 0 : 1)*/;
         jiNonNullParams.add(nonNullPosition);
         argumentPositionNullness[nonNullPosition] = Nullness.NONNULL;
       }


### PR DESCRIPTION
Previously, when JarInfer wrote an `astubx` file, it treated the receiver parameter of an instance method as being at parameter index 0.  In other places we do library modeling, the receiver parameter is ignored and the next parameter is treated as being at index 0.  The latter handling is more sensible for NullAway, as we have not needed to do any kind of library modeling of receiver parameters yet.

This PR switches the JarInfer logic to ignore the receiver parameter like in other places.  This breaks pre-existing `astubx` files, so we disable an integration test for now.  We will bump the astubx version and fix up existing files in a later PR as part of an overall fix to #1072 (fixing in multiple PRs to ease reviewing).