### PR TITLE
remove use of deprecated Gradle API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,5 +155,7 @@ tasks.register('installGitHooks', Copy) {
         rename 'pre-commit-stub', 'pre-commit'
     }
     into file('.git/hooks')
-    fileMode 0777
+    filePermissions {
+        unix(0777)
+    }
 }


### PR DESCRIPTION
The `fileMode` API will be removed in Gradle 9.0
