### PR TITLE
Fix JarInfer handling of generic types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-        mavenLocal()
     }
 
     // Spotless complains when applied to the folders containing projects

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
+        mavenLocal()
     }
 
     // Spotless complains when applied to the folders containing projects

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.7",
+    wala                   : "1.6.8-SNAPSHOT",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.8-SNAPSHOT",
+    wala                   : "1.6.8",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.8",
+    wala                   : "1.6.9",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -512,24 +512,24 @@ public class DefinitelyDerefedParamsDriver {
     Preconditions.checkArgument(
         mtd instanceof ShrikeCTMethod, "Method is not a ShrikeCTMethod from bytecodes");
     String classType = getSourceLevelQualifiedTypeName(mtd.getDeclaringClass().getReference());
-    MethodTypeSignature sig = null;
+    MethodTypeSignature genericSignature = null;
     try {
-      sig = ((ShrikeCTMethod) mtd).getMethodTypeSignature();
+      genericSignature = ((ShrikeCTMethod) mtd).getMethodTypeSignature();
     } catch (InvalidClassFileException e) {
-      // TODO log something
+      // don't fail, just proceed without the generic signature
+      LOG(DEBUG, "DEBUG", "Invalid class file exception: " + e.getMessage());
     }
     String returnType;
     int numParams = mtd.isStatic() ? mtd.getNumberOfParameters() : mtd.getNumberOfParameters() - 1;
     String[] argTypes = new String[numParams];
-    if (sig != null) {
-      // generics involved
-      returnType = getSourceLevelQualifiedTypeName(sig.getReturnType().toString());
-      TypeSignature[] argTypeSigs = sig.getArguments();
+    if (genericSignature != null) {
+      // get types that include generic type arguments
+      returnType = getSourceLevelQualifiedTypeName(genericSignature.getReturnType().toString());
+      TypeSignature[] argTypeSigs = genericSignature.getArguments();
       for (int i = 0; i < argTypeSigs.length; i++) {
         argTypes[i] = getSourceLevelQualifiedTypeName(argTypeSigs[i].toString());
       }
-    } else {
-      // classType = classType.replaceAll("\\$", "\\."); // handle inner class
+    } else { // no generics
       returnType = mtd.isInit() ? null : getSourceLevelQualifiedTypeName(mtd.getReturnType());
       int argi = mtd.isStatic() ? 0 : 1; // Skip 'this' parameter
       for (int i = 0; i < numParams; i++) {

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -44,6 +44,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.types.generics.MethodTypeSignature;
 import com.ibm.wala.types.generics.TypeSignature;
+import com.ibm.wala.types.generics.TypeVariableSignature;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.config.FileOfClasses;
 import com.uber.nullaway.libmodel.MethodAnnotationsRecord;
@@ -558,12 +559,19 @@ public class DefinitelyDerefedParamsDriver {
   }
 
   private static String getQualifiedTypeName(String typeName) {
-    if (typeName.endsWith(";")) {
-      typeName = typeName.substring(0, typeName.length() - 1);
+    if (!typeName.endsWith(";")) {
+      typeName = typeName + ";";
+      // typeName = typeName.substring(0, typeName.length() - 1);
     }
     boolean isGeneric = typeName.contains("<");
     if (!isGeneric) {
-      return StringStuff.jvmToReadableType(typeName);
+      TypeSignature ts = TypeSignature.make(typeName);
+      if (ts.isTypeVariable()) {
+        return ((TypeVariableSignature) ts).getIdentifier();
+      } else {
+        String tsStr = ts.toString();
+        return StringStuff.jvmToReadableType(tsStr.substring(0, tsStr.length() - 1));
+      }
     }
     int idx = typeName.indexOf("<");
     String baseType = typeName.substring(0, idx);

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -570,12 +570,15 @@ public class DefinitelyDerefedParamsDriver {
         return ((TypeVariableSignature) ts).getIdentifier();
       } else {
         String tsStr = ts.toString();
-        return StringStuff.jvmToReadableType(tsStr.substring(0, tsStr.length() - 1));
+        if (tsStr.endsWith(";")) {
+          tsStr = tsStr.substring(0, tsStr.length() - 1);
+        }
+        return StringStuff.jvmToReadableType(tsStr);
       }
     }
     int idx = typeName.indexOf("<");
     String baseType = typeName.substring(0, idx);
-    String[] genericTypeArgs = typeName.substring(idx + 1, typeName.length() - 1).split(";");
+    String[] genericTypeArgs = typeName.substring(idx + 1, typeName.length() - 2).split(";");
     for (int i = 0; i < genericTypeArgs.length; i++) {
       genericTypeArgs[i] = getQualifiedTypeName(genericTypeArgs[i]);
     }

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -462,6 +462,27 @@ public class JarInferTest {
   }
 
   @Test
+  public void testMethodWithGenericParameter() throws Exception {
+    testTemplate(
+        "testMethodWithGenericParameter",
+        "generic",
+        "TestGeneric",
+        ImmutableMap.of(
+            "generic.TestGeneric:java.lang.String getString(generic.TestGeneric.Generic<java.lang.String,java.lang.String>)",
+            Set.of(0)),
+        "public class TestGeneric {",
+        "  static class Generic<T,U> {",
+        "    public String foo(T t) {",
+        "      return \"hi\";",
+        "    }",
+        "  }",
+        "  public String getString(Generic<String,String> g) {",
+        "    return g.foo(\"test\");",
+        "  }",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -448,8 +448,7 @@ public class JarInferTest {
         "testGenericMethod",
         "generic",
         "TestGeneric",
-        ImmutableMap.of(
-            "generic.TestGeneric:java.lang.String foo(java.lang.Object)", Sets.newHashSet(0)),
+        ImmutableMap.of("generic.TestGeneric:java.lang.String foo(T)", Sets.newHashSet(0)),
         "public class TestGeneric<T> {",
         "  public String foo(T t) {",
         "    return t.toString();",
@@ -469,7 +468,7 @@ public class JarInferTest {
         "TestGeneric",
         ImmutableMap.of(
             "generic.TestGeneric:java.lang.String getString(generic.TestGeneric.Generic<java.lang.String,java.lang.String>)",
-            Set.of(0)),
+            Sets.newHashSet(0)),
         "public class TestGeneric {",
         "  static class Generic<T,U> {",
         "    public String foo(T t) {",

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -88,6 +88,8 @@ public class JarInferIntegrationTest {
             "    Toys.Generic<String> g = new Toys.Generic<>();",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    g.getString(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.genericParam(null);",
             "  }",
             "}")
         .doTest();

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -46,7 +46,6 @@ public class Toys {
   public static void genericParam(Generic<String> g) {
     g.getString("hello");
   }
-  ;
 
   public static void main(String arg[]) throws java.io.IOException {
     String s = "test string...";

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -43,6 +43,11 @@ public class Toys {
     }
   }
 
+  public static void genericParam(Generic<String> g) {
+    g.getString("hello");
+  }
+  ;
+
   public static void main(String arg[]) throws java.io.IOException {
     String s = "test string...";
     Foo f = new Foo("let's");

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -27,7 +27,6 @@ import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
@@ -229,23 +228,17 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
     String methodSign =
         method.enclClass().getQualifiedName().toString()
             + ":"
-            + (method.isStaticOrInstanceInit()
-                ? ""
-                : getSimpleTypeName(method.getReturnType()) + " ")
+            + (method.isStaticOrInstanceInit() ? "" : method.getReturnType() + " ")
             + method.getSimpleName()
             + "(";
     if (!method.getParameters().isEmpty()) {
-      for (Symbol.VarSymbol var : method.getParameters()) {
-        methodSign += getSimpleTypeName(var.type) + ", ";
-      }
-      methodSign = methodSign.substring(0, methodSign.lastIndexOf(','));
+      methodSign +=
+          String.join(
+              ", ",
+              method.getParameters().stream().map(p -> p.type.toString()).toArray(String[]::new));
     }
     methodSign += ")";
     LOG(DEBUG, "DEBUG", "@ method sign: " + methodSign);
     return methodSign;
-  }
-
-  private String getSimpleTypeName(Type typ) {
-    return typ.toString();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InferredJARModelsHandler.java
@@ -38,7 +38,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
 import org.jspecify.annotations.Nullable;
 
@@ -247,10 +246,6 @@ public class InferredJARModelsHandler extends BaseNoOpHandler {
   }
 
   private String getSimpleTypeName(Type typ) {
-    if (typ.getKind() == TypeKind.TYPEVAR) {
-      return typ.getUpperBound().tsym.getQualifiedName().toString();
-    } else {
-      return typ.toString();
-    }
+    return typ.toString();
   }
 }


### PR DESCRIPTION
In particular, fix cases where the type of a method parameter either contains generic type arguments or is itself a type variable.  These fixes are needed for #1072.

We take advantage of the fact that even though `javac` erases generics, it stores full generic type signatures in class file attributes, which WALA is able to read.  So we can recover generic type information from these attributes.  We needed a bug fix from WALA for this to work, hence the WALA version bump.

Not every case is supported here (e.g., we haven't tested generic methods).  But these changes are enough to enable #1072 to move forward, after which we will have a single place to add features and fix bugs.