### PR TITLE
Suggest correct fix when array component of non-nullable array is made null.

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -502,13 +502,8 @@ public class NullAway extends BugChecker
           String message = "Writing @Nullable expression into array with @NonNull contents.";
           ErrorMessage errorMessage =
               new ErrorMessage(MessageTypes.ASSIGN_NULLABLE_TO_NONNULL_ARRAY, message);
-          // Future enhancements which auto-fix such warnings will require modification to this
-          // logic
           return errorBuilder.createErrorDescription(
-              errorMessage,
-              buildDescription(tree),
-              state,
-              ASTHelpers.getSymbol(tree.getVariable()));
+              errorMessage, buildDescription(tree), state, arraySymbol);
         }
       }
     }

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -2126,4 +2126,46 @@ public class SerializationTest extends NullAwayTestsBase {
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
         .doTest();
   }
+
+  @Test
+  public void errorSerializationTestArrayComponentNull() {
+    SerializationTestHelper<ErrorDisplay> tester = new SerializationTestHelper<>(root);
+    tester
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SerializeFixMetadata=true",
+                "-XepOpt:NullAway:JSpecifyMode=true",
+                "-XepOpt:NullAway:FixSerializationConfigPath=" + configPath))
+        .addSourceLines(
+            "com/uber/A.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class A {",
+            "  String [] foo = {\"SomeRandomWords\"};",
+            "  void spin() {",
+            "    // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents.",
+            "    foo[1] = null;",
+            "  }",
+            "}")
+        .setExpectedOutputs(
+            new ErrorDisplay(
+                "ASSIGN_NULLABLE_TO_NONNULL_ARRAY",
+                "Writing @Nullable expression into array with @NonNull contents.",
+                "com.uber.A",
+                "spin()",
+                233,
+                "com/uber/A.java",
+                "FIELD",
+                "com.uber.A",
+                "null",
+                "foo",
+                "null",
+                "com/uber/A.java"))
+        .setFactory(errorDisplayFactory)
+        .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
+        .doTest();
+  }
 }


### PR DESCRIPTION
This PR changes the `ErrorDescription` to pass the `arraySymbol` as the 'nonNullTarget' for a suggested fix in the scenario when the content of an array with component non-nullable is made null. 

I have made the above change and tested it in the unit case `errorSerializationTestArrayComponentNull()` in the `SerializationTest.java` class.