### PR TITLE
Fix reading of JSpecify @Nullable annotations from varargs parameter in bytecode

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -540,15 +540,30 @@ public class NullabilityUtil {
    *     otherwise
    */
   public static boolean isArrayElementNullable(Symbol arraySymbol, Config config) {
-    for (Attribute.TypeCompound t : arraySymbol.getRawTypeAttributes()) {
-      for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
-        if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
-          if (Nullness.isNullableAnnotation(t.type.toString(), config)) {
-            return true;
-          }
-        }
-      }
+    // TODO remove copy-paste!!!!!
+    if (getTypeUseAnnotations(arraySymbol, config, /* onlyDirect= */ false)
+        .anyMatch(
+            t -> {
+              for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
+                if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
+                  if (Nullness.isNullableAnnotation(t.type.toString(), config)) {
+                    return true;
+                  }
+                }
+              }
+              return false;
+            })) {
+      return true;
     }
+    //    for (Attribute.TypeCompound t : arraySymbol.getRawTypeAttributes()) {
+    //      for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
+    //        if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
+    //          if (Nullness.isNullableAnnotation(t.type.toString(), config)) {
+    //            return true;
+    //          }
+    //        }
+    //      }
+    //    }
     // For varargs symbols we also consider the elements to be @Nullable if there is a @Nullable
     // declaration annotation on the parameter
     // NOTE this flag check does not work for the varargs parameter of a method defined in bytecodes

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -51,6 +51,7 @@ import com.sun.tools.javac.util.JCDiagnostic;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
@@ -328,13 +329,13 @@ public class NullabilityUtil {
       return rawTypeAttributes.filter(
           (t) ->
               t.position.type.equals(TargetType.METHOD_RETURN)
-                  && isDirectTypeUseAnnotation(t, symbol, config));
+                  && (!onlyDirect || isDirectTypeUseAnnotation(t, symbol, config)));
     } else {
       // filter for annotations directly on the type
       return rawTypeAttributes.filter(
           t ->
               targetTypeMatches(symbol, t.position)
-                  && (!onlyDirect || NullabilityUtil.isDirectTypeUseAnnotation(t, symbol, config)));
+                  && (!onlyDirect || isDirectTypeUseAnnotation(t, symbol, config)));
     }
   }
 
@@ -540,13 +541,35 @@ public class NullabilityUtil {
    *     otherwise
    */
   public static boolean isArrayElementNullable(Symbol arraySymbol, Config config) {
-    // TODO remove copy-paste!!!!!
+    return checkArrayElementAnnotations(
+        arraySymbol,
+        config,
+        Nullness::isNullableAnnotation,
+        Nullness::hasNullableDeclarationAnnotation);
+  }
+
+  /**
+   * Checks if the annotations on the elements of some array symbol satisfy some predicate.
+   *
+   * @param arraySymbol the array symbol
+   * @param config NullAway configuration
+   * @param typeUseCheck the predicate to check the type-use annotations
+   * @param declarationCheck the predicate to check the declaration annotations (applied only to
+   *     varargs symbols)
+   * @return true if the annotations on the elements of the array symbol satisfy the given
+   *     predicates, false otherwise
+   */
+  private static boolean checkArrayElementAnnotations(
+      Symbol arraySymbol,
+      Config config,
+      BiPredicate<String, Config> typeUseCheck,
+      BiPredicate<Symbol, Config> declarationCheck) {
     if (getTypeUseAnnotations(arraySymbol, config, /* onlyDirect= */ false)
         .anyMatch(
             t -> {
               for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
                 if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
-                  if (Nullness.isNullableAnnotation(t.type.toString(), config)) {
+                  if (typeUseCheck.test(t.type.toString(), config)) {
                     return true;
                   }
                 }
@@ -555,20 +578,10 @@ public class NullabilityUtil {
             })) {
       return true;
     }
-    //    for (Attribute.TypeCompound t : arraySymbol.getRawTypeAttributes()) {
-    //      for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
-    //        if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
-    //          if (Nullness.isNullableAnnotation(t.type.toString(), config)) {
-    //            return true;
-    //          }
-    //        }
-    //      }
-    //    }
-    // For varargs symbols we also consider the elements to be @Nullable if there is a @Nullable
-    // declaration annotation on the parameter
+    // For varargs symbols we also check for declaration annotations on the parameter
     // NOTE this flag check does not work for the varargs parameter of a method defined in bytecodes
     if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
-      return Nullness.hasNullableDeclarationAnnotation(arraySymbol, config);
+      return declarationCheck.test(arraySymbol, config);
     }
     return false;
   }
@@ -597,27 +610,11 @@ public class NullabilityUtil {
    *     otherwise
    */
   public static boolean isArrayElementNonNull(Symbol arraySymbol, Config config) {
-    if (getTypeUseAnnotations(arraySymbol, config, /* onlyDirect= */ false)
-        .anyMatch(
-            t -> {
-              for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
-                if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
-                  if (Nullness.isNonNullAnnotation(t.type.toString(), config)) {
-                    return true;
-                  }
-                }
-              }
-              return false;
-            })) {
-      return true;
-    }
-    // For varargs symbols we also consider the elements to be @NonNull if there is a @NonNull
-    // declaration annotation on the parameter
-    // NOTE this flag check does not work for the varargs parameter of a method defined in bytecodes
-    if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
-      return Nullness.hasNonNullDeclarationAnnotation(arraySymbol, config);
-    }
-    return false;
+    return checkArrayElementAnnotations(
+        arraySymbol,
+        config,
+        Nullness::isNonNullAnnotation,
+        Nullness::hasNonNullDeclarationAnnotation);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -549,44 +549,6 @@ public class NullabilityUtil {
   }
 
   /**
-   * Checks if the annotations on the elements of some array symbol satisfy some predicate.
-   *
-   * @param arraySymbol the array symbol
-   * @param config NullAway configuration
-   * @param typeUseCheck the predicate to check the type-use annotations
-   * @param declarationCheck the predicate to check the declaration annotations (applied only to
-   *     varargs symbols)
-   * @return true if the annotations on the elements of the array symbol satisfy the given
-   *     predicates, false otherwise
-   */
-  private static boolean checkArrayElementAnnotations(
-      Symbol arraySymbol,
-      Config config,
-      BiPredicate<String, Config> typeUseCheck,
-      BiPredicate<Symbol, Config> declarationCheck) {
-    if (getTypeUseAnnotations(arraySymbol, config, /* onlyDirect= */ false)
-        .anyMatch(
-            t -> {
-              for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
-                if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
-                  if (typeUseCheck.test(t.type.toString(), config)) {
-                    return true;
-                  }
-                }
-              }
-              return false;
-            })) {
-      return true;
-    }
-    // For varargs symbols we also check for declaration annotations on the parameter
-    // NOTE this flag check does not work for the varargs parameter of a method defined in bytecodes
-    if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
-      return declarationCheck.test(arraySymbol, config);
-    }
-    return false;
-  }
-
-  /**
    * Checks if the given varargs symbol has a {@code @Nullable} annotation for its elements. Works
    * for both source and bytecode.
    *
@@ -630,6 +592,44 @@ public class NullabilityUtil {
       Symbol varargsSymbol, Config config) {
     return isArrayElementNonNull(varargsSymbol, config)
         || Nullness.hasNonNullDeclarationAnnotation(varargsSymbol, config);
+  }
+
+  /**
+   * Checks if the annotations on the elements of some array symbol satisfy some predicate.
+   *
+   * @param arraySymbol the array symbol
+   * @param config NullAway configuration
+   * @param typeUseCheck the predicate to check the type-use annotations
+   * @param declarationCheck the predicate to check the declaration annotations (applied only to
+   *     varargs symbols)
+   * @return true if the annotations on the elements of the array symbol satisfy the given
+   *     predicates, false otherwise
+   */
+  private static boolean checkArrayElementAnnotations(
+      Symbol arraySymbol,
+      Config config,
+      BiPredicate<String, Config> typeUseCheck,
+      BiPredicate<Symbol, Config> declarationCheck) {
+    if (getTypeUseAnnotations(arraySymbol, config, /* onlyDirect= */ false)
+        .anyMatch(
+            t -> {
+              for (TypeAnnotationPosition.TypePathEntry entry : t.position.location) {
+                if (entry.tag == TypeAnnotationPosition.TypePathEntryKind.ARRAY) {
+                  if (typeUseCheck.test(t.type.toString(), config)) {
+                    return true;
+                  }
+                }
+              }
+              return false;
+            })) {
+      return true;
+    }
+    // For varargs symbols we also check for declaration annotations on the parameter
+    // NOTE this flag check does not work for the varargs parameter of a method defined in bytecodes
+    if ((arraySymbol.flags() & Flags.VARARGS) != 0) {
+      return declarationCheck.test(arraySymbol, config);
+    }
+    return false;
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -107,6 +107,22 @@ public class VarargsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void nullableVarArgsFromBytecodeJSpecify() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.Varargs;",
+            "public class Test {",
+            "  public void testTypeUse() {",
+            "    String x = null;",
+            "    Varargs.typeUseNullableElementsJSpecify(x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void nullableTypeUseVarargs() {
     defaultCompilationHelper
         .addSourceLines(

--- a/test-java-lib/src/main/java/com/uber/lib/Varargs.java
+++ b/test-java-lib/src/main/java/com/uber/lib/Varargs.java
@@ -7,4 +7,7 @@ public class Varargs {
   public Varargs(@Nullable String... args) {}
 
   public static void typeUse(String @org.jspecify.annotations.Nullable ... args) {}
+
+  public static void typeUseNullableElementsJSpecify(
+      @org.jspecify.annotations.Nullable String... args) {}
 }


### PR DESCRIPTION
Fixes #1088 

We had correct code in one place for reading `@NonNull` annotations, but didn't use it for `@Nullable`.  Get rid of the code duplication so we share the logic now.