### PR TITLE
Handle case null in switch statements

### DIFF
--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -244,4 +244,27 @@ public class SwitchTests {
             "}")
         .doTest();
   }
+
+  @Test
+  public void switchStatementCaseNull() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class Test {",
+            "    public enum NullableEnum {",
+            "        VALUE1, VALUE2;",
+            "    }",
+            "    static Object handleNullableEnumCaseNullDefaultStatement(@Nullable NullableEnum nullableEnum) {",
+            "        Object result;",
+            "        switch (nullableEnum) {",
+            "            case null -> result = new Object();",
+            "            default -> result = nullableEnum.toString();",
+            "        }",
+            "        return result;",
+            "    }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -688,7 +688,7 @@ public class NullAway extends BugChecker
       switchSelectorExpression = ((ParenthesizedTree) switchSelectorExpression).getExpression();
     }
 
-    if (mayBeNullExpr(state, switchSelectorExpression)) {
+    if (!TreeUtils.hasNullCaseLabel(tree) && mayBeNullExpr(state, switchSelectorExpression)) {
       String message =
           "switch expression " + state.getSourceForNode(switchSelectorExpression) + " is @Nullable";
       ErrorMessage errorMessage =

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -207,7 +207,7 @@ public class CoreTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void supportSwitchExpression() {
+  public void switchOnNullable() {
     defaultCompilationHelper
         .addSourceLines(
             "TestPositive.java",


### PR DESCRIPTION
In Java 21+, when a `switch` statement contains `case null`, the expression being switched on is allowed to be `null`.

Fixes #930 