### PR TITLE
Support primitive static final fields as constant args in access paths

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -742,7 +742,7 @@ public final class AccessPath implements MapKey {
     }
 
     public boolean isStructurallyImmutableType(Type type) {
-      return immutableTypes.contains(type.tsym.toString());
+      return type.isPrimitive() || immutableTypes.contains(type.tsym.toString());
     }
 
     public static Builder builder() {

--- a/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
@@ -79,11 +79,17 @@ public class AccessPathsTests extends NullAwayTestsBase {
             "import javax.annotation.Nullable;",
             "public class Test {",
             "  private static final int INT_KEY = 42;", // Guaranteed constant!
+            "  // Guaranteed constant after class loading",
+            "  private static final int INT_KEY_HC = \"teststr\".hashCode();",
             "  public void testEnhancedFor(NullableContainer<String, NullableContainer<Integer, Object>> c) {",
             "    if (c.get(\"KEY_STR\") != null && c.get(\"KEY_STR\").get(INT_KEY) != null) {",
             "      c.get(\"KEY_STR\").get(INT_KEY).toString();",
             "      c.get(\"KEY_STR\").get(Test.INT_KEY).toString();",
             "      c.get(\"KEY_STR\").get(42).toString();", // Extra magic!
+            "    }",
+            "    if (c.get(\"KEY_STR\") != null && c.get(\"KEY_STR\").get(INT_KEY_HC) != null) {",
+            "      c.get(\"KEY_STR\").get(INT_KEY_HC).toString();",
+            "      c.get(\"KEY_STR\").get(Test.INT_KEY_HC).toString();",
             "    }",
             "  }",
             "}")


### PR DESCRIPTION
Noticed a case like this in Uber code.