### PR TITLE
Report error for @Nullable synchronized block expression

### DIFF
--- a/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
+++ b/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
@@ -3,6 +3,7 @@ package com.uber.nullaway.jmh;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Tests that all our JMH benchmarks compile successfully */
@@ -14,6 +15,7 @@ public class BenchmarkCompilationTest {
   }
 
   @Test
+  @Ignore("need to update caffeine version")
   public void testCaffeine() throws IOException {
     assertTrue(new CaffeineCompiler().compile());
   }

--- a/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
+++ b/jmh/src/test/java/com/uber/nullaway/jmh/BenchmarkCompilationTest.java
@@ -15,7 +15,7 @@ public class BenchmarkCompilationTest {
   }
 
   @Test
-  @Ignore("need to update caffeine version")
+  @Ignore("Need to update caffeine version; https://github.com/uber/NullAway/issues/1108")
   public void testCaffeine() throws IOException {
     assertTrue(new CaffeineCompiler().compile());
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1776,9 +1776,9 @@ public class NullAway extends BugChecker
       ErrorMessage errorMessage =
           new ErrorMessage(
               MessageTypes.DEREFERENCE_NULLABLE,
-              "synchronized block expression "
+              "synchronized block expression \""
                   + state.getSourceForNode(lockExpr)
-                  + " is @Nullable");
+                  + "\" is @Nullable");
       return errorBuilder.createErrorDescription(
           errorMessage, buildDescription(lockExpr), state, null);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -82,6 +82,7 @@ import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
@@ -186,7 +187,8 @@ public class NullAway extends BugChecker
         BugChecker.CompoundAssignmentTreeMatcher,
         BugChecker.SwitchTreeMatcher,
         BugChecker.TypeCastTreeMatcher,
-        BugChecker.ParameterizedTypeTreeMatcher {
+        BugChecker.ParameterizedTypeTreeMatcher,
+        BugChecker.SynchronizedTreeMatcher {
 
   static final String INITIALIZATION_CHECK_NAME = "NullAway.Init";
   static final String OPTIONAL_CHECK_NAME = "NullAway.Optional";
@@ -1758,6 +1760,27 @@ public class NullAway extends BugChecker
             "enhanced-for expression " + state.getSourceForNode(expr) + " is @Nullable");
     if (mayBeNullExpr(state, expr)) {
       return errorBuilder.createErrorDescription(errorMessage, buildDescription(expr), state, null);
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchSynchronized(SynchronizedTree tree, VisitorState state) {
+    ExpressionTree lockExpr = tree.getExpression();
+    // For a synchronized block `synchronized (e) { ... }`, javac returns `(e)` as the expression.
+    // We strip the outermost parentheses for a nicer-looking error message.
+    if (lockExpr instanceof ParenthesizedTree) {
+      lockExpr = ((ParenthesizedTree) lockExpr).getExpression();
+    }
+    if (mayBeNullExpr(state, lockExpr)) {
+      ErrorMessage errorMessage =
+          new ErrorMessage(
+              MessageTypes.DEREFERENCE_NULLABLE,
+              "synchronized block expression "
+                  + state.getSourceForNode(lockExpr)
+                  + " is @Nullable");
+      return errorBuilder.createErrorDescription(
+          errorMessage, buildDescription(lockExpr), state, null);
     }
     return Description.NO_MATCH;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1071,4 +1071,20 @@ public class CoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void synchronizedDeref() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "TestCase.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class TestCase {",
+            "  public static void foo(@Nullable Object lock) {",
+            "    // BUG: Diagnostic contains: synchronized block expression lock is @Nullable",
+            "    synchronized (lock) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1081,7 +1081,7 @@ public class CoreTests extends NullAwayTestsBase {
             "import org.jspecify.annotations.Nullable;",
             "public class TestCase {",
             "  public static void foo(@Nullable Object lock) {",
-            "    // BUG: Diagnostic contains: synchronized block expression lock is @Nullable",
+            "    // BUG: Diagnostic contains: synchronized block expression \"lock\" is @Nullable",
             "    synchronized (lock) {}",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1080,8 +1080,11 @@ public class CoreTests extends NullAwayTestsBase {
             "package com.uber;",
             "import org.jspecify.annotations.Nullable;",
             "public class TestCase {",
-            "  public static void foo(@Nullable Object lock) {",
+            "  public static void testPositive(@Nullable Object lock) {",
             "    // BUG: Diagnostic contains: synchronized block expression \"lock\" is @Nullable",
+            "    synchronized (lock) {}",
+            "  }",
+            "  public static void testNegative(Object lock) {",
             "    synchronized (lock) {}",
             "  }",
             "}")


### PR DESCRIPTION
Fixes #1103 

The Caffeine JMH benchmark now fails due to the new checking; we will update in a follow-up (#1108)