### PR TITLE
Add support for parameter types with wildcards for JarInfer

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -566,6 +566,9 @@ public class DefinitelyDerefedParamsDriver {
    * @return source-level qualified type name.
    */
   private static String getSourceLevelQualifiedTypeName(String typeName) {
+    if (isWildcard(typeName)) {
+      return sourceLevelWildcardType(typeName);
+    }
     if (!typeName.endsWith(";")) {
       // we need the semicolon since some of WALA's TypeSignature APIs expect it
       typeName = typeName + ";";
@@ -596,6 +599,24 @@ public class DefinitelyDerefedParamsDriver {
           + "<"
           + String.join(",", genericTypeArgs)
           + ">";
+    }
+  }
+
+  private static boolean isWildcard(String typeName) {
+    char firstChar = typeName.charAt(0);
+    return firstChar == '*' || firstChar == '+' || firstChar == '-';
+  }
+
+  private static String sourceLevelWildcardType(String typeName) {
+    switch (typeName.charAt(0)) {
+      case '*':
+        return "?";
+      case '+':
+        return "? extends " + getSourceLevelQualifiedTypeName(typeName.substring(1));
+      case '-':
+        return "? super " + getSourceLevelQualifiedTypeName(typeName.substring(1));
+      default:
+        throw new RuntimeException("unexpected wildcard type name" + typeName);
     }
   }
 }

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -482,6 +482,33 @@ public class JarInferTest {
   }
 
   @Test
+  public void wildcards() throws Exception {
+    testTemplate(
+        "wildcards",
+        "generic",
+        "TestGeneric",
+        ImmutableMap.of(
+            "generic.TestGeneric:void genericWildcardLower(generic.TestGeneric.Generic<? super java.lang.String>)",
+            Sets.newHashSet(0),
+            "generic.TestGeneric:void genericWildcard(generic.TestGeneric.Generic<?>)",
+            Sets.newHashSet(0),
+            "generic.TestGeneric:java.lang.String genericWildcardUpper(generic.TestGeneric.Generic<? extends java.lang.String>)",
+            Sets.newHashSet(0)),
+        "public class TestGeneric {",
+        "  public abstract static class Generic<T> {",
+        "    public String getString(T t) {",
+        "      return \"t\";",
+        "    }",
+        "    public void doNothing() {}",
+        "    public abstract T getSomething();",
+        "  }",
+        "  public static void genericWildcard(Generic<?> g) { g.doNothing(); };",
+        "  public static String genericWildcardUpper(Generic<? extends String> g) { return g.getSomething(); };",
+        "  public static void genericWildcardLower(Generic<? super String> g) { g.getString(\"hello\"); };",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -84,12 +84,39 @@ public class JarInferIntegrationTest {
             "import org.jspecify.annotations.Nullable;",
             "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
             "class Test {",
-            "  void test1() {",
-            "    Toys.Generic<String> g = new Toys.Generic<>();",
+            "  void test1(Toys.Generic<String> g) {",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    g.getString(null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericParam(null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void wildcards() {
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:JarInferEnabled=true",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
+            "class Test {",
+            "  void test1() {",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.genericWildcard(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.genericWildcardUpper(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.genericWildcardLower(null);",
             "  }",
             "}")
         .doTest();

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -54,17 +54,14 @@ public class Toys {
   public static void genericWildcard(Generic<?> g) {
     g.doNothing();
   }
-  ;
 
   public static String genericWildcardUpper(Generic<? extends String> g) {
     return g.getSomething();
   }
-  ;
 
   public static void genericWildcardLower(Generic<? super String> g) {
     g.getString("hello");
   }
-  ;
 
   public static void main(String arg[]) throws java.io.IOException {
     String s = "test string...";

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -37,15 +37,34 @@ public class Toys {
     return o.hashCode();
   }
 
-  public static class Generic<T> {
+  public abstract static class Generic<T> {
     public String getString(T t) {
       return t.toString();
     }
+
+    public void doNothing() {}
+
+    public abstract T getSomething();
   }
 
   public static void genericParam(Generic<String> g) {
     g.getString("hello");
   }
+
+  public static void genericWildcard(Generic<?> g) {
+    g.doNothing();
+  }
+  ;
+
+  public static String genericWildcardUpper(Generic<? extends String> g) {
+    return g.getSomething();
+  }
+  ;
+
+  public static void genericWildcardLower(Generic<? super String> g) {
+    g.getString("hello");
+  }
+  ;
 
   public static void main(String arg[]) throws java.io.IOException {
     String s = "test string...";

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -1370,8 +1370,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
           for (Map.Entry<Integer, Set<String>> entry : innerEntry.getValue().entrySet()) {
             Integer index = entry.getKey();
             if (index >= 0 && entry.getValue().stream().anyMatch(a -> a.contains("Nullable"))) {
-              // remove spaces
-              methodNameAndSignature = methodNameAndSignature.replaceAll("\\s", "");
+              // remove spaces after commas
+              methodNameAndSignature = methodNameAndSignature.replaceAll(",\\s", ",");
               mapBuilder.put(methodRef(className, methodNameAndSignature), index);
             }
           }
@@ -1403,8 +1403,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                           + methodEntry.getKey()
                           + " arg "
                           + argEntry.getKey());
-                  // remove spaces
-                  methodNameAndSignature = methodNameAndSignature.replaceAll("\\s", "");
+                  // remove spaces after commas
+                  methodNameAndSignature = methodNameAndSignature.replaceAll(",\\s", ",");
                   mapBuilder.put(methodRef(className, methodNameAndSignature), index);
                 }
               }


### PR DESCRIPTION
Partially addresses #1096 

Converts wildcard types stored in bytecodes to the corresponding source-level types.  We will add this support to the library models code in a follow up.