### PR TITLE
Fix issue with annotations in `module-info.java` files

### DIFF
--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
@@ -35,6 +35,7 @@ public class ModuleInfoTests {
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",
+            "@SuppressWarnings(\"some-warning-name\")",
             "module com.uber.mymodule {",
             "  // Important: two-level deep module tests matching of identifier `java` as base expression;",
             "  // see further discussion at https://github.com/uber/NullAway/pull/544#discussion_r780829467",

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -486,6 +486,12 @@ public class NullAway extends BugChecker
       doUnboxingCheck(state, tree.getExpression());
     }
     Symbol assigned = ASTHelpers.getSymbol(tree.getVariable());
+    if (assigned instanceof Symbol.MethodSymbol) {
+      // javac generates an AssignmentTree for setting an annotation attribute value.  E.g., for
+      // `@SuppressWarnings("foo")`, javac generates an AssignmentTree of the form `value() =
+      // "foo"`, where the LHS is a MethodSymbol.  We don't want to analyze these.
+      return Description.NO_MATCH;
+    }
     if (assigned != null && codeAnnotationInfo.isSymbolUnannotated(assigned, config, handler)) {
       // assigning to symbol that is unannotated
       return Description.NO_MATCH;


### PR DESCRIPTION
`javac` generates `AssignmentTree`s for assigning annotation attributes that, in the context of a `module-info.java` file, was causing a crash.  Just skip analysis of such assignments.