### PR TITLE
Properly handle nested generics and multiple wildcard type args in JarInfer

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -526,6 +526,12 @@ public class DefinitelyDerefedParamsDriver {
       // get types that include generic type arguments
       returnType = getSourceLevelQualifiedTypeName(genericSignature.getReturnType().toString());
       TypeSignature[] argTypeSigs = genericSignature.getArguments();
+      if (argTypeSigs.length != numParams) {
+        throw new RuntimeException(
+            String.format(
+                "Mismatch in number of parameters in generic signature: %s with %d vs %s with %d",
+                mtd.getSignature(), numParams, genericSignature, argTypeSigs.length));
+      }
       for (int i = 0; i < argTypeSigs.length; i++) {
         argTypes[i] = getSourceLevelQualifiedTypeName(argTypeSigs[i].toString());
       }
@@ -591,6 +597,7 @@ public class DefinitelyDerefedParamsDriver {
       int idx = typeName.indexOf("<");
       String baseType = typeName.substring(0, idx);
       // generic type args are separated by semicolons in signature stored in bytecodes
+      // TODO this does not handle nested generic types properly!
       String[] genericTypeArgs = typeName.substring(idx + 1, typeName.length() - 2).split(";");
       for (int i = 0; i < genericTypeArgs.length; i++) {
         genericTypeArgs[i] = getSourceLevelQualifiedTypeName(genericTypeArgs[i]);

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -529,12 +529,13 @@ public class DefinitelyDerefedParamsDriver {
       // get types that include generic type arguments
       returnType = getSourceLevelQualifiedTypeName(genericSignature.getReturnType().toString());
       TypeSignature[] argTypeSigs = genericSignature.getArguments();
-      if (argTypeSigs.length != numParams) {
-        throw new RuntimeException(
-            String.format(
-                "Mismatch in number of parameters in generic signature: %s with %d vs %s with %d",
-                mtd.getSignature(), numParams, genericSignature, argTypeSigs.length));
-      }
+      Verify.verify(
+          argTypeSigs.length != numParams,
+          "Mismatch in number of parameters in generic signature: %s with %s vs %s with %s",
+          mtd.getSignature(),
+          numParams,
+          genericSignature,
+          argTypeSigs.length);
       for (int i = 0; i < argTypeSigs.length; i++) {
         argTypes[i] = getSourceLevelQualifiedTypeName(argTypeSigs[i].toString());
       }

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -530,6 +530,23 @@ public class JarInferTest {
   }
 
   @Test
+  public void multiArgWildcards() throws Exception {
+    testTemplate(
+        "multiArgWildcards",
+        "generic",
+        "TestGeneric",
+        ImmutableMap.of(
+            "generic.TestGeneric:void genericMultiWildcard(java.lang.String, generic.TestGeneric.Generic<?,?>)",
+            Sets.newHashSet(1)),
+        "public class TestGeneric {",
+        "  public abstract static class Generic<T,U> {",
+        "    public void doNothing() {}",
+        "  }",
+        "  public static void genericMultiWildcard(String s, Generic<?,?> g) { g.doNothing(); };",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -547,6 +547,23 @@ public class JarInferTest {
   }
 
   @Test
+  public void nestedWildcard() throws Exception {
+    testTemplate(
+        "nestedWildcard",
+        "generic",
+        "TestGeneric",
+        ImmutableMap.of(
+            "generic.TestGeneric:void nestedWildcard(generic.TestGeneric.Generic<generic.TestGeneric.Generic<?>>)",
+            Sets.newHashSet(0)),
+        "public class TestGeneric {",
+        "  public abstract static class Generic<T> {",
+        "    public void doNothing() {}",
+        "  }",
+        "  public static void nestedWildcard(Generic<Generic<?>> g) { g.doNothing(); };",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -482,6 +482,27 @@ public class JarInferTest {
   }
 
   @Test
+  public void nestedGeneric() throws Exception {
+    testTemplate(
+        "nestedGeneric",
+        "generic",
+        "TestGeneric",
+        ImmutableMap.of(
+            "generic.TestGeneric:java.lang.String getString(generic.TestGeneric.Generic<generic.TestGeneric.Generic<java.lang.String>>)",
+            Sets.newHashSet(0)),
+        "public class TestGeneric {",
+        "  static class Generic<T> {",
+        "    public String foo(T t) {",
+        "      return \"hi\";",
+        "    }",
+        "  }",
+        "  public String getString(Generic<Generic<String>> g) {",
+        "    return g.foo(null);",
+        "  }",
+        "}");
+  }
+
+  @Test
   public void wildcards() throws Exception {
     testTemplate(
         "wildcards",

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -89,6 +89,8 @@ public class JarInferIntegrationTest {
             "    g.getString(null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericParam(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.nestedGenericParam(null);",
             "  }",
             "}")
         .doTest();
@@ -117,6 +119,9 @@ public class JarInferIntegrationTest {
             "    Toys.genericWildcardUpper(null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericWildcardLower(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.doubleGenericWildcard(\"\", null);",
+            "    Toys.doubleGenericWildcardNullOk(\"\", null);",
             "  }",
             "}")
         .doTest();

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -116,6 +116,8 @@ public class JarInferIntegrationTest {
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericWildcard(null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
+            "    Toys.nestedGenericWildcard(null);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericWildcardUpper(null);",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
             "    Toys.genericWildcardLower(null);",

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -59,6 +59,10 @@ public class Toys {
     g.doNothing();
   }
 
+  public static void nestedGenericWildcard(Generic<Generic<?>> g) {
+    g.doNothing();
+  }
+
   public static String genericWildcardUpper(Generic<? extends String> g) {
     return g.getSomething();
   }

--- a/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
+++ b/jar-infer/test-java-lib-jarinfer/src/main/java/com/uber/nullaway/jarinfer/toys/unannotated/Toys.java
@@ -51,6 +51,10 @@ public class Toys {
     g.getString("hello");
   }
 
+  public static void nestedGenericParam(Generic<Generic<String>> g) {
+    g.getString(null);
+  }
+
   public static void genericWildcard(Generic<?> g) {
     g.doNothing();
   }
@@ -61,6 +65,20 @@ public class Toys {
 
   public static void genericWildcardLower(Generic<? super String> g) {
     g.getString("hello");
+  }
+
+  public abstract static class DoubleGeneric<T, U> {
+    public void doNothing() {}
+  }
+
+  public static void doubleGenericWildcard(String s, DoubleGeneric<?, ?> g) {
+    g.doNothing();
+  }
+
+  public static void doubleGenericWildcardNullOk(String s, DoubleGeneric<?, ?> g) {
+    if (g != null) {
+      g.doNothing();
+    }
   }
 
   public static void main(String arg[]) throws java.io.IOException {


### PR DESCRIPTION
Our previous code would crash on nested generic types or when multiple unbounded wildcard type arguments were passed consecutively. 