### PR TITLE
Skip checks involving wildcard generic type arguments

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -55,6 +55,11 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     for (int i = 0; i < lhsTypeArguments.size(); i++) {
       Type lhsTypeArgument = lhsTypeArguments.get(i);
       Type rhsTypeArgument = rhsTypeArguments.get(i);
+      if (lhsTypeArgument.getKind().equals(TypeKind.WILDCARD)
+          || rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
+        // TODO Handle wildcard types
+        continue;
+      }
       boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsTypeArgument, state);
       boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsTypeArgument, state);
       if (isLHSNullableAnnotated != isRHSNullableAnnotated) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2084,6 +2084,24 @@ public class GenericsTests extends NullAwayTestsBase {
             "        Supplier<? extends @Nullable Object> s = () -> null;",
             "    }",
             "}")
+        .addSourceLines(
+            "Test2.java",
+            "package com.uber;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jetbrains.annotations.Contract;",
+            "public class Test2 {",
+            "    @Contract(\"null -> true\")",
+            "    public static boolean isEmpty(@Nullable Map<?, ? extends @Nullable Object> map) {",
+            "        return (map == null || map.isEmpty());",
+            "    }",
+            "    static void foo() {",
+            "        Map<String, @Nullable Object> variables = new HashMap<>();",
+            "        if (isEmpty(variables)) { /* do nothing */ }",
+            "        variables.toString();",
+            "    }",
+            "}")
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2069,6 +2069,24 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1126() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.util.function.Supplier;",
+            "public class Test {",
+            "    static class K<T extends @Nullable Object> {}",
+            "    void foo(K<@Nullable Object> k) {",
+            "        K<? extends @Nullable Object> k2 = k;",
+            "        Supplier<? extends @Nullable Object> s = () -> null;",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
We need to handle wildcards eventually, but in the meantime, avoid reporting false positives.

Fixes #1126 