### PR TITLE
Properly handle conditional expression within parens as RHS of assignment

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -19,6 +19,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
@@ -584,7 +585,12 @@ public final class GenericsChecks {
       ConditionalExpressionTree tree, VisitorState state) {
     // hack: sometimes array nullability doesn't get computed correctly for a conditional expression
     // on the RHS of an assignment.  So, look at the type of the assignment tree.
-    Tree parent = state.getPath().getParentPath().getLeaf();
+    TreePath parentPath = state.getPath().getParentPath();
+    Tree parent = parentPath.getLeaf();
+    while (parent instanceof ParenthesizedTree) {
+      parentPath = parentPath.getParentPath();
+      parent = parentPath.getLeaf();
+    }
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
       return getTreeType(parent, state);
     }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2046,6 +2046,21 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1127() {
+    makeHelper()
+        .addSourceLines(
+            "Main.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class Main {",
+            "  void arrayAssign(boolean b, @Nullable String @Nullable [] vals) {",
+            "    @Nullable String[] arr = (b ? vals : null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void nullUnmarkedGenericField() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1127 

Our previous (hacky) logic for determining the type of a conditional expression on the RHS of an assignment did not account for the expression possibly being enclosed in parentheses.