### PR TITLE
Remove need to use JSpecify's @Nullable annotation

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -3,6 +3,7 @@ package com.uber.nullaway.generics;
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
+import com.uber.nullaway.Config;
 import java.util.List;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
@@ -14,9 +15,11 @@ import javax.lang.model.type.TypeKind;
  */
 public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<Boolean, Type> {
   private final VisitorState state;
+  private final Config config;
 
-  CheckIdenticalNullabilityVisitor(VisitorState state) {
+  CheckIdenticalNullabilityVisitor(VisitorState state, Config config) {
     this.state = state;
+    this.config = config;
   }
 
   @Override
@@ -60,8 +63,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
         // TODO Handle wildcard types
         continue;
       }
-      boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsTypeArgument, state);
-      boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsTypeArgument, state);
+      boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsTypeArgument, config);
+      boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsTypeArgument, config);
       if (isLHSNullableAnnotated != isRHSNullableAnnotated) {
         return false;
       }
@@ -91,8 +94,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     Type.ArrayType arrRhsType = (Type.ArrayType) rhsType;
     Type lhsComponentType = lhsType.getComponentType();
     Type rhsComponentType = arrRhsType.getComponentType();
-    boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsComponentType, state);
-    boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsComponentType, state);
+    boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsComponentType, config);
+    boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsComponentType, config);
     if (isRHSNullableAnnotated != isLHSNullableAnnotated) {
       return false;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -457,7 +457,8 @@ public final class GenericsChecks {
       Symbol.MethodSymbol methodSymbol,
       NullAway analysis,
       VisitorState state) {
-    if (!analysis.getConfig().isJSpecifyMode()) {
+    Config config = analysis.getConfig();
+    if (!config.isJSpecifyMode()) {
       return;
     }
 
@@ -466,11 +467,10 @@ public final class GenericsChecks {
       // bail out of any checking involving raw types for now
       return;
     }
-    Type returnExpressionType = getTreeType(retExpr, analysis.getConfig());
+    Type returnExpressionType = getTreeType(retExpr, config);
     if (formalReturnType != null && returnExpressionType != null) {
       boolean isReturnTypeValid =
-          subtypeParameterNullability(
-              formalReturnType, returnExpressionType, state, analysis.getConfig());
+          subtypeParameterNullability(formalReturnType, returnExpressionType, state, config);
       if (!isReturnTypeValid) {
         reportInvalidReturnTypeError(
             retExpr, formalReturnType, returnExpressionType, state, analysis);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -103,7 +103,7 @@ public final class GenericsChecks {
       return;
     }
     boolean[] typeParamsWithNullableUpperBound =
-        getTypeParamsWithNullableUpperBound(baseType, config, state, handler);
+        getTypeParamsWithNullableUpperBound(baseType, config, handler);
     com.sun.tools.javac.util.List<Type> baseTypeArgs = baseType.tsym.type.getTypeArguments();
     for (int i = 0; i < baseTypeArgs.size(); i++) {
       if (nullableTypeArguments.containsKey(i) && !typeParamsWithNullableUpperBound[i]) {
@@ -116,7 +116,7 @@ public final class GenericsChecks {
   }
 
   private static boolean[] getTypeParamsWithNullableUpperBound(
-      Type type, Config config, VisitorState state, Handler handler) {
+      Type type, Config config, Handler handler) {
     Symbol.TypeSymbol tsym = type.tsym;
     com.sun.tools.javac.util.List<Type> baseTypeArgs = tsym.type.getTypeArguments();
     boolean[] result = new boolean[baseTypeArgs.size()];
@@ -139,8 +139,8 @@ public final class GenericsChecks {
     if (rawTypeAttributes != null) {
       for (Attribute.TypeCompound typeCompound : rawTypeAttributes) {
         if (typeCompound.position.type.equals(TargetType.CLASS_TYPE_PARAMETER_BOUND)
-            && ASTHelpers.isSameType(
-                typeCompound.type, JSPECIFY_NULLABLE_TYPE_SUPPLIER.get(state), state)) {
+            && Nullness.isNullableAnnotation(
+                typeCompound.type.tsym.getQualifiedName().toString(), config)) {
           int index = typeCompound.position.parameter_index;
           result[index] = true;
         }
@@ -369,9 +369,10 @@ public final class GenericsChecks {
    *
    * @param tree A tree for which we need the type with preserved annotations.
    * @param state the visitor state
+   * @param config the analysis config
    * @return Type of the tree with preserved annotations.
    */
-  private static @Nullable Type getTreeType(Tree tree, VisitorState state) {
+  private static @Nullable Type getTreeType(Tree tree, VisitorState state, Config config) {
     if (tree instanceof NewClassTree
         && ((NewClassTree) tree).getIdentifier() instanceof ParameterizedTypeTree) {
       ParameterizedTypeTree paramTypedTree =
@@ -381,10 +382,10 @@ public final class GenericsChecks {
         // TODO: support diamond operators
         return null;
       }
-      return typeWithPreservedAnnotations(paramTypedTree, state);
+      return typeWithPreservedAnnotations(paramTypedTree, state, config);
     } else if (tree instanceof NewArrayTree
         && ((NewArrayTree) tree).getType() instanceof AnnotatedTypeTree) {
-      return typeWithPreservedAnnotations(tree, state);
+      return typeWithPreservedAnnotations(tree, state, config);
     } else {
       Type result;
       if (tree instanceof VariableTree || tree instanceof IdentifierTree) {
@@ -428,7 +429,7 @@ public final class GenericsChecks {
     if (!analysis.getConfig().isJSpecifyMode()) {
       return;
     }
-    Type lhsType = getTreeType(tree, state);
+    Type lhsType = getTreeType(tree, state, analysis.getConfig());
     Tree rhsTree;
     if (tree instanceof VariableTree) {
       VariableTree varTree = (VariableTree) tree;
@@ -442,10 +443,11 @@ public final class GenericsChecks {
     if (rhsTree == null || rhsTree.getKind().equals(Tree.Kind.NULL_LITERAL)) {
       return;
     }
-    Type rhsType = getTreeType(rhsTree, state);
+    Type rhsType = getTreeType(rhsTree, state, analysis.getConfig());
 
     if (lhsType != null && rhsType != null) {
-      boolean isAssignmentValid = subtypeParameterNullability(lhsType, rhsType, state);
+      boolean isAssignmentValid =
+          subtypeParameterNullability(lhsType, rhsType, state, analysis.getConfig());
       if (!isAssignmentValid) {
         reportInvalidAssignmentInstantiationError(tree, lhsType, rhsType, state, analysis);
       }
@@ -475,10 +477,11 @@ public final class GenericsChecks {
       // bail out of any checking involving raw types for now
       return;
     }
-    Type returnExpressionType = getTreeType(retExpr, state);
+    Type returnExpressionType = getTreeType(retExpr, state, analysis.getConfig());
     if (formalReturnType != null && returnExpressionType != null) {
       boolean isReturnTypeValid =
-          subtypeParameterNullability(formalReturnType, returnExpressionType, state);
+          subtypeParameterNullability(
+              formalReturnType, returnExpressionType, state, analysis.getConfig());
       if (!isReturnTypeValid) {
         reportInvalidReturnTypeError(
             retExpr, formalReturnType, returnExpressionType, state, analysis);
@@ -498,20 +501,20 @@ public final class GenericsChecks {
    * @param state the visitor state
    */
   private static boolean identicalTypeParameterNullability(
-      Type lhsType, Type rhsType, VisitorState state) {
-    return lhsType.accept(new CheckIdenticalNullabilityVisitor(state), rhsType);
+      Type lhsType, Type rhsType, VisitorState state, Config config) {
+    return lhsType.accept(new CheckIdenticalNullabilityVisitor(state, config), rhsType);
   }
 
   /**
-   * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState)}, but allows for
-   * covariant array subtyping at the top level.
+   * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState, Config)}, but allows
+   * for covariant array subtyping at the top level.
    *
    * @param lhsType type for the lhs of the assignment
    * @param rhsType type for the rhs of the assignment
    * @param state the visitor state
    */
   private static boolean subtypeParameterNullability(
-      Type lhsType, Type rhsType, VisitorState state) {
+      Type lhsType, Type rhsType, VisitorState state, Config config) {
     if (lhsType.getKind().equals(TypeKind.ARRAY) && rhsType.getKind().equals(TypeKind.ARRAY)) {
       // for array types we must allow covariance, i.e., an array of @NonNull references is a
       // subtype of an array of @Nullable references; see
@@ -520,15 +523,15 @@ public final class GenericsChecks {
       Type.ArrayType rhsArrayType = (Type.ArrayType) rhsType;
       Type lhsComponentType = lhsArrayType.getComponentType();
       Type rhsComponentType = rhsArrayType.getComponentType();
-      boolean isLHSNullableAnnotated = isNullableAnnotated(lhsComponentType, state);
-      boolean isRHSNullableAnnotated = isNullableAnnotated(rhsComponentType, state);
+      boolean isLHSNullableAnnotated = isNullableAnnotated(lhsComponentType, config);
+      boolean isRHSNullableAnnotated = isNullableAnnotated(rhsComponentType, config);
       // an array of @Nullable references is _not_ a subtype of an array of @NonNull references
       if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
         return false;
       }
-      return identicalTypeParameterNullability(lhsComponentType, rhsComponentType, state);
+      return identicalTypeParameterNullability(lhsComponentType, rhsComponentType, state, config);
     } else {
-      return identicalTypeParameterNullability(lhsType, rhsType, state);
+      return identicalTypeParameterNullability(lhsType, rhsType, state, config);
     }
   }
 
@@ -541,8 +544,8 @@ public final class GenericsChecks {
    * @param state the visitor state
    * @return A Type with preserved annotations.
    */
-  private static Type typeWithPreservedAnnotations(Tree tree, VisitorState state) {
-    return tree.accept(new PreservedAnnotationTreeVisitor(state), null);
+  private static Type typeWithPreservedAnnotations(Tree tree, VisitorState state, Config config) {
+    return tree.accept(new PreservedAnnotationTreeVisitor(state, config), null);
   }
 
   /**
@@ -562,28 +565,29 @@ public final class GenericsChecks {
    */
   public static void checkTypeParameterNullnessForConditionalExpression(
       ConditionalExpressionTree tree, NullAway analysis, VisitorState state) {
-    if (!analysis.getConfig().isJSpecifyMode()) {
+    Config config = analysis.getConfig();
+    if (!config.isJSpecifyMode()) {
       return;
     }
 
     Tree truePartTree = tree.getTrueExpression();
     Tree falsePartTree = tree.getFalseExpression();
 
-    Type condExprType = getConditionalExpressionType(tree, state);
-    Type truePartType = getTreeType(truePartTree, state);
-    Type falsePartType = getTreeType(falsePartTree, state);
+    Type condExprType = getConditionalExpressionType(tree, state, config);
+    Type truePartType = getTreeType(truePartTree, state, config);
+    Type falsePartType = getTreeType(falsePartTree, state, config);
     // The condExpr type should be the least-upper bound of the true and false part types.  To check
     // the nullability annotations, we check that the true and false parts are assignable to the
     // type of the whole expression
     if (condExprType != null) {
       if (truePartType != null) {
-        if (!subtypeParameterNullability(condExprType, truePartType, state)) {
+        if (!subtypeParameterNullability(condExprType, truePartType, state, config)) {
           reportMismatchedTypeForTernaryOperator(
               truePartTree, condExprType, truePartType, state, analysis);
         }
       }
       if (falsePartType != null) {
-        if (!subtypeParameterNullability(condExprType, falsePartType, state)) {
+        if (!subtypeParameterNullability(condExprType, falsePartType, state, config)) {
           reportMismatchedTypeForTernaryOperator(
               falsePartTree, condExprType, falsePartType, state, analysis);
         }
@@ -592,7 +596,7 @@ public final class GenericsChecks {
   }
 
   private static @Nullable Type getConditionalExpressionType(
-      ConditionalExpressionTree tree, VisitorState state) {
+      ConditionalExpressionTree tree, VisitorState state, Config config) {
     // hack: sometimes array nullability doesn't get computed correctly for a conditional expression
     // on the RHS of an assignment.  So, look at the type of the assignment tree.
     TreePath parentPath = state.getPath().getParentPath();
@@ -602,9 +606,9 @@ public final class GenericsChecks {
       parent = parentPath.getLeaf();
     }
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
-      return getTreeType(parent, state);
+      return getTreeType(parent, state, config);
     }
-    return getTreeType(tree, state);
+    return getTreeType(tree, state, config);
   }
 
   /**
@@ -625,7 +629,8 @@ public final class GenericsChecks {
       boolean isVarArgs,
       NullAway analysis,
       VisitorState state) {
-    if (!analysis.getConfig().isJSpecifyMode()) {
+    Config config = analysis.getConfig();
+    if (!config.isJSpecifyMode()) {
       return;
     }
     Type invokedMethodType = methodSymbol.type;
@@ -634,7 +639,8 @@ public final class GenericsChecks {
       ExpressionTree methodSelect = ((MethodInvocationTree) tree).getMethodSelect();
       Type enclosingType;
       if (methodSelect instanceof MemberSelectTree) {
-        enclosingType = getTreeType(((MemberSelectTree) methodSelect).getExpression(), state);
+        enclosingType =
+            getTreeType(((MemberSelectTree) methodSelect).getExpression(), state, config);
       } else {
         // implicit this parameter
         enclosingType = methodSymbol.owner.type;
@@ -662,9 +668,9 @@ public final class GenericsChecks {
         // bail out of any checking involving raw types for now
         return;
       }
-      Type actualParameter = getTreeType(actualParams.get(i), state);
+      Type actualParameter = getTreeType(actualParams.get(i), state, config);
       if (actualParameter != null) {
-        if (!subtypeParameterNullability(formalParameter, actualParameter, state)) {
+        if (!subtypeParameterNullability(formalParameter, actualParameter, state, config)) {
           reportInvalidParametersNullabilityError(
               formalParameter, actualParameter, actualParams.get(i), state, analysis);
         }
@@ -675,12 +681,13 @@ public final class GenericsChecks {
           (Type.ArrayType) formalParamTypes.get(formalParamTypes.size() - 1);
       Type varargsElementType = varargsArrayType.elemtype;
       for (int i = formalParamTypes.size() - 1; i < actualParams.size(); i++) {
-        Type actualParameterType = getTreeType(actualParams.get(i), state);
+        Type actualParameterType = getTreeType(actualParams.get(i), state, config);
         // If the actual parameter type is assignable to the varargs array type, then the call site
         // is passing the varargs directly in an array, and we should skip our check.
         if (actualParameterType != null
             && !state.getTypes().isAssignable(actualParameterType, varargsArrayType)) {
-          if (!subtypeParameterNullability(varargsElementType, actualParameterType, state)) {
+          if (!subtypeParameterNullability(
+              varargsElementType, actualParameterType, state, config)) {
             reportInvalidParametersNullabilityError(
                 varargsElementType, actualParameterType, actualParams.get(i), state, analysis);
           }
@@ -752,7 +759,7 @@ public final class GenericsChecks {
    */
   public static Nullness getGenericMethodReturnTypeNullness(
       Symbol.MethodSymbol method, Symbol enclosingSymbol, VisitorState state, Config config) {
-    Type enclosingType = getTypeForSymbol(enclosingSymbol, state);
+    Type enclosingType = getTypeForSymbol(enclosingSymbol, state, config);
     return getGenericMethodReturnTypeNullness(method, enclosingType, state, config);
   }
 
@@ -761,9 +768,10 @@ public final class GenericsChecks {
    *
    * @param symbol the symbol
    * @param state the visitor state
+   * @param config the analysis config
    * @return the type for {@code symbol}
    */
-  private static @Nullable Type getTypeForSymbol(Symbol symbol, VisitorState state) {
+  private static @Nullable Type getTypeForSymbol(Symbol symbol, VisitorState state, Config config) {
     if (symbol.isAnonymous()) {
       // For anonymous classes, symbol.type does not contain annotations on generic type parameters.
       // So, we get a correct type from the enclosing NewClassTree.
@@ -773,7 +781,7 @@ public final class GenericsChecks {
         throw new RuntimeException(
             "method should be inside a NewClassTree " + state.getSourceForNode(path.getLeaf()));
       }
-      Type typeFromTree = getTreeType(newClassTree, state);
+      Type typeFromTree = getTreeType(newClassTree, state, config);
       if (typeFromTree != null) {
         verify(state.getTypes().isAssignable(symbol.type, typeFromTree));
       }
@@ -853,7 +861,7 @@ public final class GenericsChecks {
       return Nullness.NONNULL;
     }
     Type methodReceiverType =
-        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state);
+        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state, config);
     if (methodReceiverType == null) {
       return Nullness.NONNULL;
     } else {
@@ -956,7 +964,7 @@ public final class GenericsChecks {
       return Nullness.NONNULL;
     }
     Type enclosingType =
-        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state);
+        getTreeType(((MemberSelectTree) tree.getMethodSelect()).getExpression(), state, config);
     return getGenericMethodParameterNullness(
         paramIndex, invokedMethodSymbol, enclosingType, state, config);
   }
@@ -998,7 +1006,7 @@ public final class GenericsChecks {
       Symbol enclosingSymbol,
       VisitorState state,
       Config config) {
-    Type enclosingType = getTypeForSymbol(enclosingSymbol, state);
+    Type enclosingType = getTypeForSymbol(enclosingSymbol, state, config);
     return getGenericMethodParameterNullness(parameterIndex, method, enclosingType, state, config);
   }
 
@@ -1047,12 +1055,13 @@ public final class GenericsChecks {
     List<? extends VariableTree> methodParameters = tree.getParameters();
     List<Type> overriddenMethodParameterTypes = overriddenMethodType.getParameterTypes();
     for (int i = 0; i < methodParameters.size(); i++) {
-      Type overridingMethodParameterType = getTreeType(methodParameters.get(i), state);
+      Config config = analysis.getConfig();
+      Type overridingMethodParameterType = getTreeType(methodParameters.get(i), state, config);
       Type overriddenMethodParameterType = overriddenMethodParameterTypes.get(i);
       if (overriddenMethodParameterType != null && overridingMethodParameterType != null) {
         // allow contravariant subtyping
         if (!subtypeParameterNullability(
-            overridingMethodParameterType, overriddenMethodParameterType, state)) {
+            overridingMethodParameterType, overriddenMethodParameterType, state, config)) {
           reportInvalidOverridingMethodParamTypeError(
               methodParameters.get(i),
               overriddenMethodParameterType,
@@ -1085,7 +1094,7 @@ public final class GenericsChecks {
     }
     // allow covariant subtyping
     if (!subtypeParameterNullability(
-        overriddenMethodReturnType, overridingMethodReturnType, state)) {
+        overriddenMethodReturnType, overridingMethodReturnType, state, analysis.getConfig())) {
       reportInvalidOverridingMethodReturnTypeError(
           tree, overriddenMethodReturnType, overridingMethodReturnType, analysis, state);
     }
@@ -1156,18 +1165,7 @@ public final class GenericsChecks {
     return callingUnannotated;
   }
 
-  public static boolean isNullableAnnotated(Type type, VisitorState state) {
-    boolean result = false;
-    // To ensure that we are checking only jspecify nullable annotations
-    Type jspecifyNullableType = JSPECIFY_NULLABLE_TYPE_SUPPLIER.get(state);
-    List<Attribute.TypeCompound> lhsAnnotations = type.getAnnotationMirrors();
-    for (Attribute.TypeCompound annotation : lhsAnnotations) {
-      if (ASTHelpers.isSameType(
-          (Type) annotation.getAnnotationType(), jspecifyNullableType, state)) {
-        result = true;
-        break;
-      }
-    }
-    return result;
+  public static boolean isNullableAnnotated(Type type, Config config) {
+    return Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -415,10 +415,11 @@ public final class GenericsChecks {
    */
   public static void checkTypeParameterNullnessForAssignability(
       Tree tree, NullAway analysis, VisitorState state) {
-    if (!analysis.getConfig().isJSpecifyMode()) {
+    Config config = analysis.getConfig();
+    if (!config.isJSpecifyMode()) {
       return;
     }
-    Type lhsType = getTreeType(tree, analysis.getConfig());
+    Type lhsType = getTreeType(tree, config);
     Tree rhsTree;
     if (tree instanceof VariableTree) {
       VariableTree varTree = (VariableTree) tree;
@@ -432,11 +433,10 @@ public final class GenericsChecks {
     if (rhsTree == null || rhsTree.getKind().equals(Tree.Kind.NULL_LITERAL)) {
       return;
     }
-    Type rhsType = getTreeType(rhsTree, analysis.getConfig());
+    Type rhsType = getTreeType(rhsTree, config);
 
     if (lhsType != null && rhsType != null) {
-      boolean isAssignmentValid =
-          subtypeParameterNullability(lhsType, rhsType, state, analysis.getConfig());
+      boolean isAssignmentValid = subtypeParameterNullability(lhsType, rhsType, state, config);
       if (!isAssignmentValid) {
         reportInvalidAssignmentInstantiationError(tree, lhsType, rhsType, state, analysis);
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -72,6 +72,8 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
       if (annotSymbol != null
           && Nullness.isNullableAnnotation(annotSymbol.getQualifiedName().toString(), config)) {
         hasNullableAnnotation = true;
+        // save the type of the nullable annotation, so that we can use it when constructing the
+        // TypeMetadata object below
         nullableType = castToNonNull(ASTHelpers.getType(annotation));
         break;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -2,7 +2,6 @@ package com.uber.nullaway.generics;
 
 import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
-import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.AnnotationTree;
@@ -33,13 +32,9 @@ import java.util.List;
  */
 public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void> {
 
-  @SuppressWarnings("UnusedVariable")
-  private final VisitorState state;
-
   private final Config config;
 
-  PreservedAnnotationTreeVisitor(VisitorState state, Config config) {
-    this.state = state;
+  PreservedAnnotationTreeVisitor(Config config) {
     this.config = config;
   }
 
@@ -81,7 +76,6 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
         break;
       }
     }
-    // Type nullableType = GenericsChecks.JSPECIFY_NULLABLE_TYPE_SUPPLIER.get(state);
     // construct a TypeMetadata object containing a nullability annotation if needed
     com.sun.tools.javac.util.List<Attribute.TypeCompound> nullableAnnotationCompound =
         hasNullableAnnotation

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -70,7 +70,9 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
     List<? extends AnnotationTree> annotations = annotatedType.getAnnotations();
     boolean hasNullableAnnotation = false;
     for (AnnotationTree annotation : annotations) {
-      if (Nullness.isNullableAnnotation(annotation.getAnnotationType().toString(), config)) {
+      if (Nullness.isNullableAnnotation(
+          ASTHelpers.getSymbol(annotation.getAnnotationType()).getQualifiedName().toString(),
+          config)) {
         hasNullableAnnotation = true;
         break;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -33,7 +33,9 @@ import java.util.List;
  */
 public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void> {
 
+  @SuppressWarnings("UnusedVariable")
   private final VisitorState state;
+
   private final Config config;
 
   PreservedAnnotationTreeVisitor(VisitorState state, Config config) {
@@ -69,15 +71,17 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
   public Type visitAnnotatedType(AnnotatedTypeTree annotatedType, Void unused) {
     List<? extends AnnotationTree> annotations = annotatedType.getAnnotations();
     boolean hasNullableAnnotation = false;
+    Type nullableType = null;
     for (AnnotationTree annotation : annotations) {
-      if (Nullness.isNullableAnnotation(
-          ASTHelpers.getSymbol(annotation.getAnnotationType()).getQualifiedName().toString(),
-          config)) {
+      Symbol annotSymbol = ASTHelpers.getSymbol(annotation.getAnnotationType());
+      if (annotSymbol != null
+          && Nullness.isNullableAnnotation(annotSymbol.getQualifiedName().toString(), config)) {
         hasNullableAnnotation = true;
+        nullableType = castToNonNull(ASTHelpers.getType(annotation));
         break;
       }
     }
-    Type nullableType = GenericsChecks.JSPECIFY_NULLABLE_TYPE_SUPPLIER.get(state);
+    // Type nullableType = GenericsChecks.JSPECIFY_NULLABLE_TYPE_SUPPLIER.get(state);
     // construct a TypeMetadata object containing a nullability annotation if needed
     com.sun.tools.javac.util.List<Attribute.TypeCompound> nullableAnnotationCompound =
         hasNullableAnnotation

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -294,6 +294,27 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void genericsChecksForAssignmentsWithNonJSpecifyAnnotations() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "class Test {",
+            "  static class NullableTypeParam<E extends @Nullable Object> {}",
+            "  static void testNoWarningForMismatch(NullableTypeParam<@Nullable String> t1) {",
+            "    // we still get an error here as we are not forcing use of JSpecify's @Nullable",
+            "    // BUG: Diagnostic contains: Cannot assign from type NullableTypeParam<@Nullable String>",
+            "    NullableTypeParam<String> t2 = t1;",
+            "  }",
+            "  static void testNegative(NullableTypeParam<@Nullable String> t1) {",
+            "    NullableTypeParam<@Nullable String> t2 = t1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void nestedChecksForAssignmentsMultipleArguments() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1327,13 +1327,23 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void issue1139() {
+  public void otherTypeUseNullableAnnotation() {
     makeHelper()
+        .addSourceLines(
+            "Nullable.java",
+            "package com.other;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "@Target(ElementType.TYPE_USE)",
+            "@Retention(RetentionPolicy.CLASS)",
+            "public @interface Nullable {}")
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
             "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
+            "import com.other.Nullable;",
             "@NullMarked",
             "class Foo {",
             "    static abstract class MyClass<T extends @Nullable Object>  {",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1327,6 +1327,31 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1139() {
+    makeHelper()
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Foo {",
+            "    static abstract class MyClass<T extends @Nullable Object>  {",
+            "        abstract T doThing(T value);",
+            "    }",
+            "    static void repro() {",
+            "        new MyClass<@Nullable Object>() {",
+            "            @Override",
+            "            @Nullable Object doThing(@Nullable Object value) {",
+            "                return value;",
+            "            }",
+            "        }.doThing(null);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void nullableVoidGenericsLambda() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -294,26 +294,6 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void genericsChecksForAssignmentsWithNonJSpecifyAnnotations() {
-    makeHelper()
-        .addSourceLines(
-            "Test.java",
-            "package com.uber;",
-            "import org.checkerframework.checker.nullness.qual.Nullable;",
-            "class Test {",
-            "  static class NullableTypeParam<E extends @Nullable Object> {}",
-            "  static void testNoWarningForMismatch(NullableTypeParam<@Nullable String> t1) {",
-            "    // no error here since we only do our checks for JSpecify @Nullable annotations",
-            "    NullableTypeParam<String> t2 = t1;",
-            "  }",
-            "  static void testNegative(NullableTypeParam<@Nullable String> t1) {",
-            "    NullableTypeParam<@Nullable String> t2 = t1;",
-            "  }",
-            "}")
-        .doTest();
-  }
-
-  @Test
   public void nestedChecksForAssignmentsMultipleArguments() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1139.  There are real scenarios where projects may not want to ship with a JSpecify dependence; see https://github.com/uber/NullAway/issues/1139#issuecomment-2638705075.  So, we remove any cases where we were specifically checking for or using JSpecify's `@Nullable` annotation.

Most of the code changes are due to the fact that now, we check if an annotation is a `@Nullable` annotation using `Nullness.hasNullableAnnotation`, which requires a `Config` object as a parameter.  So we need to thread a `Config` object as a parameter through a bunch of methods.  