### PR TITLE
Ignore Spring Framework 6.2 `@MockitoBean`, `@MockitoSpyBean` fields

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -178,7 +178,9 @@ final class ErrorProneCLIFlagsConfig implements Config {
           "org.checkerframework.checker.nullness.qual.MonotonicNonNull",
           "org.springframework.beans.factory.annotation.Autowired",
           "org.springframework.boot.test.mock.mockito.MockBean",
-          "org.springframework.boot.test.mock.mockito.SpyBean");
+          "org.springframework.boot.test.mock.mockito.SpyBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoSpyBean");
 
   private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
 

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -388,6 +388,8 @@ public class FrameworkTests extends NullAwayTestsBase {
     defaultCompilationHelper
         .addSourceFile("testdata/springboot-annotations/MockBean.java")
         .addSourceFile("testdata/springboot-annotations/SpyBean.java")
+        .addSourceFile("testdata/springboot-annotations/MockitoBean.java")
+        .addSourceFile("testdata/springboot-annotations/MockitoSpyBean.java")
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
@@ -406,7 +408,13 @@ public class FrameworkTests extends NullAwayTestsBase {
             "import org.junit.jupiter.api.Test;",
             "import org.springframework.boot.test.mock.mockito.SpyBean;",
             "import org.springframework.boot.test.mock.mockito.MockBean;",
+            "import org.springframework.test.context.bean.override.mockito.MockitoBean;",
+            "import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;",
             "public class TestCase {",
+            "  @MockitoSpyBean",
+            "  private Foo sf62Spy;", // Initialized by spring test (via Mockito).
+            "  @MockitoBean",
+            "  private Foo sf62Mock;", // Initialized by spring test (via Mockito).
             "  @SpyBean",
             "  private Foo spy;", // Initialized by spring test (via Mockito).
             "  @MockBean",
@@ -415,6 +423,8 @@ public class FrameworkTests extends NullAwayTestsBase {
             "  void springTest() {",
             "    spy.setBar(\"hello\");",
             "    mock.setBar(\"hello\");",
+            "    sf62Spy.setBar(\"hello\");",
+            "    sf62Mock.setBar(\"hello\");",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/springboot-annotations/MockitoBean.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/springboot-annotations/MockitoBean.java
@@ -1,0 +1,13 @@
+package org.springframework.test.context.bean.override.mockito;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MockitoBean {
+}

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/springboot-annotations/MockitoSpyBean.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/springboot-annotations/MockitoSpyBean.java
@@ -1,0 +1,13 @@
+package org.springframework.test.context.bean.override.mockito;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MockitoSpyBean {
+}


### PR DESCRIPTION
Spring Framework 6.2 introduced two annotations, `@MockitoBean` and `@MockitoSpyBean`, that supersede Spring Boot's `@MockBean` and `@SpyBean`. Add these annotations to the field ignore list.