### PR TITLE
Add more bailouts for raw types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -44,7 +44,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       return true;
     }
     // bail out of checking raw types for now
-    if (rhsTypeAsSuper.isRaw()) {
+    if (rhsTypeAsSuper.isRaw() || lhsType.isRaw()) {
       return true;
     }
     List<Type> lhsTypeArguments = lhsType.getTypeArguments();

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -504,6 +504,9 @@ public final class GenericsChecks {
    */
   private static boolean subtypeParameterNullability(
       Type lhsType, Type rhsType, VisitorState state, Config config) {
+    if (lhsType.isRaw()) {
+      return true;
+    }
     if (lhsType.getKind().equals(TypeKind.ARRAY) && rhsType.getKind().equals(TypeKind.ARRAY)) {
       // for array types we must allow covariance, i.e., an array of @NonNull references is a
       // subtype of an array of @Nullable references; see

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1023,6 +1023,26 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void rawVarargsParam() {
+    makeHelper()
+        .addSourceLines(
+            "Foo.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Foo {",
+            "  public interface Supplier<T extends @Nullable Object> extends java.util.function.Supplier<T> {",
+            "  }",
+            "  public static void waitForAll(Runnable callback, Supplier... suppliers) {",
+            "  }",
+            "  public static void test(Supplier<Object> sup2) {",
+            "     waitForAll(() -> {}, sup2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void nestedGenericTypeAssignment() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1151 

The extra check in `CheckIdenticalNullabilityVisitor` is not needed to fix this bug but seemed like a prudent addition.