### PR TITLE
Add missing override to `RestoreNullnessAnnotationsVisitor`

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -120,6 +120,18 @@ public class TypeSubstitutionUtils {
       return updated != null ? updated : t;
     }
 
+    @Override
+    public Type visitForAll(Type.ForAll t, Type other) {
+      Type methodType = t.qtype;
+      Type otherMethodType = ((Type.ForAll) other).qtype;
+      Type newMethodType = visit(methodType, otherMethodType);
+      if (methodType == newMethodType) {
+        return t;
+      } else {
+        return new Type.ForAll(t.tvars, newMethodType);
+      }
+    }
+
     /**
      * Updates the nullability annotations on a type {@code t} based on the nullability annotations
      * on a type variable {@code other}.

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2258,6 +2258,26 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1129() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.util.function.Consumer;",
+            "class Test {",
+            "    interface BodySpec<B, S extends BodySpec<B, S>> {",
+            "        <T extends S> T value(Consumer<@Nullable B> consumer);",
+            "    }",
+            "    abstract class DefaultBodySpec<B, S extends BodySpec<B, S>> implements BodySpec<B, S> {",
+            "        @Override",
+            "        public abstract <T extends S> T value(Consumer<@Nullable B> consumer);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
We missed the case for `ForAll` types (for generic methods)

Fixes #1129 