### PR TITLE
JSpecify: properly handle lambdas in anonymous inner classes

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -800,6 +800,10 @@ public class NullAway extends BugChecker
             paramNullness =
                 GenericsChecks.getGenericMethodParameterNullness(
                     i, overriddenMethod, ASTHelpers.getType(memberReferenceTree), state, config);
+          } else if (lambdaExpressionTree != null) {
+            paramNullness =
+                GenericsChecks.getGenericMethodParameterNullness(
+                    i, overriddenMethod, ASTHelpers.getType(lambdaExpressionTree), state, config);
           } else {
             // Use the enclosing class of the overriding method to find generic type arguments
             paramNullness =

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -794,16 +794,17 @@ public class NullAway extends BugChecker
         } else if (config.isJSpecifyMode()) {
           // Check if the parameter type is a type variable and the corresponding generic type
           // argument is @Nullable
-          if (memberReferenceTree != null) {
-            // For a method reference, we get generic type arguments from the javac's inferred type
-            // for the tree, which seems to properly preserve type-use annotations
+          if (memberReferenceTree != null || lambdaExpressionTree != null) {
+            // For a method reference or lambda, we get generic type arguments from the javac's
+            // inferred type for the tree, which seems to properly preserve type-use annotations
             paramNullness =
                 GenericsChecks.getGenericMethodParameterNullness(
-                    i, overriddenMethod, ASTHelpers.getType(memberReferenceTree), state, config);
-          } else if (lambdaExpressionTree != null) {
-            paramNullness =
-                GenericsChecks.getGenericMethodParameterNullness(
-                    i, overriddenMethod, ASTHelpers.getType(lambdaExpressionTree), state, config);
+                    i,
+                    overriddenMethod,
+                    ASTHelpers.getType(
+                        memberReferenceTree != null ? memberReferenceTree : lambdaExpressionTree),
+                    state,
+                    config);
           } else {
             // Use the enclosing class of the overriding method to find generic type arguments
             paramNullness =

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -825,7 +825,7 @@ public final class GenericsChecks {
       path = ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class);
       NewClassTree newClassTree = (NewClassTree) path.getLeaf();
       while (newClassTree.getClassBody() == null) {
-        newClassTree = ASTHelpers.findEnclosingNode(path, NewClassTree.class);
+        newClassTree = castToNonNull(ASTHelpers.findEnclosingNode(path, NewClassTree.class));
       }
       if (newClassTree == null) {
         throw new RuntimeException(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -824,6 +824,7 @@ public final class GenericsChecks {
       TreePath path = state.getPath();
       path = ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class);
       NewClassTree newClassTree = (NewClassTree) path.getLeaf();
+      // The NewClassTree for the enclosing anonymous class will have a non-null class body
       while (newClassTree.getClassBody() == null) {
         newClassTree = castToNonNull(ASTHelpers.findEnclosingNode(path, NewClassTree.class));
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -765,9 +765,13 @@ public final class GenericsChecks {
   private static @Nullable Type getTypeForSymbol(Symbol symbol, VisitorState state, Config config) {
     if (symbol.isAnonymous()) {
       // For anonymous classes, symbol.type does not contain annotations on generic type parameters.
-      // So, we get a correct type from the enclosing NewClassTree.
+      // So, we get a correct type from the enclosing NewClassTree representing the anonymous class.
       TreePath path = state.getPath();
-      NewClassTree newClassTree = ASTHelpers.findEnclosingNode(path, NewClassTree.class);
+      path = ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class);
+      NewClassTree newClassTree = (NewClassTree) path.getLeaf();
+      while (newClassTree.getClassBody() == null) {
+        newClassTree = ASTHelpers.findEnclosingNode(path, NewClassTree.class);
+      }
       if (newClassTree == null) {
         throw new RuntimeException(
             "method should be inside a NewClassTree " + state.getSourceForNode(path.getLeaf()));

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -824,13 +824,10 @@ public final class GenericsChecks {
       TreePath path = state.getPath();
       path = ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class);
       NewClassTree newClassTree = (NewClassTree) path.getLeaf();
-      // The NewClassTree for the enclosing anonymous class will have a non-null class body
-      while (newClassTree.getClassBody() == null) {
-        newClassTree = castToNonNull(ASTHelpers.findEnclosingNode(path, NewClassTree.class));
-      }
-      if (newClassTree == null) {
+      if (newClassTree == null || newClassTree.getClassBody() == null) {
         throw new RuntimeException(
-            "method should be inside a NewClassTree " + state.getSourceForNode(path.getLeaf()));
+            "method should be directly inside an anonymous NewClassTree "
+                + state.getSourceForNode(path.getLeaf()));
       }
       Type typeFromTree = getTreeType(newClassTree, config);
       if (typeFromTree != null) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -774,7 +774,11 @@ public final class GenericsChecks {
       }
       Type typeFromTree = getTreeType(newClassTree, config);
       if (typeFromTree != null) {
-        verify(state.getTypes().isAssignable(symbol.type, typeFromTree));
+        verify(
+            state.getTypes().isAssignable(symbol.type, typeFromTree),
+            "%s is not assignable to %s",
+            symbol.type,
+            typeFromTree);
       }
       return typeFromTree;
     } else {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2298,6 +2298,35 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1156() {
+    makeHelper()
+        .addSourceLines(
+            "Foo.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.function.Function;",
+            "import java.util.function.Supplier;",
+            "@NullMarked",
+            "public class Foo implements Supplier<Integer> {",
+            "  public Foo(Function<Integer, Integer> func) {",
+            "  }",
+            "  @Override",
+            "  public Integer get() {",
+            "    return 0;",
+            "  }",
+            "  public static void test() {",
+            "    new Supplier<Boolean>() {",
+            "      @Override",
+            "      public Boolean get() {",
+            "        Foo foo = new Foo(x -> 1);",
+            "        return true;",
+            "      }",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -527,7 +527,7 @@ public class GenericsTests extends NullAwayTestsBase {
             "    A<@Nullable Object> p = x -> x.toString();",
             "  }",
             "  static void testNegative() {",
-            "    A<Object, Object> p = x -> \"hello\";",
+            "    A<Object> p = x -> \"hello\";",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -508,6 +508,32 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void testForLambdaInAssignment() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  interface A<T1 extends @Nullable Object> {",
+            "    String function(T1 o);",
+            "  }",
+            "  static String foo(Object o) {",
+            "    return o.toString();",
+            "  }",
+            "  static void testPositive() {",
+            "    // BUG: Diagnostic contains: dereferenced expression x is @Nullable",
+            "    A<@Nullable Object> p = x -> x.toString();",
+            "  }",
+            "  static void testNegative() {",
+            "    A<Object, Object> p = x -> \"hello\";",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testForMethodReferenceForClassFieldAssignment() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1156

When checking correctness of lambda overrides we get the type from `javac`'s inferred type rather than using the enclosing class.  Also, when getting the type of an anonymous class we add some extra assertions to ensure we find the right `NewClassTree` representing the anonymous class.  I _think_ we'll always get the right tree now, but the asserts give peace of mind.