### PR TITLE
Update to Error Prone 2.37.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,13 +25,13 @@ jobs:
             epVersion: 2.31.0
           - os: macos-latest
             java: 17
-            epVersion: 2.36.0
+            epVersion: 2.37.0
           - os: windows-latest
             java: 17
-            epVersion: 2.36.0
+            epVersion: 2.37.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.36.0
+            epVersion: 2.37.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.36.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.37.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.36.0"
+def latestErrorProneVersion = "2.37.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -22,6 +22,7 @@
 
 package com.uber.nullaway;
 
+import static com.google.errorprone.util.ASTHelpers.enclosingClass;
 import static com.uber.nullaway.ASTHelpersBackports.hasDirectAnnotationWithSimpleName;
 import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 
@@ -112,7 +113,7 @@ public final class CodeAnnotationInfo {
    *     {@code @Generated}; false otherwise
    */
   public boolean isGenerated(Symbol symbol, Config config) {
-    Symbol.ClassSymbol classSymbol = ASTHelpers.enclosingClass(symbol);
+    Symbol.ClassSymbol classSymbol = enclosingClass(symbol);
     if (classSymbol == null) {
       Preconditions.checkArgument(
           isClassFieldOfPrimitiveType(
@@ -139,7 +140,7 @@ public final class CodeAnnotationInfo {
         && symbol.owner != null
         && symbol.owner.getKind().equals(ElementKind.CLASS)
         && symbol.owner.getQualifiedName().equals(symbol.owner.getSimpleName())
-        && symbol.owner.enclClass() == null;
+        && enclosingClass(symbol) == null;
   }
 
   /**
@@ -163,7 +164,7 @@ public final class CodeAnnotationInfo {
       // have weirder problems than this)
       return true;
     } else {
-      classSymbol = castToNonNull(ASTHelpers.enclosingClass(symbol));
+      classSymbol = castToNonNull(enclosingClass(symbol));
     }
     ClassCacheRecord classCacheRecord = get(classSymbol, config, handler);
     boolean inAnnotatedClass = classCacheRecord.isNullnessAnnotated;
@@ -217,7 +218,7 @@ public final class CodeAnnotationInfo {
           || owner.getKind().equals(ElementKind.CONSTRUCTOR)) {
         enclosingMethod = (Symbol.MethodSymbol) owner;
       }
-      Symbol.ClassSymbol enclosingClass = ASTHelpers.enclosingClass(classSymbol);
+      Symbol.ClassSymbol enclosingClass = enclosingClass(classSymbol);
       // enclosingClass can be null in weird cases like for array methods
       if (enclosingClass != null) {
         ClassCacheRecord recordForEnclosing = get(enclosingClass, config, handler);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -654,12 +654,11 @@ public class NullAway extends BugChecker
       // If this is a @NullMarked method of a @NullUnmarked local or anonymous class, we need to set
       // its environment mapping, since we skipped it during matchClass.
       TreePath pathToEnclosingClass =
-          castToNonNull(
-              ASTHelpers.findPathFromEnclosingNodeToTopLevel(state.getPath(), ClassTree.class));
-      ClassTree enclosingClass = (ClassTree) pathToEnclosingClass.getLeaf();
-      if (enclosingClass == null) {
+          ASTHelpers.findPathFromEnclosingNodeToTopLevel(state.getPath(), ClassTree.class);
+      if (pathToEnclosingClass == null) {
         return;
       }
+      ClassTree enclosingClass = (ClassTree) pathToEnclosingClass.getLeaf();
       NestingKind nestingKind = ASTHelpers.getSymbol(enclosingClass).getNestingKind();
       if (nestingKind.equals(NestingKind.LOCAL) || nestingKind.equals(NestingKind.ANONYMOUS)) {
         updateEnvironmentMapping(pathToEnclosingClass, state);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -654,7 +654,8 @@ public class NullAway extends BugChecker
       // If this is a @NullMarked method of a @NullUnmarked local or anonymous class, we need to set
       // its environment mapping, since we skipped it during matchClass.
       TreePath pathToEnclosingClass =
-          ASTHelpers.findPathFromEnclosingNodeToTopLevel(state.getPath(), ClassTree.class);
+          castToNonNull(
+              ASTHelpers.findPathFromEnclosingNodeToTopLevel(state.getPath(), ClassTree.class));
       ClassTree enclosingClass = (ClassTree) pathToEnclosingClass.getLeaf();
       if (enclosingClass == null) {
         return;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStoreInitializer.java
@@ -1,5 +1,7 @@
 package com.uber.nullaway.dataflow;
 
+import static com.google.errorprone.util.ASTHelpers.enclosingClass;
+
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.util.Trees;
@@ -66,15 +68,15 @@ public abstract class NullnessStoreInitializer {
     // we need this while loop since we can have a NestingKind.NESTED class (i.e., a nested
     // class declared at the top-level within its enclosing class) nested (possibly deeply)
     // within a NestingKind.ANONYMOUS or NestingKind.LOCAL class
-    while (symbol.getNestingKind().isNested()) {
+    while (symbol != null && symbol.getNestingKind().isNested()) {
       if (symbol.getNestingKind().equals(NestingKind.ANONYMOUS)
           || symbol.getNestingKind().equals(NestingKind.LOCAL)) {
         return Trees.instance(JavacProcessingEnvironment.instance(context)).getTree(symbol);
       } else {
         // symbol.owner is the enclosing element, which could be a class or a method.
-        // if it's a class, the enclClass() method will (surprisingly) return the class itself,
+        // if it's a class, the enclosingClass() method will (surprisingly) return the class itself,
         // so this works
-        symbol = symbol.owner.enclClass();
+        symbol = enclosingClass(symbol);
       }
     }
     return null;

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV3Adapter.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/adapters/SerializationV3Adapter.java
@@ -22,6 +22,8 @@
 
 package com.uber.nullaway.fixserialization.adapters;
 
+import static com.google.errorprone.util.ASTHelpers.enclosingClass;
+import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import static com.uber.nullaway.fixserialization.out.ErrorInfo.EMPTY_NONNULL_TARGET_LOCATION_STRING;
 import static java.util.stream.Collectors.joining;
 
@@ -93,7 +95,7 @@ public class SerializationV3Adapter implements SerializationAdapter {
     if (methodSymbol.isConstructor()) {
       // For constructors, method's simple name is <init> and not the enclosing class, need to
       // locate the enclosing class.
-      Symbol.ClassSymbol encClass = methodSymbol.owner.enclClass();
+      Symbol.ClassSymbol encClass = castToNonNull(enclosingClass(methodSymbol));
       Name name = encClass.getSimpleName();
       if (name.isEmpty()) {
         // An anonymous class cannot declare its own constructor. Based on this assumption and our

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -822,9 +822,10 @@ public final class GenericsChecks {
       // For anonymous classes, symbol.type does not contain annotations on generic type parameters.
       // So, we get a correct type from the enclosing NewClassTree representing the anonymous class.
       TreePath path = state.getPath();
-      path = ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class);
+      path =
+          castToNonNull(ASTHelpers.findPathFromEnclosingNodeToTopLevel(path, NewClassTree.class));
       NewClassTree newClassTree = (NewClassTree) path.getLeaf();
-      if (newClassTree == null || newClassTree.getClassBody() == null) {
+      if (newClassTree.getClassBody() == null) {
         throw new RuntimeException(
             "method should be directly inside an anonymous NewClassTree "
                 + state.getSourceForNode(path.getLeaf()));

--- a/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
@@ -11,6 +11,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link com.uber.nullaway.NullAway}. */
 @RunWith(JUnit4.class)
+@SuppressWarnings("deprecation")
 public class AndroidTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class ContractsTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -31,16 +31,19 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CoreTests extends NullAwayTestsBase {
 
+  @SuppressWarnings("deprecation")
   @Test
   public void coreNullabilityPositiveCases() {
     defaultCompilationHelper.addSourceFile("testdata/NullAwayPositiveCases.java").doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void nullabilityAnonymousClass() {
     defaultCompilationHelper.addSourceFile("testdata/NullAwayAnonymousClass.java").doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void coreNullabilityNegativeCases() {
     defaultCompilationHelper
@@ -51,6 +54,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void assertSupportPositiveCases() {
     defaultCompilationHelper
@@ -58,6 +62,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void assertSupportNegativeCases() {
     makeTestHelperWithArgs(
@@ -276,6 +281,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testCastToNonNull() {
     defaultCompilationHelper
@@ -297,6 +303,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testCastToNonNullExtraArgsWarning() {
     defaultCompilationHelper
@@ -403,6 +410,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testCapturingScopes() {
     defaultCompilationHelper.addSourceFile("testdata/CapturingScopes.java").doTest();
@@ -654,6 +662,7 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void tryFinallySupport() {
     defaultCompilationHelper.addSourceFile("testdata/NullAwayTryFinallyCases.java").doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class FrameworkTests extends NullAwayTestsBase {
   @Test
   public void lombokSupportTesting() {

--- a/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class InitializationTests extends NullAwayTestsBase {
   @Test
   public void initFieldPositiveCases() {

--- a/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
@@ -3,16 +3,19 @@ package com.uber.nullaway;
 import org.junit.Test;
 
 public class Java8Tests extends NullAwayTestsBase {
+  @SuppressWarnings("deprecation")
   @Test
   public void java8PositiveCases() {
     defaultCompilationHelper.addSourceFile("testdata/NullAwayJava8PositiveCases.java").doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void java8NegativeCases() {
     defaultCompilationHelper.addSourceFile("testdata/NullAwayJava8NegativeCases.java").doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void functionalMethodSuperInterface() {
     defaultCompilationHelper
@@ -20,6 +23,7 @@ public class Java8Tests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void functionalMethodOverrideSuperInterface() {
     defaultCompilationHelper

--- a/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class ThriftTests extends NullAwayTestsBase {
   @Test
   public void testThriftIsSet() {

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -3,6 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class UnannotatedTests extends NullAwayTestsBase {
 
   @Test


### PR DESCRIPTION
We suppress some warnings on tests as they will be much easier to fix with text blocks, which we can only use once we require JDK 17 (see #1170).  