### PR TITLE
Don't treat `@ParametricNullness` as `@Nullable` in JSpecify mode

### DIFF
--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
         exclude group: "junit", module: "junit"
     }
     testImplementation deps.test.jsr305Annotations
-    testImplementation "com.google.guava:guava:31.1-jre"
+    testImplementation "com.google.guava:guava:33.4.5-jre"
 
     errorProneOldest deps.build.errorProneCheckApiOld
     errorProneOldest(deps.build.errorProneTestHelpersOld) {

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -183,12 +183,14 @@ public enum Nullness implements AbstractValue<Nullness> {
         || annotName.endsWith(".checkerframework.checker.nullness.compatqual.NullableDecl")
         // matches javax.annotation.CheckForNull and edu.umd.cs.findbugs.annotations.CheckForNull
         || annotName.endsWith(".CheckForNull")
-        // matches any of the multiple @ParametricNullness annotations used within Guava
-        // (see https://github.com/google/guava/issues/6126)
-        // We check the simple name first and the package prefix second for boolean short
-        // circuiting, as Guava includes
-        // many annotations
-        || (annotName.endsWith(".ParametricNullness") && annotName.startsWith("com.google.common."))
+        // matches any of the multiple @ParametricNullness annotations used within Guava (see
+        // https://github.com/google/guava/issues/6126). We check the simple name first and the
+        // package prefix second for boolean short circuiting, as Guava includes many annotations.
+        // We do _not_ match @ParametricNullness annotations in JSpecify mode and rely on generics
+        // checking instead.
+        || (!config.isJSpecifyMode()
+            && annotName.endsWith(".ParametricNullness")
+            && annotName.startsWith("com.google.common."))
         || (config.acknowledgeAndroidRecent()
             && annotName.equals("androidx.annotation.RecentlyNullable"))
         || config.isCustomNullableAnnotation(annotName);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -22,6 +22,8 @@ package com.uber.nullaway.handlers;
  * THE SOFTWARE.
  */
 
+import static com.uber.nullaway.NullabilityUtil.castToNonNull;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -377,7 +379,7 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
       } else if (collectCallToRecordsAndInnerMethodsOrLambdas.containsKey(outerCallInChain)) {
         // Update mapOrCollectRecordToFilterMap for all relevant methods / lambdas
         for (CollectRecordAndInnerMethod collectRecordAndInnerMethod :
-            collectCallToRecordsAndInnerMethodsOrLambdas.get(outerCallInChain)) {
+            collectCallToRecordsAndInnerMethodsOrLambdas.get(castToNonNull(outerCallInChain))) {
           MapOrCollectMethodToFilterInstanceRecord record =
               new MapOrCollectMethodToFilterInstanceRecord(
                   collectRecordAndInnerMethod.getCollectLikeMethodRecord(), filterMethodOrLambda);


### PR DESCRIPTION
Fixes #1173 

In JSpecify mode, we should rely on our checking of generic types and not treat `@ParametricNullness` as a `@Nullable` annotation.