### PR TITLE
Suggest castToNonNull fix for unboxing error

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -197,6 +197,7 @@ public class ErrorBuilder {
       case PASS_NULLABLE:
       case ASSIGN_FIELD_NULLABLE:
       case SWITCH_EXPRESSION_NULLABLE:
+      case UNBOX_NULLABLE:
         if (config.getCastToNonNullMethod() != null && canBeCastToNonNull(suggestTree)) {
           builder = addCastToNonNullFix(suggestTree, builder, state);
         } else {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1837,7 +1837,7 @@ public class NullAway extends BugChecker
               new ErrorMessage(MessageTypes.UNBOX_NULLABLE, "unboxing of a @Nullable value");
           state.reportMatch(
               errorBuilder.createErrorDescription(
-                  errorMessage, buildDescription(tree), state, null));
+                  errorMessage, tree, buildDescription(tree), state, null));
         }
       }
     }

--- a/nullaway/src/test/java/com/uber/nullaway/AutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AutoSuggestTest.java
@@ -380,4 +380,37 @@ public class AutoSuggestTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void castToNonNullForUnboxing() throws IOException {
+    makeTestHelper()
+        .addInputLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @Nullable Integer i;",
+            "  int test1() {",
+            "    return i;",
+            "  }",
+            "  void test2() {",
+            "    int x = i;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "package com.uber;",
+            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  @Nullable Integer i;",
+            "  int test1() {",
+            "    return castToNonNull(i);",
+            "  }",
+            "  void test2() {",
+            "    int x = castToNonNull(i);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
It is true that if such an inserted cast ever fails, the program will fail immediately after with an NPE (in the case that the cast method doesn't fail fast).  Still, it's worthwhile to support this, to enable narrower automated suppressions of these warnings.