### PR TITLE
Update to Checker Framework 3.49.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
-        mavenLocal()
     }
 
     // Spotless complains when applied to the folders containing projects

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ subprojects { project ->
     repositories {
         mavenCentral()
         google()
+        mavenLocal()
     }
 
     // Spotless complains when applied to the folders containing projects

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.48.0",
+    checkerFramework       : "3.49.1",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ if (project.hasProperty("epApiVersion")) {
 
 def versions = [
     asm                    : "9.3",
-    checkerFramework       : "3.49.1",
+    checkerFramework       : "3.49.2",
     // for comparisons in other parts of the build
     errorProneLatest       : latestErrorProneVersion,
     // The version of Error Prone used to check NullAway's code.

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -22,7 +22,7 @@ plugins {
 // We must null out sourceCompatibility and targetCompatibility to use toolchains.
 java.sourceCompatibility = null
 java.targetCompatibility = null
-java.toolchain.languageVersion.set JavaLanguageVersion.of(21)
+java.toolchain.languageVersion.set JavaLanguageVersion.of(23)
 
 configurations {
     // We use this configuration to expose a module path that can be

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -267,4 +267,28 @@ public class SwitchTests {
             "}")
         .doTest();
   }
+
+  @Test
+  public void issue1168() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "NullAwayDiscardError.java",
+            "package com.uber;",
+            "",
+            "public class NullAwayDiscardError {",
+            "",
+            "    public sealed interface IntOrBool {}",
+            "    public record WrappedInt(int a) implements IntOrBool {}",
+            "    public record WrappedBoolean(boolean b) implements IntOrBool {}",
+            "",
+            "    public static void unwrap(IntOrBool i) {",
+            "        switch(i) {",
+            "            case WrappedInt(_) -> {}",
+            "            case WrappedBoolean(_) -> {}",
+            "        }",
+            "    }",
+            "",
+            "}")
+        .doTest();
+  }
 }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -274,20 +274,16 @@ public class SwitchTests {
         .addSourceLines(
             "NullAwayDiscardError.java",
             "package com.uber;",
-            "",
             "public class NullAwayDiscardError {",
-            "",
             "    public sealed interface IntOrBool {}",
             "    public record WrappedInt(int a) implements IntOrBool {}",
             "    public record WrappedBoolean(boolean b) implements IntOrBool {}",
-            "",
             "    public static void unwrap(IntOrBool i) {",
             "        switch(i) {",
             "            case WrappedInt(_) -> {}",
             "            case WrappedBoolean(_) -> {}",
             "        }",
             "    }",
-            "",
             "}")
         .doTest();
   }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -57,6 +57,7 @@ import org.checkerframework.nullaway.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.nullaway.dataflow.analysis.TransferInput;
 import org.checkerframework.nullaway.dataflow.analysis.TransferResult;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
+import org.checkerframework.nullaway.dataflow.cfg.node.AnyPatternNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.ArrayAccessNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.ArrayCreationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.ArrayTypeNode;
@@ -1151,6 +1152,12 @@ public class AccessPathNullnessPropagation
   public TransferResult<Nullness, NullnessStore> visitDeconstructorPattern(
       DeconstructorPatternNode deconstructorPatternNode,
       TransferInput<Nullness, NullnessStore> input) {
+    return noStoreChanges(NULLABLE, input);
+  }
+
+  @Override
+  public TransferResult<Nullness, NullnessStore> visitAnyPattern(
+      AnyPatternNode anyPatternNode, TransferInput<Nullness, NullnessStore> input) {
     return noStoreChanges(NULLABLE, input);
   }
 


### PR DESCRIPTION
This version adds basic support for unnamed patterns (introduced in JDK 22) so NullAway no longer crashes on them.

Fixes #1168 