### PR TITLE
Don't check synchronized blocks within unannotated code

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1798,6 +1798,9 @@ public class NullAway extends BugChecker
 
   @Override
   public Description matchSynchronized(SynchronizedTree tree, VisitorState state) {
+    if (!withinAnnotatedCode(state)) {
+      return Description.NO_MATCH;
+    }
     ExpressionTree lockExpr = tree.getExpression();
     // For a synchronized block `synchronized (e) { ... }`, javac returns `(e)` as the expression.
     // We strip the outermost parentheses for a nicer-looking error message.

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1118,4 +1118,20 @@ public class CoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void synchronizedInUnannotatedLambda() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "public class Foo {",
+            "    void foo() {",
+            "        Runnable runnable = () -> {",
+            "            Object lock = new Object();",
+            "            synchronized (lock) {}",
+            "        };",
+            "    }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #1184 

We forgot to add the standard check for unannotated code to `matchSynchronized`