### PR TITLE
Test on JDK 24

### DIFF
--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
 }
 
 // Do not generate reports for individual projects
@@ -65,7 +65,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[21, 23].each { majorVersion ->
+[21, 24].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         onlyIf {
             // Only run when using the latest Error Prone version

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -115,11 +115,11 @@ def test = [
     commonsLang3            : "org.apache.commons:commons-lang3:3.8.1",
     commonsLang             : "commons-lang:commons-lang:2.6",
     jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
-    lombok                  : "org.projectlombok:lombok:1.18.34",
+    lombok                  : "org.projectlombok:lombok:1.18.38",
     springBeans             : "org.springframework:spring-beans:5.3.7",
     springContext           : "org.springframework:spring-context:5.3.7",
     grpcCore                : "io.grpc:grpc-core:1.15.1", // Should upgrade, but this matches our guava version
-    mockito                 : "org.mockito:mockito-core:5.13.0",
+    mockito                 : "org.mockito:mockito-core:5.16.1",
     javaxAnnotationApi      : "javax.annotation:javax.annotation-api:1.3.2",
     assertJ                 : "org.assertj:assertj-core:3.23.1",
 ]

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -50,4 +50,9 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }
 
+tasks.getByName('testJdk24').configure {
+    // not working until we update WALA
+    onlyIf { false }
+}
+
 apply plugin: 'com.vanniktech.maven.publish'

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -51,7 +51,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.getByName('testJdk24').configure {
-    // not working until we update WALA
+    // Will not work until WALA is updated to support JDK 24; see https://github.com/uber/NullAway/issues/1189
     onlyIf { false }
 }
 

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -22,7 +22,7 @@ plugins {
 // We must null out sourceCompatibility and targetCompatibility to use toolchains.
 java.sourceCompatibility = null
 java.targetCompatibility = null
-java.toolchain.languageVersion.set JavaLanguageVersion.of(23)
+java.toolchain.languageVersion.set JavaLanguageVersion.of(24)
 
 configurations {
     // We use this configuration to expose a module path that can be

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -51,7 +51,17 @@ tasks.withType(Test).configureEach { test ->
     ]
 }
 
+// Disable tasks for specific JDK versions; we only run on the recent JDK version specified above
 tasks.getByName('testJdk21').configure {
-    // We don't need this task since we already run the tests on JDK 21
     onlyIf { false }
+}
+tasks.getByName('testJdk24').configure {
+    onlyIf { false }
+}
+
+tasks.getByName('test').configure {
+    // older EP versions don't work on JDK 24+
+    onlyIf {
+        deps.versions.errorProneApi == deps.versions.errorProneLatest
+    }
 }


### PR DESCRIPTION
We enable testing on JDK 24 except for JarInfer which requires an update from WALA; see https://github.com/uber/NullAway/issues/1189.  All 3rd-party version bumps are to get JDK 24 support.