### PR TITLE
Fix multiple issues with `NewClassTree`s that have enclosing expressions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -443,7 +443,7 @@ public class NullAway extends BugChecker
     }
     ExpressionTree enclosingExpression = tree.getEnclosingExpression();
     if (enclosingExpression != null) {
-      // technically this is not a dereference; there is a requireNonull() call in the
+      // technically this is not a dereference; there is a requireNonNull() call in the
       // bytecode.  but it's close enough for error reporting
       Description desc = matchDereference(enclosingExpression, tree, state);
       if (!desc.equals(Description.NO_MATCH)) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -441,6 +441,15 @@ public class NullAway extends BugChecker
     if (methodSymbol == null) {
       throw new RuntimeException("not expecting unresolved method here");
     }
+    ExpressionTree enclosingExpression = tree.getEnclosingExpression();
+    if (enclosingExpression != null) {
+      // technically this is not a dereference; there is a requireNonull() call in the
+      // bytecode.  but it's close enough for error reporting
+      Description desc = matchDereference(enclosingExpression, tree, state);
+      if (!desc.equals(Description.NO_MATCH)) {
+        state.reportMatch(desc);
+      }
+    }
     List<? extends ExpressionTree> actualParams = tree.getArguments();
     if (tree.getClassBody() != null) {
       // invoking constructor of anonymous class

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -442,7 +442,7 @@ public class NullAway extends BugChecker
       throw new RuntimeException("not expecting unresolved method here");
     }
     List<? extends ExpressionTree> actualParams = tree.getArguments();
-    if (tree.getClassBody() != null && actualParams.size() > 0) {
+    if (tree.getClassBody() != null /* && actualParams.size() > 0*/) {
       // passing parameters to constructor of anonymous class
       // this constructor just invokes the constructor of the superclass, and
       // in the AST does not have the parameter nullability annotations from the superclass.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -442,8 +442,8 @@ public class NullAway extends BugChecker
       throw new RuntimeException("not expecting unresolved method here");
     }
     List<? extends ExpressionTree> actualParams = tree.getArguments();
-    if (tree.getClassBody() != null /* && actualParams.size() > 0*/) {
-      // passing parameters to constructor of anonymous class
+    if (tree.getClassBody() != null) {
+      // invoking constructor of anonymous class
       // this constructor just invokes the constructor of the superclass, and
       // in the AST does not have the parameter nullability annotations from the superclass.
       // so, treat as if the superclass constructor is being invoked directly
@@ -1861,18 +1861,7 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol methodSymbol,
       List<? extends ExpressionTree> actualParams) {
     List<VarSymbol> formalParams = methodSymbol.getParameters();
-
     boolean varArgsMethod = methodSymbol.isVarArgs();
-    if (formalParams.size() != actualParams.size()
-        && !varArgsMethod
-        && !methodSymbol.isStatic()
-        && methodSymbol.isConstructor()
-        && methodSymbol.enclClass().isInner()) {
-      // In special cases like one in issue #366
-      // formal params and actual params do not match while using JDK11+
-      // we bail out in this particular case
-      return Description.NO_MATCH;
-    }
 
     // always do unboxing checks, whether or not the invoked method is annotated
     for (int i = 0; i < formalParams.size() && i < actualParams.size(); i++) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -445,10 +445,7 @@ public class NullAway extends BugChecker
     if (enclosingExpression != null) {
       // technically this is not a dereference; there is a requireNonNull() call in the
       // bytecode.  but it's close enough for error reporting
-      Description desc = matchDereference(enclosingExpression, tree, state);
-      if (!desc.equals(Description.NO_MATCH)) {
-        state.reportMatch(desc);
-      }
+      state.reportMatch(matchDereference(enclosingExpression, tree, state));
     }
     List<? extends ExpressionTree> actualParams = tree.getArguments();
     if (tree.getClassBody() != null) {

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1134,4 +1134,19 @@ public class CoreTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void issue1888() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Outer.java",
+            "package com.uber;",
+            "class Outer {",
+            "    class Inner {}",
+            "    static Inner f(Outer outer) {",
+            "        return outer.new Inner() {};",
+            "    }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1136,7 +1136,7 @@ public class CoreTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void issue1888() {
+  public void enclosingExpressionForNewClassTree() {
     defaultCompilationHelper
         .addSourceLines(
             "Outer.java",

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1141,9 +1141,14 @@ public class CoreTests extends NullAwayTestsBase {
         .addSourceLines(
             "Outer.java",
             "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
             "class Outer {",
             "    class Inner {}",
-            "    static Inner f(Outer outer) {",
+            "    static Inner testNegative(Outer outer) {",
+            "        return outer.new Inner() {};",
+            "    }",
+            "    static Inner testPositive(@Nullable Outer outer) {",
+            "        // BUG: Diagnostic contains: dereferenced expression outer is @Nullable",
             "        return outer.new Inner() {};",
             "    }",
             "}")


### PR DESCRIPTION
Fixes #1188, exactly as suggested in that issue.  This both simplifies the code and fixes a false negative with `@Nullable` enclosing expressions.