### PR TITLE
Ensure classes null-marked by library model detected in all places

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -115,9 +115,9 @@ public final class CodeAnnotationInfo {
   public boolean isGenerated(Symbol symbol, Config config) {
     Symbol.ClassSymbol classSymbol = enclosingClass(symbol);
     if (classSymbol == null) {
+      // One known case where this can happen: int.class, void.class, etc.
       Preconditions.checkArgument(
-          isClassFieldOfPrimitiveType(
-              symbol), // One known case where this can happen: int.class, void.class, etc.
+          isClassFieldOfPrimitiveType(symbol),
           String.format(
               "Unexpected symbol passed to CodeAnnotationInfo.isGenerated(...) with null enclosing class: %s",
               symbol));
@@ -152,7 +152,7 @@ public final class CodeAnnotationInfo {
    * @return true if symbol represents an entity contained in a class that is unannotated; false
    *     otherwise
    */
-  public boolean isSymbolUnannotated(Symbol symbol, Config config, @Nullable Handler handler) {
+  public boolean isSymbolUnannotated(Symbol symbol, Config config, Handler handler) {
     Symbol.ClassSymbol classSymbol;
     if (symbol instanceof Symbol.ClassSymbol) {
       classSymbol = (Symbol.ClassSymbol) symbol;
@@ -245,7 +245,11 @@ public final class CodeAnnotationInfo {
       record =
           new ClassCacheRecord(classSymbol, isAnnotatedTopLevelClass(classSymbol, config, handler));
     }
-    classCache.put(classSymbol, record);
+    // Don't update the cache if the handler is null, as we may not have full info about classes
+    // being null-marked via library models
+    if (handler != null) {
+      classCache.put(classSymbol, record);
+    }
     return record;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2601,7 +2601,7 @@ public class NullAway extends BugChecker
               "unexpected null symbol for dereference expression " + state.getSourceForNode(expr));
         }
         exprMayBeNull =
-            NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo);
+            NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, handler, codeAnnotationInfo);
         break;
       case IDENTIFIER:
         if (exprSymbol == null) {
@@ -2610,7 +2610,8 @@ public class NullAway extends BugChecker
         }
         if (exprSymbol.getKind() == ElementKind.FIELD) {
           exprMayBeNull =
-              NullabilityUtil.mayBeNullFieldFromType(exprSymbol, config, codeAnnotationInfo);
+              NullabilityUtil.mayBeNullFieldFromType(
+                  exprSymbol, config, handler, codeAnnotationInfo);
         } else {
           // rely on dataflow analysis for local variables
           exprMayBeNull = true;

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -48,6 +48,7 @@ import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.JCDiagnostic;
+import com.uber.nullaway.handlers.Handler;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -476,10 +477,10 @@ public class NullabilityUtil {
    *     the field might be null; false otherwise
    */
   public static boolean mayBeNullFieldFromType(
-      Symbol symbol, Config config, CodeAnnotationInfo codeAnnotationInfo) {
+      Symbol symbol, Config config, Handler handler, CodeAnnotationInfo codeAnnotationInfo) {
     return !(symbol.getSimpleName().toString().equals("class")
             || symbol.isEnum()
-            || codeAnnotationInfo.isSymbolUnannotated(symbol, config, null))
+            || codeAnnotationInfo.isSymbolUnannotated(symbol, config, handler))
         && Nullness.hasNullableOrMonotonicNonNullAnnotation(symbol, config);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -751,7 +751,8 @@ public class AccessPathNullnessPropagation
         break;
       case UNKNOWN:
         fieldMayBeNull =
-            NullabilityUtil.mayBeNullFieldFromType(symbol, config, getCodeAnnotationInfo(state));
+            NullabilityUtil.mayBeNullFieldFromType(
+                symbol, config, handler, getCodeAnnotationInfo(state));
         break;
       default:
         // Should be unreachable unless NullnessHint changes, cases above are exhaustive!

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -50,10 +50,12 @@ public class Handlers {
     // requested it
     boolean acknowledgeRestrictive =
         config.acknowledgeRestrictiveAnnotations() || config.isJSpecifyMode();
+    RestrictiveAnnotationHandler restrictiveAnnotationHandler = null;
     if (acknowledgeRestrictive) {
       // This runs before LibraryModelsHandler, so that library models can override third-party
       // bytecode annotations
-      handlerListBuilder.add(new RestrictiveAnnotationHandler(config));
+      restrictiveAnnotationHandler = new RestrictiveAnnotationHandler(config);
+      handlerListBuilder.add(restrictiveAnnotationHandler);
     }
     if (config.handleTestAssertionLibraries()) {
       handlerListBuilder.add(new AssertionHandler(methodNameUtil));
@@ -86,7 +88,12 @@ public class Handlers {
     handlerListBuilder.add(new LombokHandler(config));
     handlerListBuilder.add(new FluentFutureHandler(config));
 
-    return new CompositeHandler(handlerListBuilder.build());
+    CompositeHandler mainHandler = new CompositeHandler(handlerListBuilder.build());
+    libraryModelsHandler.initMainHandler(mainHandler);
+    if (restrictiveAnnotationHandler != null) {
+      restrictiveAnnotationHandler.initMainHandler(mainHandler);
+    }
+    return mainHandler;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -87,12 +87,14 @@ public class Handlers {
     }
     handlerListBuilder.add(new LombokHandler(config));
     handlerListBuilder.add(new FluentFutureHandler(config));
-
     CompositeHandler mainHandler = new CompositeHandler(handlerListBuilder.build());
-    libraryModelsHandler.initMainHandler(mainHandler);
+
+    // Initialize the handlers that need to be aware of the main handler
     if (restrictiveAnnotationHandler != null) {
       restrictiveAnnotationHandler.initMainHandler(mainHandler);
     }
+    libraryModelsHandler.initMainHandler(mainHandler);
+
     return mainHandler;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -33,6 +33,7 @@ import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
+import com.uber.nullaway.annotations.Initializer;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import org.checkerframework.nullaway.dataflow.cfg.node.FieldAccessNode;
@@ -42,9 +43,15 @@ import org.jspecify.annotations.Nullable;
 public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
 
   private final Config config;
+  private Handler mainHandler;
 
   RestrictiveAnnotationHandler(Config config) {
     this.config = config;
+  }
+
+  @Initializer
+  public void initMainHandler(Handler mainHandler) {
+    this.mainHandler = mainHandler;
   }
 
   /**
@@ -61,7 +68,7 @@ public class RestrictiveAnnotationHandler extends BaseNoOpHandler {
    */
   private boolean isSymbolRestrictivelyNullable(Symbol symbol, Context context) {
     CodeAnnotationInfo codeAnnotationInfo = getCodeAnnotationInfo(context);
-    return (codeAnnotationInfo.isSymbolUnannotated(symbol, config, null)
+    return (codeAnnotationInfo.isSymbolUnannotated(symbol, config, mainHandler)
         // with the generated-as-unannotated option enabled, we want to ignore annotations in
         // generated code no matter what
         && !(config.treatGeneratedAsUnannotated() && codeAnnotationInfo.isGenerated(symbol, config))

--- a/nullaway/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -264,4 +264,29 @@ public class CustomLibraryModelsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void issue1194() {
+    makeLibraryModelsTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:JSpecifyMode=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.uber.lib.unannotated.ProviderNullMarkedViaModel;",
+            "import org.jspecify.annotations.Nullable;",
+            "public class Test {",
+            "  void use(Object o) {}",
+            "  void f(Object o) {",
+            "    use(o);",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter",
+            "    use(provider.get());",
+            "  }",
+            "  ProviderNullMarkedViaModel<@Nullable Object> provider = () -> null;",
+            "}")
+        .doTest();
+  }
 }

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/ProviderNullMarkedViaModel.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/ProviderNullMarkedViaModel.java
@@ -1,0 +1,5 @@
+package com.uber.lib.unannotated;
+
+public interface ProviderNullMarkedViaModel<T> {
+  T get();
+}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -132,4 +132,14 @@ public class TestLibraryModels implements LibraryModels {
             fieldRef("com.uber.lib.unannotated.UnannotatedWithModels", "nullableFieldUnannotated2"))
         .build();
   }
+
+  @Override
+  public ImmutableSetMultimap<String, Integer> typeVariablesWithNullableUpperBounds() {
+    return ImmutableSetMultimap.of("com.uber.lib.unannotated.ProviderNullMarkedViaModel", 0);
+  }
+
+  @Override
+  public ImmutableSet<String> nullMarkedClasses() {
+    return ImmutableSet.of("com.uber.lib.unannotated.ProviderNullMarkedViaModel");
+  }
 }


### PR DESCRIPTION
Fixes #1194 

Previously we were sloppy about allowing a null `Handler` to be passed into `CodeAnnotationInfo` and then caching the result.  Here we change the code to always pass a non-null `Handler` in to public APIs of `CodeAnnotationInfo`, and we avoid caching if the handler is ever `null` from an internal call.
