### PR TITLE
JSpecify: handle varargs whose element type is a type variable

### DIFF
--- a/guava-recent-unit-tests/build.gradle
+++ b/guava-recent-unit-tests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
         exclude group: "junit", module: "junit"
     }
     testImplementation deps.test.jsr305Annotations
-    testImplementation "com.google.guava:guava:33.4.5-jre"
+    testImplementation "com.google.guava:guava:33.4.8-jre"
 
     errorProneOldest deps.build.errorProneCheckApiOld
     errorProneOldest(deps.build.errorProneTestHelpersOld) {

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -45,7 +45,7 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
                     // make google packages unannotated
                     "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
     jspecifyCompilationHelper =

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -45,7 +45,9 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
-                    // We only need com.google.common here since we are still trying to support
+                    // Since Guava is now @NullMarked we shouldn't need com.google.common in the
+                    // annotated packages list.
+                    // We still need it here since we are still trying to support
                     // Error Prone 2.14.0, on which reading @NullMarked from the package-info.java
                     // file isn't working using ASTHelpers for some reason.
                     // TODO Once we bump our minimum Error Prone version, remove com.google.common

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -47,7 +47,7 @@ public class NullAwayGuavaParametricNullnessTests {
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                     // make google packages unannotated
-                    "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated,com.google.common"));
+                    "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
     jspecifyCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())
             .setArgs(
@@ -245,16 +245,18 @@ public class NullAwayGuavaParametricNullnessTests {
 
   @Test
   public void newHashSetPassingNullable() {
-    defaultCompilationHelper
+    // to ensure javac reads proper generic types from the Guava jar
+    Assume.assumeTrue(Runtime.version().feature() >= 23);
+    jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
             "import com.google.common.collect.Sets;",
             "import java.util.Set;",
-            "import javax.annotation.Nullable;",
+            "import org.jspecify.annotations.*;",
+            "@NullMarked",
             "class Test {",
             "  public static void test(@Nullable String s) {",
-            "    Set<String> params = Sets.newHashSet(s);",
+            "    Set<@Nullable String> params = Sets.<@Nullable String>newHashSet(s);",
             "  }",
             "}")
         .doTest();

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -256,7 +256,7 @@ public class NullAwayGuavaParametricNullnessTests {
             "@NullMarked",
             "class Test {",
             "  public static void test(@Nullable String s) {",
-            "    Set<@Nullable String> params = Sets.<@Nullable String>newHashSet(s);",
+            "    Set<@Nullable String> params = Sets.newHashSet(s);",
             "  }",
             "}")
         .doTest();

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -45,8 +45,9 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
-                    "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                    // make google packages unannotated
+                    "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated,com.google.common"));
     jspecifyCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())
             .setArgs(
@@ -238,6 +239,23 @@ public class NullAwayGuavaParametricNullnessTests {
             "             }",
             "        };",
             "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void newHashSetPassingNullable() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import com.google.common.collect.Sets;",
+            "import java.util.Set;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  public static void test(@Nullable String s) {",
+            "    Set<String> params = Sets.newHashSet(s);",
+            "  }",
             "}")
         .doTest();
   }

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -45,8 +45,12 @@ public class NullAwayGuavaParametricNullnessTests {
                 Arrays.asList(
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
+                    // We only need com.google.common here since we are still trying to support
+                    // Error Prone 2.14.0, on which reading @NullMarked from the package-info.java
+                    // file isn't working using ASTHelpers for some reason.
+                    // TODO Once we bump our minimum Error Prone version, remove com.google.common
+                    //  from this list.
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
-                    // make google packages unannotated
                     "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
     jspecifyCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1995,6 +1995,14 @@ public class NullAway extends BugChecker
     return checkCastToNonNullTakesNullable(tree, state, methodSymbol, actualParams);
   }
 
+  /**
+   * Checks if the method invocation is a varargs call, i.e., if individual arguments are being
+   * passed in the varargs position. If false, it means that an array is being passed in the varargs
+   * position.
+   *
+   * @param tree the method invocation tree (MethodInvocationTree or NewClassTree)
+   * @return true if the method invocation is a varargs call, false otherwise
+   */
   private boolean isVarArgsCall(Tree tree) {
     Type varargsElement =
         tree instanceof JCTree.JCMethodInvocation

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1950,7 +1950,11 @@ public class NullAway extends BugChecker
           Type type = ASTHelpers.getType(methodInvocationTree.getMethodSelect());
           if (type != null) {
             List<? extends TypeMirror> parameterTypes = ((ExecutableType) type).getParameterTypes();
-            varargsArrayType = (Type.ArrayType) parameterTypes.get(parameterTypes.size() - 1);
+            TypeMirror lastParameterType = parameterTypes.get(parameterTypes.size() - 1);
+            // For some JDK reflective APIs sometimes the type at the call site is not an ArrayType
+            if (lastParameterType instanceof Type.ArrayType) {
+              varargsArrayType = (Type.ArrayType) lastParameterType;
+            }
           }
         }
         if (varargsArrayType == null) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2004,6 +2004,7 @@ public class NullAway extends BugChecker
    * @return true if the method invocation is a varargs call, false otherwise
    */
   private boolean isVarArgsCall(Tree tree) {
+    // javac sets the varargsElement field to a non-null value if the invocation is a varargs call
     Type varargsElement =
         tree instanceof JCTree.JCMethodInvocation
             ? ((JCTree.JCMethodInvocation) tree).varargsElement

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1179,6 +1179,15 @@ public final class GenericsChecks {
     }
   }
 
+  /**
+   * Returns the nullness of a formal parameter type, based on the nullability annotations on the
+   * type.
+   *
+   * @param type The type of the parameter
+   * @param config The analysis config
+   * @param isVarargsParam true if the parameter is a varargs parameter
+   * @return The nullness of the parameter type
+   */
   private static Nullness getParameterTypeNullness(
       Type type, Config config, boolean isVarargsParam) {
     if (isVarargsParam) {
@@ -1187,12 +1196,14 @@ public final class GenericsChecks {
           type.getKind().equals(TypeKind.ARRAY),
           "expected array type for varargs parameter, got %s",
           type);
+      // use the component type to determine nullness
       Type.ArrayType arrayType = (Type.ArrayType) type;
       Type componentType = arrayType.getComponentType();
       return getTypeNullness(componentType, config);
+    } else {
+      // For non-varargs, we just check the type itself
+      return getTypeNullness(type, config);
     }
-    // For non-varargs, we just check the type itself
-    return getTypeNullness(type, config);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1026,7 +1026,6 @@ public final class GenericsChecks {
               .getParameterTypes();
       // If this condition evaluates to false, we fall through to the subsequent logic, to handle
       // type variables declared on the enclosing class
-      // TODO we need something like com.uber.nullaway.Nullness.paramHasNullableAnnotation
       if (substitutedParamTypes != null
           && Objects.equals(
               getParameterTypeNullness(
@@ -1111,10 +1110,13 @@ public final class GenericsChecks {
       // @Nullable annotation is handled elsewhere)
       return Nullness.NONNULL;
     }
+    boolean isVarargsParam =
+        method.isVarArgs() && parameterIndex == method.getParameters().size() - 1;
+
     Type methodType =
         TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, method, config);
     Type paramType = methodType.getParameterTypes().get(parameterIndex);
-    return getTypeNullness(paramType, config);
+    return getParameterTypeNullness(paramType, config, isVarargsParam);
   }
 
   /**
@@ -1185,7 +1187,6 @@ public final class GenericsChecks {
           type.getKind().equals(TypeKind.ARRAY),
           "expected array type for varargs parameter, got %s",
           type);
-      // If the type is an array type, we check the component type
       Type.ArrayType arrayType = (Type.ArrayType) type;
       Type componentType = arrayType.getComponentType();
       return getTypeNullness(componentType, config);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -559,6 +559,8 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "class Test {",
             "    <T extends Object> void varargsTest(T @Nullable... args) {}",
             "    void f() {",
+            "        String[] x = null;",
+            "        this.<String>varargsTest(x);",
             "        this.<String>varargsTest((String[])null);",
             "    }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -548,6 +548,23 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void nullableVarargsArray() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "    <T extends Object> void varargsTest(T @Nullable... args) {}",
+            "    void f() {",
+            "        this.<String>varargsTest((String[])null);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -526,6 +526,28 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void varargsOfGenericType() {
+    makeHelper()
+        .addSourceLines(
+            "Varargs.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Varargs {",
+            "    static <T extends @Nullable Object> void foo(T... args) {",
+            "    }",
+            "    static void testNegative(@Nullable String s) {",
+            "        Varargs.<@Nullable String>foo(s);",
+            "    }",
+            "    static void testPositive(@Nullable String s) {",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        Varargs.<String>foo(s);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -567,6 +567,37 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void varargsConstructor() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "    static class Foo {",
+            "      <T> Foo(T @Nullable... args) {}",
+            "    }",
+            "    void testNegative() {",
+            "        String[] x = null;",
+            "        Foo f = new <String>Foo(x);",
+            "        f = new <String>Foo((String[])null);",
+            "    }",
+            "    static class Bar {",
+            "      <T> Bar(T... args) {}",
+            "    }",
+            "    void testPositive() {",
+            "        String[] x = null;",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        Bar b = new <String>Bar(x);",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        b = new <String>Bar((String[])null);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2353,6 +2353,32 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void varargsOfGenericType() {
+    makeHelper()
+        .addSourceLines(
+            "Varargs.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Varargs {",
+            "    static class Foo<T extends @Nullable Object> {",
+            "        void foo(T... args) {",
+            "        }",
+            "    }",
+            "    static void testNegative(@Nullable String s) {",
+            "        Foo<@Nullable String> f = new Foo<>();",
+            "        f.foo(s);",
+            "    }",
+            "    static void testPositive(@Nullable String s) {",
+            "        Foo<String> f = new Foo<>();",
+            "        // BUG: Diagnostic contains: passing @Nullable parameter",
+            "        f.foo(s);",
+            "    }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
Partially addresses #1199.  After substituting for a type variable, we were not retrieving the correct nullability for a varargs parameter, which should be the nullability of the component, not the array type itself.

Also adds some simplification of our handling of varargs calls based on a tip from @jeffrey-easyesi