### PR TITLE
Update to Error Prone 2.38.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,13 +25,13 @@ jobs:
             epVersion: 2.31.0
           - os: macos-latest
             java: 17
-            epVersion: 2.37.0
+            epVersion: 2.38.0
           - os: windows-latest
             java: 17
-            epVersion: 2.37.0
+            epVersion: 2.38.0
           - os: ubuntu-latest
             java: 17
-            epVersion: 2.37.0
+            epVersion: 2.38.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           ORG_GRADLE_PROJECT_epApiVersion: ${{ matrix.epVersion }}
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.37.0' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '17' && matrix.epVersion == '2.38.0' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ import org.gradle.util.VersionNumber
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneVersion = "2.14.0"
 // Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.37.0"
+def latestErrorProneVersion = "2.38.0"
 // Default to using latest tested Error Prone version
 def defaultErrorProneVersion =  latestErrorProneVersion
 def errorProneVersionToCompileAgainst = defaultErrorProneVersion

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -118,9 +118,8 @@ public final class CodeAnnotationInfo {
       // One known case where this can happen: int.class, void.class, etc.
       Preconditions.checkArgument(
           isClassFieldOfPrimitiveType(symbol),
-          String.format(
-              "Unexpected symbol passed to CodeAnnotationInfo.isGenerated(...) with null enclosing class: %s",
-              symbol));
+          "Unexpected symbol passed to CodeAnnotationInfo.isGenerated(...) with null enclosing class: %s",
+          symbol);
       return false;
     }
     Symbol.ClassSymbol outermostClassSymbol = get(classSymbol, config, null).outermostClassSymbol;

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -379,13 +379,14 @@ public class ErrorBuilder {
     Tree currTree = state.getPath().getLeaf();
     Preconditions.checkArgument(
         currTree.getKind() == Tree.Kind.METHOD_INVOCATION,
-        String.format("Expected castToNonNull invocation expression, found:\n%s", currTree));
+        "Expected castToNonNull invocation expression, found:\n%s",
+        currTree);
     MethodInvocationTree invTree = (MethodInvocationTree) currTree;
     Preconditions.checkArgument(
         invTree.getArguments().contains(suggestTree),
-        String.format(
-            "Method invocation tree %s does not contain the expression %s as an argument being cast",
-            invTree, suggestTree));
+        "Method invocation tree %s does not contain the expression %s as an argument being cast",
+        invTree,
+        suggestTree);
     // Remove the call to castToNonNull:
     SuggestedFix fix =
         SuggestedFix.builder().replace(invTree, state.getSourceForNode(suggestTree)).build();

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -256,7 +256,13 @@ public interface LibraryModels {
      * produced by {@link Symbol.MethodSymbol#toString()} and will not work for arbitrary strings.
      */
     private static String stripAnnotationsFromMethodSymbolString(String str) {
-      return str.replaceAll("@[^ ]+ ", "");
+      String annotationWithSpace = "@[\\w.]+\\s";
+      // annotations within a varargs array can look like:
+      // java.lang.@org.jspecify.annotations.Nullable Object@org.jspecify.annotations.Nullable...
+      // we want to match the annotation without consuming the ellipsis, so we use a lookahead
+      String annotationOfVarargsArray = "@[\\w.]+(?=\\.\\.\\.)";
+      String annotationRegex = annotationWithSpace + "|" + annotationOfVarargsArray;
+      return str.replaceAll(annotationRegex, "");
     }
 
     @Override


### PR DESCRIPTION
Fixed a couple of minor new warnings.  Also, pulling in EP 2.38.0 pulls in the latest version of Guava for our tests, and this Guava version has more JSpecify annotations.  This new Guava version exposed a bug in our logic for stripping annotations out of method signatures on recent JDK versions, for varargs arrays; we fix it here.