### PR TITLE
Properly handle method references to null-unmarked methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -500,7 +500,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
 
   @Override
   public boolean acknowledgeRestrictiveAnnotations() {
-    return isAcknowledgeRestrictive;
+    return isAcknowledgeRestrictive || jspecifyMode;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -500,6 +500,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
 
   @Override
   public boolean acknowledgeRestrictiveAnnotations() {
+    // restrictive annotations must always be acknowledged in JSpecify mode
     return isAcknowledgeRestrictive || jspecifyMode;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -776,6 +776,8 @@ public class NullAway extends BugChecker
    *     LambdaExpressionTree}; otherwise {@code null}
    * @param memberReferenceTree if the overriding method is a member reference (which "overrides" a
    *     functional interface method), the {@link MemberReferenceTree}; otherwise {@code null}
+   * @param state visitor state
+   * @param overridingMethod if available, the symbol for the overriding method
    * @return discovered error, or {@link Description#NO_MATCH} if no error
    */
   private Description checkParamOverriding(
@@ -792,11 +794,13 @@ public class NullAway extends BugChecker
     boolean isOverriddenMethodAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(overriddenMethod, config, handler);
     boolean isOverridingMethodAnnotated =
-        memberReferenceTree == null
-            || !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler);
+        (overridingMethod != null
+                && !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler))
+            || lambdaExpressionTree != null;
 
     // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
     // null, parameter i is treated as unannotated.
+    // TODO add task to correct type to @Nullable Nullness[]
     Nullness[] overriddenMethodArgNullnessMap = new Nullness[superParamSymbols.size()];
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
@@ -877,6 +881,10 @@ public class NullAway extends BugChecker
     //    }
 
     // TODO test overriding with varargs, bunch of other tests
+    //  specific tests to write: (1) lambda for varargs FI with explicit type on argument, (2)
+    //  method ref to varargs method with explicit @NonNull annotation on varargs array, (3) method
+    //  ref to varargs method with explicit @NonNull on array contents in JSpecify mode, (4) method
+    //  ref to varargs method with explicit @Nullable on array contents in JSpecify mode,
     // for unbound member references, we need to adjust parameter indices by 1 when matching with
     // overridden method
     int startParam = unboundMemberRef ? 1 : 0;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -875,6 +875,7 @@ public class NullAway extends BugChecker
     //      return Description.NO_MATCH;
     //    }
 
+    // TODO test overriding with varargs, bunch of other tests
     // for unbound member references, we need to adjust parameter indices by 1 when matching with
     // overridden method
     int startParam = unboundMemberRef ? 1 : 0;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -792,7 +792,8 @@ public class NullAway extends BugChecker
     boolean isOverriddenMethodAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(overriddenMethod, config, handler);
     boolean isOverridingMethodAnnotated =
-        !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler);
+        memberReferenceTree == null
+            || !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler);
 
     // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
     // null, parameter i is treated as unannotated.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -872,19 +872,6 @@ public class NullAway extends BugChecker
           null);
     }
 
-    // no need to check parameter overriding if the overriding method is unannotated
-    //    if (!isOverridingMethodAnnotated) {
-    //      // TODO what about restrictive annotations like @NonNull on a parameter or @Nullable on
-    // a
-    //      // return?
-    //      return Description.NO_MATCH;
-    //    }
-
-    // TODO test overriding with varargs, bunch of other tests
-    //  specific tests to write: (1) lambda for varargs FI with explicit type on argument, (2)
-    //  method ref to varargs method with explicit @NonNull annotation on varargs array, (3) method
-    //  ref to varargs method with explicit @NonNull on array contents in JSpecify mode, (4) method
-    //  ref to varargs method with explicit @Nullable on array contents in JSpecify mode,
     // for unbound member references, we need to adjust parameter indices by 1 when matching with
     // overridden method
     int startParam = unboundMemberRef ? 1 : 0;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -800,7 +800,6 @@ public class NullAway extends BugChecker
 
     // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
     // null, parameter i is treated as unannotated.
-    // TODO add task to correct type to @Nullable Nullness[]
     Nullness[] overriddenMethodArgNullnessMap = new Nullness[superParamSymbols.size()];
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -46,12 +46,8 @@ public class Handlers {
     ImmutableList.Builder<Handler> handlerListBuilder = ImmutableList.builder();
     MethodNameUtil methodNameUtil = new MethodNameUtil();
 
-    // Acknowledge restrictive annotations if in JSpecify mode or if the user has explicitly
-    // requested it
-    boolean acknowledgeRestrictive =
-        config.acknowledgeRestrictiveAnnotations() || config.isJSpecifyMode();
     RestrictiveAnnotationHandler restrictiveAnnotationHandler = null;
-    if (acknowledgeRestrictive) {
+    if (config.acknowledgeRestrictiveAnnotations()) {
       // This runs before LibraryModelsHandler, so that library models can override third-party
       // bytecode annotations
       restrictiveAnnotationHandler = new RestrictiveAnnotationHandler(config);

--- a/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
@@ -428,4 +428,62 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void methodRefToNullUnmarked() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "@NullMarked",
+            "class Test {",
+            "  interface I {",
+            "    void m(@Nullable Object o);",
+            "  }",
+            "  @NullUnmarked",
+            "  void unmarkedParam(Object o) {}",
+            "  @NullUnmarked",
+            "  void nonNullParam(@NonNull Object o) {}",
+            "  void test() {",
+            "    I i = this::unmarkedParam;",
+            "    // BUG: Diagnostic contains: parameter o of referenced method is @NonNull",
+            "    I i2 = this::nonNullParam;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void methodRefToNullUnmarkedVarargs() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "@NullMarked",
+            "class Test {",
+            "  interface I {",
+            "    void m(Object @Nullable ... o);",
+            "  }",
+            "  @NullUnmarked",
+            "  void unmarkedParam(Object... o) {}",
+            "  @NullUnmarked",
+            "  void nonNullParam(Object @NonNull ... o) {}",
+            "  void test() {",
+            "    I i = this::unmarkedParam;",
+            "    // BUG: Diagnostic contains: parameter o of referenced method is @NonNull",
+            "    I i2 = this::nonNullParam;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2353,6 +2353,31 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void methodReferenceToNullUnmarked() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "import java.util.function.Function;",
+            "@NullMarked",
+            "public class Test {",
+            "  @NullUnmarked",
+            "  public static Boolean isNull(Object o) { return o == null; }",
+            "  @NullUnmarked",
+            "  public static Boolean isNullRestrictParam(@NonNull Object o) { return o == null; }",
+            "  @NullUnmarked",
+            "  public static @Nullable Boolean isNullRestrictReturn(Object o) { return o == null; }",
+            "  static Function<@Nullable Object, Boolean> filter1 = Test::isNull;",
+            "  // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
+            "  static Function<@Nullable Object, Boolean> filter2 = Test::isNullRestrictParam;",
+            "  // BUG: Diagnostic contains: referenced method returns @Nullable",
+            "  static Function<@Nullable Object, Boolean> filter3 = Test::isNullRestrictReturn;",
+            "  static Function<@Nullable Object, @Nullable Boolean> filter4 = Test::isNullRestrictReturn;",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2369,7 +2369,7 @@ public class GenericsTests extends NullAwayTestsBase {
             "  @NullUnmarked",
             "  public static @Nullable Boolean isNullRestrictReturn(Object o) { return o == null; }",
             "  static Function<@Nullable Object, Boolean> filter1 = Test::isNull;",
-            "  // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
+            "  // BUG: Diagnostic contains: parameter o of referenced method is @NonNull, but parameter in functional",
             "  static Function<@Nullable Object, Boolean> filter2 = Test::isNullRestrictParam;",
             "  // BUG: Diagnostic contains: referenced method returns @Nullable",
             "  static Function<@Nullable Object, Boolean> filter3 = Test::isNullRestrictReturn;",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
@@ -1256,4 +1256,32 @@ public class NullMarkednessTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void methodRefToNullUnmarkedNoAcknowledgeRestrictive() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "@NullMarked",
+            "class Test {",
+            "  interface I {",
+            "    void m(@Nullable Object o);",
+            "  }",
+            "  @NullUnmarked",
+            "  void unmarkedParam(Object o) {}",
+            "  @NullUnmarked",
+            "  void nonNullParam(@NonNull Object o) {}",
+            "  void test() {",
+            "    I i = this::unmarkedParam;",
+            "    // no error since we don't acknowledge restrictive annotations",
+            "    I i2 = this::nonNullParam;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #1195 

We adjust our method overriding checks for a method reference to a `@NullUnmarked` method.  Any overriding should be allowed, except in the presence of a restrictive annotation (`@Nullable` on the return or `@NonNull` on a parameter).  Also add tests for `@NonNull` on the varargs parameter.