### PR TITLE
More flexible handling of AssertJ `isNotNull` methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/AssertionHandler.java
@@ -60,7 +60,8 @@ public class AssertionHandler extends BaseNoOpHandler {
     // Look for statements of the form: assertThat(A).isNotNull() or
     // assertThat(A).isInstanceOf(Foo.class)
     // A will not be NULL after this statement.
-    if (methodNameUtil.isMethodIsNotNull(callee) || methodNameUtil.isMethodIsInstanceOf(callee)) {
+    if (methodNameUtil.isMethodIsNotNull(callee, state)
+        || methodNameUtil.isMethodIsInstanceOf(callee, state)) {
       AccessPath ap = getAccessPathForNotNullAssertThatExpr(node, state, apContext);
       if (ap != null) {
         bothUpdates.set(ap, NONNULL);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
@@ -22,8 +22,12 @@ package com.uber.nullaway.handlers;
  * THE SOFTWARE.
  */
 
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.util.Name;
 import com.uber.nullaway.annotations.Initializer;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
@@ -41,8 +45,6 @@ class MethodNameUtil {
   // assertions in this handler.
   private static final String IS_NOT_NULL_METHOD = "isNotNull";
   private static final String IS_OWNER_TRUTH_SUBJECT = "com.google.common.truth.Subject";
-  private static final String IS_OWNER_ASSERTJ_ABSTRACT_ASSERT =
-      "org.assertj.core.api.AbstractAssert";
   private static final String IS_INSTANCE_OF_METHOD = "isInstanceOf";
   private static final String IS_INSTANCE_OF_ANY_METHOD = "isInstanceOfAny";
   private static final String IS_TRUE_METHOD = "isTrue";
@@ -79,6 +81,10 @@ class MethodNameUtil {
   private static final String NULL_VALUE_MATCHER = "nullValue";
   private static final String INSTANCE_OF_MATCHER = "instanceOf";
 
+  private static final String ASSERTJ_ASSERT_INTERFACE = "org.assertj.core.api.Assert";
+  private static final Supplier<Type> ASSERTJ_ASSERT_TYPE_SUPPLIER =
+      Suppliers.typeFromString(ASSERTJ_ASSERT_INTERFACE);
+
   // Names of the methods (and their owners) used to identify assertions in this handler. Name used
   // here refers to com.sun.tools.javac.util.Name. Comparing methods using Names is faster than
   // comparing using strings.
@@ -87,7 +93,6 @@ class MethodNameUtil {
   private Name isInstanceOf;
   private Name isInstanceOfAny;
   private Name isOwnerTruthSubject;
-  private Name isOwnerAssertJAbstractAssert;
 
   private Name isTrue;
   private Name isFalse;
@@ -130,7 +135,6 @@ class MethodNameUtil {
   void initializeMethodNames(Name.Table table) {
     isNotNull = table.fromString(IS_NOT_NULL_METHOD);
     isOwnerTruthSubject = table.fromString(IS_OWNER_TRUTH_SUBJECT);
-    isOwnerAssertJAbstractAssert = table.fromString(IS_OWNER_ASSERTJ_ABSTRACT_ASSERT);
 
     isInstanceOf = table.fromString(IS_INSTANCE_OF_METHOD);
     isInstanceOfAny = table.fromString(IS_INSTANCE_OF_ANY_METHOD);
@@ -172,16 +176,16 @@ class MethodNameUtil {
     instanceOfMatcher = table.fromString(INSTANCE_OF_MATCHER);
   }
 
-  boolean isMethodIsNotNull(Symbol.MethodSymbol methodSymbol) {
+  boolean isMethodIsNotNull(Symbol.MethodSymbol methodSymbol, VisitorState state) {
     return matchesMethod(methodSymbol, isNotNull, isOwnerTruthSubject)
-        || matchesMethod(methodSymbol, isNotNull, isOwnerAssertJAbstractAssert);
+        || matchesAssertJAssertMethod(methodSymbol, isNotNull, state);
   }
 
-  boolean isMethodIsInstanceOf(Symbol.MethodSymbol methodSymbol) {
+  boolean isMethodIsInstanceOf(Symbol.MethodSymbol methodSymbol, VisitorState state) {
     return matchesMethod(methodSymbol, isInstanceOf, isOwnerTruthSubject)
-        || matchesMethod(methodSymbol, isInstanceOf, isOwnerAssertJAbstractAssert)
+        || matchesAssertJAssertMethod(methodSymbol, isInstanceOf, state)
         // Truth doesn't seem to have isInstanceOfAny
-        || matchesMethod(methodSymbol, isInstanceOfAny, isOwnerAssertJAbstractAssert);
+        || matchesAssertJAssertMethod(methodSymbol, isInstanceOfAny, state);
   }
 
   boolean isMethodAssertTrue(Symbol.MethodSymbol methodSymbol) {
@@ -301,6 +305,15 @@ class MethodNameUtil {
       Symbol.MethodSymbol methodSymbol, Name toMatchMethodName, Name toMatchOwnerName) {
     return methodSymbol.name.equals(toMatchMethodName)
         && methodSymbol.owner.getQualifiedName().equals(toMatchOwnerName);
+  }
+
+  private boolean matchesAssertJAssertMethod(
+      Symbol.MethodSymbol methodSymbol, Name toMatchMethodName, VisitorState state) {
+    if (!methodSymbol.name.equals(toMatchMethodName)) {
+      return false;
+    }
+    return ASTHelpers.isSubtype(
+        methodSymbol.owner.type, ASSERTJ_ASSERT_TYPE_SUPPLIER.get(state), state);
   }
 
   boolean isUtilInitialized() {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/MethodNameUtil.java
@@ -81,9 +81,8 @@ class MethodNameUtil {
   private static final String NULL_VALUE_MATCHER = "nullValue";
   private static final String INSTANCE_OF_MATCHER = "instanceOf";
 
-  private static final String ASSERTJ_ASSERT_INTERFACE = "org.assertj.core.api.Assert";
   private static final Supplier<Type> ASSERTJ_ASSERT_TYPE_SUPPLIER =
-      Suppliers.typeFromString(ASSERTJ_ASSERT_INTERFACE);
+      Suppliers.typeFromString("org.assertj.core.api.Assert");
 
   // Names of the methods (and their owners) used to identify assertions in this handler. Name used
   // here refers to com.sun.tools.javac.util.Name. Comparing methods using Names is faster than
@@ -307,6 +306,15 @@ class MethodNameUtil {
         && methodSymbol.owner.getQualifiedName().equals(toMatchOwnerName);
   }
 
+  /**
+   * Checks if the method is an AssertJ assert method, i.e., it has the same name as
+   * toMatchMethodName and its owner is a subtype of AssertJ's Assert class.
+   *
+   * @param methodSymbol the method symbol to check
+   * @param toMatchMethodName the method name to match
+   * @param state the visitor state
+   * @return {@code true} if the method matches, {@code false} otherwise
+   */
   private boolean matchesAssertJAssertMethod(
       Symbol.MethodSymbol methodSymbol, Name toMatchMethodName, VisitorState state) {
     if (!methodSymbol.name.equals(toMatchMethodName)) {

--- a/nullaway/src/test/java/com/uber/nullaway/AssertionLibsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AssertionLibsTests.java
@@ -526,4 +526,27 @@ public class AssertionLibsTests extends NullAwayTestsBase {
             "}")
         .doTest();
   }
+
+  @Test
+  public void collectionAssertIsNotNull() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "import java.util.Collection;",
+            "import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;",
+            "@NullMarked",
+            "class Test {",
+            "  void test(@Nullable Collection<String> c) {",
+            "    assertThat(c).isNotNull();",
+            "    c.size();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/AssertionLibsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AssertionLibsTests.java
@@ -539,7 +539,7 @@ public class AssertionLibsTests extends NullAwayTestsBase {
             "Test.java",
             "import org.jspecify.annotations.*;",
             "import java.util.Collection;",
-            "import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;",
+            "import static org.assertj.core.api.Assertions.assertThat;",
             "@NullMarked",
             "class Test {",
             "  void test(@Nullable Collection<String> c) {",


### PR DESCRIPTION
Fixes #1219 

Previously, we would only consider the `isNotNull` method of `org.assertj.core.api.AbstractAssert` to be valid.  Now, we allow `isNotNull` of any class that implements the `org.assertj.core.api.Assert` interface, which handles the case from #1219 and more.