### PR TITLE
Add `AdditionalSuppressionNames` configuration option

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -241,11 +241,11 @@ public interface Config {
   @Nullable String getCastToNonNullMethod();
 
   /**
-   * Gets the additional suppression names.
+   * Gets the suppression name aliases.
    *
-   * @return the additional names that should be honored as part of a @SuppressWarnings annotation.
+   * @return the name aliases that should be honored as part of a @SuppressWarnings annotation.
    */
-  Set<String> getAdditionalSuppressionNames();
+  Set<String> getSuppressionNameAliases();
 
   /**
    * Gets an optional comment to add to auto-fix suppressions.

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -241,6 +241,13 @@ public interface Config {
   @Nullable String getCastToNonNullMethod();
 
   /**
+   * Gets the additional suppression names.
+   *
+   * @return the additional names that should be honored as part of a @SuppressWarnings annotation.
+   */
+  Set<String> getAdditionalSuppressionNames();
+
+  /**
    * Gets an optional comment to add to auto-fix suppressions.
    *
    * @return the comment to add to @SuppressWarnings annotations inserted into fix suggestions

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -180,7 +180,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public Set<String> getAdditionalSuppressionNames() {
+  public Set<String> getSuppressionNameAliases() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -180,6 +180,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public Set<String> getAdditionalSuppressionNames() {
+    throw new IllegalStateException(ERROR_MESSAGE);
+  }
+
+  @Override
   public String getAutofixSuppressionComment() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -79,6 +79,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_OPTIONAL_CLASS_PATHS =
       EP_FL_NAMESPACE + ":CheckOptionalEmptinessCustomClasses";
   static final String FL_SUPPRESS_COMMENT = EP_FL_NAMESPACE + ":AutoFixSuppressionComment";
+  static final String FL_SUPPRESS_NAMES = EP_FL_NAMESPACE + ":AdditionalSuppressionNames";
 
   static final String FL_SKIP_LIBRARY_MODELS = EP_FL_NAMESPACE + ":IgnoreLibraryModelsFor";
 
@@ -228,6 +229,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final ImmutableSet<String> contractAnnotations;
   private final @Nullable String castToNonNullMethod;
   private final String autofixSuppressionComment;
+  private final ImmutableSet<String> additionalSuppressionNames;
   private final ImmutableSet<String> skippedLibraryModels;
   private final ImmutableSet<String> extraFuturesClasses;
 
@@ -313,6 +315,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
       throw new IllegalStateException(
           "Invalid -XepOpt:" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
     }
+    additionalSuppressionNames = getFlagStringSet(flags, FL_SUPPRESS_NAMES);
     skippedLibraryModels = getFlagStringSet(flags, FL_SKIP_LIBRARY_MODELS);
     extraFuturesClasses = getFlagStringSet(flags, FL_EXTRA_FUTURES);
 
@@ -532,6 +535,11 @@ final class ErrorProneCLIFlagsConfig implements Config {
   @Override
   public @Nullable String getCastToNonNullMethod() {
     return castToNonNullMethod;
+  }
+
+  @Override
+  public ImmutableSet<String> getAdditionalSuppressionNames() {
+    return additionalSuppressionNames;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -79,7 +79,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_OPTIONAL_CLASS_PATHS =
       EP_FL_NAMESPACE + ":CheckOptionalEmptinessCustomClasses";
   static final String FL_SUPPRESS_COMMENT = EP_FL_NAMESPACE + ":AutoFixSuppressionComment";
-  static final String FL_SUPPRESS_NAMES = EP_FL_NAMESPACE + ":AdditionalSuppressionNames";
+  static final String FL_SUPPRESS_NAMES = EP_FL_NAMESPACE + ":SuppressionNameAliases";
 
   static final String FL_SKIP_LIBRARY_MODELS = EP_FL_NAMESPACE + ":IgnoreLibraryModelsFor";
 
@@ -229,7 +229,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final ImmutableSet<String> contractAnnotations;
   private final @Nullable String castToNonNullMethod;
   private final String autofixSuppressionComment;
-  private final ImmutableSet<String> additionalSuppressionNames;
+  private final ImmutableSet<String> suppressionNameAliases;
   private final ImmutableSet<String> skippedLibraryModels;
   private final ImmutableSet<String> extraFuturesClasses;
 
@@ -315,7 +315,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
       throw new IllegalStateException(
           "Invalid -XepOpt:" + FL_SUPPRESS_COMMENT + " value. Comment must be single line.");
     }
-    additionalSuppressionNames = getFlagStringSet(flags, FL_SUPPRESS_NAMES);
+    suppressionNameAliases = getFlagStringSet(flags, FL_SUPPRESS_NAMES);
     skippedLibraryModels = getFlagStringSet(flags, FL_SKIP_LIBRARY_MODELS);
     extraFuturesClasses = getFlagStringSet(flags, FL_EXTRA_FUTURES);
 
@@ -538,8 +538,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
   }
 
   @Override
-  public ImmutableSet<String> getAdditionalSuppressionNames() {
-    return additionalSuppressionNames;
+  public ImmutableSet<String> getSuppressionNameAliases() {
+    return suppressionNameAliases;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -306,7 +306,12 @@ public class NullAway extends BugChecker
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = this::isMethodUnannotated;
-    errorBuilder = new ErrorBuilder(config, canonicalName(), allNames());
+    ImmutableSet<String> allSuppressionNames =
+        ImmutableSet.<String>builder()
+            .addAll(allNames())
+            .addAll(config.getAdditionalSuppressionNames())
+            .build();
+    errorBuilder = new ErrorBuilder(config, canonicalName(), allSuppressionNames);
   }
 
   private boolean isMethodUnannotated(MethodInvocationNode invocationNode) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -306,11 +306,13 @@ public class NullAway extends BugChecker
     config = new ErrorProneCLIFlagsConfig(flags);
     handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = this::isMethodUnannotated;
-    ImmutableSet<String> allSuppressionNames =
-        ImmutableSet.<String>builder()
-            .addAll(allNames())
-            .addAll(config.getAdditionalSuppressionNames())
-            .build();
+    Set<String> allSuppressionNames =
+        config.getAdditionalSuppressionNames().isEmpty()
+            ? allNames()
+            : ImmutableSet.<String>builder()
+                .addAll(allNames())
+                .addAll(config.getAdditionalSuppressionNames())
+                .build();
     errorBuilder = new ErrorBuilder(config, canonicalName(), allSuppressionNames);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -23,7 +23,6 @@
 package com.uber.nullaway;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
-import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
 import static com.sun.source.tree.Tree.Kind.OTHER;
 import static com.uber.nullaway.ASTHelpersBackports.hasDirectAnnotationWithSimpleName;
 import static com.uber.nullaway.ASTHelpersBackports.isStatic;
@@ -307,11 +306,11 @@ public class NullAway extends BugChecker
     handler = Handlers.buildDefault(config);
     nonAnnotatedMethod = this::isMethodUnannotated;
     Set<String> allSuppressionNames =
-        config.getAdditionalSuppressionNames().isEmpty()
+        config.getSuppressionNameAliases().isEmpty()
             ? allNames()
             : ImmutableSet.<String>builder()
                 .addAll(allNames())
-                .addAll(config.getAdditionalSuppressionNames())
+                .addAll(config.getSuppressionNameAliases())
                 .build();
     errorBuilder = new ErrorBuilder(config, canonicalName(), allSuppressionNames);
   }

--- a/nullaway/src/test/java/com/uber/nullaway/AdditionalSuppressionNamesTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AdditionalSuppressionNamesTests.java
@@ -1,0 +1,37 @@
+package com.uber.nullaway;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class AdditionalSuppressionNamesTests extends NullAwayTestsBase {
+
+  @Test
+  public void additionalSuppressionNamesTest() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:AdditionalSuppressionNames=Foo,Bar"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Test {",
+            "  @SuppressWarnings(\"Foo\")",
+            "  void foo(@Nullable Object o) {",
+            "    o.getClass();",
+            "  }",
+            "  @SuppressWarnings(\"Bar\")",
+            "  void bar(@Nullable Object o) {",
+            "    o.getClass();",
+            "  }",
+            "  @SuppressWarnings(\"Baz\")",
+            "  void baz(@Nullable Object o) {",
+            "    // BUG: Diagnostic contains: dereferenced expression o is @Nullable",
+            "    o.getClass();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/SuppressionNameAliasesTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SuppressionNameAliasesTests.java
@@ -3,7 +3,7 @@ package com.uber.nullaway;
 import java.util.Arrays;
 import org.junit.Test;
 
-public class AdditionalSuppressionNamesTests extends NullAwayTestsBase {
+public class SuppressionNameAliasesTests extends NullAwayTestsBase {
 
   @Test
   public void additionalSuppressionNamesTest() {
@@ -12,7 +12,7 @@ public class AdditionalSuppressionNamesTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AdditionalSuppressionNames=Foo,Bar"))
+                "-XepOpt:NullAway:SuppressionNameAliases=Foo,Bar"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",


### PR DESCRIPTION
Prior to this change, NullAway could be skipped only with an explicit `@SuppressWarnings("NullAway")` annotation. However, existing inspections like `DataFlowIssue` by JetBrains imply that NullAway should be skipped too.

With this change, NullAway can be configured to back off when additional names are present, via the `SuppressionNameAliases` configuration option.

* Closes #1230

## Documentation

Here is the text I propose to add to https://github.com/uber/NullAway/wiki/Configuration#command-line-options;

```markdown
### Suppression Name Aliases (Version 0.12.8 and after)

  - `-XepOpt:NullAway:SuppressionNameAliases=...`

A list of names to suppress NullAway using a `@SuppressWarnings` annotation, similar to `@SuppressWarnings("NullAway")`.
This is useful when other warnings are already suppressed in the codebase and NullAway should be suppressed as well, such as with JetBrains' [`DataFlowIssue`](https://www.jetbrains.com/help/inspectopedia/DataFlowIssue.html) inspection.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom suppression name aliases in warning suppression annotations.
* **Tests**
  * Introduced new tests to verify correct handling of custom suppression name aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->