### PR TITLE
Fix to handling of `case null`

### DIFF
--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -269,6 +269,29 @@ public class SwitchTests {
   }
 
   @Test
+  public void caseNullTypeRefinement() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "TestCase.java",
+            "import java.io.IOException;",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "public class TestCase {",
+            "    boolean hasRelevantMessage(IOException ioException)",
+            "    {",
+            "        String message = ioException.getMessage();",
+            "        return switch (message)",
+            "        {",
+            "            case null -> false;",
+            "            case \"Operation timed out\", \"Connection reset by peer\", \"Premature EOF\", \"Error writing to server\" -> true;",
+            "            default -> message.contains(\"GOAWAY received\");",
+            "        };",
+            "    }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void issue1168() {
     defaultCompilationHelper
         .addSourceLines(

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -965,7 +965,11 @@ public class AccessPathNullnessPropagation
       // between the switch expression and the case operand.
       Node switchOperand = caseNode.getSwitchOperand().getExpression();
       Node caseOperand = caseOperands.get(0);
-      return handleEqualityComparison(input, switchOperand, caseOperand, true);
+      if (caseOperand instanceof NullLiteralNode) {
+        return handleEqualityComparison(input, switchOperand, caseOperand, true);
+      } else {
+        return noStoreChanges(NULLABLE, input);
+      }
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -965,11 +965,7 @@ public class AccessPathNullnessPropagation
       // between the switch expression and the case operand.
       Node switchOperand = caseNode.getSwitchOperand().getExpression();
       Node caseOperand = caseOperands.get(0);
-      if (caseOperand instanceof NullLiteralNode) {
-        return handleEqualityComparison(input, switchOperand, caseOperand, true);
-      } else {
-        return noStoreChanges(NULLABLE, input);
-      }
+      return handleEqualityComparison(input, switchOperand, caseOperand, true);
     }
   }
 


### PR DESCRIPTION
Fixes #1233.  Our handling of `case null` didn't actually check it was only operating for a `null` literal in the case, so it was getting applied too broadly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify handling of null and string cases in switch expressions with type refinement and nullness annotations.

* **Bug Fixes**
  * Enhanced nullness propagation accuracy in switch-case expressions by supplying explicit nullness information for the case operand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->