### PR TITLE
Add library model for Apache Commons CollectionUtils.isNotEmpty, Amazon CollectionUtils.IsNullOrEmpty, and a couple Amazon StringUtils methods

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -123,6 +123,7 @@ def test = [
     mockito                 : "org.mockito:mockito-core:5.16.1",
     javaxAnnotationApi      : "javax.annotation:javax.annotation-api:1.3.2",
     assertJ                 : "org.assertj:assertj-core:3.23.1",
+    amazonUtils             : "software.amazon.awssdk:utils:2.32.19",
 ]
 
 ext.deps = [

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     testImplementation deps.test.mockito
     testImplementation deps.test.javaxAnnotationApi
     testImplementation deps.test.assertJ
+    testImplementation deps.test.amazonUtils
     // This is for a test exposing a CFG construction failure in the Checker Framework.  We can probably remove it once
     // the issue is fixed upstream and we update. See https://github.com/typetools/checker-framework/issues/6396.
     testImplementation 'org.apache.spark:spark-sql_2.12:3.3.2'

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -725,9 +725,9 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 0)
             .put(
                 methodRef(
-                    "com.amazonaws.util.CollectionUtils",
-                    "isNullOrEmpty(java.util.Collection<?>)"),
+                    "com.amazonaws.util.CollectionUtils", "isNullOrEmpty(java.util.Collection<?>)"),
                 0)
+            .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"),0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("spark.utils.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -728,7 +728,14 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                     "software.amazon.awssdk.utils.CollectionUtils",
                     "isNullOrEmpty(java.util.Collection<?>)"),
                 0)
-            .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"), 0)
+            .put(
+                methodRef(
+                    "software.amazon.awssdk.utils.StringUtils", "isEmpty(java.lang.CharSequence)"),
+                0)
+            .put(
+                methodRef(
+                    "software.amazon.awssdk.utils.StringUtils", "isBlank(java.lang.CharSequence)"),
+                0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("spark.utils.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -725,7 +725,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 0)
             .put(
                 methodRef(
-                    "com.amazonaws.util.CollectionUtils", "isNullOrEmpty(java.util.Collection<?>)"),
+                    "software.amazon.awssdk.utils.CollectionUtils", "isNullOrEmpty(java.util.Collection<?>)"),
                 0)
             .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"), 0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -725,7 +725,8 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 0)
             .put(
                 methodRef(
-                    "software.amazon.awssdk.utils.CollectionUtils", "isNullOrEmpty(java.util.Collection<?>)"),
+                    "software.amazon.awssdk.utils.CollectionUtils",
+                    "isNullOrEmpty(java.util.Collection<?>)"),
                 0)
             .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"), 0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -713,6 +713,21 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 methodRef(
                     "org.springframework.util.CollectionUtils", "isEmpty(java.util.Collection<?>)"),
                 0)
+            .put(
+                methodRef(
+                    "org.apache.commons.collections.CollectionUtils",
+                    "isEmpty(java.util.Collection)"),
+                0)
+            .put(
+                methodRef(
+                    "org.apache.commons.collections4.CollectionUtils",
+                    "isEmpty(java.util.Collection<?>)"),
+                0)
+            .put(
+                methodRef(
+                    "com.amazonaws.util.CollectionUtils",
+                    "isNullOrEmpty(java.util.Collection<?>)"),
+                0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("spark.utils.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -727,7 +727,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 methodRef(
                     "com.amazonaws.util.CollectionUtils", "isNullOrEmpty(java.util.Collection<?>)"),
                 0)
-            .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"),0)
+            .put(methodRef("com.amazonaws.util.StringUtils", "isNullOrEmpty(java.lang.String)"), 0)
             .put(methodRef("org.springframework.util.StringUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("org.springframework.util.ObjectUtils", "isEmpty(java.lang.Object)"), 0)
             .put(methodRef("spark.utils.ObjectUtils", "isEmpty(java.lang.Object[])"), 0)

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1069,6 +1069,66 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void apacheCollectionsCollectionUtilsIsEmpty() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import org.apache.commons.collections.CollectionUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable List<String> s) {",
+            "    if(CollectionUtils.isEmpty(s)) {",
+            "      return;",
+            "    }",
+            "    s.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void apacheCollections4CollectionUtilsIsEmpty() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import org.apache.commons.collections4.CollectionUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable List<String> s) {",
+            "    if(CollectionUtils.isEmpty(s)) {",
+            "      return;",
+            "    }",
+            "    s.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void amazonAwsUtilCollectionUtilsIsNullOrEmpty() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import com.amazonaws.util.CollectionUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable List<String> s) {",
+            "    if(CollectionUtils.isNullOrEmpty(s)) {",
+            "      return;",
+            "    }",
+            "    s.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void filesIsDirectory() {
     defaultCompilationHelper
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1129,6 +1129,32 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void amazonAwsStringUtilsIsEmptyOrIsBlank() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            "package com.uber;",
+            "import software.amazon.awssdk.utils.StringUtils;",
+            "import org.jetbrains.annotations.Nullable;",
+            "import java.util.List;",
+            "public class Foo {",
+            "  public void bar(@Nullable String s) {",
+            "    if(StringUtils.isEmpty(s)) {",
+            "      return;",
+            "    }",
+            "    s.hashCode();",
+            "  }",
+            "  public void baz(@Nullable String s) {",
+            "    if(StringUtils.isBlank(s)) {",
+            "      return;",
+            "    }",
+            "    s.hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void filesIsDirectory() {
     defaultCompilationHelper
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1114,7 +1114,7 @@ public class FrameworkTests extends NullAwayTestsBase {
         .addSourceLines(
             "Foo.java",
             "package com.uber;",
-            "import com.amazonaws.util.CollectionUtils;",
+            "import software.amazon.awssdk.utils.CollectionUtils;",
             "import org.jetbrains.annotations.Nullable;",
             "import java.util.List;",
             "public class Foo {",


### PR DESCRIPTION
## Summary
This PR extends DefaultLibraryModels to recognize additional null-check helper methods from common libraries, ensuring NullAway treats them as guarding against null values.

Added support for:
* org.apache.commons.collections.CollectionUtils.isEmpty(Collection)
* org.apache.commons.collections4.CollectionUtils.isEmpty(Collection<?>)
* software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty(Collection<?>)


Each method is now mapped so that NullAway understands they perform null checks on their first argument.

Added corresponding unit tests in FrameworkTests to validate behavior for Apache Commons Collections, Apache Commons Collections4, and AWS CollectionUtils.

Impact
With these changes, NullAway will correctly recognize these helper methods as null guards, reducing false positives when developers use them to validate collections or objects before dereferencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded recognition of common null/empty guards to include additional collection and string utility methods (Apache Commons, Commons Lang/3, AWS SDK utils, Spark utils, Android TextUtils), improving null-safety analysis.

* **Tests**
  * Added tests verifying null/empty guard handling for Apache Commons Collections, Commons Collections4, AWS SDK utils, and AWS StringUtils isEmpty/isBlank paths.

* **Chores**
  * Added AWS SDK utils as a test dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->