### PR TITLE
Test reading JSpecify annotations from bytecodes on JDK 21

### DIFF
--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -21,8 +21,10 @@
  */
 package com.uber.nullaway.guava;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAway;
+import com.uber.nullaway.NullabilityUtil;
 import java.util.Arrays;
 import org.junit.Assume;
 import org.junit.Before;
@@ -54,14 +56,18 @@ public class NullAwayGuavaParametricNullnessTests {
                     //  from this list.
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
                     "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
+    ImmutableList.Builder<String> jspecifyArgsBuilder =
+        ImmutableList.<String>builder()
+            .add("-d", temporaryFolder.getRoot().getAbsolutePath())
+            .add("-XepOpt:NullAway:OnlyNullMarked=true")
+            .add("-XepOpt:NullAway:JSpecifyMode=true");
+    if (NullabilityUtil.isJDK21Update8OrHigher()) {
+      jspecifyArgsBuilder.add("-XDaddTypeAnnotationsToSymbol=true");
+    }
+
     jspecifyCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())
-            .setArgs(
-                Arrays.asList(
-                    "-d",
-                    temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:OnlyNullMarked=true",
-                    "-XepOpt:NullAway:JSpecifyMode=true"));
+            .setArgs(jspecifyArgsBuilder.build());
   }
 
   @Test
@@ -92,7 +98,7 @@ public class NullAwayGuavaParametricNullnessTests {
   @Test
   public void jspecifyFutureCallback() {
     // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 23);
+    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -140,7 +146,7 @@ public class NullAwayGuavaParametricNullnessTests {
   @Test
   public void jspecifyIterables() {
     // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 23);
+    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -170,7 +176,7 @@ public class NullAwayGuavaParametricNullnessTests {
   @Test
   public void jspecifyComparators() {
     // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 23);
+    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -252,7 +258,7 @@ public class NullAwayGuavaParametricNullnessTests {
   @Test
   public void newHashSetPassingNullable() {
     // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 23);
+    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -21,11 +21,10 @@
  */
 package com.uber.nullaway.guava;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAway;
-import com.uber.nullaway.NullabilityUtil;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,18 +55,15 @@ public class NullAwayGuavaParametricNullnessTests {
                     //  from this list.
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.google.common",
                     "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"));
-    ImmutableList.Builder<String> jspecifyArgsBuilder =
-        ImmutableList.<String>builder()
-            .add("-d", temporaryFolder.getRoot().getAbsolutePath())
-            .add("-XepOpt:NullAway:OnlyNullMarked=true")
-            .add("-XepOpt:NullAway:JSpecifyMode=true");
-    if (NullabilityUtil.isJDK21Update8OrHigher()) {
-      jspecifyArgsBuilder.add("-XDaddTypeAnnotationsToSymbol=true");
-    }
-
     jspecifyCompilationHelper =
         CompilationTestHelper.newInstance(NullAway.class, getClass())
-            .setArgs(jspecifyArgsBuilder.build());
+            .setArgs(
+                List.of(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true",
+                    "-XepOpt:NullAway:JSpecifyMode=true",
+                    "-XDaddTypeAnnotationsToSymbol=true"));
   }
 
   @Test

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -187,15 +187,6 @@ project.tasks.named('check').configure {
 }
 
 tasks.withType(Test).configureEach { test ->
-    if (test.javaVersion < JavaVersion.VERSION_22) {
-        // Certain tests involving reading annotations from bytecode will not pass on pre-JDK-22 javac
-        // until the fix for https://bugs.openjdk.org/browse/JDK-8225377 is backported or until we add
-        // workarounds.  See https://github.com/uber/NullAway/issues/1005.
-        test.filter {
-            excludeTestsMatching "com.uber.nullaway.jspecify.BytecodeGenericsTests.genericsChecksForParamPassingAndReturns"
-            excludeTestsMatching "com.uber.nullaway.jspecify.BytecodeGenericsTests.genericsChecksForFieldAssignments"
-        }
-    }
     // hack: for some reasons the ErrorProneCLIFlagsConfigTest does not pass on EP 2.31.0,
     // though it passes on both older and newer Error Prone versions (???).  Not worth tracking
     // down

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -662,4 +662,10 @@ public class NullabilityUtil {
             : ((JCTree.JCNewClass) tree).varargsElement;
     return varargsElement != null;
   }
+
+  /** Checks if the JDK version is 21, update 8 or higher (i.e., 21.0.8, 21.0.9, etc.). */
+  public static boolean isJDK21Update8OrHigher() {
+    Runtime.Version version = Runtime.version();
+    return version.feature() == 21 && version.interim() == 0 && version.update() >= 8;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -662,10 +662,4 @@ public class NullabilityUtil {
             : ((JCTree.JCNewClass) tree).varargsElement;
     return varargsElement != null;
   }
-
-  /** Checks if the JDK version is 21, update 8 or higher (i.e., 21.0.8, 21.0.9, etc.). */
-  public static boolean isJDK21Update8OrHigher() {
-    Runtime.Version version = Runtime.version();
-    return version.feature() == 21 && version.interim() == 0 && version.update() >= 8;
-  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
@@ -1,7 +1,6 @@
 package com.uber.nullaway;
 
 import com.google.errorprone.CompilationTestHelper;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,7 +16,7 @@ public abstract class NullAwayTestsBase {
   public void setup() {
     defaultCompilationHelper =
         makeTestHelperWithArgs(
-            Arrays.asList(
+            List.of(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:KnownInitializers="
@@ -33,7 +32,8 @@ public abstract class NullAwayTestsBase {
                 "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.nullaway.testdata.TestAnnot",
                 "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
                 "-XepOpt:NullAway:ExternalInitAnnotations=com.uber.ExternalInit",
-                "-XepOpt:NullAway:ExcludedFieldAnnotations=com.uber.ExternalFieldInit"));
+                "-XepOpt:NullAway:ExcludedFieldAnnotations=com.uber.ExternalFieldInit",
+                "-XDaddTypeAnnotationsToSymbol=true"));
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -1,9 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
-import com.uber.nullaway.NullabilityUtil;
+import java.util.List;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -248,14 +247,10 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
   }
 
   private CompilationTestHelper makeHelper() {
-    ImmutableList.Builder<String> args =
-        ImmutableList.<String>builder()
-            .add(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:JSpecifyMode=true");
-    if (NullabilityUtil.isJDK21Update8OrHigher()) {
-      args.add("-XDaddTypeAnnotationsToSymbol=true");
-    }
-    return makeTestHelperWithArgs(args.build());
+    return makeTestHelperWithArgs(
+        List.of(
+            "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+            "-XepOpt:NullAway:JSpecifyMode=true",
+            "-XDaddTypeAnnotationsToSymbol=true"));
   }
 }


### PR DESCRIPTION
As of JDK 21.0.8, the patch to properly expose type use annotations via standard APIs has landed, [guarded behind the flag `-XDaddTypeAnnotationsToSymbol=true`](https://github.com/openjdk/jdk21u/commit/bb83d5935ddc206cd809166c7e71983c62e73f71).  This PR runs the relevant tests on JDK 21 by passing that flag where needed.  This means NullAway regression tests will fail on versions of JDK 21 older than 21.0.8, but we can document that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage by enabling previously excluded generics-related tests.
  * Added runtime guards for JDK 21+ to ensure reliable execution.
  * Standardized test configuration for consistent compiler settings.

* **Chores**
  * Simplified Gradle test filtering to run tests consistently across Java versions.

* **Notes**
  * No changes to public API or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->