### PR TITLE
Add tests for gh-1246

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2342,6 +2342,50 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Ignore("https://github.com/uber/NullAway/issues/1246")
+  @Test
+  public void nullableSuperConstructorArg() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Test {",
+            "  private static class A<T extends @Nullable Object> {",
+            "    A(T t) {}",
+            "  }",
+            "  private static class B extends A<@Nullable Object> {",
+            "    B() {",
+            "      super(null);",
+            "  }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Ignore("https://github.com/uber/NullAway/issues/1246")
+  @Test
+  public void nullableSuperMethodArg() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Test {",
+            "  private static class A<T extends @Nullable Object> {",
+            "    void m(T t) {}",
+            "  }",
+            "  private static class B extends A<@Nullable Object> {",
+            "    void test() {",
+            "      m(null);",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   @Test
   public void newNullableWithArg() {
     makeHelper()


### PR DESCRIPTION
This adds (Ignored) tests for the failures for nullable super invocations described in gh-1246

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added two unit tests covering nullability interactions in generic type hierarchies, including passing null to a superclass constructor and to a superclass method parameter.
  * Tests are currently disabled pending resolution of a known issue, ensuring future verification once enabled.
  * Improves coverage for nullness behavior with bounded type parameters and annotations, helping validate expected behavior in inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->