### PR TITLE
Build Spring with snapshot build as a CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,7 @@ jobs:
   compile-other-projects:
     name: "Build ${{ matrix.project }} with snapshot"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - project: caffeine

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,6 +107,6 @@ jobs:
         run: git clone --depth 1 ${{ matrix.url }} /tmp/${{ matrix.project }}
       - name: Run ${{ matrix.project }} build
         run: |
-          cp .github/workflows/caffeine-use-snapshot.gradle.kts /tmp/${{ matrix.project }}
+          cp .github/workflows/use-snapshot.gradle.kts /tmp/${{ matrix.project }}
           cd /tmp/${{ matrix.project }}
-          ./gradlew --init-script caffeine-use-snapshot.gradle.kts build -x test -x javadoc
+          ./gradlew --init-script use-snapshot.gradle.kts build -x test -x javadoc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,6 +86,8 @@ jobs:
             url: https://github.com/ben-manes/caffeine.git
           - project: spring-framework
             url: https://github.com/spring-projects/spring-framework.git
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,10 +76,16 @@ jobs:
         if: matrix.java == '17'
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
-  caffeine-gradle-task:
-    name: "Build Caffeine with snapshot"
+  compile-other-projects:
+    name: "Build ${{ matrix.project }} with snapshot"
+    strategy:
+      matrix:
+        include:
+          - project: caffeine
+            url: https://github.com/ben-manes/caffeine.git
+          - project: spring-framework
+            url: https://github.com/spring-projects/spring-framework.git
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4
@@ -94,12 +100,12 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: 'false'
         run: ./gradlew publishToMavenLocal
-      - name: Create a temporary directory for Caffeine
-        run: mkdir -p /tmp/caffeine
-      - name: Clone Caffeine repository
-        run: git clone --depth 1 https://github.com/ben-manes/caffeine.git /tmp/caffeine
-      - name: Run caffeine build
+      - name: Create a temporary directory for ${{ matrix.project }}
+        run: mkdir -p /tmp/${{ matrix.project }}
+      - name: Clone ${{ matrix.project }} repository
+        run: git clone --depth 1 ${{ matrix.url }} /tmp/${{ matrix.project }}
+      - name: Run ${{ matrix.project }} build
         run: |
-          cp .github/workflows/caffeine-use-snapshot.gradle.kts /tmp/caffeine
-          cd /tmp/caffeine
+          cp .github/workflows/caffeine-use-snapshot.gradle.kts /tmp/${{ matrix.project }}
+          cd /tmp/${{ matrix.project }}
           ./gradlew --init-script caffeine-use-snapshot.gradle.kts build -x test -x javadoc

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -17,6 +17,7 @@ gradle.projectsLoaded {
           }
         }
         cacheChangingModulesFor(0, "seconds")
+        cacheDynamicVersionsFor(0, "seconds")
       }
     }
   }

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,4 +1,4 @@
-// An init script to override Caffeine's build configuration to use a snapshot version of NullAway
+// An init script to override a build configuration to use a snapshot version of NullAway
 allprojects {
   repositories {
     mavenCentral()

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,9 +1,7 @@
 // An init script to override a build configuration to use a snapshot version of NullAway
 allprojects {
   repositories {
-    mavenCentral()
     mavenLocal()
-    gradlePluginPortal()
   }
 }
 

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,6 +1,10 @@
 // An init script to override a build configuration to use a snapshot version of NullAway
 allprojects {
-  repositories.add(mavenLocal())
+  repositories {
+    mavenCentral()
+    mavenLocal()
+    gradlePluginPortal()
+  }
 }
 
 gradle.projectsLoaded {

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,10 +1,6 @@
 // An init script to override a build configuration to use a snapshot version of NullAway
 allprojects {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-    gradlePluginPortal()
-  }
+  repositories.add(mavenLocal())
 }
 
 gradle.projectsLoaded {

--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,7 +1,9 @@
 // An init script to override a build configuration to use a snapshot version of NullAway
 allprojects {
   repositories {
+    mavenCentral()
     mavenLocal()
+    gradlePluginPortal()
   }
 }
 


### PR DESCRIPTION
Just like we build Caffeine on CI, this PR adds a job to build the Spring Framework with the latest NullAway snapshot.  Fortunately a lot of build configuration can be shared between the two projects.

This is a non-blocking job (it fact it's failing right now) but hopefully it will give us some early signal on new crashes and other disruptive changes we may be making.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI now runs a matrix to build multiple external projects (e.g., caffeine and spring-framework), with pipeline steps parameterized for flexible, scalable verification.
  - Build job renamed and generalized to run per-project builds and read-only repository permissions added.
- Documentation
  - Clarified build script comment and enabled caching for dynamic dependency versions to shorten repeated build time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->