### PR TITLE
Add more instance fields to `GenericsChecks`

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2682,7 +2682,7 @@ public class NullAway extends BugChecker
     }
     if (config.isJSpecifyMode()
         && genericsChecks
-            .getGenericReturnNullnessAtInvocation(exprSymbol, invocationTree, state, config)
+            .getGenericReturnNullnessAtInvocation(exprSymbol, invocationTree, state)
             .equals(Nullness.NULLABLE)) {
       return true;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -1103,7 +1103,7 @@ public class AccessPathNullnessPropagation
       if (tree != null) {
         Nullness nullness =
             genericsChecks.getGenericReturnNullnessAtInvocation(
-                ASTHelpers.getSymbol(tree), tree, state, config);
+                ASTHelpers.getSymbol(tree), tree, state);
         return nullness.equals(NULLABLE);
       }
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -3,7 +3,6 @@ package com.uber.nullaway.generics;
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
-import com.uber.nullaway.Config;
 import java.util.List;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
@@ -15,11 +14,11 @@ import javax.lang.model.type.TypeKind;
  */
 public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<Boolean, Type> {
   private final VisitorState state;
-  private final Config config;
+  private final GenericsChecks genericsChecks;
 
-  CheckIdenticalNullabilityVisitor(VisitorState state, Config config) {
+  CheckIdenticalNullabilityVisitor(VisitorState state, GenericsChecks genericsChecks) {
     this.state = state;
-    this.config = config;
+    this.genericsChecks = genericsChecks;
   }
 
   @Override
@@ -63,8 +62,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
         // TODO Handle wildcard types
         continue;
       }
-      boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsTypeArgument, config);
-      boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsTypeArgument, config);
+      boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsTypeArgument);
+      boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsTypeArgument);
       if (isLHSNullableAnnotated != isRHSNullableAnnotated) {
         return false;
       }
@@ -94,8 +93,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     Type.ArrayType arrRhsType = (Type.ArrayType) rhsType;
     Type lhsComponentType = lhsType.getComponentType();
     Type rhsComponentType = arrRhsType.getComponentType();
-    boolean isLHSNullableAnnotated = GenericsChecks.isNullableAnnotated(lhsComponentType, config);
-    boolean isRHSNullableAnnotated = GenericsChecks.isNullableAnnotated(rhsComponentType, config);
+    boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsComponentType);
+    boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsComponentType);
     if (isRHSNullableAnnotated != isLHSNullableAnnotated) {
       return false;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -448,7 +448,6 @@ public final class GenericsChecks {
    * #inferredSubstitutionsForGenericMethodCalls map with the inferred type.
    *
    * @param state the visitor state
-   * @param state the visitor state
    * @param invocationTree the method invocation tree representing the call to a generic method
    * @param typeFromAssignmentContext the type being "assigned to" in the assignment context
    * @param exprType the type of the right-hand side of the pseudo-assignment, which may be null
@@ -585,7 +584,7 @@ public final class GenericsChecks {
    */
   private boolean identicalTypeParameterNullability(
       Type lhsType, Type rhsType, VisitorState state) {
-    return lhsType.accept(new CheckIdenticalNullabilityVisitor(state, config), rhsType);
+    return lhsType.accept(new CheckIdenticalNullabilityVisitor(state, this), rhsType);
   }
 
   /**
@@ -1305,14 +1304,6 @@ public final class GenericsChecks {
    */
   public void clearCache() {
     inferredSubstitutionsForGenericMethodCalls.clear();
-  }
-
-  /**
-   * Static helper to check if a type is explicitly annotated as nullable. Note: prefer the instance
-   * method when a GenericsChecks instance is available.
-   */
-  public static boolean isNullableAnnotated(Type type, Config config) {
-    return Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
   }
 
   public boolean isNullableAnnotated(Type type) {


### PR DESCRIPTION
This helps us delete a ton of individual method parameters and will make other changes in inference easier.  This is a pure refactoring PR with no logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined generics-related nullability checks by moving to instance-based logic initialized via constructors.
  - Reduced parameter passing and centralized configuration/handler usage for improved encapsulation and maintainability.
  - Converted previous static-style calls to instance methods without altering user-facing behavior.
  - Preserved public API surface; no changes required for integrators.
- Chores
  - Added internal comments clarifying initialization order to prevent construction-time issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->