### PR TITLE
remove unneeded checkNotCall call

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -987,8 +987,6 @@ public class AccessPathNullnessPropagation
     ReadableUpdates elseUpdates = new ReadableUpdates();
     ReadableUpdates bothUpdates = new ReadableUpdates();
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(node.getTree());
-    Preconditions.checkNotNull(
-        callee); // this could be null before https://github.com/google/error-prone/pull/2902
     setReceiverNonnull(bothUpdates, node.getTarget().getReceiver(), callee);
     setNullnessForMapCalls(
         node, callee, node.getArguments(), values(input), thenUpdates, bothUpdates);


### PR DESCRIPTION
Unnecessary since https://github.com/google/error-prone/commit/c2e14f24facfae7a0e38e78dd4005f25c7f4f8b4, which shipped with EP 2.11.0 (before our earliest supported version)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents an exception during analysis when a method receiver is missing or unknown, improving stability and preventing interruptions.
  * Retains existing nullness behavior for valid/non-null receivers; map-related nullness updates now safely handle absent receivers.
  * No changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->