### PR TITLE
Fail build on JDK 21 versions before 21.0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ if (JavaVersion.current() == JavaVersion.VERSION_21) {
     def runtimeVersion = Runtime.version()
     if (runtimeVersion.feature() == 21 && runtimeVersion.update() < 8) {
         throw new GradleException(
-                "Building NullAway on JDK 21 requires at least 21.0.8, but found ${runtimeVersion}.  Please upgrade to 21.0.8 or later, or to the most recent JDK release."
+        "Building NullAway on JDK 21 requires at least 21.0.8, but found ${runtimeVersion}.  Please upgrade to 21.0.8 or later, or to the most recent JDK release."
         )
     }
 }


### PR DESCRIPTION
Some JSpecify tests now fail on earlier JDK 21 versions (see #1245).  To avoid confusion, fail the whole build if one of these versions is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Builds now require JDK 21.0.8+ when running on Java 21; earlier Java 21 updates will fail fast with a clear error before tasks run. This applies across all subprojects. No dependency or plugin changes. If you hit the error, upgrade your JDK to 21.0.8 or later; builds on other Java versions behave as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->