### PR TITLE
JSpecify: Fix crash when overriding with raw types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -81,6 +81,7 @@ public class TypeSubstitutionUtils {
 
     @Override
     public Type visitMethodType(Type.MethodType t, Type other) {
+      // other can be a ForAll whose qtype is a MethodType; asMethodType() safely unwraps it.
       Type.MethodType otherMethodType = other.asMethodType();
       List<Type> argtypes = t.argtypes;
       Type restype = t.restype;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -81,7 +81,7 @@ public class TypeSubstitutionUtils {
 
     @Override
     public Type visitMethodType(Type.MethodType t, Type other) {
-      Type.MethodType otherMethodType = (Type.MethodType) other;
+      Type.MethodType otherMethodType = other.asMethodType();
       List<Type> argtypes = t.argtypes;
       Type restype = t.restype;
       List<Type> thrown = t.thrown;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -207,6 +207,7 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** For issue 1250. Checks that we don't crash when overriding with raw types. */
   @Test
   public void overrideWithRawTypes() {
     makeHelper()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -207,7 +207,7 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  /** For issue 1250. Checks that we don't crash when overriding with raw types. */
+  /** For issue 1264. Checks that we don't crash when overriding with raw types. */
   @Test
   public void overrideWithRawTypes() {
     makeHelper()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -207,6 +207,30 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void overrideWithRawTypes() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "public class Test {",
+            "  static class A<T> {}",
+            "  static class B<T> {",
+            "    public <X> X accept(A<X> a) {",
+            "      throw new RuntimeException();",
+            "    }",
+            "  }",
+            "  static class Raw extends B {",
+            "    @Override",
+            "    public Object accept(A a) {",
+            "      throw new RuntimeException();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
Fixes #1264 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved robustness when analyzing generic method types to prevent rare crashes; safer method-type handling reduces risk of ClassCastExceptions.
- Tests
  - Added a test covering inheritance with raw-type overrides to ensure stable behavior and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->