### PR TITLE
Clarify JDK version to use for best JSpecify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NullAway is *fast*.  It is built as a plugin to [Error Prone](http://errorprone.
 
 ### Overview
 
-NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.14.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.
+NullAway requires that you build your code with [Error Prone](http://errorprone.info), version 2.14.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  The instructions below assume you are using Gradle; see [the docs](https://github.com/uber/NullAway/wiki/Configuration#other-build-systems) for discussion of other build systems.  If you are building with JSpecify mode enabled, we recommend building with the most recent JDK available; see [the wiki docs on JSpecify support](https://github.com/uber/NullAway/wiki/JSpecify-Support) for more details.
 
 ### Gradle
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README Overview to recommend using the most recent JDK when JSpecify mode is enabled.
  * Added a link to the JSpecify support wiki for up-to-date compatibility details and guidance.
  * Clarifies setup best practices without changing build steps or configuration.
  * No impact on application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->