### PR TITLE
Don't use deprecated `buildDir`

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -157,7 +157,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
     // Configure compilation to run with Error Prone and NullAway
     source = sourceSets.main.java
     classpath = sourceSets.main.compileClasspath
-    destinationDirectory = file("$buildDir/ignoredClasses")
+    destinationDirectory.set(layout.buildDirectory.dir('ignoredClasses'))
     options.annotationProcessorPath = files(
             configurations.errorproneExtended.asCollection(),
             sourceSets.main.annotationProcessorPath,


### PR DESCRIPTION
Gradle's `$buildDir` is deprecated.  This replaces it by a more modern equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use modern Gradle APIs for resolving build output directories, improving build compatibility, reliability, and maintainability. This is an internal infrastructure change with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->