### PR TITLE
Record when generic method inference fails

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -820,7 +820,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "    Foo<String> foo3 = make(\"hello\", null, \"world\");",
             "    Foo<@Nullable String> foo4 = make(\"hello\", \"world\");",
             "    Foo<@Nullable String> foo5 = make(\"hello\", \"world\", makeStr(null));",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'makeStr(null)' where @NonNull is required",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
             "    Foo<String> foo6 = make(\"hello\", \"world\", makeStr(null));",
             "    // Inference from assignment context only (no args)",
             "    Foo<String> foo7 = make();",


### PR DESCRIPTION
This may be a mild performance optimization, as we will no longer repeatedly perform inference for a call if it failed the first time.  More importantly, for future changes like fixing #1263, it may be useful to be able to assert that inference has _not_ already run for certain calls, and this change enables such assertions.  