### PR TITLE
Support java.util.Objects.toString()

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -812,6 +812,7 @@ public class LibraryModelsHandler extends BaseNoOpHandler {
                 methodRef(
                     "com.google.common.collect.ImmutableMap", "getOrDefault(java.lang.Object,V)"),
                 1)
+            .put(methodRef("java.util.Objects", "toString(java.lang.Object,java.lang.String)"), 1)
             .build();
 
     private static final ImmutableSet<MethodRef> NULLABLE_RETURNS =

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1155,6 +1155,26 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void defaultLibraryModelsObjectToString() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Objects;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "  void objectsToString(@Nullable Object o) {",
+            "    String p = Objects.toString(o, \"foo\");",
+            "    String n = Objects.toString(o, null);",
+            "    p.hashCode();",
+            "    // BUG: Diagnostic contains: dereferenced",
+            "    n.hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void filesIsDirectory() {
     defaultCompilationHelper
         .addSourceLines(


### PR DESCRIPTION
Add support for java.util.Objects.toString(). Closes #1282 

When passing `null` as a nullDefault String, the Object is not guaranteed nonNull.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for java.util.Objects.toString(Object, String). The return value is now considered nullable when the default string argument may be null, preventing unsafe dereferences. Calls with a non-null default string remain treated as non-null.

* **Tests**
  * Added a test validating the updated behavior for Objects.toString with both non-null and null default string arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->