### PR TITLE
Invoke generic method inference in more places

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2711,9 +2711,12 @@ public class NullAway extends BugChecker
     if (Nullness.hasNullableAnnotation(exprSymbol, config)) {
       return true;
     }
+    // NOTE: we cannot rely on state.getPath() here to get a TreePath to the invocation, since
+    // sometimes the invocation is a sub-node of the leaf of the path.  So, here if inference runs,
+    // it will do so without an assignment context.  If this becomes a problem, we can revisit
     if (config.isJSpecifyMode()
         && genericsChecks
-            .getGenericReturnNullnessAtInvocation(exprSymbol, invocationTree, state)
+            .getGenericReturnNullnessAtInvocation(exprSymbol, invocationTree, null, state)
             .equals(Nullness.NULLABLE)) {
       return true;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -1155,7 +1155,7 @@ public class AccessPathNullnessPropagation
       if (tree != null) {
         Nullness nullness =
             genericsChecks.getGenericReturnNullnessAtInvocation(
-                ASTHelpers.getSymbol(tree), tree, state);
+                ASTHelpers.getSymbol(tree), tree, node.getTreePath(), state);
         return nullness.equals(NULLABLE);
       }
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1497,7 +1497,7 @@ public final class GenericsChecks {
    * Returns a pretty-printed representation of type suitable for error messages. The representation
    * uses simple names rather than fully-qualified names, and retains all type-use annotations.
    */
-  public static String prettyTypeForError(Type type, VisitorState state) {
+  private static String prettyTypeForError(Type type, VisitorState state) {
     return type.accept(new GenericTypePrettyPrintingVisitor(state), null);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1303,7 +1303,7 @@ public final class GenericsChecks {
     return null;
   }
 
-  private @Nullable GenericsChecks.InvocationAndContext getInvocationInferenceInfoForAssignment(
+  private @Nullable InvocationAndContext getInvocationInferenceInfoForAssignment(
       Tree assignment, MethodInvocationTree invocation) {
     Preconditions.checkArgument(
         assignment instanceof AssignmentTree || assignment instanceof VariableTree);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1221,8 +1221,15 @@ public final class GenericsChecks {
           return getTypeFromAssignmentContext(parentPath, state);
         }
         AtomicReference<Type> formalParamTypeRef = new AtomicReference<>();
-        new InvocationArguments(
-                parentInvocation, (Type.MethodType) ASTHelpers.getType(parentInvocation))
+        Type type = ASTHelpers.getSymbol(parentInvocation).type;
+        //        verify(
+        //            type instanceof Type.MethodType,
+        //            "expected MethodType but got %s (%s) for invocation %s (%s)",
+        //            type,
+        //            type.getClass(),
+        //            state.getSourceForNode(parentInvocation),
+        //            parentInvocation);
+        new InvocationArguments(parentInvocation, type.asMethodType())
             .forEach(
                 (arg, pos, formalParamType, unused) -> {
                   if (arg == invocation) {
@@ -1230,12 +1237,10 @@ public final class GenericsChecks {
                   }
                 });
         return new InvocationAndType(
-            parentInvocation, Objects.requireNonNull(formalParamTypeRef.get()));
-        //        for (ExpressionTree arg : parentInvocation.getArguments()) {
-        //          if (arg == invocation) {
-        //            return getTreeType(parentInvocation);
-        //          }
-        //        }
+            parentInvocation,
+            Objects.requireNonNull(
+                formalParamTypeRef.get(),
+                "did not find " + invocation + " as argument of " + parentInvocation));
       } else if (exprParent instanceof ConditionalExpressionTree) {
         // TODO
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1238,7 +1238,7 @@ public final class GenericsChecks {
       // find the enclosing method and return its return type
       TreePath enclosingMethodOrLambda =
           NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(parentPath);
-      // TODO handle lambdas
+      // TODO handle lambdas; https://github.com/uber/NullAway/issues/1288
       if (enclosingMethodOrLambda != null
           && enclosingMethodOrLambda.getLeaf() instanceof MethodTree) {
         MethodTree enclosingMethod = (MethodTree) enclosingMethodOrLambda.getLeaf();

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -79,9 +79,9 @@ public final class GenericsChecks {
   /** Indicates failed inference of nullability of type variables at a call */
   private static final class InferenceFailure implements MethodInferenceResult {
     @SuppressWarnings("UnusedVariable") // keep this as it may be useful in the future
-    final @Nullable String errorMessage;
+    final String errorMessage;
 
-    InferenceFailure(@Nullable String errorMessage) {
+    InferenceFailure(String errorMessage) {
       this.errorMessage = errorMessage;
     }
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1244,13 +1244,6 @@ public final class GenericsChecks {
         }
         AtomicReference<Type> formalParamTypeRef = new AtomicReference<>();
         Type type = ASTHelpers.getSymbol(parentInvocation).type;
-        //        verify(
-        //            type instanceof Type.MethodType,
-        //            "expected MethodType but got %s (%s) for invocation %s (%s)",
-        //            type,
-        //            type.getClass(),
-        //            state.getSourceForNode(parentInvocation),
-        //            parentInvocation);
         new InvocationArguments(parentInvocation, type.asMethodType())
             .forEach(
                 (arg, pos, formalParamType, unused) -> {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1149,6 +1149,7 @@ public final class GenericsChecks {
    *
    * @param tree the method invocation tree
    * @param forAllType the generic method type
+   * @param path the path to the invocation tree, or null if not available
    * @param state the visitor state
    * @return the substituted method type for the generic method
    */
@@ -1221,7 +1222,8 @@ public final class GenericsChecks {
    * @param path the path to the invocation
    * @param state the visitor state
    * @return the correct invocation on which to perform inference, along with the relevant
-   *     assignment context information, or {@code null} if no good assignment context can be found
+   *     assignment context information. If no assignment context is available, the
+   *     typeFromAssignmentContext field of the result will be null.
    */
   private InvocationAndContext getInvocationAndContextForInference(
       TreePath path, VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1169,15 +1169,15 @@ public final class GenericsChecks {
         // have not yet attempted inference for this call
         MethodInvocationTree invocationTree = (MethodInvocationTree) tree;
         InvocationAndContext invocationAndType =
-            path == null ? null : getInvocationAndContextForInference(path, state);
+            path == null
+                ? new InvocationAndContext(invocationTree, null, false)
+                : getInvocationAndContextForInference(path, state);
         result =
-            invocationAndType == null
-                ? runInferenceForCall(state, invocationTree, null, false)
-                : runInferenceForCall(
-                    state,
-                    invocationAndType.invocation,
-                    invocationAndType.typeFromAssignmentContext,
-                    invocationAndType.assignedToLocal);
+            runInferenceForCall(
+                state,
+                invocationAndType.invocation,
+                invocationAndType.typeFromAssignmentContext,
+                invocationAndType.assignedToLocal);
       }
       if (result instanceof InferenceSuccess) {
         return getTypeWithInferredNullability(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -473,11 +473,11 @@ public final class GenericsChecks {
     if (tree instanceof VariableTree) {
       VariableTree varTree = (VariableTree) tree;
       rhsTree = varTree.getInitializer();
-      assignedToLocal = isLocalVariableAssignment(varTree);
+      assignedToLocal = isAssignmentToLocalVariable(varTree);
     } else if (tree instanceof AssignmentTree) {
       AssignmentTree assignmentTree = (AssignmentTree) tree;
       rhsTree = assignmentTree.getExpression();
-      assignedToLocal = isLocalVariableAssignment(assignmentTree);
+      assignedToLocal = isAssignmentToLocalVariable(assignmentTree);
     } else {
       throw new RuntimeException("Unexpected tree type: " + tree.getKind());
     }
@@ -500,7 +500,7 @@ public final class GenericsChecks {
     }
   }
 
-  private static boolean isLocalVariableAssignment(Tree tree) {
+  private static boolean isAssignmentToLocalVariable(Tree tree) {
     Symbol treeSymbol;
     if (tree instanceof VariableTree) {
       treeSymbol = ASTHelpers.getSymbol((VariableTree) tree);
@@ -563,6 +563,19 @@ public final class GenericsChecks {
         Collections.emptyMap());
   }
 
+  /**
+   * Runs inference for a generic method call, side-effecting the
+   * #inferredTypeVarNullabilityForGenericCalls map with the result.
+   *
+   * @param state the visitor state
+   * @param invocationTree the method invocation tree representing the call to a generic method
+   * @param typeFromAssignmentContext the type being "assigned to" in the assignment context, or
+   *     {@code null} if the type is unavailable or the method result is not assigned anywhere
+   * @param assignedToLocal true if the method call result is assigned to a local variable, false
+   *     otherwise
+   * @return the inference result, either success with inferred type variable nullability or failure
+   *     with an error message
+   */
   private MethodInferenceResult runInferenceForCall(
       VisitorState state,
       MethodInvocationTree invocationTree,
@@ -1281,7 +1294,8 @@ public final class GenericsChecks {
     Type treeType = getTreeType(assignment);
     return treeType == null
         ? null
-        : new InvocationInferenceInfo(invocation, treeType, isLocalVariableAssignment(assignment));
+        : new InvocationInferenceInfo(
+            invocation, treeType, isAssignmentToLocalVariable(assignment));
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -79,9 +79,9 @@ public final class GenericsChecks {
   /** Indicates failed inference of nullability of type variables at a call */
   private static final class InferenceFailure implements MethodInferenceResult {
     @SuppressWarnings("UnusedVariable") // keep this as it may be useful in the future
-    final String errorMessage;
+    final @Nullable String errorMessage;
 
-    InferenceFailure(String errorMessage) {
+    InferenceFailure(@Nullable String errorMessage) {
       this.errorMessage = errorMessage;
     }
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -133,7 +133,6 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
-  @Ignore("requires inference of generic method type arguments")
   public void genericMethodAndVoidTypeWithInference() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -741,7 +741,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void firstOrDefaultSelfContained() {
-    makeHelper()
+    makeHelperWithInferenceFailureWarning()
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.*;",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1141,26 +1141,54 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** various cases where dataflow analysis forces inference to run for a generic method call */
   @Test
-  public void genericMethodCallAsReceiver() {
+  public void inferenceFromDataflow() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.NullMarked;",
             "import org.jspecify.annotations.Nullable;",
-            "",
             "@NullMarked",
             "public class Test {",
             "  static <U extends @Nullable Object> U id(U u) {",
             "    return u;",
             "  }",
-            "",
-            "  static void test() {",
+            "  static void testReceiver() {",
             "    // to ensure that dataflow runs",
             "    Object x = new Object(); x.toString();",
             "    Object y = null;",
             "    // BUG: Diagnostic contains: passing @Nullable parameter 'y' where @NonNull is required",
             "    id(y).toString();",
+            "  }",
+            "  static Object testReturn() {",
+            "    // to ensure that dataflow runs",
+            "    Object x = new Object(); x.toString();",
+            "    Object y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y' where @NonNull is required",
+            "    return id(y);",
+            "  }",
+            "  static Object testReturnWithParens() {",
+            "    // to ensure that dataflow runs",
+            "    Object x = new Object(); x.toString();",
+            "    Object y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y' where @NonNull is required",
+            "    return (((id(y))));",
+            "  }",
+            "  static Object testReturnNested() {",
+            "    // to ensure that dataflow runs",
+            "    Object x = new Object(); x.toString();",
+            "    Object y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y' where @NonNull is required",
+            "    return id(id(y));",
+            "  }",
+            "  static void takesNonNull(Object o) {}",
+            "  static void testParam() {",
+            "    // to ensure that dataflow runs",
+            "    Object x = new Object(); x.toString();",
+            "    Object y = null;",
+            "    // BUG: Diagnostic contains: passing @Nullable parameter 'y' where @NonNull is required",
+            "    takesNonNull(id(y));",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -766,7 +766,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "    result2.hashCode();",
             "    // should infer T -> @Nullable String (testing that inference is called from dataflow)",
             "    String result3 = firstOrDefault(Collections.singletonList(null), \"hello\");",
-            "    // BUG: Diagnostic contains: dereferenced expression result is @Nullable",
+            "    // BUG: Diagnostic contains: dereferenced expression result3 is @Nullable",
             "    result3.hashCode();",
             "  }",
             "}")


### PR DESCRIPTION
Fixes #1262, fixes #1263 

We now invoke inference for generic method calls in more places, including when it gets queried from dataflow analysis of a full method.  Where possible, we provide a `TreePath` to the relevant call.  With this `TreePath`, we can reconstruct the assignment context of the call and use that information when performing inference (see the new `getInvocationAndContextForInference` method).  In some cases, we pass `null` as the `TreePath` since one is not readily available.  I _believe_ that in most / all of these cases, inference should have already been performed for the call, so we should be able to use the cached result.  If / when we find cases where that didn't happen, and it is impacting the inference result negatively, we can fix in follow ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path-aware nullness inference for generic method calls that selects the correct invocation/assignment context, including nested calls and assignment sites.
* **Bug Fixes**
  * More accurate generic return nullness determination to reduce incorrect diagnostics in complex call and assignment patterns.
* **Performance**
  * Per-invocation caching to speed repeated inference and reuse results across related calls.
* **Tests**
  * Re-enabled and expanded generics inference tests, adding dataflow-triggered inference scenarios and related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->