### PR TITLE
Add a self-contained test case for #1157

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1194,6 +1194,28 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * Self-contained test for https://github.com/uber/NullAway/issues/1157. We need to import
+   * JSpecify JDK models to get the original test working properly.
+   */
+  @Test
+  public void atomicReferenceFieldUpdaterSelfContained() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.*;",
+            "@NullMarked",
+            "public class Test {",
+            "    static class AtomicReferenceFieldUpdater<T, V extends @Nullable Object> {",
+            "      public static <U,W extends @Nullable Object> AtomicReferenceFieldUpdater<U,W> ",
+            "        newUpdater(Class<U> tclass, Class<@NonNull W> vclass, String fieldName) { throw new RuntimeException(); }",
+            "    }",
+            "    static final AtomicReferenceFieldUpdater<Test, @Nullable Object> RESULT_UPDATER =",
+            "            AtomicReferenceFieldUpdater.newUpdater(Test.class, Object.class, \"result\");",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(


### PR DESCRIPTION
Inference works now for code like that of #1157 but the original test case doesn't work since we still lack JSpecify JDK models (#950).  This PR adds a self-contained test case (not using the standard library) to show that inference now works correctly for this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a self-contained test that validates nullness inference and warnings for generic atomic field updaters under JSpecify nullness annotations. This expands coverage of complex generic scenarios and ensures consistent behavior when mixing nullable and non-null type bounds. The added test strengthens reliability and helps prevent regressions related to nullness modeling with generic updaters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->