### PR TITLE
Use inference for generic call passed as receiver to instance method

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1400,7 +1400,13 @@ public final class GenericsChecks {
           enclosingType = castToNonNull(ASTHelpers.getType(enclosingClassTree));
         }
       } else if (methodSelect instanceof MemberSelectTree) {
-        enclosingType = getTreeType(((MemberSelectTree) methodSelect).getExpression());
+        ExpressionTree receiver = ((MemberSelectTree) methodSelect).getExpression();
+        if (isGenericCallNeedingInference(receiver)) {
+          enclosingType =
+              inferGenericMethodCallType(state, (MethodInvocationTree) receiver, null, false);
+        } else {
+          enclosingType = getTreeType(receiver);
+        }
       }
     } else {
       Verify.verify(tree instanceof NewClassTree);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -438,6 +438,9 @@ public final class GenericsChecks {
         } else {
           result = ASTHelpers.getType(assignmentTree);
         }
+      } else if (tree instanceof MethodInvocationTree
+          && isGenericCallNeedingInference((MethodInvocationTree) tree)) {
+        result = inferGenericMethodCallType(state, (MethodInvocationTree) tree, null, false);
       } else {
         result = ASTHelpers.getType(tree);
       }
@@ -531,7 +534,7 @@ public final class GenericsChecks {
   private Type inferGenericMethodCallType(
       VisitorState state,
       MethodInvocationTree invocationTree,
-      Type typeFromAssignmentContext,
+      @Nullable Type typeFromAssignmentContext,
       boolean assignedToLocal) {
     Verify.verify(isGenericCallNeedingInference(invocationTree));
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1400,7 +1400,8 @@ public final class GenericsChecks {
           enclosingType = castToNonNull(ASTHelpers.getType(enclosingClassTree));
         }
       } else if (methodSelect instanceof MemberSelectTree) {
-        ExpressionTree receiver = ((MemberSelectTree) methodSelect).getExpression();
+        ExpressionTree receiver =
+            ASTHelpers.stripParentheses(((MemberSelectTree) methodSelect).getExpression());
         if (isGenericCallNeedingInference(receiver)) {
           enclosingType =
               inferGenericMethodCallType(state, (MethodInvocationTree) receiver, null, false);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -438,9 +438,6 @@ public final class GenericsChecks {
         } else {
           result = ASTHelpers.getType(assignmentTree);
         }
-      } else if (tree instanceof MethodInvocationTree
-          && isGenericCallNeedingInference((MethodInvocationTree) tree)) {
-        result = inferGenericMethodCallType(state, (MethodInvocationTree) tree, null, false);
       } else {
         result = ASTHelpers.getType(tree);
       }
@@ -534,7 +531,7 @@ public final class GenericsChecks {
   private Type inferGenericMethodCallType(
       VisitorState state,
       MethodInvocationTree invocationTree,
-      @Nullable Type typeFromAssignmentContext,
+      Type typeFromAssignmentContext,
       boolean assignedToLocal) {
     Verify.verify(isGenericCallNeedingInference(invocationTree));
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -531,7 +531,7 @@ public final class GenericsChecks {
   private Type inferGenericMethodCallType(
       VisitorState state,
       MethodInvocationTree invocationTree,
-      Type typeFromAssignmentContext,
+      @Nullable Type typeFromAssignmentContext,
       boolean assignedToLocal) {
     Verify.verify(isGenericCallNeedingInference(invocationTree));
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1212,8 +1212,8 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "    }",
             "    static final AtomicReferenceFieldUpdater<Test, @Nullable Object> RESULT_UPDATER =",
             "            AtomicReferenceFieldUpdater.newUpdater(Test.class, Object.class, \"result\");",
-                "}")
-            .doTest();
+            "}")
+        .doTest();
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1236,6 +1236,9 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "  static void test() {",
             "    // BUG: Diagnostic contains: dereferenced expression",
             "    make(null).get().toString();",
+            "    // Also with a parenthesized receiver",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    ((make(null))).get().toString();",
             "  }",
             "}")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1212,6 +1212,31 @@ public class GenericMethodTests extends NullAwayTestsBase {
             "    }",
             "    static final AtomicReferenceFieldUpdater<Test, @Nullable Object> RESULT_UPDATER =",
             "            AtomicReferenceFieldUpdater.newUpdater(Test.class, Object.class, \"result\");",
+                "}")
+            .doTest();
+  }
+
+  @Test
+  public void inferenceFromReceiverPassing() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class Test {",
+            "  static class Foo<T extends @Nullable Object> {",
+            "    T get() {",
+            "      throw new UnsupportedOperationException();",
+            "    }",
+            "  }",
+            "  static <U extends @Nullable Object> Foo<U> make(U u) {",
+            "    throw new RuntimeException();",
+            "  }",
+            "  static void test() {",
+            "    // BUG: Diagnostic contains: dereferenced expression",
+            "    make(null).get().toString();",
+            "  }",
             "}")
         .doTest();
   }


### PR DESCRIPTION
See the new test; we missed this case before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved nullability analysis for chained calls where a generic method invocation is used as the receiver; the analyzer now infers receiver types when explicit type arguments are absent, yielding more accurate diagnostics.

- Bug Fixes
  - Reduced incorrect or missing diagnostics for generic method receivers and nullable types; better detection of potential null dereferences.

- Tests
  - Added test coverage validating inference and error reporting for nullable receivers in generic method call chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->