### PR TITLE
Accept any annotation with simple name `Contract`, and change reporting of invalid contract annotations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -213,7 +213,10 @@ public class NullabilityUtil {
         elementValues.entrySet()) {
       ExecutableElement elem = entry.getKey();
       if (elem.getSimpleName().contentEquals("value")) {
-        return (String) entry.getValue().getValue();
+        Object value = entry.getValue().getValue();
+        if (value instanceof String) {
+          return (String) value;
+        }
       }
     }
     // not found

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -78,9 +78,7 @@ public class Handlers {
     if (config.checkOptionalEmptiness()) {
       handlerListBuilder.add(new OptionalEmptinessHandler(config, methodNameUtil));
     }
-    if (config.checkContracts()) {
-      handlerListBuilder.add(new ContractCheckHandler(config));
-    }
+    handlerListBuilder.add(new ContractCheckHandler(config));
     handlerListBuilder.add(new LombokHandler(config));
     handlerListBuilder.add(new FluentFutureHandler(config));
     CompositeHandler mainHandler = new CompositeHandler(handlerListBuilder.build());

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -42,7 +42,8 @@ import com.uber.nullaway.handlers.MethodAnalysisContext;
 import java.util.Set;
 
 /**
- * This Handler parses the jetbrains @Contract annotation and tries to check if the contract is
+ * This Handler parses @Contract-style annotations (JetBrains or any annotation with simple name
+ * "Contract", plus any configured custom annotations) and tries to check if the contract is
  * followed.
  *
  * <p>Currently, it supports the case when there is only one clause in the contract. The clause of
@@ -118,6 +119,7 @@ public class ContractCheckHandler extends BaseNoOpHandler {
                       analysis.buildDescription(tree),
                       state,
                       null));
+          checkMethodBody = false;
         } else if (!checkableValueConstraints.contains(valueConstraint)) {
           checkMethodBody = false;
         }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -95,8 +95,7 @@ public class ContractCheckHandler extends BaseNoOpHandler {
           getAntecedent(clause, tree, analysis, state, callee, tree.getParameters().size());
       String consequent = getConsequent(clause, tree, analysis, state, callee);
 
-      // only check if config.checkContracts() is true
-      boolean supported = config.checkContracts();
+      boolean checkMethodBody = config.checkContracts();
 
       for (int i = 0; i < antecedent.length; ++i) {
         String valueConstraint = antecedent[i].trim();
@@ -120,15 +119,15 @@ public class ContractCheckHandler extends BaseNoOpHandler {
                       state,
                       null));
         } else if (!checkableValueConstraints.contains(valueConstraint)) {
-          supported = false;
+          checkMethodBody = false;
         }
       }
 
       if (!consequent.equals("!null")) {
-        supported = false;
+        checkMethodBody = false;
       }
 
-      if (!supported) {
+      if (!checkMethodBody) {
         return;
       }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -75,8 +75,8 @@ public class ContractCheckHandler extends BaseNoOpHandler {
       NullAway analysis = methodAnalysisContext.analysis();
       VisitorState state = methodAnalysisContext.state();
       String[] antecedent =
-          getAntecedent(clause, tree, analysis, state, callee, tree.getParameters().size());
-      String consequent = getConsequent(clause, tree, analysis, state, callee);
+          getAntecedent(clause, tree, analysis, state, callee, tree.getParameters().size(), config);
+      String consequent = getConsequent(clause, tree, analysis, state, callee, config);
 
       boolean supported = true;
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -66,6 +66,15 @@ public class ContractCheckHandler extends BaseNoOpHandler {
     this.config = config;
   }
 
+  /**
+   * Perform checks on any {@code @Contract} annotations on the method. By default, we check for
+   * syntactic well-formedness of the annotation. If {@code config.checkContracts()} is true, we
+   * also check that the method body is consistent with contracts whose value constraints are one of
+   * "_", "null", or "!null" in the antecedent and "!null" in the consequent.
+   *
+   * @param tree The AST node for the method being matched.
+   * @param methodAnalysisContext The MethodAnalysisContext object
+   */
   @Override
   public void onMatchMethod(MethodTree tree, MethodAnalysisContext methodAnalysisContext) {
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(tree);
@@ -86,7 +95,8 @@ public class ContractCheckHandler extends BaseNoOpHandler {
           getAntecedent(clause, tree, analysis, state, callee, tree.getParameters().size());
       String consequent = getConsequent(clause, tree, analysis, state, callee);
 
-      boolean supported = true;
+      // only check if config.checkContracts() is true
+      boolean supported = config.checkContracts();
 
       for (int i = 0; i < antecedent.length; ++i) {
         String valueConstraint = antecedent[i].trim();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -117,7 +117,8 @@ public class ContractHandler extends BaseNoOpHandler {
       // This method currently handles contracts of the form `(true|false) -> fail`, other
       // contracts are handled by 'onDataflowVisitMethodInvocation' which has access to more
       // dataflow information.
-      if (!"fail".equals(getConsequent(clause, tree, analysis, storedVisitorState, callee))) {
+      if (!"fail"
+          .equals(getConsequent(clause, tree, analysis, storedVisitorState, callee, config))) {
         continue;
       }
       String[] antecedent =
@@ -127,7 +128,8 @@ public class ContractHandler extends BaseNoOpHandler {
               analysis,
               storedVisitorState,
               callee,
-              originalNode.getArguments().size());
+              originalNode.getArguments().size(),
+              config);
       // Find a single value constraint that is not already known. If more than one argument with
       // unknown nullness affects the method's result, then ignore this clause.
       Node arg = null;
@@ -195,8 +197,8 @@ public class ContractHandler extends BaseNoOpHandler {
     for (String clause : ContractUtils.getContractClauses(callee, config)) {
 
       String[] antecedent =
-          getAntecedent(clause, tree, analysis, state, callee, node.getArguments().size());
-      String consequent = getConsequent(clause, tree, analysis, state, callee);
+          getAntecedent(clause, tree, analysis, state, callee, node.getArguments().size(), config);
+      String consequent = getConsequent(clause, tree, analysis, state, callee, config);
 
       // Find a single value constraint that is not already known. If more than one argument with
       // unknown nullness affects the method's result, then ignore this clause.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -271,7 +271,7 @@ public class ContractHandler extends BaseNoOpHandler {
           arg = node.getArgument(i);
           argAntecedentNullness = valueConstraint.equals("null") ? Nullness.NULL : Nullness.NONNULL;
         } else {
-          // unsupported, but we report an error only on the method
+          // invalid, but we report an error only on method declarations
           supported = false;
           break;
         }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -134,6 +134,12 @@ public class ContractUtils {
     return null;
   }
 
+  /**
+   * Checks if the input string, which is a qualified name, has simple name "Contract".
+   *
+   * @param input the qualified name to check
+   * @return true if the simple name is "Contract", false otherwise
+   */
   private static boolean endsWithContract(String input) {
     int lastDot = input.lastIndexOf('.');
     if (lastDot == -1 || lastDot == input.length() - 1) {
@@ -154,6 +160,13 @@ public class ContractUtils {
     return EMPTY_STRING_ARRAY;
   }
 
+  /**
+   * Determines whether we should report an invalid contract for the tree. Right now, we only report
+   * invalid contracts for method declarations ({@link MethodTree}s).
+   *
+   * @param tree the AST node to check
+   * @return true if we should report an invalid contract for this tree, false otherwise
+   */
   private static boolean shouldReportInvalidContract(Tree tree) {
     return tree instanceof MethodTree;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -1,6 +1,5 @@
 package com.uber.nullaway.handlers.contract;
 
-import com.google.common.base.Function;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -28,7 +27,7 @@ public class ContractUtils {
    */
   public static Set<String> trimReceivers(Set<String> fieldNames) {
     return fieldNames.stream()
-        .map((Function<String, String>) input -> input.substring(input.lastIndexOf(".") + 1))
+        .map(input -> input.substring(input.lastIndexOf(".") + 1))
         .collect(Collectors.toSet());
   }
 
@@ -101,7 +100,7 @@ public class ContractUtils {
               + " (incorrect number of arguments in the clause's antecedent ["
               + antecedent.length
               + "], should be the same as the number of "
-              + "arguments in for the method ["
+              + "arguments for the method ["
               + numOfArguments
               + "]).";
       state.reportMatch(
@@ -127,7 +126,7 @@ public class ContractUtils {
   static @Nullable String getContractString(Symbol.MethodSymbol methodSymbol, Config config) {
     for (AnnotationMirror annotation : methodSymbol.getAnnotationMirrors()) {
       String name = AnnotationUtils.annotationName(annotation);
-      if (endsWithContract(name) || config.isContractAnnotation(name)) {
+      if (hasSimpleNameContract(name) || config.isContractAnnotation(name)) {
         return NullabilityUtil.getAnnotationValue(methodSymbol, name);
       }
     }
@@ -140,7 +139,7 @@ public class ContractUtils {
    * @param input the qualified name to check
    * @return true if the simple name is "Contract", false otherwise
    */
-  private static boolean endsWithContract(String input) {
+  private static boolean hasSimpleNameContract(String input) {
     int lastDot = input.lastIndexOf('.');
     String simpleName;
     if (lastDot == -1) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -142,10 +142,13 @@ public class ContractUtils {
    */
   private static boolean endsWithContract(String input) {
     int lastDot = input.lastIndexOf('.');
-    if (lastDot == -1 || lastDot == input.length() - 1) {
-      return false;
+    String simpleName;
+    if (lastDot == -1) {
+      simpleName = input;
+    } else {
+      simpleName = input.substring(lastDot + 1);
     }
-    return input.substring(lastDot + 1).equals("Contract");
+    return simpleName.equals("Contract");
   }
 
   static String[] getContractClauses(Symbol.MethodSymbol callee, Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -49,7 +49,7 @@ public class ContractUtils {
       String message =
           "Invalid @Contract annotation detected for method "
               + callee
-              + ". It contains the following uparseable clause: "
+              + ". It contains the following unparseable clause: "
               + clause
               + "(see https://www.jetbrains.com/help/idea/contract-annotations.html).";
       state.reportMatch(
@@ -92,7 +92,7 @@ public class ContractUtils {
       String message =
           "Invalid @Contract annotation detected for method "
               + callee
-              + ". It contains the following uparseable clause: "
+              + ". It contains the following unparseable clause: "
               + clause
               + " (incorrect number of arguments in the clause's antecedent ["
               + antecedent.length
@@ -123,11 +123,19 @@ public class ContractUtils {
   static @Nullable String getContractString(Symbol.MethodSymbol methodSymbol, Config config) {
     for (AnnotationMirror annotation : methodSymbol.getAnnotationMirrors()) {
       String name = AnnotationUtils.annotationName(annotation);
-      if (config.isContractAnnotation(name)) {
+      if (endsWithContract(name) || config.isContractAnnotation(name)) {
         return NullabilityUtil.getAnnotationValue(methodSymbol, name);
       }
     }
     return null;
+  }
+
+  private static boolean endsWithContract(String input) {
+    int lastDot = input.lastIndexOf('.');
+    if (lastDot == -1 || lastDot == input.length() - 1) {
+      return false;
+    }
+    return input.substring(lastDot + 1).equals("Contract");
   }
 
   static String[] getContractClauses(Symbol.MethodSymbol callee, Config config) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -52,7 +52,7 @@ public class ContractUtils {
                 + callee
                 + ". It contains the following unparseable clause: "
                 + clause
-                + "(see https://www.jetbrains.com/help/idea/contract-annotations.html).";
+                + " (see https://www.jetbrains.com/help/idea/contract-annotations.html).";
         state.reportMatch(
             analysis
                 .getErrorBuilder()

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -153,6 +153,64 @@ public class ContractsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void malformedNonJetbrainsContracts() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CustomContractAnnotations=com.example.library.CustomContract",
+                "-XepOpt:NullAway:CheckContracts=true"))
+        .addSourceLines(
+            "CustomContract.java",
+            "package com.example.library;",
+            "import static java.lang.annotation.RetentionPolicy.CLASS;",
+            "import java.lang.annotation.Retention;",
+            "@Retention(CLASS)",
+            "public @interface CustomContract {",
+            "  String value();",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Target;",
+            "import com.example.library.CustomContract;",
+            "class Test {",
+            "  @Target(ElementType.METHOD)",
+            "  public @interface Contract {",
+            "      String value();",
+            "  }",
+            "  @Contract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object foo(@Nullable Object o) { return o; }",
+            "  @Contract(\"!null -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object bar(@Nullable Object o, String s) { return o; }",
+            "  @Contract(\"jabberwocky -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object baz(@Nullable Object o) { return o; }",
+            "  @Contract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object dontcare(@Nullable Object o) { return o; }",
+            "  @CustomContract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object foo2(@Nullable Object o) { return o; }",
+            "  @CustomContract(\"!null -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object bar2(@Nullable Object o, String s) { return o; }",
+            "  @CustomContract(\"jabberwocky -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object baz2(@Nullable Object o) { return o; }",
+            "  @CustomContract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "  static @Nullable Object dontcare2(@Nullable Object o) { return o; }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void contractNonVarArg() {
     makeTestHelperWithArgs(
             Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -19,6 +19,32 @@ public class ContractsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void noContractCheckErrorsWithoutFlag() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.jetbrains.annotations.Contract;",
+            "class Test {",
+            "  @Contract(\"_, !null -> !null\")",
+            "  @Nullable",
+            "  Object foo(Object a, @Nullable Object b) {",
+            "    if (a.hashCode() % 2 == 0) {",
+            "      // no error since CheckContracts is not set",
+            "      return null;",
+            "    }",
+            "    return new Object();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void checkContractNegativeCases() {
     makeTestHelperWithArgs(
             Arrays.asList(
@@ -174,8 +200,7 @@ public class ContractsTests extends NullAwayTestsBase {
             Arrays.asList(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:CheckContracts=true"))
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -218,8 +243,7 @@ public class ContractsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:CustomContractAnnotations=com.example.library.CustomContract",
-                "-XepOpt:NullAway:CheckContracts=true"))
+                "-XepOpt:NullAway:CustomContractAnnotations=com.example.library.CustomContract"))
         .addSourceLines(
             "CustomContract.java",
             "package com.example.library;",

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -115,7 +115,8 @@ public class ContractsTests extends NullAwayTestsBase {
             Arrays.asList(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckContracts=true"))
         .addSourceLines(
             "Test.java",
             "package com.uber;",
@@ -123,24 +124,28 @@ public class ContractsTests extends NullAwayTestsBase {
             "import org.jetbrains.annotations.Contract;",
             "class Test {",
             "  @Contract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
             "  static @Nullable Object foo(@Nullable Object o) { return o; }",
             "  @Contract(\"!null -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
             "  static @Nullable Object bar(@Nullable Object o, String s) { return o; }",
             "  @Contract(\"jabberwocky -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
             "  static @Nullable Object baz(@Nullable Object o) { return o; }",
-            // We don't care as long as nobody calls the method:
             "  @Contract(\"!null -> -> !null\")",
+            "  // BUG: Diagnostic contains: Invalid @Contract annotation",
             "  static @Nullable Object dontcare(@Nullable Object o) { return o; }",
+            "  // don't report errors about invalid contract annotations at calls to these methods",
             "  static Object test1() {",
-            "    // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
             "    return foo(null);",
             "  }",
             "  static Object test2() {",
-            "    // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
             "    return bar(null, \"\");",
             "  }",
             "  static Object test3() {",
-            "    // BUG: Diagnostic contains: Invalid @Contract annotation",
+            "    // BUG: Diagnostic contains: returning @Nullable expression",
             "    return baz(null);",
             "  }",
             "}")

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.Tree;
@@ -29,13 +28,11 @@ public class ContractUtilsTest {
     state = mock(VisitorState.class);
     symbol = mock(Symbol.class);
     config = mock(Config.class);
-    when(symbol.getAnnotationMirrors()).thenReturn(com.sun.tools.javac.util.List.nil());
   }
 
   @Test
   public void getEmptyAntecedent() {
-    String[] antecedent =
-        ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0, config);
+    String[] antecedent = ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0);
 
     assertArrayEquals(new String[0], antecedent);
     verifyNoInteractions(tree, state, analysis, symbol, config);

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +20,7 @@ public class ContractUtilsTest {
   private NullAway analysis;
   private VisitorState state;
   private Symbol symbol;
+  private Config config;
 
   @Before
   public void setUp() {
@@ -25,13 +28,16 @@ public class ContractUtilsTest {
     analysis = mock(NullAway.class, RETURNS_MOCKS);
     state = mock(VisitorState.class);
     symbol = mock(Symbol.class);
+    config = mock(Config.class);
+    when(symbol.getAnnotationMirrors()).thenReturn(com.sun.tools.javac.util.List.nil());
   }
 
   @Test
   public void getEmptyAntecedent() {
-    String[] antecedent = ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0);
+    String[] antecedent =
+        ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0, config);
 
     assertArrayEquals(new String[0], antecedent);
-    verifyNoInteractions(tree, state, analysis, symbol);
+    verifyNoInteractions(tree, state, analysis, symbol, config);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
-import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +18,6 @@ public class ContractUtilsTest {
   private NullAway analysis;
   private VisitorState state;
   private Symbol symbol;
-  private Config config;
 
   @Before
   public void setUp() {
@@ -27,7 +25,6 @@ public class ContractUtilsTest {
     analysis = mock(NullAway.class, RETURNS_MOCKS);
     state = mock(VisitorState.class);
     symbol = mock(Symbol.class);
-    config = mock(Config.class);
   }
 
   @Test
@@ -35,6 +32,6 @@ public class ContractUtilsTest {
     String[] antecedent = ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0);
 
     assertArrayEquals(new String[0], antecedent);
-    verifyNoInteractions(tree, state, analysis, symbol, config);
+    verifyNoInteractions(tree, state, analysis, symbol);
   }
 }


### PR DESCRIPTION
Fixes #1222 
Fixes #1215 

We make the following changes to NullAway's handling of `@Contract` annotations.  First, NullAway now treats any annotation with simple name `Contract` as a contract annotation, not just the JetBrains `@Contract`.  This improves the user experience when using third-party libraries containing non-Jetbrains `@Contract` annotations on public APIs, as those annotation types no longer need to be specified as a custom contract annotation to be picked up by NullAway.  (The custom contract annotation option is still supported, in case someone wants to use an annotation as a contract that doesn't have simple name `Contract`.)

Second, NullAway now only reports errors for malformed `@Contract` annotations on the corresponding method declaration, _not_ on calls to the method.  Reporting malformed `@Contract` errors on calls to methods was a bad behavior, since the method declaration could be in a library that cannot be easily modified.

It's possible this change will lead to unexpected behavior, if users were writing non-Jetbrains annotations named `@Contract` and with similar arguments to `@Contract` but did not want them used by NullAway.  But this seems unlikely, so we go ahead and make this change without an option to disable it.  We can add such an option later if we hear about any issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader contract recognition (treats simple-name "Contract" as a contract) and contract checking enabled by default.

* **Bug Fixes**
  * Stricter contract validation: unknown constraint values now report explicit errors; known but non-checkable constraints mark contracts unsupported.
  * Invalid-contract diagnostics moved to method declarations (fewer call-site reports).
  * Safer annotation-value handling to avoid runtime type errors.

* **Tests**
  * Added tests for custom/non‑JetBrains and malformed contract annotations.

* **Documentation**
  * Minor wording and Javadoc fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->