### PR TITLE
[Cleanup] Refactor away unnecessary Predicate

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -42,7 +42,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
 import org.checkerframework.nullaway.dataflow.analysis.AnalysisResult;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodAccessNode;
-import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.Node;
 import org.jspecify.annotations.Nullable;
 
@@ -65,8 +64,7 @@ public final class AccessPathNullnessAnalysis {
   private @Nullable AccessPathNullnessPropagation contractNullnessPropagation;
 
   // Use #instance to instantiate
-  private AccessPathNullnessAnalysis(
-      Predicate<MethodInvocationNode> methodReturnsNonNull, VisitorState state, NullAway analysis) {
+  private AccessPathNullnessAnalysis(VisitorState state, NullAway analysis) {
     Config config = analysis.getConfig();
     Handler handler = analysis.getHandler();
     apContext =
@@ -75,23 +73,13 @@ public final class AccessPathNullnessAnalysis {
             .build();
     this.nullnessPropagation =
         new AccessPathNullnessPropagation(
-            Nullness.NONNULL,
-            methodReturnsNonNull,
-            state,
-            apContext,
-            analysis,
-            new CoreNullnessStoreInitializer());
+            Nullness.NONNULL, state, apContext, analysis, new CoreNullnessStoreInitializer());
     this.dataFlow = new DataFlow(config.assertsEnabled(), handler);
 
     if (config.checkContracts()) {
       this.contractNullnessPropagation =
           new AccessPathNullnessPropagation(
-              Nullness.NONNULL,
-              methodReturnsNonNull,
-              state,
-              apContext,
-              analysis,
-              new ContractNullnessStoreInitializer());
+              Nullness.NONNULL, state, apContext, analysis, new ContractNullnessStoreInitializer());
     }
   }
 
@@ -99,17 +87,14 @@ public final class AccessPathNullnessAnalysis {
    * Get the per-Javac instance of the analysis.
    *
    * @param state visitor state for the compilation
-   * @param methodReturnsNonNull predicate determining whether a method is assumed to return NonNull
-   *     value
    * @param analysis instance of NullAway analysis
    * @return instance of the analysis
    */
-  public static AccessPathNullnessAnalysis instance(
-      VisitorState state, Predicate<MethodInvocationNode> methodReturnsNonNull, NullAway analysis) {
+  public static AccessPathNullnessAnalysis instance(VisitorState state, NullAway analysis) {
     Context context = state.context;
     AccessPathNullnessAnalysis instance = context.get(FIELD_NULLNESS_ANALYSIS_KEY);
     if (instance == null) {
-      instance = new AccessPathNullnessAnalysis(methodReturnsNonNull, state, analysis);
+      instance = new AccessPathNullnessAnalysis(state, analysis);
       context.put(FIELD_NULLNESS_ANALYSIS_KEY, instance);
     }
     return instance;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -172,13 +172,12 @@ public class AccessPathNullnessPropagation
 
   public AccessPathNullnessPropagation(
       Nullness defaultAssumption,
-      Predicate<MethodInvocationNode> methodReturnsNonNull,
       VisitorState state,
       AccessPath.AccessPathContext apContext,
       NullAway analysis,
       NullnessStoreInitializer nullnessStoreInitializer) {
     this.defaultAssumption = defaultAssumption;
-    this.methodReturnsNonNull = methodReturnsNonNull;
+    this.methodReturnsNonNull = analysis::isMethodUnannotated;
     this.state = state;
     this.apContext = apContext;
     this.config = analysis.getConfig();


### PR DESCRIPTION
A fairly minor refactor, removing the `nonAnnotatedMethod` predicate from NullAway.java.

As far as I can tell, this was used in the very beginning to avoid threading the `NullAway` object further into dataflow classes, but with JSpecify, that ship has sailed and we have the main analysis passed around at least as far down as the constructor for `AccessPathNullnessPropagation`. Unless we care a lot about `NullAway.isMethodUnannotated(...)` being a private method, this means we can skip passing the predicate along separate from the analysis instance.

Let me know if I am missing a reason for this, but there didn't seem to be an obvious one to me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined nullness analysis and propagation APIs to reduce configuration overhead.
  - Removed the need to supply custom return-nullability predicates; logic now derives from the built-in analysis.
  - Minor public API adjustments to support the new flow and enable easier extensibility.
  - No functional changes expected for typical usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->