### PR TITLE
Test on JDK 25

### DIFF
--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -65,7 +65,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[17, 24].each { majorVersion ->
+[17, 25].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         onlyIf {
             // Only run when using the latest Error Prone version

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -126,7 +126,7 @@ def test = [
     springBeans             : "org.springframework:spring-beans:5.3.7",
     springContext           : "org.springframework:spring-context:5.3.7",
     grpcCore                : "io.grpc:grpc-core:1.15.1", // Should upgrade, but this matches our guava version
-    mockito                 : "org.mockito:mockito-core:5.16.1",
+    mockito                 : "org.mockito:mockito-core:5.19.0",
     javaxAnnotationApi      : "javax.annotation:javax.annotation-api:1.3.2",
     assertJ                 : "org.assertj:assertj-core:3.23.1",
     amazonUtils             : "software.amazon.awssdk:utils:2.32.19",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ def versions = [
     // The version of Error Prone that NullAway is compiled and tested against
     errorProneApi          : errorProneVersionToCompileAgainst,
     support                : "27.1.1",
-    wala                   : "1.6.9",
+    wala                   : "1.6.12",
     commonscli             : "1.4",
     autoValue              : "1.10.2",
     autoService            : "1.1.1",

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -50,9 +50,4 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }
 
-tasks.getByName('testJdk25').configure {
-    // Will not work until WALA is updated to support JDK 24; see https://github.com/uber/NullAway/issues/1189
-    onlyIf { false }
-}
-
 apply plugin: 'com.vanniktech.maven.publish'

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -50,7 +50,7 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }
 
-tasks.getByName('testJdk24').configure {
+tasks.getByName('testJdk25').configure {
     // Will not work until WALA is updated to support JDK 24; see https://github.com/uber/NullAway/issues/1189
     onlyIf { false }
 }

--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -47,7 +47,7 @@ import com.ibm.wala.types.generics.MethodTypeSignature;
 import com.ibm.wala.types.generics.TypeSignature;
 import com.ibm.wala.types.generics.TypeVariableSignature;
 import com.ibm.wala.util.collections.Iterator2Iterable;
-import com.ibm.wala.util.config.FileOfClasses;
+import com.ibm.wala.util.config.PatternsFilter;
 import com.uber.nullaway.libmodel.MethodAnnotationsRecord;
 import com.uber.nullaway.libmodel.StubxWriter;
 import java.io.ByteArrayInputStream;
@@ -240,7 +240,7 @@ public class DefinitelyDerefedParamsDriver {
     }
     AnalysisScope scope = AnalysisScopeReader.instance.makeBasePrimordialScope(null);
     scope.setExclusions(
-        new FileOfClasses(
+        new PatternsFilter(
             new ByteArrayInputStream(DEFAULT_EXCLUSIONS.getBytes(StandardCharsets.UTF_8))));
     if (jarIS != null) {
       scope.addInputStreamForJarToScope(ClassLoaderReference.Application, jarIS);

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -22,7 +22,7 @@ plugins {
 // We must null out sourceCompatibility and targetCompatibility to use toolchains.
 java.sourceCompatibility = null
 java.targetCompatibility = null
-java.toolchain.languageVersion.set JavaLanguageVersion.of(24)
+java.toolchain.languageVersion.set JavaLanguageVersion.of(25)
 
 configurations {
     // We use this configuration to expose a module path that can be
@@ -57,7 +57,7 @@ tasks.withType(Test).configureEach { test ->
 tasks.getByName('testJdk17').configure {
     onlyIf { false }
 }
-tasks.getByName('testJdk24').configure {
+tasks.getByName('testJdk25').configure {
     onlyIf { false }
 }
 


### PR DESCRIPTION
We also update to the latest WALA release, which supports running on JDK 25, so we can re-enable JarInfer tests.  Other changes are straightforward.  We will update the JDK version we use to build in CI to JDK 25 in a subsequent PR.

Fixes #1189 