### PR TITLE
Improve generic method inference lambda test

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -861,9 +861,11 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.*;",
-            "import java.util.function.Supplier;",
             "@NullMarked",
             "class Test {",
+            "    static interface Supplier<R extends @Nullable Object> {",
+            "        R get();",
+            "    }",
             "    static <R> void invoke(Supplier<@Nullable R> supplier) {}",
             "    static <R extends @Nullable Object> R invokeWithReturn(Supplier<R> supplier) {",
             "        return supplier.get();",


### PR DESCRIPTION
Before this test used the standard library `Supplier` type which we still treat as unmarked, so understanding its behavior was hard.  Now the test is self-contained.  Note it is still ignored since we don't have the support yet.