### PR TITLE
Update Gradle command used for integration tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,4 +88,4 @@ jobs:
         run: |
           cp .github/workflows/use-snapshot.gradle.kts /tmp/${{ matrix.project }}
           cd /tmp/${{ matrix.project }}
-          ./gradlew --init-script use-snapshot.gradle.kts build -x check -x assemble
+          ./gradlew --init-script use-snapshot.gradle.kts assemble


### PR DESCRIPTION
`assemble` should work better than excluding tasks as we did before.  See also https://github.com/ben-manes/caffeine/issues/1925


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the continuous integration build to assemble release artifacts more efficiently, reducing pipeline time and improving consistency of produced binaries.
  * Excludes test execution and documentation generation in this build step to focus on artifact creation, aligning with release packaging needs.
  * No changes to user-facing functionality; this update enhances reliability and speed of delivery for downloadable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->