### PR TITLE
Add changelog for 0.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ In this release, NullAway checks the requirement that JSpecify mode is only run 
 configuration, and fails if it detects an incompatibility.
 See <https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions> for details.
 
-## What's Changed
 * Use inference for generic call passed as receiver to instance method (#1293)
 * Accept any annotation with simple name `Contract`, and change reporting of invalid contract annotations (#1295)
 * Properly model AtomicReference.get() in JSpecify mode (#1298)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added changelog entry for Version 0.12.11 documenting a new JSpecify compatibility check that ensures JSpecify mode only runs on compatible javac versions/configurations and fails when incompatible. Includes a "What's Changed" summary of new features, maintenance items, and internal improvements. No public API or exported-declaration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->