### PR TITLE
Fix test args for SuggestedFixesTests

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -23,11 +23,6 @@ public final class JSpecifyJavacConfig {
 
   private JSpecifyJavacConfig() {}
 
-  /** Returns the compiler arguments required to enable JSpecify mode in tests. */
-  public static List<String> jspecifyModeArgs() {
-    return JSPECIFY_MODE_ARGS;
-  }
-
   /**
    * Returns a copy of {@code args} with the JSpecify-specific compiler arguments appended.
    *

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/SuggestedFixesTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/SuggestedFixesTests.java
@@ -1,10 +1,10 @@
 package com.uber.nullaway.jspecify;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,21 +17,14 @@ public class SuggestedFixesTests {
 
   private BugCheckerRefactoringTestHelper makeTestHelper() {
     List<String> args =
-        new ArrayList<>(
+        JSpecifyJavacConfig.withJSpecifyModeArgs(
             List.of(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-processorpath",
-                SuggestedFixesTests.class
-                    .getProtectionDomain()
-                    .getCodeSource()
-                    .getLocation()
-                    .getPath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
-    args.addAll(JSpecifyJavacConfig.jspecifyModeArgs());
-    args.add("-XepOpt:NullAway:SuggestSuppressions=true");
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SuggestSuppressions=true"));
     return BugCheckerRefactoringTestHelper.newInstance(NullAway.class, getClass())
-        .setArgs(args.toArray(new String[0]));
+        .setArgs(ImmutableList.copyOf(args));
   }
 
   @Test


### PR DESCRIPTION
Test-only cleanup change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed public utility method from JSpecify configuration class; callers should use alternative methods for argument composition.
  * Refactored internal test utilities to simplify argument handling and construction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->