### PR TITLE
Enable the VoidMissingNullable checker and autofix all extant warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ subprojects { project ->
             check("UnnecessaryFinal", CheckSeverity.ERROR)
             check("PreferredInterfaceType", CheckSeverity.ERROR)
             check("AnnotationPosition", CheckSeverity.ERROR)
+            check("VoidMissingNullable", CheckSeverity.ERROR)
             // To enable auto-patching, uncomment the line below, replace [CheckerName] with
             // the checker(s) you want to apply patches for (comma-separated), and above, disable
             // "-Werror"

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/cfg/NullAwayCFGBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/cfg/NullAwayCFGBuilder.java
@@ -28,6 +28,7 @@ import org.checkerframework.nullaway.dataflow.cfg.node.ThrowNode;
 import org.checkerframework.nullaway.javacutil.AnnotationProvider;
 import org.checkerframework.nullaway.javacutil.BasicAnnotationProvider;
 import org.checkerframework.nullaway.javacutil.trees.TreeBuilder;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A NullAway specific CFGBuilder subclass, which allows to more directly control the AST to CFG
@@ -222,7 +223,7 @@ public final class NullAwayCFGBuilder extends CFGBuilder {
     }
 
     @Override
-    public MethodInvocationNode visitMethodInvocation(MethodInvocationTree tree, Void p) {
+    public MethodInvocationNode visitMethodInvocation(MethodInvocationTree tree, @Nullable Void p) {
       MethodInvocationNode originalNode = super.visitMethodInvocation(tree, null);
       return handler.onCFGBuildPhase1AfterVisitMethodInvocation(this, tree, originalNode);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeVariable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An implementation of {@link ConstraintSolver} that uses a work-list algorithm to propagate
@@ -80,7 +81,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     subtype.accept(new AddSubtypeConstraintsVisitor(localVariableType), supertype);
   }
 
-  class AddSubtypeConstraintsVisitor extends Types.DefaultTypeVisitor<Void, Type> {
+  class AddSubtypeConstraintsVisitor extends Types.DefaultTypeVisitor<@Nullable Void, Type> {
     private boolean localVariableType;
 
     AddSubtypeConstraintsVisitor(boolean localVariableType) {
@@ -88,7 +89,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     }
 
     @Override
-    public Void visitType(Type subtype, Type supertype) {
+    public @Nullable Void visitType(Type subtype, Type supertype) {
       // handle flow into a type variable.  the check for !(subtype instanceof TypeVar) is a
       // small optimization, as that case should be handled in visitTypeVar.
       if (!localVariableType && (supertype instanceof TypeVar) && !(subtype instanceof TypeVar)) {
@@ -98,7 +99,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     }
 
     @Override
-    public Void visitClassType(ClassType subtype, Type supertype) {
+    public @Nullable Void visitClassType(ClassType subtype, Type supertype) {
       if (supertype instanceof ClassType) {
         Type subtypeAsSuper =
             TypeSubstitutionUtils.asSuper(
@@ -130,7 +131,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     }
 
     @Override
-    public Void visitArrayType(Type.ArrayType subtype, Type supertype) {
+    public @Nullable Void visitArrayType(Type.ArrayType subtype, Type supertype) {
       if (supertype instanceof Type.ArrayType) {
         Type.ArrayType superArrayType = (Type.ArrayType) supertype;
         // recursing, so set localVariableType to false
@@ -146,7 +147,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     }
 
     @Override
-    public Void visitTypeVar(TypeVar subtype, Type supertype) {
+    public @Nullable Void visitTypeVar(TypeVar subtype, Type supertype) {
       if (!localVariableType) {
         directlyConstrainTypePair(subtype, supertype);
       }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
@@ -8,6 +8,7 @@ import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A visitor that pretty prints a generic type including its type-use nullability annotations, for
@@ -16,7 +17,8 @@ import com.sun.tools.javac.code.Types;
  * <p>This code is a modified and extended version of code in {@link
  * com.google.errorprone.util.Signatures}
  */
-final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<String, Void> {
+final class GenericTypePrettyPrintingVisitor
+    extends Types.DefaultTypeVisitor<String, @Nullable Void> {
 
   private final VisitorState state;
 
@@ -25,7 +27,7 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
   }
 
   @Override
-  public String visitWildcardType(Type.WildcardType t, Void unused) {
+  public String visitWildcardType(Type.WildcardType t, @Nullable Void unused) {
     // NOTE: we have not tested this code yet as we do not yet support wildcard types
     StringBuilder sb = new StringBuilder();
     sb.append(t.kind);
@@ -36,7 +38,7 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
   }
 
   @Override
-  public String visitClassType(Type.ClassType t, Void s) {
+  public String visitClassType(Type.ClassType t, @Nullable Void s) {
     if (t.isIntersection()) {
       return prettyIntersectionType((Type.IntersectionClassType) t);
     }
@@ -72,12 +74,12 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
   }
 
   @Override
-  public String visitCapturedType(Type.CapturedType t, Void s) {
+  public String visitCapturedType(Type.CapturedType t, @Nullable Void s) {
     return t.wildcard.accept(this, null);
   }
 
   @Override
-  public String visitArrayType(Type.ArrayType t, Void unused) {
+  public String visitArrayType(Type.ArrayType t, @Nullable Void unused) {
     StringBuilder sb = new StringBuilder();
     sb.append(t.elemtype.accept(this, null));
     for (Attribute.TypeCompound compound : t.getAnnotationMirrors()) {
@@ -88,7 +90,7 @@ final class GenericTypePrettyPrintingVisitor extends Types.DefaultTypeVisitor<St
   }
 
   @Override
-  public String visitType(Type t, Void s) {
+  public String visitType(Type t, @Nullable Void s) {
     return t.toString();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -20,6 +20,7 @@ import com.uber.nullaway.Nullness;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Visitor For getting the preserved Annotation Types for the nested generic type arguments within a
@@ -27,7 +28,7 @@ import java.util.List;
  * generic type arguments in its types for NewClassTrees. We need a visitor since the nested
  * arguments may appear on different kinds of type trees, e.g., ArrayTypeTrees.
  */
-public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void> {
+public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, @Nullable Void> {
 
   private final Config config;
 
@@ -36,19 +37,19 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
   }
 
   @Override
-  public Type visitNewArray(NewArrayTree tree, Void p) {
+  public Type visitNewArray(NewArrayTree tree, @Nullable Void p) {
     Type elemType = tree.getType().accept(this, null);
     return new Type.ArrayType(elemType, castToNonNull(ASTHelpers.getType(tree)).tsym);
   }
 
   @Override
-  public Type visitArrayType(ArrayTypeTree tree, Void p) {
+  public Type visitArrayType(ArrayTypeTree tree, @Nullable Void p) {
     Type elemType = tree.getType().accept(this, null);
     return new Type.ArrayType(elemType, castToNonNull(ASTHelpers.getType(tree)).tsym);
   }
 
   @Override
-  public Type visitParameterizedType(ParameterizedTypeTree tree, Void p) {
+  public Type visitParameterizedType(ParameterizedTypeTree tree, @Nullable Void p) {
     Type.ClassType baseType = (Type.ClassType) tree.getType().accept(this, null);
     List<? extends Tree> typeArguments = tree.getTypeArguments();
     List<Type> newTypeArgs = new ArrayList<>();
@@ -61,7 +62,7 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
   }
 
   @Override
-  public Type visitAnnotatedType(AnnotatedTypeTree annotatedType, Void unused) {
+  public Type visitAnnotatedType(AnnotatedTypeTree annotatedType, @Nullable Void unused) {
     List<? extends AnnotationTree> annotations = annotatedType.getAnnotations();
     boolean hasNullableAnnotation = false;
     Type nullableType = null;
@@ -92,7 +93,7 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, Void
 
   /** By default, just use the type computed by javac */
   @Override
-  protected Type defaultAction(Tree node, Void unused) {
+  protected Type defaultAction(Tree node, @Nullable Void unused) {
     return castToNonNull(ASTHelpers.getType(node));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeVarWithSymbolCollector.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeVarWithSymbolCollector.java
@@ -24,7 +24,8 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Not safe to run multiple times; create a fresh visitor for each root type to scan.
  */
-public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<Void, Void> {
+public final class TypeVarWithSymbolCollector
+    extends Types.DefaultTypeVisitor<@Nullable Void, @Nullable Void> {
 
   private final Element symbol;
   private final Set<TypeVar> matches = new LinkedHashSet<>();
@@ -49,7 +50,7 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
 
   // ---- Core matching logic ----
   @Override
-  public Void visitTypeVar(TypeVar t, Void p) {
+  public @Nullable Void visitTypeVar(TypeVar t, @Nullable Void p) {
     if (t.tsym == symbol) {
       matches.add(t);
     }
@@ -60,7 +61,7 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
 
   // ---- Common container types ----
   @Override
-  public Void visitClassType(ClassType t, Void p) {
+  public @Nullable Void visitClassType(ClassType t, @Nullable Void p) {
     for (Type arg : t.getTypeArguments()) {
       scan(arg);
     }
@@ -70,20 +71,20 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
   }
 
   @Override
-  public Void visitArrayType(ArrayType t, Void p) {
+  public @Nullable Void visitArrayType(ArrayType t, @Nullable Void p) {
     scan(t.getComponentType());
     return null;
   }
 
   @Override
-  public Void visitWildcardType(WildcardType t, Void p) {
+  public @Nullable Void visitWildcardType(WildcardType t, @Nullable Void p) {
     scan(t.getExtendsBound());
     scan(t.getSuperBound());
     return null;
   }
 
   @Override
-  public Void visitCapturedType(CapturedType t, Void p) {
+  public @Nullable Void visitCapturedType(CapturedType t, @Nullable Void p) {
     scan(t.getUpperBound());
     scan(t.getLowerBound());
     scan(t.wildcard);
@@ -92,7 +93,7 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
 
   // ---- Functional / executable types ----
   @Override
-  public Void visitMethodType(MethodType t, Void p) {
+  public @Nullable Void visitMethodType(MethodType t, @Nullable Void p) {
     scan(t.getReturnType());
     for (Type pt : t.getParameterTypes()) {
       scan(pt);
@@ -104,7 +105,7 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
   }
 
   @Override
-  public Void visitForAll(ForAll t, Void p) {
+  public @Nullable Void visitForAll(ForAll t, @Nullable Void p) {
     scan(t.qtype);
     for (Type type : t.getTypeArguments()) {
       scan(type);
@@ -114,7 +115,7 @@ public final class TypeVarWithSymbolCollector extends Types.DefaultTypeVisitor<V
 
   // ---- Trivial / leaf types we don't need to descend into ----
   @Override
-  public Void visitType(Type t, Void p) {
+  public @Nullable Void visitType(Type t, @Nullable Void p) {
     // Fallback: best-effort traversal via type arguments, if any.
     for (Type arg : t.getTypeArguments()) {
       scan(arg);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -40,6 +40,7 @@ import com.uber.nullaway.Nullness;
 import com.uber.nullaway.handlers.BaseNoOpHandler;
 import com.uber.nullaway.handlers.MethodAnalysisContext;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This Handler parses @Contract-style annotations (JetBrains or any annotation with simple name
@@ -134,9 +135,9 @@ public class ContractCheckHandler extends BaseNoOpHandler {
       }
 
       // we scan the method tree for the return nodes and check the contract
-      new TreePathScanner<Void, Void>() {
+      new TreePathScanner<@Nullable Void, @Nullable Void>() {
         @Override
-        public Void visitReturn(ReturnTree returnTree, Void unused) {
+        public @Nullable Void visitReturn(ReturnTree returnTree, @Nullable Void unused) {
 
           VisitorState returnState = state.withPath(getCurrentPath());
           Nullness nullness =

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
@@ -123,9 +123,9 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
 
   private void buildUpReturnToEnclosingMethodMap(VisitorState methodState) {
     returnTreesInMethodUnderAnalysis.clear();
-    new TreePathScanner<Void, Void>() {
+    new TreePathScanner<@Nullable Void, @Nullable Void>() {
       @Override
-      public Void visitReturn(ReturnTree node, Void unused) {
+      public @Nullable Void visitReturn(ReturnTree node, @Nullable Void unused) {
         TreePath enclosingMethod =
             NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(getCurrentPath());
         if (enclosingMethod == null) {


### PR DESCRIPTION
`@Nullable Void` is required by JSpecify.  No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled enhanced error detection in the build process to improve code quality.
  * Updated internal type annotations across the codebase for better null-safety handling and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->