### PR TITLE
Enable EqualsMissingNullable check and fix all extant warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ subprojects { project ->
             check("PreferredInterfaceType", CheckSeverity.ERROR)
             check("AnnotationPosition", CheckSeverity.ERROR)
             check("VoidMissingNullable", CheckSeverity.ERROR)
+            check("EqualsMissingNullable", CheckSeverity.ERROR)
             // To enable auto-patching, uncomment the line below, replace [CheckerName] with
             // the checker(s) you want to apply patches for (comma-separated), and above, disable
             // "-Werror"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -56,7 +56,7 @@ def versions = [
     support                : "27.1.1",
     wala                   : "1.6.12",
     commonscli             : "1.4",
-    autoValue              : "1.10.2",
+    autoValue              : "1.11.0",
     autoService            : "1.1.1",
     javaparser             : "3.26.2",
     googlejavaformat       : "1.30.0",

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -624,5 +624,11 @@ final class ErrorProneCLIFlagsConfig implements Config {
     abstract String enclosingClass();
 
     abstract String methodName();
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -31,6 +31,7 @@ import com.uber.nullaway.handlers.stream.StreamTypeRecord;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 /** Provides models for library routines for the null checker. */
 public interface LibraryModels {
@@ -271,7 +272,7 @@ public interface LibraryModels {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
       if (this == o) {
         return true;
       }
@@ -312,5 +313,11 @@ public interface LibraryModels {
     public static FieldRef fieldRef(String enclosingClass, String fieldName) {
       return new AutoValue_LibraryModels_FieldRef(enclosingClass, fieldName);
     }
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2932,5 +2932,11 @@ public class NullAway extends BugChecker
      * annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations.
      */
     abstract ImmutableSet<MethodTree> staticInitializerMethods();
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPath.java
@@ -576,7 +576,7 @@ public final class AccessPath implements MapKey {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -657,7 +657,7 @@ public final class AccessPath implements MapKey {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
       if (obj instanceof StringMapKey) {
         return this.key.equals(((StringMapKey) obj).key);
       }
@@ -686,7 +686,7 @@ public final class AccessPath implements MapKey {
      */
     @Override
     @JacocoIgnoreGenerated
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
       if (obj instanceof NumericMapKey) {
         return this.key == ((NumericMapKey) obj).key;
       }
@@ -724,7 +724,7 @@ public final class AccessPath implements MapKey {
      */
     @Override
     @JacocoIgnoreGenerated
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
       if (this == o) {
         return true;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/ArrayIndexElement.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/ArrayIndexElement.java
@@ -2,6 +2,7 @@ package com.uber.nullaway.dataflow;
 
 import java.util.Objects;
 import javax.lang.model.element.Element;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents an array index element of an AccessPath, encapsulating access to array elements either
@@ -58,7 +59,7 @@ public class ArrayIndexElement implements AccessPathElement {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj instanceof ArrayIndexElement) {
       ArrayIndexElement other = (ArrayIndexElement) obj;
       return Objects.equals(javaElement, other.javaElement) && Objects.equals(index, other.index);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -341,6 +341,12 @@ public final class DataFlow {
     }
 
     abstract TreePath codePath();
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 
   @AutoValue
@@ -355,6 +361,12 @@ public final class DataFlow {
     abstract ForwardTransferFunction<?, ?> transferFunction();
 
     abstract ControlFlowGraph cfg();
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 
   /** A pair of Analysis and ControlFlowGraph. */

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/FieldOrMethodCallElement.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/FieldOrMethodCallElement.java
@@ -34,7 +34,7 @@ public class FieldOrMethodCallElement implements AccessPathElement {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj instanceof FieldOrMethodCallElement) {
       FieldOrMethodCallElement other = (FieldOrMethodCallElement) obj;
       return this.javaElement.equals(other.javaElement)

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -121,7 +121,7 @@ public class ApacheThriftIsSetHandler extends BaseNoOpHandler {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
       if (this == o) {
         return true;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/MethodAnalysisContext.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/MethodAnalysisContext.java
@@ -26,6 +26,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.uber.nullaway.NullAway;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context object for checks on methods. Contains the {@link NullAway} instance, the {@link
@@ -49,7 +50,7 @@ public class MethodAnalysisContext {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -69,6 +69,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.nullaway.dataflow.cfg.node.LocalVariableNode;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This Handler transfers nullability info through chains of calls to methods of
@@ -140,6 +141,12 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
     abstract CollectLikeMethodRecord getCollectLikeMethodRecord();
 
     abstract Tree getInnerMethodOrLambda();
+
+    @Override
+    public abstract boolean equals(@Nullable Object o);
+
+    @Override
+    public abstract int hashCode();
   }
 
   // Maps collect calls in the observable call chain to the relevant (collect record, inner method

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/stream/CollectLikeMethodRecord.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/stream/CollectLikeMethodRecord.java
@@ -25,6 +25,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import java.util.function.Function;
 import java.util.stream.Collector;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An immutable model describing a collect-like method from a stream-based API, such as {@link
@@ -81,4 +82,10 @@ public abstract class CollectLikeMethodRecord implements MapOrCollectLikeMethodR
    */
   @Override
   public abstract ImmutableSet<Integer> argsFromStream();
+
+  @Override
+  public abstract boolean equals(@Nullable Object o);
+
+  @Override
+  public abstract int hashCode();
 }


### PR DESCRIPTION
`equals` should always accept a `null` argument.  Sadly, to make the check work for AutoValue-generated code, we had to add abstract `equals` and `hashCode` methods to the `@AutoValue` classes.  Once we can require JDK 17, we can switch to records and get rid of `AutoValue` and possibly this problem will go away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new error-prone check for detecting equals methods missing proper nullable annotations on parameters.

* **Dependencies**
  * Updated AutoValue dependency from version 1.10.2 to 1.11.0.

* **Code Quality**
  * Enhanced null-safety across the codebase with explicit, nullable-aware implementations for equality semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->