### PR TITLE
Bump to AutoValue 1.11.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -56,7 +56,7 @@ def versions = [
     support                : "27.1.1",
     wala                   : "1.6.12",
     commonscli             : "1.4",
-    autoValue              : "1.11.0",
+    autoValue              : "1.11.1",
     autoService            : "1.1.1",
     javaparser             : "3.26.2",
     googlejavaformat       : "1.30.0",

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -624,11 +624,5 @@ final class ErrorProneCLIFlagsConfig implements Config {
     abstract String enclosingClass();
 
     abstract String methodName();
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -313,11 +313,5 @@ public interface LibraryModels {
     public static FieldRef fieldRef(String enclosingClass, String fieldName) {
       return new AutoValue_LibraryModels_FieldRef(enclosingClass, fieldName);
     }
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2932,11 +2932,5 @@ public class NullAway extends BugChecker
      * annotated with annotations passed to -XepOpt:NullAway:CustomInitializerAnnotations.
      */
     abstract ImmutableSet<MethodTree> staticInitializerMethods();
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -341,12 +341,6 @@ public final class DataFlow {
     }
 
     abstract TreePath codePath();
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 
   @AutoValue
@@ -361,12 +355,6 @@ public final class DataFlow {
     abstract ForwardTransferFunction<?, ?> transferFunction();
 
     abstract ControlFlowGraph cfg();
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 
   /** A pair of Analysis and ControlFlowGraph. */

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -69,7 +69,6 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.nullaway.dataflow.cfg.node.LocalVariableNode;
-import org.jspecify.annotations.Nullable;
 
 /**
  * This Handler transfers nullability info through chains of calls to methods of
@@ -141,12 +140,6 @@ class StreamNullabilityPropagator extends BaseNoOpHandler {
     abstract CollectLikeMethodRecord getCollectLikeMethodRecord();
 
     abstract Tree getInnerMethodOrLambda();
-
-    @Override
-    public abstract boolean equals(@Nullable Object o);
-
-    @Override
-    public abstract int hashCode();
   }
 
   // Maps collect calls in the observable call chain to the relevant (collect record, inner method


### PR DESCRIPTION
This lets us undo some of the boilerplate added in #1339 that was required to please the `EqualsMissingNullable` check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AutoValue dependency to version 1.11.1.

* **Refactor**
  * Simplified equality and hashing implementations across multiple components by removing redundant method declarations and relying on generated implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->