### PR TITLE
Better fix for dataflow analysis caching

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/DataFlow.java
@@ -159,7 +159,7 @@ public final class DataFlow {
     RunOnceForwardAnalysisImpl<A, S, T> analysis =
         (RunOnceForwardAnalysisImpl<A, S, T>) analysisCache.getUnchecked(aparams);
     if (performAnalysis) {
-      analysis.performAnalysisIfNeeded(cfg);
+      analysis.performAnalysis(cfg);
     }
 
     return new Result<>() {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/RunOnceForwardAnalysisImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/RunOnceForwardAnalysisImpl.java
@@ -7,10 +7,10 @@ import org.checkerframework.nullaway.dataflow.analysis.Store;
 import org.checkerframework.nullaway.dataflow.cfg.ControlFlowGraph;
 
 /**
- * A ForwardAnalysis implementation that provides a method {@link
- * #performAnalysisIfNeeded(ControlFlowGraph)} to perform the analysis at most once.
+ * A ForwardAnalysis implementation that overrides {@link #performAnalysis(ControlFlowGraph)} to
+ * perform the analysis at most once.
  */
-public class RunOnceForwardAnalysisImpl<
+class RunOnceForwardAnalysisImpl<
         V extends AbstractValue<V>, S extends Store<S>, T extends ForwardTransferFunction<V, S>>
     extends ForwardAnalysisImpl<V, S, T> {
 
@@ -25,7 +25,8 @@ public class RunOnceForwardAnalysisImpl<
    *
    * @param cfg the control flow graph to analyze
    */
-  public void performAnalysisIfNeeded(ControlFlowGraph cfg) {
+  @Override
+  public void performAnalysis(ControlFlowGraph cfg) {
     if (!analysisPerformed) {
       super.performAnalysis(cfg);
       analysisPerformed = true;


### PR DESCRIPTION
Fixes #1351 

We get rid of having two related caches that can get out of sync.  Instead, we create a new `RunOnceForwardAnalysisImpl` class that allows for running a dataflow analysis at most once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved analysis caching to simplify and speed reuse of analysis results.
  * Introduced a run-once analysis wrapper to ensure each analysis executes at most once, reducing redundant work.
  * Removed redundant per-parameter run-tracking and related invalidation logic, streamlining cache management and instantiation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->