### PR TITLE
Don't report matches from RequireExplicitNullMarking when run at SUGGESTION level

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/RequireExplicitNullMarking.java
+++ b/nullaway/src/main/java/com/uber/nullaway/RequireExplicitNullMarking.java
@@ -45,15 +45,14 @@ import javax.lang.model.element.NestingKind;
 public final class RequireExplicitNullMarking extends BugChecker
     implements BugChecker.ClassTreeMatcher {
 
-  /**
-   * The BugPattern annotation on this class, used below to determine whether to report a match or
-   * not.
-   */
-  private static final BugPattern BUG_PATTERN =
-      RequireExplicitNullMarking.class.getAnnotation(BugPattern.class);
-
   @Override
   public Description matchClass(ClassTree classTree, VisitorState state) {
+    SeverityLevel severityLevel = state.severityMap().get(this.getClass().getSimpleName());
+    // If the severity is SUGGESTION, we do not want to report a match, to avoid noisy NOTE-level
+    // messages from javac.
+    if (SeverityLevel.SUGGESTION.equals(severityLevel)) {
+      return Description.NO_MATCH;
+    }
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
     if (classSymbol == null) {
       return Description.NO_MATCH;
@@ -66,13 +65,7 @@ public final class RequireExplicitNullMarking extends BugChecker
         return Description.NO_MATCH;
       }
     }
-    SeverityLevel severityLevel =
-        state.severityMap().getOrDefault(BUG_PATTERN.name(), BUG_PATTERN.severity());
-    // If the severity is SUGGESTION, we do not want to report a match, to avoid noisy NOTE-level
-    // messages from javac.
-    return SeverityLevel.SUGGESTION.equals(severityLevel)
-        ? Description.NO_MATCH
-        : describeMatch(classTree);
+    return describeMatch(classTree);
   }
 
   private static boolean hasNullMarkedOrNullUnmarkedAnnotation(Symbol symbol) {

--- a/nullaway/src/test/java/com/uber/nullaway/RequireExplicitNullMarkingTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/RequireExplicitNullMarkingTest.java
@@ -10,10 +10,14 @@ import org.junit.runners.JUnit4;
 public class RequireExplicitNullMarkingTest {
 
   private CompilationTestHelper compilationHelper;
+  private CompilationTestHelper compilationHelperSuggestionLevel;
 
   @Before
   public void setUp() {
     compilationHelper =
+        CompilationTestHelper.newInstance(RequireExplicitNullMarking.class, getClass())
+            .setArgs("-Xep:RequireExplicitNullMarking:WARN");
+    compilationHelperSuggestionLevel =
         CompilationTestHelper.newInstance(RequireExplicitNullMarking.class, getClass());
   }
 
@@ -27,6 +31,19 @@ public class RequireExplicitNullMarkingTest {
             "class MissingAnnotation {",
             "  // no report on nested class",
             "  class NestedClass {}",
+            "}")
+        .doTest();
+  }
+
+  /** Test that at SUGGESTION level, no report is made for missing annotations */
+  @Test
+  public void noReportAtDefaultLevel() {
+    compilationHelperSuggestionLevel
+        .addSourceLines(
+            "test/MissingAnnotation.java",
+            "package test;",
+            "// no warning here since we're at the default SUGGESTION level",
+            "class MissingAnnotation {",
             "}")
         .doTest();
   }


### PR DESCRIPTION
Fixes #1363.  What we really want to do is ship this check in a disabled state, but I don't immediately see a way to do that.  So, as a workaround, don't emit matches when the check is run at the `SUGGESTION` level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The RequireExplicitNullMarking checker now respects severity level configuration and no longer produces diagnostic reports at the default SUGGESTION level, reducing unnecessary noise in build outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->