### PR TITLE
Add gradle.properties file for nullaway-bom module

### DIFF
--- a/nullaway-bom/gradle.properties
+++ b/nullaway-bom/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2017. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=NullAway
+POM_ARTIFACT_ID=nullaway-bom
+POM_PACKAGING=jar


### PR DESCRIPTION
This ensures the generated pom has a project name, required by Maven Central

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Maven Bill of Materials configuration for improved dependency management capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->