### PR TITLE
Further updates to nullaway-bom POM properties

### DIFF
--- a/nullaway-bom/gradle.properties
+++ b/nullaway-bom/gradle.properties
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
-POM_NAME=NullAway
+POM_NAME=NullAway (Bill of Materials)
 POM_ARTIFACT_ID=nullaway-bom
-POM_PACKAGING=jar
+POM_PACKAGING=pom
+POM_DESCRIPTION=This Bill of Materials POM can be used to ease dependency management when referencing multiple NullAway artifacts using Gradle or Maven.


### PR DESCRIPTION
* Set packaging to pom instead of jar
* Set a better name and description

Tested locally and the generated POM better matches [what AssertJ does](https://repo1.maven.org/maven2/org/assertj/assertj-bom/3.27.6/assertj-bom-3.27.6.pom).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NullAway Bill of Materials package metadata and configuration, including naming and packaging format, to properly identify and document its purpose for managing multiple NullAway artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->