### PR TITLE
Support added for JUnit's @TempDir

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ def support = [
 def test = [
     junit4                  : "junit:junit:4.13.2",
     junit5Jupiter           : [
-        "org.junit.jupiter:junit-jupiter-api:5.0.2",
+        "org.junit.jupiter:junit-jupiter-api:5.14.0",
         "org.apiguardian:apiguardian-api:1.0.0"
     ],
     jetbrainsAnnotations    : "org.jetbrains:annotations:24.1.0",

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -183,7 +183,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
           "org.springframework.boot.test.mock.mockito.MockBean",
           "org.springframework.boot.test.mock.mockito.SpyBean",
           "org.springframework.test.context.bean.override.mockito.MockitoBean",
-          "org.springframework.test.context.bean.override.mockito.MockitoSpyBean");
+          "org.springframework.test.context.bean.override.mockito.MockitoSpyBean",
+          "org.junit.jupiter.api.io.TempDir");
 
   private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
 

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -432,6 +432,34 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void junitTempDir() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "TestCase.java",
+            "package com.uber;",
+            "import java.io.File;",
+            "import java.nio.file.Path;",
+            "import org.junit.jupiter.api.BeforeAll;",
+            "import org.junit.jupiter.api.Test;",
+            "import org.junit.jupiter.api.io.TempDir;",
+            "public class TestCase {",
+            "  @TempDir",
+            "  static Path staticTempDir;",
+            "  @TempDir",
+            "  File instanceTempDir;",
+            "  @BeforeAll",
+            "  static void staticTest() {",
+            "    staticTempDir.toFile();",
+            "  }",
+            "  @Test",
+            "  void instanceTest() {",
+            "    instanceTempDir.exists();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void springAutowiredConstructorTest() {
     defaultCompilationHelper
         .addSourceLines(


### PR DESCRIPTION
This PR adds support for [Junit @TempDir extension](https://docs.junit.org/current/writing-tests/built-in-extensions.html#TempDirectory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JUnit 5 dependency to a newer version.

* **Tests**
  * Added test coverage for JUnit 5 temporary directory annotation support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->