### PR TITLE
Stop matching switch expression kind using strings

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2700,16 +2700,12 @@ public class NullAway extends BugChecker
         break;
       case CONDITIONAL_EXPRESSION:
       case ASSIGNMENT:
+      case SWITCH_EXPRESSION:
         exprMayBeNull = true;
         break;
       default:
-        // match switch expressions by comparing strings, so the code compiles on JDK versions < 12
-        if (expr.getKind().name().equals("SWITCH_EXPRESSION")) {
-          exprMayBeNull = true;
-        } else {
-          throw new RuntimeException(
-              "whoops, better handle " + expr.getKind() + " " + state.getSourceForNode(expr));
-        }
+        throw new RuntimeException(
+            "whoops, better handle " + expr.getKind() + " " + state.getSourceForNode(expr));
     }
     exprMayBeNull = handler.onOverrideMayBeNullExpr(this, expr, exprSymbol, state, exprMayBeNull);
     return exprMayBeNull && nullnessFromDataflow(state, expr);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1051,21 +1051,17 @@ public final class GenericsChecks {
       return false;
     }
     expr = NullabilityUtil.stripParensAndCasts(expr);
-    switch (expr.getKind()) {
-      case ARRAY_ACCESS:
-      case MEMBER_SELECT:
-      case METHOD_INVOCATION:
-      case IDENTIFIER:
-      case ASSIGNMENT:
-      case CONDITIONAL_EXPRESSION:
-        return true;
-      default:
-        // match switch expressions by comparing strings, so the code compiles on JDK versions < 12
-        if (expr.getKind().name().equals("SWITCH_EXPRESSION")) {
-          return true;
-        }
-        return false;
-    }
+    return switch (expr.getKind()) {
+      case ARRAY_ACCESS,
+          MEMBER_SELECT,
+          METHOD_INVOCATION,
+          IDENTIFIER,
+          ASSIGNMENT,
+          CONDITIONAL_EXPRESSION,
+          SWITCH_EXPRESSION ->
+          true;
+      default -> false;
+    };
   }
 
   private Type updateTypeWithNullness(


### PR DESCRIPTION
Fixes #1403 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Java 12+ switch expressions with more consistent null analysis.
  * Enhanced error reporting for unsupported expression types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->