### PR TITLE
Refactoring: clarify docs and naming for RestoreNullnessAnnotationsVisitor

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -83,7 +83,7 @@ public class TypeSubstitutionUtils {
    * @param extraTypeVariableAnnotations Additional annotations to consider for type variables. If
    *     there is no explicit nullability annotation on a type variable {@code X} in {@code
    *     origType}, but {@code X} is present as a key in this map, the corresponding annotation will
-   *     use when substituting in {@code newType}. If {@code X} has an explicit nullability
+   *     be used when substituting in {@code newType}. If {@code X} has an explicit nullability
    *     annotation in {@code origType}, that takes precedence over this map.
    * @return the new type with explicit nullability annotations restored
    */
@@ -109,8 +109,8 @@ public class TypeSubstitutionUtils {
     /**
      * Additional annotations to consider for type variables. If there is no explicit nullability
      * annotation on a type variable {@code X}, but {@code X} is present as a key in this map, the
-     * corresponding annotation will use when substituting in the visited type. If {@code X} has an
-     * explicit nullability annotation, that takes precedence over this map.
+     * corresponding annotation will be used when substituting in the visited type. If {@code X} has
+     * an explicit nullability annotation, that takes precedence over this map.
      */
     private final Map<Symbol.TypeVariableSymbol, AnnotationMirror> extraTypeVariableAnnotations;
 


### PR DESCRIPTION
No behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed parameter/field related to extra type-variable nullability annotations across public signatures, constructors and internal usages; updated related documentation. No behavioral or API-semantic changes—purely naming and clarity improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->