### PR TITLE
Clarify comment in test

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
@@ -677,7 +677,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
             "    return null;",
             "  }",
             "}")
-        // Note: Safe to have same-name files in recent Error Prone, but breaks EP 2.4.0
+        // Note: unsafe to have two source files with the same path in the same test, so use Test2
         .addSourceLines(
             "Test2.java",
             "package com.example.thirdparty.marked;",


### PR DESCRIPTION
Using the same source file path in the same test is bad, regardless of Error Prone version

No behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data configuration by using distinct test files instead of duplicate file paths, improving test clarity and reducing potential confusion in the test setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->