### PR TITLE
Update comments in NullabilityUtil#hasAnyAnnotationMatching

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -206,13 +206,13 @@ public class NullabilityUtil {
    */
   public static boolean hasAnyAnnotationMatching(
       Symbol symbol, Config config, Predicate<String> predicate) {
+    // check for declaration annotations
     for (AnnotationMirror annotationMirror : symbol.getAnnotationMirrors()) {
       if (predicate.test(annotationMirror.getAnnotationType().toString())) {
         return true;
       }
     }
-    // we need this loop over the type's annotation mirrors in cases like explicitly-annotated
-    // lambda parameters, possibly due to bugs in javac
+    // check for type use annotations
     for (AnnotationMirror annotationMirror : symbol.type.getAnnotationMirrors()) {
       if (predicate.test(annotationMirror.getAnnotationType().toString())) {
         return true;


### PR DESCRIPTION
In #1452 we added a comment implying that change was needed due to a `javac` bug but that was incorrect; it was our bug that was being masked before.  This PR fixes the comments (no behavior change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal code comments for clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->