### PR TITLE
Re-introduce annotations elided by `javac` for certain cases

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1965,9 +1965,21 @@ public final class GenericsChecks {
   }
 
   /**
-   * For some calls, javac drops nested type-use nullability annotations in inferred substitutions
-   * for method type variables. Recover these annotations from the corresponding actual argument
-   * types, while preserving one consistent top-level substitution per method type variable.
+   * In narrow cases, javac drops nested type-use nullability annotations on type variables in its
+   * inferred type for a generic method at a call site. See
+   * https://github.com/uber/NullAway/issues/1455. This method aims to restore those annotations
+   * based on the types of actual parameters. It does not attempt to be a very general fix, as we do
+   * not fully understand the scenarios where this can arise.
+   *
+   * @param invocationTree the method invocation tree for the generic method call
+   * @param origMethodType the declared method type for the generic method (to identify formal
+   *     parameters whose type is a type variable of the method)
+   * @param methodTypeAtCallSite the method type for the generic method as inferred by javac at the
+   *     call site
+   * @param state the visitor state
+   * @return a method type based on {@code methodTypeAtCallSite} but with some nested nullability
+   *     annotations on type variables restored to match those on actual parameters passed at the
+   *     call site
    */
   @SuppressWarnings("ReferenceEquality")
   private Type.MethodType restoreNestedNullabilityForTypeVarArguments(
@@ -1977,66 +1989,66 @@ public final class GenericsChecks {
       VisitorState state) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
     if (methodSymbol.isVarArgs()) {
-      // TODO handle varargs methods
+      // skip handling of varargs for now
       return methodTypeAtCallSite;
     }
-    com.sun.tools.javac.util.List<Type> origArgTypes = origMethodType.getParameterTypes();
-    com.sun.tools.javac.util.List<Type> callSiteArgTypes = methodTypeAtCallSite.getParameterTypes();
-    List<? extends ExpressionTree> callArgs = invocationTree.getArguments();
-    if (origArgTypes.size() != callSiteArgTypes.size() || callArgs.size() != origArgTypes.size()) {
-      return methodTypeAtCallSite;
-    }
+    com.sun.tools.javac.util.List<Type> genericMethodParamTypes =
+        origMethodType.getParameterTypes();
+    com.sun.tools.javac.util.List<Type> callSiteParamTypes =
+        methodTypeAtCallSite.getParameterTypes();
+    List<? extends ExpressionTree> actualParams = invocationTree.getArguments();
 
     // use this map to store repaired substitutions for method type variables, to ensure we use the
-    // same repaired
-    // substitution for all occurrences of the same method type variable
+    // same repaired substitution for all occurrences of the same type variable
     Map<Symbol.TypeVariableSymbol, Type> repairedTopLevelSubstitutions = new HashMap<>();
     ListBuffer<Type> updatedArgTypes = new ListBuffer<>();
     boolean changed = false;
-    for (int i = 0; i < origArgTypes.size(); i++) {
-      Type updatedType = callSiteArgTypes.get(i);
-      Type origArgType = origArgTypes.get(i);
-      if (origArgType instanceof Type.TypeVar typeVar
-          && typeVar.tsym.owner == methodSymbol
-          && !(updatedType instanceof Type.TypeVar)) {
+    for (int i = 0; i < genericMethodParamTypes.size(); i++) {
+      Type callSiteParamType = callSiteParamTypes.get(i);
+      Type genericMethodParamType = genericMethodParamTypes.get(i);
+      // only attempt a repair when the generic method's parameter type is a type variable of the
+      // method
+      if (genericMethodParamType instanceof Type.TypeVar typeVar
+          && typeVar.tsym.owner == methodSymbol) {
         Symbol.TypeVariableSymbol typeVarSymbol = (Symbol.TypeVariableSymbol) typeVar.tsym;
         Type repairedSubstitution = repairedTopLevelSubstitutions.get(typeVarSymbol);
         if (repairedSubstitution != null) {
-          if (!state
-              .getTypes()
-              .isSameType(
-                  state.getTypes().erasure(repairedSubstitution),
-                  state.getTypes().erasure(updatedType))) {
-            // Inconsistent substitution for the same top-level type variable; bail out.
-            return methodTypeAtCallSite;
-          }
-          if (repairedSubstitution != updatedType) {
+          // re-use the previous substitution, to ensure consistency
+          if (repairedSubstitution != callSiteParamType) {
             changed = true;
-            updatedType = repairedSubstitution;
+            callSiteParamType = repairedSubstitution;
           }
         } else { // need to compute the substitution
-          Type actualArgType = getTreeType(callArgs.get(i), state);
+          Type actualArgType = getTreeType(actualParams.get(i), state);
+          // only handle cases of non-raw actual parameter types that have the same base type as the
+          // inferred parameter type at the call site
           if (actualArgType != null
               && !actualArgType.isRaw()
               && state
                   .getTypes()
                   .isSameType(
                       state.getTypes().erasure(actualArgType),
-                      state.getTypes().erasure(updatedType))) {
+                      state.getTypes().erasure(callSiteParamType))) {
+            // restore explicit nested annotations from the actual parameter type to the call site
+            // parameter type (this will only apply to nested type variables within
+            // callSiteParamType)
             Type restoredType =
                 TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-                    actualArgType, updatedType, config, Collections.emptyMap());
+                    actualArgType, callSiteParamType, config, Collections.emptyMap());
+            // remember the substitution so we use it consistently at other parameter positions
             repairedTopLevelSubstitutions.put(typeVarSymbol, restoredType);
-            if (restoredType != updatedType) {
+            if (restoredType != callSiteParamType) {
               changed = true;
-              updatedType = restoredType;
+              callSiteParamType = restoredType;
             }
           } else {
-            repairedTopLevelSubstitutions.put(typeVarSymbol, updatedType);
+            // remember that we did _not_ change anything, again for consistency across parameter
+            // positions
+            repairedTopLevelSubstitutions.put(typeVarSymbol, callSiteParamType);
           }
         }
       }
-      updatedArgTypes.append(updatedType);
+      updatedArgTypes.append(callSiteParamType);
     }
     if (!changed) {
       return methodTypeAtCallSite;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1551,6 +1551,16 @@ public class GenericMethodTests extends NullAwayTestsBase {
               void test() {
                 acceptSup(sup);
               }
+              <T extends Supplier<?>> void acceptTwoSup(T supplier1, T supplier2) {
+              }
+              Supplier<OuterT> sup2 = make2();
+              Supplier<OuterT> make2() {
+                throw new RuntimeException();
+              }
+              void test2() {
+                // BUG: Diagnostic contains: incompatible types: Supplier<OuterT> cannot be converted to @NonNull Supplier<@Nullable OuterT>
+                acceptTwoSup(sup, sup2);
+              }
             }
             """)
         .doTest();


### PR DESCRIPTION
Fixes #1455 

For reference here is the test case:
```java
@NullMarked
class Foo<OuterT> {

  interface Supplier<T extends @Nullable Object> {
    T get();
  }

  Supplier<@Nullable OuterT> sup;

  <T extends Supplier<?>> T acceptSup(T supplier) {
    return supplier;
  }

  void test() {
    acceptSup(sup);
  }
}
```
What goes wrong here is at the call `acceptSup(sup)`, `javac` infers the type argument to be `Supplier<OuterT>`, dropping the `@Nullable` annotation on `OuterT` seen in the declaration of `sup`.  I cannot figure out exactly when annotations get dropped; e.g., it does not seem to happen if `sup` is a formal parameter rather than a field.  For the case above, our inference correctly infers that `T` itself should be `@NonNull`, but then we still report an error since `Supplier<@Nullable OuterT>` (the type of `sup`) is incompatible with `Supplier<OuterT>` (what we think is the formal parameter type).

This started happening in 0.13.0 due to https://github.com/uber/NullAway/pull/1348, because we started computing the proper method types at call sites to report better error messages.  Unfortunately, this is leading to unforeseen interactions with `javac`'s type inference like the issue above; but I'd like to see if we can work around the corner cases since it's important to have good error messages.

For this case, we add a method `restoreMissingNullabilityFromSingleTopLevelTypeVarArguments` that repairs the method type by re-introducing explicit nullability annotations nested in actual parameter types onto the formal parameter types.  We try to tailor the fix narrowly for this case and to not introduce unsoundness by re-introducing annotations across parameter positions inconsistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety for generic method calls by restoring nested nullability on inferred type arguments, ensuring consistent substitutions and safely falling back when restoration isn’t possible.

* **Tests**
  * Added a unit test covering generic method type inference and warning behavior for JSPECIFY-style nullability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->