### PR TITLE
Improve printing of annotated type variables in error messages

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
@@ -67,6 +67,18 @@ final class GenericTypePrettyPrintingVisitor
     return sb.toString();
   }
 
+  @Override
+  public String visitTypeVar(Type.TypeVar t, @Nullable Void unused) {
+    StringBuilder sb = new StringBuilder();
+    for (Attribute.TypeCompound compound : t.getAnnotationMirrors()) {
+      sb.append('@');
+      sb.append(compound.type.accept(this, null));
+      sb.append(' ');
+    }
+    sb.append(t.tsym.getSimpleName());
+    return sb.toString();
+  }
+
   private String prettyIntersectionType(Type.IntersectionClassType t) {
     return t.getBounds().stream()
         .map(type -> ((Type) type).accept(this, null))

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2422,7 +2422,7 @@ public class GenericsTests extends NullAwayTestsBase {
                     foo(f);
                 }
                 void testPositive1(Function<@Nullable V, V> f) {
-                    // BUG: Diagnostic contains: incompatible types: Function<@org.jspecify.annotations.Nullable V, V>
+                    // BUG: Diagnostic contains: incompatible types: Function<@Nullable V, V>
                     foo(f);
                 }
                 void testPositive2(Function<V, V> f) {
@@ -2430,7 +2430,7 @@ public class GenericsTests extends NullAwayTestsBase {
                     foo(f);
                 }
                 void testPositive3(Function<@Nullable V, @Nullable V> f) {
-                    // BUG: Diagnostic contains: incompatible types: Function<@org.jspecify.annotations.Nullable V, @org.jspecify.annotations.Nullable V> cannot be converted to
+                    // BUG: Diagnostic contains: incompatible types: Function<@Nullable V, @Nullable V> cannot be converted to
                     foo(f);
                 }
             }


### PR DESCRIPTION
Use the simple name for annotations rather than the fully-qualified name.  Only changes printing of error messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message formatting for generic type variables and intersection types in diagnostic output.

* **Tests**
  * Updated test expectations to reflect improved diagnostic message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->