### PR TITLE
Use text blocks in `CustomLibraryModelsTests`

### DIFF
--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -48,25 +48,27 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
             "AnnotatedWithModels.java",
-            "package com.uber;",
-            "public class AnnotatedWithModels {",
-            "   Object field = new Object();",
-            "   // implicitly @Nullable due to library model",
-            "   Object returnsNullFromModel() {",
-            "      // null is valid here only because of the library model",
-            "      return null;",
-            "   }",
-            "   Object nullableReturn() {",
-            "       // BUG: Diagnostic contains: returning @Nullable",
-            "       return returnsNullFromModel();",
-            "   }",
-            "   void run() {",
-            "       // just to make sure, flow analysis is also impacted by library models information",
-            "      Object temp = returnsNullFromModel();",
-            "       // BUG: Diagnostic contains: assigning @Nullable",
-            "      this.field = temp;",
-            "   }",
-            "}")
+            """
+            package com.uber;
+            public class AnnotatedWithModels {
+               Object field = new Object();
+               // implicitly @Nullable due to library model
+               Object returnsNullFromModel() {
+                  // null is valid here only because of the library model
+                  return null;
+               }
+               Object nullableReturn() {
+                   // BUG: Diagnostic contains: returning @Nullable
+                   return returnsNullFromModel();
+               }
+               void run() {
+                   // just to make sure, flow analysis is also impacted by library models information
+                  Object temp = returnsNullFromModel();
+                   // BUG: Diagnostic contains: assigning @Nullable
+                  this.field = temp;
+               }
+            }
+            """)
         .doTest();
   }
 
@@ -81,26 +83,28 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride;",
-            "import javax.annotation.Nullable;",
-            "public class Test {",
-            "  void bar(RestrictivelyAnnotatedFIWithModelOverride f) {",
-            "     // Param is @NullableDecl in bytecode, overridden by library model",
-            "     // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull",
-            "     f.apply(null);",
-            "  }",
-            "  void foo() {",
-            "    RestrictivelyAnnotatedFIWithModelOverride func = (x) -> {",
-            "     // Param is @NullableDecl in bytecode, overridden by library model, thus safe",
-            "     return x.toString();",
-            "    };",
-            "  }",
-            "  void baz() {",
-            "     // Safe to pass, since Function can't have a null instance parameter",
-            "     bar(Object::toString);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride;
+            import javax.annotation.Nullable;
+            public class Test {
+              void bar(RestrictivelyAnnotatedFIWithModelOverride f) {
+                 // Param is @NullableDecl in bytecode, overridden by library model
+                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull
+                 f.apply(null);
+              }
+              void foo() {
+                RestrictivelyAnnotatedFIWithModelOverride func = (x) -> {
+                 // Param is @NullableDecl in bytecode, overridden by library model, thus safe
+                 return x.toString();
+                };
+              }
+              void baz() {
+                 // Safe to pass, since Function can't have a null instance parameter
+                 bar(Object::toString);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -115,32 +119,36 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated"))
         .addSourceLines(
             "CallMethods.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.UnannotatedWithModels;",
-            "import javax.annotation.Nullable;",
-            "public class CallMethods {",
-            "  Object testWithoutCheck(UnannotatedWithModels u) {",
-            "     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
-            "     return u.returnsNullUnannotated();",
-            "  }",
-            "  Object testWithCheck(@Nullable Object o) {",
-            "     if (UnannotatedWithModels.isNonNull(o)) {",
-            "       return o;",
-            "     }",
-            "     return new Object();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            import javax.annotation.Nullable;
+            public class CallMethods {
+              Object testWithoutCheck(UnannotatedWithModels u) {
+                 // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                 return u.returnsNullUnannotated();
+              }
+              Object testWithCheck(@Nullable Object o) {
+                 if (UnannotatedWithModels.isNonNull(o)) {
+                   return o;
+                 }
+                 return new Object();
+              }
+            }
+            """)
         .addSourceLines(
             "OverrideCheck.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.UnannotatedWithModels;",
-            "import javax.annotation.Nullable;",
-            "public class OverrideCheck extends UnannotatedWithModels {",
-            "  @Nullable",
-            "  public Object returnsNullUnannotated() {",
-            "     return null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            import javax.annotation.Nullable;
+            public class OverrideCheck extends UnannotatedWithModels {
+              @Nullable
+              public Object returnsNullUnannotated() {
+                 return null;
+              }
+            }
+            """)
         .doTest();
     // Now test disabling the library model
     makeLibraryModelsTestHelperWithArgs(
@@ -152,38 +160,42 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:IgnoreLibraryModelsFor=com.uber.lib.unannotated.UnannotatedWithModels.returnsNullUnannotated,com.uber.lib.unannotated.UnannotatedWithModels.isNonNull"))
         .addSourceLines(
             "CallMethods.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.UnannotatedWithModels;",
-            "import javax.annotation.Nullable;",
-            "public class CallMethods {",
-            "  Object testWithoutCheck(UnannotatedWithModels u) {",
-            "     // Ok. Library model ignored",
-            "     return u.returnsNullUnannotated();",
-            "  }",
-            "  Object testWithoutCheckNonIgnoredMethod(UnannotatedWithModels u) {",
-            "     // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
-            "     return u.returnsNullUnannotated2();",
-            "  }",
-            "  Object testWithCheck(@Nullable Object o) {",
-            "     if (UnannotatedWithModels.isNonNull(o)) {",
-            "       // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type",
-            "       return o;",
-            "     }",
-            "     return new Object();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            import javax.annotation.Nullable;
+            public class CallMethods {
+              Object testWithoutCheck(UnannotatedWithModels u) {
+                 // Ok. Library model ignored
+                 return u.returnsNullUnannotated();
+              }
+              Object testWithoutCheckNonIgnoredMethod(UnannotatedWithModels u) {
+                 // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                 return u.returnsNullUnannotated2();
+              }
+              Object testWithCheck(@Nullable Object o) {
+                 if (UnannotatedWithModels.isNonNull(o)) {
+                   // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                   return o;
+                 }
+                 return new Object();
+              }
+            }
+            """)
         .addSourceLines(
             "OverrideCheck.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.UnannotatedWithModels;",
-            "import javax.annotation.Nullable;",
-            "public class OverrideCheck extends UnannotatedWithModels {",
-            "  @Nullable", // Still safe, because the method is not @NonNull, it's unannotated
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            import javax.annotation.Nullable;
+            public class OverrideCheck extends UnannotatedWithModels {
+              @Nullable // Still safe, because the method is not @NonNull, it's unannotated
             // without model!
-            "  public Object returnsNullUnannotated() {",
-            "     return null;",
-            "  }",
-            "}")
+              public Object returnsNullUnannotated() {
+                 return null;
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -199,26 +211,28 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:IgnoreLibraryModelsFor=com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride.apply"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride;",
-            "import javax.annotation.Nullable;",
-            "public class Test {",
-            "  void bar(RestrictivelyAnnotatedFIWithModelOverride f) {",
-            "     // Param is @NullableDecl in bytecode, and library model making it non-null is skipped",
-            "     f.apply(null);",
-            "  }",
-            "  void foo() {",
-            "    RestrictivelyAnnotatedFIWithModelOverride func = (x) -> {",
-            "     // Param is @NullableDecl in bytecode, and overriding library model is ignored, thus unsafe",
-            "     // BUG: Diagnostic contains: dereferenced expression x is @Nullable",
-            "     return x.toString();",
-            "    };",
-            "  }",
-            "  void baz() {",
-            "     // BUG: Diagnostic contains: unbound instance method reference cannot be used",
-            "     bar(Object::toString);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride;
+            import javax.annotation.Nullable;
+            public class Test {
+              void bar(RestrictivelyAnnotatedFIWithModelOverride f) {
+                 // Param is @NullableDecl in bytecode, and library model making it non-null is skipped
+                 f.apply(null);
+              }
+              void foo() {
+                RestrictivelyAnnotatedFIWithModelOverride func = (x) -> {
+                 // Param is @NullableDecl in bytecode, and overriding library model is ignored, thus unsafe
+                 // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                 return x.toString();
+                };
+              }
+              void baz() {
+                 // BUG: Diagnostic contains: unbound instance method reference cannot be used
+                 bar(Object::toString);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -231,31 +245,33 @@ public class CustomLibraryModelsTests {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.UnannotatedWithModels;",
-            "public class Test {",
-            "   UnannotatedWithModels uwm = new UnannotatedWithModels();",
-            "   Object nonnullField = new Object();",
-            "   void assignNullableFromLibraryModelField() {",
-            "      // BUG: Diagnostic contains: assigning @Nullable",
-            "      this.nonnullField = uwm.nullableFieldUnannotated1;",
-            "      // BUG: Diagnostic contains: assigning @Nullable",
-            "      this.nonnullField = uwm.nullableFieldUnannotated2;",
-            "   }",
-            "   void flowTest() {",
-            "      if(uwm.nullableFieldUnannotated1 != null) {",
-            "         // no error here, to check that library models only initialize  flow store",
-            "         this.nonnullField = uwm.nullableFieldUnannotated1;",
-            "      }",
-            "   }",
-            "   String dereferenceTest() {",
-            "      // BUG: Diagnostic contains: dereferenced expression uwm.nullableFieldUnannotated1 is @Nullable",
-            "      return uwm.nullableFieldUnannotated1.toString();",
-            "   }",
-            "   void assignmentTest() {",
-            "      uwm.nullableFieldUnannotated1 = null;",
-            "   }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            public class Test {
+               UnannotatedWithModels uwm = new UnannotatedWithModels();
+               Object nonnullField = new Object();
+               void assignNullableFromLibraryModelField() {
+                  // BUG: Diagnostic contains: assigning @Nullable
+                  this.nonnullField = uwm.nullableFieldUnannotated1;
+                  // BUG: Diagnostic contains: assigning @Nullable
+                  this.nonnullField = uwm.nullableFieldUnannotated2;
+               }
+               void flowTest() {
+                  if(uwm.nullableFieldUnannotated1 != null) {
+                     // no error here, to check that library models only initialize  flow store
+                     this.nonnullField = uwm.nullableFieldUnannotated1;
+                  }
+               }
+               String dereferenceTest() {
+                  // BUG: Diagnostic contains: dereferenced expression uwm.nullableFieldUnannotated1 is @Nullable
+                  return uwm.nullableFieldUnannotated1.toString();
+               }
+               void assignmentTest() {
+                  uwm.nullableFieldUnannotated1 = null;
+               }
+            }
+            """)
         .doTest();
   }
 
@@ -269,18 +285,20 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.lib.unannotated.ProviderNullMarkedViaModel;",
-            "import org.jspecify.annotations.Nullable;",
-            "public class Test {",
-            "  void use(Object o) {}",
-            "  void f(Object o) {",
-            "    use(o);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter",
-            "    use(provider.get());",
-            "  }",
-            "  ProviderNullMarkedViaModel<@Nullable Object> provider = () -> null;",
-            "}")
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.ProviderNullMarkedViaModel;
+            import org.jspecify.annotations.Nullable;
+            public class Test {
+              void use(Object o) {}
+              void f(Object o) {
+                use(o);
+                // BUG: Diagnostic contains: passing @Nullable parameter
+                use(provider.get());
+              }
+              ProviderNullMarkedViaModel<@Nullable Object> provider = () -> null;
+            }
+            """)
         .doTest();
   }
 
@@ -294,20 +312,22 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.ProviderNullMarkedViaModel;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void test() {",
-            "    ProviderNullMarkedViaModel<@Nullable Object> p = ProviderNullMarkedViaModel.of(null);",
-            "    // BUG: Diagnostic contains: dereferenced expression p.get() is @Nullable",
-            "    p.get().toString();",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ProviderNullMarkedViaModel<Object> q = ProviderNullMarkedViaModel.of(null);",
-            "    ProviderNullMarkedViaModel<Object> r = ProviderNullMarkedViaModel.of(new Object());",
-            "    r.get().toString();",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.ProviderNullMarkedViaModel;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void test() {
+                ProviderNullMarkedViaModel<@Nullable Object> p = ProviderNullMarkedViaModel.of(null);
+                // BUG: Diagnostic contains: dereferenced expression p.get() is @Nullable
+                p.get().toString();
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ProviderNullMarkedViaModel<Object> q = ProviderNullMarkedViaModel.of(null);
+                ProviderNullMarkedViaModel<Object> r = ProviderNullMarkedViaModel.of(new Object());
+                r.get().toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -321,15 +341,17 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void test() {",
-            "    NestedAnnots<@Nullable String> g = NestedAnnots.genericMethod(String.class);",
-            "    NestedAnnots<Integer> g2 = NestedAnnots.genericMethod(Integer.class);",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void test() {
+                NestedAnnots<@Nullable String> g = NestedAnnots.genericMethod(String.class);
+                NestedAnnots<Integer> g2 = NestedAnnots.genericMethod(Integer.class);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -343,18 +365,20 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void testPositive(NestedAnnots<NestedAnnots<String>> p) {",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    NestedAnnots.deeplyNested(p);",
-            "  }",
-            "  void testNegative(NestedAnnots<NestedAnnots<@Nullable String>> p) {",
-            "    NestedAnnots.deeplyNested(p);",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void testPositive(NestedAnnots<NestedAnnots<String>> p) {
+                // BUG: Diagnostic contains: incompatible types
+                NestedAnnots.deeplyNested(p);
+              }
+              void testNegative(NestedAnnots<NestedAnnots<@Nullable String>> p) {
+                NestedAnnots.deeplyNested(p);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -368,18 +392,20 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void testPositive() {",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    NestedAnnots<NestedAnnots<String>[]> unused = NestedAnnots.nestedArray1();",
-            "  }",
-            "  void testNegative() {",
-            "    NestedAnnots<NestedAnnots<@Nullable String>[]> unused = NestedAnnots.nestedArray1();",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void testPositive() {
+                // BUG: Diagnostic contains: incompatible types
+                NestedAnnots<NestedAnnots<String>[]> unused = NestedAnnots.nestedArray1();
+              }
+              void testNegative() {
+                NestedAnnots<NestedAnnots<@Nullable String>[]> unused = NestedAnnots.nestedArray1();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -393,18 +419,20 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void testPositive() {",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    NestedAnnots<String[]> unused = NestedAnnots.nestedArray2();",
-            "  }",
-            "  void testNegative() {",
-            "    NestedAnnots<String @Nullable []> unused = NestedAnnots.nestedArray2();",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void testPositive() {
+                // BUG: Diagnostic contains: incompatible types
+                NestedAnnots<String[]> unused = NestedAnnots.nestedArray2();
+              }
+              void testNegative() {
+                NestedAnnots<String @Nullable []> unused = NestedAnnots.nestedArray2();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -418,19 +446,21 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void testUpper(NestedAnnots<@Nullable String> t) {",
-            "    // TODO report an error here when we support wildcards",
-            "    NestedAnnots.wildcardUpper(t);",
-            "  }",
-            "  void testLower(NestedAnnots<String> t) {",
-            "    // TODO report an error here when we support wildcards",
-            "    NestedAnnots.wildcardLower(t);",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void testUpper(NestedAnnots<@Nullable String> t) {
+                // TODO report an error here when we support wildcards
+                NestedAnnots.wildcardUpper(t);
+              }
+              void testLower(NestedAnnots<String> t) {
+                // TODO report an error here when we support wildcards
+                NestedAnnots.wildcardLower(t);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -444,22 +474,24 @@ public class CustomLibraryModelsTests {
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
             "Test.java",
-            "import com.uber.lib.unannotated.NestedAnnots;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  void testPositive() {",
-            "    NestedAnnots.multipleArgs(",
-            "        // BUG: Diagnostic contains: incompatible types",
-            "        new NestedAnnots<@Nullable String>(),",
-            "        // BUG: Diagnostic contains: incompatible types",
-            "        new NestedAnnots<Integer>());",
-            "  }",
-            "  void testNegative() {",
-            "    NestedAnnots.multipleArgs(",
-            "        new NestedAnnots<String>(), new NestedAnnots<@Nullable Integer>());",
-            "  }",
-            "}")
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              void testPositive() {
+                NestedAnnots.multipleArgs(
+                    // BUG: Diagnostic contains: incompatible types
+                    new NestedAnnots<@Nullable String>(),
+                    // BUG: Diagnostic contains: incompatible types
+                    new NestedAnnots<Integer>());
+              }
+              void testNegative() {
+                NestedAnnots.multipleArgs(
+                    new NestedAnnots<String>(), new NestedAnnots<@Nullable Integer>());
+              }
+            }
+            """)
         .doTest();
   }
 


### PR DESCRIPTION
No functionality changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test code formatting for improved readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->