### PR TITLE
Handle nested restrictive annotations on type variables in @NullUnmarked code

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2083,13 +2083,18 @@ public class NullAway extends BugChecker
         }
       }
 
-      // perform generics checks for calls to annotated methods in JSpecify mode
-      if (config.isJSpecifyMode()) {
-        genericsChecks.compareGenericTypeParameterNullabilityForCall(methodSymbol, tree, state);
-        if (!methodSymbol.getTypeParameters().isEmpty()) {
-          genericsChecks.checkGenericMethodCallTypeArguments(tree, state);
-        }
+      // perform generics checks for type arguments on calls to annotated methods in JSpecify mode
+      if (config.isJSpecifyMode() && !methodSymbol.getTypeParameters().isEmpty()) {
+        genericsChecks.checkGenericMethodCallTypeArguments(tree, state);
       }
+    }
+
+    // Perform generics checks for calls in JSpecify mode, including calls to @NullUnmarked
+    // methods.  For @NullUnmarked methods, only restrictive (explicit) nullness annotations
+    // on type parameters are enforced (see #1488).
+    if (config.isJSpecifyMode()) {
+      genericsChecks.compareGenericTypeParameterNullabilityForCall(
+          methodSymbol, tree, state, isMethodAnnotated);
     }
 
     // Allow handlers to override the list of non-null argument positions. For a varargs parameter,

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -5,6 +5,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.Config;
+import com.uber.nullaway.Nullness;
 import java.util.List;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
@@ -18,12 +19,22 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private final VisitorState state;
   private final GenericsChecks genericsChecks;
   private final Config config;
+  private final boolean isMethodUnannotated;
 
   CheckIdenticalNullabilityVisitor(
       VisitorState state, GenericsChecks genericsChecks, Config config) {
+    this(state, genericsChecks, config, false);
+  }
+
+  CheckIdenticalNullabilityVisitor(
+      VisitorState state,
+      GenericsChecks genericsChecks,
+      Config config,
+      boolean isMethodUnannotated) {
     this.state = state;
     this.genericsChecks = genericsChecks;
     this.config = config;
+    this.isMethodUnannotated = isMethodUnannotated;
   }
 
   @Override
@@ -71,7 +82,17 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsTypeArgument);
       boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsTypeArgument);
       if (isLHSNullableAnnotated != isRHSNullableAnnotated) {
-        return false;
+        // In @NullUnmarked code, unannotated type arguments are unconstrained.  Only flag
+        // a mismatch when the formal (LHS) type argument has an explicit nullness annotation.
+        if (isMethodUnannotated
+            && !isLHSNullableAnnotated
+            && !Nullness.hasNonNullAnnotation(
+                lhsTypeArgument.getAnnotationMirrors().stream(), config)) {
+          // LHS is unannotated in @NullUnmarked context; skip this level but still check
+          // nested types below (which may have restrictive annotations)
+        } else {
+          return false;
+        }
       }
       // nested generics
       if (!lhsTypeArgument.accept(this, rhsTypeArgument)) {
@@ -104,7 +125,14 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsComponentType);
     boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsComponentType);
     if (isRHSNullableAnnotated != isLHSNullableAnnotated) {
-      return false;
+      if (isMethodUnannotated
+          && !isLHSNullableAnnotated
+          && !Nullness.hasNonNullAnnotation(
+              lhsComponentType.getAnnotationMirrors().stream(), config)) {
+        // LHS component is unannotated in @NullUnmarked context; skip this level
+      } else {
+        return false;
+      }
     }
     return lhsComponentType.accept(this, rhsComponentType);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -82,12 +82,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsTypeArgument);
       boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsTypeArgument);
       if (isLHSNullableAnnotated != isRHSNullableAnnotated) {
-        // In @NullUnmarked code, unannotated type arguments are unconstrained.  Only flag
-        // a mismatch when the formal (LHS) type argument has an explicit nullness annotation.
-        if (isMethodUnannotated
-            && !isLHSNullableAnnotated
-            && !Nullness.hasNonNullAnnotation(
-                lhsTypeArgument.getAnnotationMirrors().stream(), config)) {
+        if (shouldSkipMismatchInUnannotatedMethod(lhsTypeArgument, isLHSNullableAnnotated)) {
           // LHS is unannotated in @NullUnmarked context; skip this level but still check
           // nested types below (which may have restrictive annotations)
         } else {
@@ -125,16 +120,27 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsComponentType);
     boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsComponentType);
     if (isRHSNullableAnnotated != isLHSNullableAnnotated) {
-      if (isMethodUnannotated
-          && !isLHSNullableAnnotated
-          && !Nullness.hasNonNullAnnotation(
-              lhsComponentType.getAnnotationMirrors().stream(), config)) {
+      if (shouldSkipMismatchInUnannotatedMethod(lhsComponentType, isLHSNullableAnnotated)) {
         // LHS component is unannotated in @NullUnmarked context; skip this level
       } else {
         return false;
       }
     }
     return lhsComponentType.accept(this, rhsComponentType);
+  }
+
+  /**
+   * Returns {@code true} when a nullability mismatch should be skipped because the LHS type has no
+   * explicit nullness annotation and we are inside {@code @NullUnmarked} code.
+   *
+   * @param lhsType the formal (LHS) type whose annotations are inspected
+   * @param isLhsNullableAnnotated whether {@code lhsType} carries a {@code @Nullable} annotation
+   */
+  private boolean shouldSkipMismatchInUnannotatedMethod(
+      Type lhsType, boolean isLhsNullableAnnotated) {
+    return isMethodUnannotated
+        && !isLhsNullableAnnotated
+        && !Nullness.hasNonNullAnnotation(lhsType.getAnnotationMirrors().stream(), config);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1445,8 +1445,7 @@ public final class GenericsChecks {
 
   /**
    * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState, boolean)}, but allows
-   * for
-   * covariant array subtyping at the top level.
+   * for covariant array subtyping at the top level.
    *
    * @param lhsType type for the lhs of the assignment
    * @param rhsType type for the rhs of the assignment

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1438,12 +1438,14 @@ public final class GenericsChecks {
    * @param state the visitor state
    */
   private boolean identicalTypeParameterNullability(
-      Type lhsType, Type rhsType, VisitorState state) {
-    return lhsType.accept(new CheckIdenticalNullabilityVisitor(state, this, config), rhsType);
+      Type lhsType, Type rhsType, VisitorState state, boolean isMethodUnannotated) {
+    return lhsType.accept(
+        new CheckIdenticalNullabilityVisitor(state, this, config, isMethodUnannotated), rhsType);
   }
 
   /**
-   * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState)}, but allows for
+   * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState, boolean)}, but allows
+   * for
    * covariant array subtyping at the top level.
    *
    * @param lhsType type for the lhs of the assignment
@@ -1451,6 +1453,11 @@ public final class GenericsChecks {
    * @param state the visitor state
    */
   private boolean subtypeParameterNullability(Type lhsType, Type rhsType, VisitorState state) {
+    return subtypeParameterNullability(lhsType, rhsType, state, false);
+  }
+
+  private boolean subtypeParameterNullability(
+      Type lhsType, Type rhsType, VisitorState state, boolean isMethodUnannotated) {
     if (lhsType.isRaw()) {
       return true;
     }
@@ -1466,11 +1473,19 @@ public final class GenericsChecks {
       boolean isRHSNullableAnnotated = isNullableAnnotated(rhsComponentType);
       // an array of @Nullable references is _not_ a subtype of an array of @NonNull references
       if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
-        return false;
+        // In @NullUnmarked code, skip if the LHS component has no explicit nullness annotation
+        if (isMethodUnannotated
+            && !Nullness.hasNonNullAnnotation(
+                lhsComponentType.getAnnotationMirrors().stream(), config)) {
+          // unannotated component in @NullUnmarked context; fall through to nested check
+        } else {
+          return false;
+        }
       }
-      return identicalTypeParameterNullability(lhsComponentType, rhsComponentType, state);
+      return identicalTypeParameterNullability(
+          lhsComponentType, rhsComponentType, state, isMethodUnannotated);
     } else {
-      return identicalTypeParameterNullability(lhsType, rhsType, state);
+      return identicalTypeParameterNullability(lhsType, rhsType, state, isMethodUnannotated);
     }
   }
 
@@ -1553,9 +1568,12 @@ public final class GenericsChecks {
    * @param methodSymbol the symbol for the method being called
    * @param tree the tree representing the method call
    * @param state the visitor state
+   * @param isMethodAnnotated whether the called method is in annotated (non-{@code @NullUnmarked})
+   *     code. When {@code false}, only restrictive (explicit) nullness annotations on type
+   *     parameters are enforced.
    */
   public void compareGenericTypeParameterNullabilityForCall(
-      Symbol.MethodSymbol methodSymbol, Tree tree, VisitorState state) {
+      Symbol.MethodSymbol methodSymbol, Tree tree, VisitorState state, boolean isMethodAnnotated) {
     Config config = analysis.getConfig();
     if (!config.isJSpecifyMode()) {
       return;
@@ -1602,13 +1620,15 @@ public final class GenericsChecks {
                 // the type of the method reference tree provided by javac may not capture
                 // nullability of nested types. So, do explicit type checks based on the return and
                 // parameter types of the referenced method
+                boolean isUnannotated = !isMethodAnnotated;
                 GenericsUtils.processMethodRefTypeRelations(
                     this,
                     formalParameter,
                     memberReferenceTree,
                     state,
                     (subtype, supertype, relationKind) -> {
-                      if (!subtypeParameterNullability(supertype, subtype, state)) {
+                      if (!subtypeParameterNullability(
+                          supertype, subtype, state, isUnannotated)) {
                         if (relationKind == MethodRefTypeRelationKind.RETURN) {
                           reportInvalidMethodReferenceReturnTypeError(
                               memberReferenceTree, supertype, subtype, state);
@@ -1646,7 +1666,8 @@ public final class GenericsChecks {
                           false,
                           false);
                 }
-                if (!subtypeParameterNullability(formalParameter, actualParameterType, state)) {
+                if (!subtypeParameterNullability(
+                    formalParameter, actualParameterType, state, !isMethodAnnotated)) {
                   reportInvalidParametersNullabilityError(
                       formalParameter, actualParameterType, currentActualParam, state);
                 }
@@ -1929,8 +1950,12 @@ public final class GenericsChecks {
         return TypeSubstitutionUtils.updateMethodTypeWithInferredNullability(
             methodTypeAtCallSite, methodType, successResult.typeVarNullability, state, config);
       } else {
-        // inference failed; just return the method type at the call site with no substitutions
-        return methodTypeAtCallSite;
+        // inference failed; restore explicit nullability annotations from the original method
+        // type to the call-site type, so restrictive annotations (e.g. @NonNull on type
+        // arguments) are still enforced
+        return TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
+                methodType, methodTypeAtCallSite, config, Collections.emptyMap())
+            .asMethodType();
       }
     }
     return TypeSubstitutionUtils.subst(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
@@ -1032,6 +1032,78 @@ public class NullMarkednessTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void nullUnmarkedRestrictiveAnnotationsOnTypeVariables() {
+    makeTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<T extends @Nullable Object> {}
+              @NullUnmarked
+              static void takeFoo(Foo<@NonNull String> f) {}
+              @NullUnmarked
+              static <T> T identity(Foo<@NonNull T> t) {
+                throw new RuntimeException("not implemented");
+              }
+              void test(Foo<@Nullable String> s, Foo<String> nonNullFoo) {
+                // Error: passing Foo<@Nullable String> where Foo<@NonNull String> is required
+                // BUG: Diagnostic contains: incompatible types
+                takeFoo(s);
+                // OK: passing Foo<String> where Foo<@NonNull String> is required
+                takeFoo(nonNullFoo);
+                // Error: passing Foo<@Nullable String> to generic identity method
+                // with restrictive @NonNull on type parameter
+                // BUG: Diagnostic contains: incompatible types
+                String x = identity(s);
+                // OK: passing Foo<String> where Foo<@NonNull String> is expected
+                String y = identity(nonNullFoo);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nullUnmarkedUnannotatedTypeVariableNoError() {
+    makeTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            import org.jspecify.annotations.Nullable;
+            import java.util.List;
+            @NullMarked
+            class Test {
+              @NullUnmarked
+              static <T> void bar(List<T> list) {}
+              void test(List<@Nullable String> s) {
+                // No error: T is unannotated in @NullUnmarked code, so unconstrained
+                bar(s);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void nullUnmarkedOuterMethodLevelWithLocalClass() {
     defaultCompilationHelper
         .addSourceLines(


### PR DESCRIPTION
Fixes #1488

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

## Description

In JSpecify mode, `@NullUnmarked` methods with explicit `@NonNull` annotations on type parameters (e.g., `Foo<@NonNull T>`) were not enforcing those restrictions at call sites. This happened because `compareGenericTypeParameterNullabilityForCall` was only invoked for annotated methods, so restrictive annotations on type variables in `@NullUnmarked` code were silently ignored.

### Changes

1. **`NullAway.java`**: Moved the `compareGenericTypeParameterNullabilityForCall` invocation outside the `if (isMethodAnnotated)` guard so it also runs for `@NullUnmarked` methods. The `checkGenericMethodCallTypeArguments` call remains gated to annotated methods only.

2. **`GenericsChecks.java`**: Added an `isMethodAnnotated` parameter to `compareGenericTypeParameterNullabilityForCall` and threaded it through `subtypeParameterNullability` and `identicalTypeParameterNullability` so the visitor knows when to apply lenient checking. Also improved the inference-failure path in `substituteTypeArgsInGenericMethodType` to restore explicit nullability annotations from the original method type, so restrictive annotations survive even when the constraint solver finds unsatisfiable constraints.

3. **`CheckIdenticalNullabilityVisitor.java`**: Added an `isMethodUnannotated` flag. When true, the visitor skips nullability mismatches for type arguments that have no explicit nullness annotation (neither `@Nullable` nor `@NonNull`), since unannotated type arguments are unconstrained in `@NullUnmarked` code. Type arguments with explicit restrictive annotations (e.g., `@NonNull`) are still enforced.

### Test cases

- **`nullUnmarkedRestrictiveAnnotationsOnTypeVariables`**: Verifies that passing `Foo<@Nullable String>` to a `@NullUnmarked` method expecting `Foo<@NonNull String>` reports an error, both for non-generic and generic method cases.
- **`nullUnmarkedUnannotatedTypeVariableNoError`**: Verifies that passing `List<@Nullable String>` to a `@NullUnmarked` method with unannotated type parameter `List<T>` does NOT report an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened generic method null-safety checks in JSpecify mode so type-argument and parameter nullability comparisons run reliably for methods with declared type parameters, with improved handling for unannotated method type parameters.
  * Improved generic method type inference to preserve explicit nullability annotations at call sites.

* **Tests**
  * Added tests validating generic type-parameter nullability behavior for annotated and unannotated method scenarios in JSpecify mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->