### PR TITLE
Add @InjectSoftAssertions to default excluded field annotations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -190,7 +190,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
           "org.springframework.test.context.bean.override.mockito.MockitoBean",
           "org.springframework.test.context.bean.override.mockito.MockitoSpyBean",
           "org.wiremock.spring.InjectWireMock",
-          "org.junit.jupiter.api.io.TempDir");
+          "org.junit.jupiter.api.io.TempDir",
+          "org.assertj.core.api.junit.jupiter.InjectSoftAssertions");
 
   private static final String DEFAULT_URL = "http://t.uber.com/nullaway";
 

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -639,6 +639,28 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void assertJInjectSoftAssertionsTest() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "TestCase.java",
+            """
+            package com.uber;
+            import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+            import org.assertj.core.api.SoftAssertions;
+            import org.junit.jupiter.api.Test;
+            public class TestCase {
+              @InjectSoftAssertions
+              SoftAssertions softAssertions;
+              @Test
+              void testWithSoftAssertions() {
+                softAssertions.assertThat(true).isTrue();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void springAutowiredConstructorTest() {
     defaultCompilationHelper
         .addSourceLines(


### PR DESCRIPTION
AssertJ's @InjectSoftAssertions annotation is used with JUnit SoftAssertionsExtension to inject SoftAssertions instances into test fields. Since the field is initialized by the framework, NullAway should not require explicit initialization.

Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for AssertJ's `@InjectSoftAssertions` annotation to be properly excluded and handled by the tool.

* **Tests**
  * Added test coverage verifying correct handling of AssertJ `@InjectSoftAssertions` annotations in JUnit 5 test frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->