### PR TITLE
Remove `onOverrideMethodInvocationVarargsArrayNullability` handler method

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/MethodParameterNullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/MethodParameterNullness.java
@@ -1,32 +1,27 @@
-package com.uber.nullaway.handlers;
+package com.uber.nullaway;
 
 import com.sun.tools.javac.code.Symbol;
-import com.uber.nullaway.Nullness;
 import org.jspecify.annotations.Nullable;
 
-/** Mutable nullness information for a method invocation's formal parameters and varargs array. */
-public final class InvocationArgumentNullness {
+/**
+ * Mutable nullness information for a method's formal parameters and varargs array. For a varargs
+ * method, the nullability of individual arguments is represented in the last parameter position,
+ * while the nullability of the varargs array itself is represented separately.
+ */
+public final class MethodParameterNullness {
 
   private final @Nullable Nullness[] parameterNullness;
   private final boolean hasVarargsArrayNullness;
   private @Nullable Nullness varargsArrayNullness;
 
-  private InvocationArgumentNullness(int parameterCount, boolean hasVarargsArrayNullness) {
+  private MethodParameterNullness(int parameterCount, boolean hasVarargsArrayNullness) {
     this.parameterNullness = new Nullness[parameterCount];
     this.hasVarargsArrayNullness = hasVarargsArrayNullness;
   }
 
-  public static InvocationArgumentNullness create(Symbol.MethodSymbol methodSymbol) {
-    return new InvocationArgumentNullness(
+  public static MethodParameterNullness create(Symbol.MethodSymbol methodSymbol) {
+    return new MethodParameterNullness(
         methodSymbol.getParameters().size(), methodSymbol.isVarArgs());
-  }
-
-  public int parameterCount() {
-    return parameterNullness.length;
-  }
-
-  public boolean hasVarargsArrayNullness() {
-    return hasVarargsArrayNullness;
   }
 
   public @Nullable Nullness getParameterNullness(int index) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -100,7 +100,6 @@ import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handlers;
-import com.uber.nullaway.handlers.InvocationArgumentNullness;
 import com.uber.nullaway.handlers.MethodAnalysisContext;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
@@ -817,8 +816,8 @@ public class NullAway extends BugChecker
               memberReferenceTree, castToNonNull(overridingMethod), state);
     }
 
-    InvocationArgumentNullness overriddenMethodArgumentNullness =
-        InvocationArgumentNullness.create(overriddenMethod);
+    MethodParameterNullness overriddenMethodArgumentNullness =
+        MethodParameterNullness.create(overriddenMethod);
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
     // (otherwise, whether we acknowledge @Nullable in unannotated code or not depends on the
@@ -2064,7 +2063,7 @@ public class NullAway extends BugChecker
         });
     boolean isMethodAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config, handler);
-    InvocationArgumentNullness argumentNullness = InvocationArgumentNullness.create(methodSymbol);
+    MethodParameterNullness argumentNullness = MethodParameterNullness.create(methodSymbol);
 
     if (isMethodAnnotated) {
       // compute which arguments are @NonNull
@@ -2113,7 +2112,7 @@ public class NullAway extends BugChecker
     }
 
     // Allow handlers to override the list of non-null argument positions.
-    InvocationArgumentNullness finalArgumentNullness =
+    MethodParameterNullness finalArgumentNullness =
         handler.onOverrideMethodInvocationParametersNullability(
             state.context, methodSymbol, isMethodAnnotated, argumentNullness);
 

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -862,6 +862,13 @@ public class NullAway extends BugChecker
         }
         overriddenMethodArgumentNullness.setParameterNullness(i, paramNullness);
       }
+      if (overriddenMethodIsVarArgs) {
+        Symbol.VarSymbol varargsParam = superParamSymbols.get(superParamSymbols.size() - 1);
+        overriddenMethodArgumentNullness.setVarargsArrayNullness(
+            Nullness.varargsArrayIsNullable(varargsParam, config)
+                ? Nullness.NULLABLE
+                : Nullness.NONNULL);
+      }
     }
 
     // Check handlers for any further/overriding nullness information
@@ -898,10 +905,8 @@ public class NullAway extends BugChecker
     int startParam = unboundMemberRef ? 1 : 0;
 
     for (int i = 0; i < superParamSymbols.size(); i++) {
-      @Nullable Nullness overriddenParameterNullness =
-          overriddenMethod.isVarArgs() && i == superParamSymbols.size() - 1
-              ? overriddenMethodArgumentNullness.getVarargsArrayNullness()
-              : overriddenMethodArgumentNullness.getParameterNullness(i);
+      Nullness overriddenParameterNullness =
+          overriddenMethodArgumentNullness.getParameterNullness(i);
       if (!Objects.equals(overriddenParameterNullness, Nullness.NULLABLE)) {
         // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridden by a @NonNull arg.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -862,13 +862,6 @@ public class NullAway extends BugChecker
         }
         overriddenMethodArgumentNullness.setParameterNullness(i, paramNullness);
       }
-      if (overriddenMethodIsVarArgs) {
-        Symbol.VarSymbol varargsParam = superParamSymbols.get(superParamSymbols.size() - 1);
-        overriddenMethodArgumentNullness.setVarargsArrayNullness(
-            Nullness.varargsArrayIsNullable(varargsParam, config)
-                ? Nullness.NULLABLE
-                : Nullness.NONNULL);
-      }
     }
 
     // Check handlers for any further/overriding nullness information

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -100,6 +100,7 @@ import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handlers;
+import com.uber.nullaway.handlers.InvocationArgumentNullness;
 import com.uber.nullaway.handlers.MethodAnalysisContext;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
@@ -816,9 +817,8 @@ public class NullAway extends BugChecker
               memberReferenceTree, castToNonNull(overridingMethod), state);
     }
 
-    // Get argument nullability for the overridden method.  If overriddenMethodArgNullnessMap[i] is
-    // null, parameter i is treated as unannotated.
-    @Nullable Nullness[] overriddenMethodArgNullnessMap = new Nullness[superParamSymbols.size()];
+    InvocationArgumentNullness overriddenMethodArgumentNullness =
+        InvocationArgumentNullness.create(overriddenMethod);
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
     // (otherwise, whether we acknowledge @Nullable in unannotated code or not depends on the
@@ -861,23 +861,32 @@ public class NullAway extends BugChecker
         } else {
           paramNullness = Nullness.NONNULL;
         }
-        overriddenMethodArgNullnessMap[i] = paramNullness;
+        overriddenMethodArgumentNullness.setParameterNullness(i, paramNullness);
+      }
+      if (overriddenMethodIsVarArgs) {
+        Symbol.VarSymbol varargsParam = superParamSymbols.get(superParamSymbols.size() - 1);
+        overriddenMethodArgumentNullness.setVarargsArrayNullness(
+            Nullness.varargsArrayIsNullable(varargsParam, config)
+                ? Nullness.NULLABLE
+                : Nullness.NONNULL);
       }
     }
 
     // Check handlers for any further/overriding nullness information
-    overriddenMethodArgNullnessMap =
+    overriddenMethodArgumentNullness =
         handler.onOverrideMethodInvocationParametersNullability(
             state.context,
             overriddenMethod,
             isOverriddenMethodAnnotated,
-            overriddenMethodArgNullnessMap);
+            overriddenMethodArgumentNullness);
 
     // If we have an unbound method reference, the first parameter of the overridden method must be
     // @NonNull, as this parameter will be used as a method receiver inside the generated lambda.
     // e.g. String::length is implemented as (@NonNull s -> s.length()) when used as a
     // SomeFunc<String> and thus incompatible with, for example, SomeFunc.apply(@Nullable T).
-    if (unboundMemberRef && Objects.equals(overriddenMethodArgNullnessMap[0], Nullness.NULLABLE)) {
+    if (unboundMemberRef
+        && Objects.equals(
+            overriddenMethodArgumentNullness.getParameterNullness(0), Nullness.NULLABLE)) {
       String message =
           "unbound instance method reference cannot be used, as first parameter of "
               + "functional interface method "
@@ -897,7 +906,11 @@ public class NullAway extends BugChecker
     int startParam = unboundMemberRef ? 1 : 0;
 
     for (int i = 0; i < superParamSymbols.size(); i++) {
-      if (!Objects.equals(overriddenMethodArgNullnessMap[i], Nullness.NULLABLE)) {
+      @Nullable Nullness overriddenParameterNullness =
+          overriddenMethod.isVarArgs() && i == superParamSymbols.size() - 1
+              ? overriddenMethodArgumentNullness.getVarargsArrayNullness()
+              : overriddenMethodArgumentNullness.getParameterNullness(i);
+      if (!Objects.equals(overriddenParameterNullness, Nullness.NULLABLE)) {
         // No need to check, unless the argument of the overridden method is effectively @Nullable,
         // in which case it can't be overridden by a @NonNull arg.
         continue;
@@ -2051,15 +2064,14 @@ public class NullAway extends BugChecker
         });
     boolean isMethodAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(methodSymbol, config, handler);
-    // If argumentPositionNullness[i] == null, parameter i is unannotated
-    @Nullable Nullness[] argumentPositionNullness = new Nullness[formalParams.size()];
+    InvocationArgumentNullness argumentNullness = InvocationArgumentNullness.create(methodSymbol);
 
     if (isMethodAnnotated) {
       // compute which arguments are @NonNull
       for (int i = 0; i < formalParams.size(); i++) {
         VarSymbol param = formalParams.get(i);
         if (param.type.isPrimitive()) {
-          argumentPositionNullness[i] = Nullness.NONNULL;
+          argumentNullness.setParameterNullness(i, Nullness.NONNULL);
         } else if (ASTHelpers.isSameType(
             param.type, Suppliers.JAVA_LANG_VOID_TYPE.get(state), state)) {
           // Temporarily treat a Void argument type as if it were @Nullable Void. Handling of Void
@@ -2068,19 +2080,27 @@ public class NullAway extends BugChecker
           // JSpecify semantics.
           // See the suppression in https://github.com/uber/NullAway/pull/608 for an example of why
           // this is needed.
-          argumentPositionNullness[i] = Nullness.NULLABLE;
+          argumentNullness.setParameterNullness(i, Nullness.NULLABLE);
         } else {
           // we need to call paramHasNullableAnnotation here since the invoked method may be defined
           // in a class file
-          argumentPositionNullness[i] =
+          argumentNullness.setParameterNullness(
+              i,
               Nullness.paramHasNullableAnnotation(methodSymbol, i, config)
                   ? Nullness.NULLABLE
                   : ((config.isJSpecifyMode()
                           && (tree instanceof MethodInvocationTree || tree instanceof NewClassTree))
                       ? genericsChecks.getGenericParameterNullnessAtInvocation(
                           i, methodSymbol, tree, state)
-                      : Nullness.NONNULL);
+                      : Nullness.NONNULL));
         }
+      }
+      if (methodSymbol.isVarArgs()) {
+        VarSymbol varargsFormalParam = formalParams.get(formalParams.size() - 1);
+        argumentNullness.setVarargsArrayNullness(
+            Nullness.varargsArrayIsNullable(varargsFormalParam, config)
+                ? Nullness.NULLABLE
+                : Nullness.NONNULL);
       }
 
       // perform generics checks for calls to annotated methods in JSpecify mode
@@ -2092,12 +2112,10 @@ public class NullAway extends BugChecker
       }
     }
 
-    // Allow handlers to override the list of non-null argument positions. For a varargs parameter,
-    // this array holds the nullness of individual varargs arguments; the case of a varargs array is
-    // handled separately
-    @Nullable Nullness[] finalArgumentPositionNullness =
+    // Allow handlers to override the list of non-null argument positions.
+    InvocationArgumentNullness finalArgumentNullness =
         handler.onOverrideMethodInvocationParametersNullability(
-            state.context, methodSymbol, isMethodAnnotated, argumentPositionNullness);
+            state.context, methodSymbol, isMethodAnnotated, argumentNullness);
 
     // now actually check the arguments
     // NOTE: the case of an invocation on a possibly-null reference
@@ -2105,28 +2123,16 @@ public class NullAway extends BugChecker
     invArgs.forEach(
         (actual, argPos, formalParamType, varArgsPassedAsArray) -> {
           if (argPos >= formalParams.size()) {
-            // extra varargs argument; nullness info stored in last position
-            argPos = finalArgumentPositionNullness.length - 1;
+            // extra varargs argument; nullness info stored in the varargs parameter slot
+            argPos = formalParams.size() - 1;
           }
           boolean argIsNonNull =
-              Objects.equals(Nullness.NONNULL, finalArgumentPositionNullness[argPos]);
+              Objects.equals(Nullness.NONNULL, finalArgumentNullness.getParameterNullness(argPos));
           if (varArgsPassedAsArray) {
             // This is the case where an array is explicitly passed in the position of the
             // varargs parameter
-            VarSymbol varargsFormalParam = formalParams.get(formalParams.size() - 1);
-            // when is the varargs array itself @NonNull?
-            // 1. For @NullMarked methods, as long as there is no @Nullable annotation
-            Nullness varargsArrayNullness =
-                (isMethodAnnotated && !Nullness.varargsArrayIsNullable(varargsFormalParam, config))
-                    ? Nullness.NONNULL
-                    : null;
-            // 2. For @NullUnmarked methods, there should be an explicit @NonNull annotation.  This
-            // is handled by the RestrictiveAnnotationHandler
-            // 3. Library model indicating it is @NonNull (handled in LibraryModelsHandler)
-            varargsArrayNullness =
-                handler.onOverrideMethodInvocationVarargsArrayNullability(
-                    state.context, methodSymbol, isMethodAnnotated, varargsArrayNullness);
-            argIsNonNull = Objects.equals(varargsArrayNullness, Nullness.NONNULL);
+            argIsNonNull =
+                Objects.equals(Nullness.NONNULL, finalArgumentNullness.getVarargsArrayNullness());
           }
           if (!argIsNonNull) {
             // argument can be @Nullable, so nothing to check

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -170,10 +170,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         // treat as non-null
         assumed = NONNULL;
       } else {
-        @Nullable Nullness fiParameterNullness =
-            fiMethodSymbol.isVarArgs() && i == parameters.size() - 1
-                ? fiArgumentNullness.getVarargsArrayNullness()
-                : fiArgumentNullness.getParameterNullness(i);
+        Nullness fiParameterNullness = fiArgumentNullness.getParameterNullness(i);
         assumed = fiParameterNullness == null ? NONNULL : fiParameterNullness;
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -20,6 +20,7 @@ import com.uber.nullaway.Nullness;
 import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.generics.TypeSubstitutionUtils;
 import com.uber.nullaway.handlers.Handler;
+import com.uber.nullaway.handlers.InvocationArgumentNullness;
 import java.util.List;
 import java.util.Objects;
 import javax.lang.model.element.Element;
@@ -132,29 +133,35 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     List<Type> overridenMethodParamTypeList =
         TypeSubstitutionUtils.memberType(types, lambdaType, fiMethodSymbol, config)
             .getParameterTypes();
-    // If fiArgumentPositionNullness[i] == null, parameter position i is unannotated
-    @Nullable Nullness[] fiArgumentPositionNullness = new Nullness[fiMethodParameters.size()];
+    InvocationArgumentNullness fiArgumentNullness =
+        InvocationArgumentNullness.create(fiMethodSymbol);
     boolean isFIAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config, handler);
     if (isFIAnnotated) {
       for (int i = 0; i < fiMethodParameters.size(); i++) {
         if (Nullness.hasNullableAnnotation(fiMethodParameters.get(i), config)) {
           // Get the Nullness if the Annotation is directly written with the parameter
-          fiArgumentPositionNullness[i] = NULLABLE;
+          fiArgumentNullness.setParameterNullness(i, NULLABLE);
         } else if (config.isJSpecifyMode()
             && Nullness.hasNullableAnnotation(
                 overridenMethodParamTypeList.get(i).getAnnotationMirrors().stream(), config)) {
           // Get the Nullness if the Annotation is indirectly applied through a generic type if we
           // are in JSpecify mode
-          fiArgumentPositionNullness[i] = NULLABLE;
+          fiArgumentNullness.setParameterNullness(i, NULLABLE);
         } else {
-          fiArgumentPositionNullness[i] = NONNULL;
+          fiArgumentNullness.setParameterNullness(i, NONNULL);
         }
       }
+      if (fiMethodSymbol.isVarArgs()) {
+        Symbol.VarSymbol varargsParam =
+            fiMethodSymbol.getParameters().get(fiMethodSymbol.getParameters().size() - 1);
+        fiArgumentNullness.setVarargsArrayNullness(
+            Nullness.varargsArrayIsNullable(varargsParam, config) ? NULLABLE : NONNULL);
+      }
     }
-    fiArgumentPositionNullness =
+    fiArgumentNullness =
         handler.onOverrideMethodInvocationParametersNullability(
-            context, fiMethodSymbol, isFIAnnotated, fiArgumentPositionNullness);
+            context, fiMethodSymbol, isFIAnnotated, fiArgumentNullness);
 
     for (int i = 0; i < parameters.size(); i++) {
       LocalVariableNode param = parameters.get(i);
@@ -170,7 +177,11 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         // treat as non-null
         assumed = NONNULL;
       } else {
-        assumed = fiArgumentPositionNullness[i] == null ? NONNULL : fiArgumentPositionNullness[i];
+        @Nullable Nullness fiParameterNullness =
+            fiMethodSymbol.isVarArgs() && i == parameters.size() - 1
+                ? fiArgumentNullness.getVarargsArrayNullness()
+                : fiArgumentNullness.getParameterNullness(i);
+        assumed = fiParameterNullness == null ? NONNULL : fiParameterNullness;
       }
       result.setInformation(AccessPath.fromLocal(param), assumed);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -15,12 +15,12 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
+import com.uber.nullaway.MethodParameterNullness;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.generics.TypeSubstitutionUtils;
 import com.uber.nullaway.handlers.Handler;
-import com.uber.nullaway.handlers.InvocationArgumentNullness;
 import java.util.List;
 import java.util.Objects;
 import javax.lang.model.element.Element;
@@ -133,8 +133,7 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
     List<Type> overridenMethodParamTypeList =
         TypeSubstitutionUtils.memberType(types, lambdaType, fiMethodSymbol, config)
             .getParameterTypes();
-    InvocationArgumentNullness fiArgumentNullness =
-        InvocationArgumentNullness.create(fiMethodSymbol);
+    MethodParameterNullness fiArgumentNullness = MethodParameterNullness.create(fiMethodSymbol);
     boolean isFIAnnotated =
         !codeAnnotationInfo.isSymbolUnannotated(fiMethodSymbol, config, handler);
     if (isFIAnnotated) {
@@ -151,12 +150,6 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
         } else {
           fiArgumentNullness.setParameterNullness(i, NONNULL);
         }
-      }
-      if (fiMethodSymbol.isVarArgs()) {
-        Symbol.VarSymbol varargsParam =
-            fiMethodSymbol.getParameters().get(fiMethodSymbol.getParameters().size() - 1);
-        fiArgumentNullness.setVarargsArrayNullness(
-            Nullness.varargsArrayIsNullable(varargsParam, config) ? NULLABLE : NONNULL);
       }
     }
     fiArgumentNullness =

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -145,31 +145,17 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public @Nullable Nullness[] onOverrideMethodInvocationParametersNullability(
+  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      @Nullable Nullness[] argumentPositionNullness) {
+      InvocationArgumentNullness argumentNullness) {
     for (Handler h : handlers) {
-      argumentPositionNullness =
+      argumentNullness =
           h.onOverrideMethodInvocationParametersNullability(
-              context, methodSymbol, isAnnotated, argumentPositionNullness);
+              context, methodSymbol, isAnnotated, argumentNullness);
     }
-    return argumentPositionNullness;
-  }
-
-  @Override
-  public @Nullable Nullness onOverrideMethodInvocationVarargsArrayNullability(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      boolean isAnnotated,
-      @Nullable Nullness varargsArrayNullness) {
-    for (Handler h : handlers) {
-      varargsArrayNullness =
-          h.onOverrideMethodInvocationVarargsArrayNullability(
-              context, methodSymbol, isAnnotated, varargsArrayNullness);
-    }
-    return varargsArrayNullness;
+    return argumentNullness;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -41,6 +41,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
+import com.uber.nullaway.MethodParameterNullness;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -145,11 +146,11 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
+  public MethodParameterNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      InvocationArgumentNullness argumentNullness) {
+      MethodParameterNullness argumentNullness) {
     for (Handler h : handlers) {
       argumentNullness =
           h.onOverrideMethodInvocationParametersNullability(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -38,6 +38,7 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.ErrorMessage;
 import com.uber.nullaway.LibraryModels;
+import com.uber.nullaway.MethodParameterNullness;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
@@ -212,16 +213,16 @@ public interface Handler {
    *     upstream handlers and the base analysis consider the parameter to be nullness-unknown,
    *     usually since the parameter is from unannotated code. For a varargs parameter, the formal
    *     parameter slot stores the nullness for when individual parameters are passed in the varargs
-   *     position, while {@link InvocationArgumentNullness#getVarargsArrayNullness()} stores the
+   *     position, while {@link MethodParameterNullness#getVarargsArrayNullness()} stores the
    *     nullness of the varargs array itself.
    * @return The updated nullness info for each argument position, as computed by the current
    *     handler.
    */
-  default InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
+  default MethodParameterNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      InvocationArgumentNullness argumentNullness) {
+      MethodParameterNullness argumentNullness) {
     // NoOp
     return argumentNullness;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -207,49 +207,23 @@ public interface Handler {
    * @param isAnnotated A boolean flag indicating whether the called method is considered to be
    *     within isAnnotated or unannotated code, used to avoid querying for this information
    *     multiple times within the same handler chain.
-   * @param argumentPositionNullness Nullness info for each argument position as computed by
-   *     upstream handlers and/or the base analysis. Some entries may be {@code null}, indicating
+   * @param argumentNullness Nullness info for each argument position as computed by upstream
+   *     handlers and/or the base analysis. Some parameter entries may be {@code null}, indicating
    *     upstream handlers and the base analysis consider the parameter to be nullness-unknown,
-   *     usually since the parameter is from unannotated code. For a varargs parameter, the nullness
-   *     for when individual parameters are passed in the varargs position will be stored in this
-   *     array. See {@link #onOverrideMethodInvocationVarargsArrayNullability} for overriding the
+   *     usually since the parameter is from unannotated code. For a varargs parameter, the formal
+   *     parameter slot stores the nullness for when individual parameters are passed in the varargs
+   *     position, while {@link InvocationArgumentNullness#getVarargsArrayNullness()} stores the
    *     nullness of the varargs array itself.
    * @return The updated nullness info for each argument position, as computed by the current
    *     handler.
    */
-  default @Nullable Nullness[] onOverrideMethodInvocationParametersNullability(
+  default InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      @Nullable Nullness[] argumentPositionNullness) {
+      InvocationArgumentNullness argumentNullness) {
     // NoOp
-    return argumentPositionNullness;
-  }
-
-  /**
-   * Called to potentially override the nullability of the array itself when a varargs method is
-   * invoked by passing an array in the varargs position.
-   *
-   * <p>This hook is intentionally separate from {@link
-   * #onOverrideMethodInvocationParametersNullability(Context, Symbol.MethodSymbol, boolean,
-   * Nullness[])}. A single parameter-slot nullness value is not expressive enough for varargs,
-   * where the array and its elements can have different nullability.
-   *
-   * @param context The current context.
-   * @param methodSymbol The method symbol for the method in question.
-   * @param isAnnotated A boolean flag indicating whether the called method is annotated
-   * @param varargsArrayNullness current value for the varargs array nullability, or {@code null} if
-   *     upstream handlers and the base analysis consider the parameter to be nullness-unknown
-   * @return Updated explicit nullability for the varargs array, or {@code varargsArrayNullness} if
-   *     the current handler does not provide an override.
-   */
-  default @Nullable Nullness onOverrideMethodInvocationVarargsArrayNullability(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      boolean isAnnotated,
-      @Nullable Nullness varargsArrayNullness) {
-    // NoOp
-    return varargsArrayNullness;
+    return argumentNullness;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/InvocationArgumentNullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/InvocationArgumentNullness.java
@@ -1,0 +1,55 @@
+package com.uber.nullaway.handlers;
+
+import com.sun.tools.javac.code.Symbol;
+import com.uber.nullaway.Nullness;
+import org.jspecify.annotations.Nullable;
+
+/** Mutable nullness information for a method invocation's formal parameters and varargs array. */
+public final class InvocationArgumentNullness {
+
+  private final @Nullable Nullness[] parameterNullness;
+  private final boolean hasVarargsArrayNullness;
+  private @Nullable Nullness varargsArrayNullness;
+
+  private InvocationArgumentNullness(int parameterCount, boolean hasVarargsArrayNullness) {
+    this.parameterNullness = new Nullness[parameterCount];
+    this.hasVarargsArrayNullness = hasVarargsArrayNullness;
+  }
+
+  public static InvocationArgumentNullness create(Symbol.MethodSymbol methodSymbol) {
+    return new InvocationArgumentNullness(
+        methodSymbol.getParameters().size(), methodSymbol.isVarArgs());
+  }
+
+  public int parameterCount() {
+    return parameterNullness.length;
+  }
+
+  public boolean hasVarargsArrayNullness() {
+    return hasVarargsArrayNullness;
+  }
+
+  public @Nullable Nullness getParameterNullness(int index) {
+    return parameterNullness[index];
+  }
+
+  public void setParameterNullness(int index, @Nullable Nullness nullness) {
+    parameterNullness[index] = nullness;
+  }
+
+  public @Nullable Nullness getVarargsArrayNullness() {
+    checkHasVarargsArrayNullness();
+    return varargsArrayNullness;
+  }
+
+  public void setVarargsArrayNullness(@Nullable Nullness nullness) {
+    checkHasVarargsArrayNullness();
+    varargsArrayNullness = nullness;
+  }
+
+  private void checkHasVarargsArrayNullness() {
+    if (!hasVarargsArrayNullness) {
+      throw new IllegalStateException("No varargs array nullness slot for non-varargs method");
+    }
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -123,47 +123,54 @@ public class LibraryModelsHandler implements Handler {
   }
 
   @Override
-  public @Nullable Nullness[] onOverrideMethodInvocationParametersNullability(
+  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      @Nullable Nullness[] argumentPositionNullness) {
+      InvocationArgumentNullness argumentNullness) {
     OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(context);
     ImmutableSet<Integer> nullableParamsFromModel =
         optimizedLibraryModels.explicitlyNullableParameters(methodSymbol);
     ImmutableSet<Integer> nonNullParamsFromModel =
         optimizedLibraryModels.nonNullParameters(methodSymbol);
     // For sanity check: $ nonNullParamsFromModel \cap nullableParamsFromModel $ should be empty
-    Set<Integer> allPositions = new HashSet<>();
+    Set<Integer> allParameterPositions = new HashSet<>();
+    boolean varargsArrayModeled = false;
     boolean varArgsMethod = methodSymbol.isVarArgs();
+    int varargsIndex = methodSymbol.getParameters().size() - 1;
     for (Integer nullParam : nullableParamsFromModel) {
-      if (varArgsMethod && nullParam == methodSymbol.getParameters().size() - 1) {
-        // For varargs, top-level library models describe the array itself. We handle that through
-        // the dedicated varargs-array hook so that element nullability can be modeled separately.
+      if (varArgsMethod && nullParam == varargsIndex) {
+        argumentNullness.setVarargsArrayNullness(NULLABLE);
+        varargsArrayModeled = true;
         continue;
       }
-      allPositions.add(nullParam);
-      argumentPositionNullness[nullParam] = NULLABLE;
+      allParameterPositions.add(nullParam);
+      argumentNullness.setParameterNullness(nullParam, NULLABLE);
     }
     for (Integer nonNullParam : nonNullParamsFromModel) {
-      if (varArgsMethod && nonNullParam == methodSymbol.getParameters().size() - 1) {
-        // See comment above: top-level nullability for the varargs parameter applies to the array,
-        // not to individually passed varargs elements.
+      if (varArgsMethod && nonNullParam == varargsIndex) {
+        if (varargsArrayModeled) {
+          throw new IllegalStateException(
+              String.format(
+                  "Library models give conflicting nullability for the following parameter of method %s: %s",
+                  methodSymbol.getQualifiedName().toString(), "varargs array"));
+        }
+        argumentNullness.setVarargsArrayNullness(NONNULL);
+        varargsArrayModeled = true;
         continue;
       }
-      if (!allPositions.add(nonNullParam)) {
+      if (!allParameterPositions.add(nonNullParam)) {
         // position was already marked as nullable
         throw new IllegalStateException(
             String.format(
                 "Library models give conflicting nullability for the following parameter of method %s: %s",
                 methodSymbol.getQualifiedName().toString(), nonNullParam.toString()));
       }
-      argumentPositionNullness[nonNullParam] = NONNULL;
+      argumentNullness.setParameterNullness(nonNullParam, NONNULL);
     }
     if (varArgsMethod) {
       ImmutableSetMultimap<Integer, NestedAnnotationInfo> nestedAnnotations =
           optimizedLibraryModels.nestedAnnotationsForMethods(methodSymbol);
-      int varargsIndex = methodSymbol.getParameters().size() - 1;
       Nullness varargsContentsNullness = null;
       for (NestedAnnotationInfo nestedAnnotation : nestedAnnotations.get(varargsIndex)) {
         // check if it's for the array element
@@ -174,7 +181,7 @@ public class LibraryModelsHandler implements Handler {
           if (varargsContentsNullness == null) {
             varargsContentsNullness =
                 nestedAnnotation.annotation() == Annotation.NULLABLE ? NULLABLE : NONNULL;
-            argumentPositionNullness[varargsIndex] = varargsContentsNullness;
+            argumentNullness.setParameterNullness(varargsIndex, varargsContentsNullness);
           } else {
             throw new IllegalStateException(
                 "varargs contents nullness set multiple times: "
@@ -183,36 +190,7 @@ public class LibraryModelsHandler implements Handler {
         }
       }
     }
-    return argumentPositionNullness;
-  }
-
-  @Override
-  public @Nullable Nullness onOverrideMethodInvocationVarargsArrayNullability(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      boolean isAnnotated,
-      @Nullable Nullness varargsArrayNullness) {
-    Nullness modeledVarargsArrayNullness = null;
-    if (methodSymbol.isVarArgs()) {
-      int varargsIndex = methodSymbol.getParameters().size() - 1;
-      OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(context);
-      boolean nullableFromModel =
-          optimizedLibraryModels.explicitlyNullableParameters(methodSymbol).contains(varargsIndex);
-      boolean nonNullFromModel =
-          optimizedLibraryModels.nonNullParameters(methodSymbol).contains(varargsIndex);
-      if (nullableFromModel && nonNullFromModel) {
-        throw new IllegalStateException(
-            String.format(
-                "Library models give conflicting varargs array nullability for method %s",
-                methodSymbol.getQualifiedName()));
-      }
-      if (nullableFromModel) {
-        modeledVarargsArrayNullness = NULLABLE;
-      } else if (nonNullFromModel) {
-        modeledVarargsArrayNullness = NONNULL;
-      }
-    }
-    return modeledVarargsArrayNullness != null ? modeledVarargsArrayNullness : varargsArrayNullness;
+    return argumentNullness;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -52,6 +52,7 @@ import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.LibraryModels;
 import com.uber.nullaway.LibraryModels.MethodRef;
+import com.uber.nullaway.MethodParameterNullness;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
@@ -123,11 +124,11 @@ public class LibraryModelsHandler implements Handler {
   }
 
   @Override
-  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
+  public MethodParameterNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      InvocationArgumentNullness argumentNullness) {
+      MethodParameterNullness argumentNullness) {
     OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(context);
     ImmutableSet<Integer> nullableParamsFromModel =
         optimizedLibraryModels.explicitlyNullableParameters(methodSymbol);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -30,6 +30,7 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.util.Context;
 import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
+import com.uber.nullaway.MethodParameterNullness;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
@@ -104,11 +105,11 @@ public class RestrictiveAnnotationHandler implements Handler {
   }
 
   @Override
-  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
+  public MethodParameterNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      InvocationArgumentNullness argumentNullness) {
+      MethodParameterNullness argumentNullness) {
     if (isAnnotated) {
       // We ignore isAnnotated code here, since annotations in code considered isAnnotated are
       // already handled by NullAway's core algorithm.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -118,7 +118,7 @@ public class RestrictiveAnnotationHandler implements Handler {
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
       boolean isVarargsParam =
           methodSymbol.isVarArgs() && i == methodSymbol.getParameters().size() - 1;
-      Symbol.@Nullable VarSymbol varargsParamSymbol =
+      Symbol.VarSymbol varargsParamSymbol =
           isVarargsParam ? methodSymbol.getParameters().get(i) : null;
       if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
         if (isVarargsParam) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -121,7 +121,7 @@ public class RestrictiveAnnotationHandler implements Handler {
       Symbol.VarSymbol varargsParamSymbol =
           isVarargsParam ? methodSymbol.getParameters().get(i) : null;
       if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
-        if (isVarargsParam) {
+        if (varargsParamSymbol != null) {
           // Special handling: ignore org.jetbrains.annotations.NotNull on varargs parameters
           // to handle kotlinc generated jars (see #720)
           boolean jetBrainsNotNullAnnotated =
@@ -135,7 +135,8 @@ public class RestrictiveAnnotationHandler implements Handler {
       } else if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
         argumentNullness.setParameterNullness(i, Nullness.NULLABLE);
       }
-      if (isVarargsParam && Nullness.varargsArrayIsNonNull(varargsParamSymbol, config)) {
+      if (varargsParamSymbol != null
+          && Nullness.varargsArrayIsNonNull(varargsParamSymbol, config)) {
         argumentNullness.setVarargsArrayNullness(Nullness.NONNULL);
       }
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -104,50 +104,41 @@ public class RestrictiveAnnotationHandler implements Handler {
   }
 
   @Override
-  public @Nullable Nullness[] onOverrideMethodInvocationParametersNullability(
+  public InvocationArgumentNullness onOverrideMethodInvocationParametersNullability(
       Context context,
       Symbol.MethodSymbol methodSymbol,
       boolean isAnnotated,
-      @Nullable Nullness[] argumentPositionNullness) {
+      InvocationArgumentNullness argumentNullness) {
     if (isAnnotated) {
       // We ignore isAnnotated code here, since annotations in code considered isAnnotated are
       // already handled by NullAway's core algorithm.
-      return argumentPositionNullness;
+      return argumentNullness;
     }
     for (int i = 0; i < methodSymbol.getParameters().size(); ++i) {
+      boolean isVarargsParam =
+          methodSymbol.isVarArgs() && i == methodSymbol.getParameters().size() - 1;
+      Symbol.@Nullable VarSymbol varargsParamSymbol =
+          isVarargsParam ? methodSymbol.getParameters().get(i) : null;
       if (Nullness.paramHasNonNullAnnotation(methodSymbol, i, config)) {
-        if (methodSymbol.isVarArgs() && i == methodSymbol.getParameters().size() - 1) {
+        if (isVarargsParam) {
           // Special handling: ignore org.jetbrains.annotations.NotNull on varargs parameters
           // to handle kotlinc generated jars (see #720)
-          Symbol.VarSymbol varargsParamSymbol = methodSymbol.getParameters().get(i);
           boolean jetBrainsNotNullAnnotated =
               NullabilityUtil.hasJetBrainsNotNullDeclarationAnnotation(varargsParamSymbol);
-          if (jetBrainsNotNullAnnotated) {
-            continue;
+          if (!jetBrainsNotNullAnnotated) {
+            argumentNullness.setParameterNullness(i, Nullness.NONNULL);
           }
+        } else {
+          argumentNullness.setParameterNullness(i, Nullness.NONNULL);
         }
-        argumentPositionNullness[i] = Nullness.NONNULL;
       } else if (Nullness.paramHasNullableAnnotation(methodSymbol, i, config)) {
-        argumentPositionNullness[i] = Nullness.NULLABLE;
+        argumentNullness.setParameterNullness(i, Nullness.NULLABLE);
+      }
+      if (isVarargsParam && Nullness.varargsArrayIsNonNull(varargsParamSymbol, config)) {
+        argumentNullness.setVarargsArrayNullness(Nullness.NONNULL);
       }
     }
-    return argumentPositionNullness;
-  }
-
-  @Override
-  public @Nullable Nullness onOverrideMethodInvocationVarargsArrayNullability(
-      Context context,
-      Symbol.MethodSymbol methodSymbol,
-      boolean isAnnotated,
-      @Nullable Nullness varargsArrayNullness) {
-    if (methodSymbol.isVarArgs()) {
-      Symbol.VarSymbol varargsParamSymbol =
-          methodSymbol.getParameters().get(methodSymbol.getParameters().size() - 1);
-      if (Nullness.varargsArrayIsNonNull(varargsParamSymbol, config)) {
-        return Nullness.NONNULL;
-      }
-    }
-    return varargsArrayNullness;
+    return argumentNullness;
   }
 
   @Override

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -694,9 +694,106 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void implicitLambdaParameterInheritsNullableVarargsArray() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              @FunctionalInterface
+              interface NullableVarargsArrayConsumer {
+                void apply(Object @Nullable... inputs);
+              }
+              void test() {
+                NullableVarargsArrayConsumer consumer =
+                    inputs -> {
+                      // BUG: Diagnostic contains: dereferenced expression inputs is @Nullable
+                      inputs.toString();
+                    };
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void implicitLambdaParameterDoesNotInheritNullableVarargsElements() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              @FunctionalInterface
+              interface NullableVarargsElementsConsumer {
+                void apply(@Nullable Object... inputs);
+              }
+              void test() {
+                NullableVarargsElementsConsumer consumer =
+                    inputs -> {
+                      inputs.toString();
+                    };
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void restrictiveAnnotationsVarargsLambdaUsesArrayNullness() {
+    makeRestrictiveHelper()
+        .addSourceLines(
+            "RestrictiveVarargsFi.java",
+            """
+            package com.uber.lib.unannotated;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullUnmarked;
+            import org.jspecify.annotations.Nullable;
+            @FunctionalInterface
+            public interface RestrictiveVarargsFi {
+              @NullUnmarked
+              void apply(@Nullable Object @NonNull... inputs);
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.unannotated.RestrictiveVarargsFi;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              void test() {
+                RestrictiveVarargsFi fi =
+                    (Object[] inputs) -> {
+                      inputs.toString();
+                    };
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
+  }
+
+  private CompilationTestHelper makeRestrictiveHelper() {
+    return makeTestHelperWithArgs(
+        JSpecifyJavacConfig.withJSpecifyModeArgs(
+            Arrays.asList(
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -749,28 +749,22 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
 
   @Test
   public void restrictiveAnnotationsVarargsLambdaUsesArrayNullness() {
-    makeRestrictiveHelper()
-        .addSourceLines(
-            "RestrictiveVarargsFi.java",
-            """
-            package com.uber.lib.unannotated;
-            import org.jspecify.annotations.NonNull;
-            import org.jspecify.annotations.NullUnmarked;
-            import org.jspecify.annotations.Nullable;
-            @FunctionalInterface
-            public interface RestrictiveVarargsFi {
-              @NullUnmarked
-              void apply(@Nullable Object @NonNull... inputs);
-            }
-            """)
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
             package com.uber;
-            import com.uber.lib.unannotated.RestrictiveVarargsFi;
+            import org.jspecify.annotations.NonNull;
             import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            import org.jspecify.annotations.Nullable;
             @NullMarked
             class Test {
+              @FunctionalInterface
+              interface RestrictiveVarargsFi {
+                @NullUnmarked
+                void apply(@Nullable Object @NonNull... inputs);
+              }
               void test() {
                 RestrictiveVarargsFi fi =
                     (Object[] inputs) -> {
@@ -786,14 +780,5 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
-  }
-
-  private CompilationTestHelper makeRestrictiveHelper() {
-    return makeTestHelperWithArgs(
-        JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true")));
   }
 }


### PR DESCRIPTION
Fixes #1501 

Instead, we return varargs array nullability through the previous `onOverrideMethodInvocationParametersNullability` handler method.  We introduce a new `MethodParameterNullness` type to encapsulate regular parameter nullability and nullability of the varargs array; `MethodParameterNullness` is mutable for efficiency (like the arrays we used before).

This PR should not change visible behavior.  Still, I wasn't sure about some corner cases involving lambdas and method overriding, so there are some new tests.  I confirmed those new tests passed even without these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked how method-parameter nullness is represented and passed through the analysis pipeline, simplifying per-parameter and varargs nullness handling.
  * Consolidated varargs-array nullness into the parameter nullness model and removed a separate varargs hook.

* **Tests**
  * Added JSpecify-mode tests exercising varargs and lambda parameter nullness inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->