### PR TITLE
Run regression tests on JDK 26

### DIFF
--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -29,6 +29,7 @@ tasks.named("jacocoTestReport") {
 }
 
 java.toolchain {
+    languageVersion = JavaLanguageVersion.of(26)
     // We prefer toolchains that include jmod files for the Java standard library, like Azul Zulu,
     // for better compatibility with WALA / JarInfer.
     // Temurin does not include jmod files as of their JDK 24 builds.

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -28,14 +28,6 @@ tasks.named("jacocoTestReport") {
     enabled = false
 }
 
-java.toolchain {
-    languageVersion = JavaLanguageVersion.of(26)
-    // We prefer toolchains that include jmod files for the Java standard library, like Azul Zulu,
-    // for better compatibility with WALA / JarInfer.
-    // Temurin does not include jmod files as of their JDK 24 builds.
-    vendor = JvmVendorSpec.AZUL
-}
-
 // Share sources folder with other projects for aggregated JaCoCo reports
 configurations.create('transitiveSourcesElements') {
     visible = false
@@ -90,6 +82,10 @@ test {
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)
+            // We prefer toolchains that include jmod files for the Java standard library, like Azul Zulu,
+            // for better compatibility with WALA / JarInfer.
+            // Temurin does not include jmod files as of their JDK 24 builds.
+            vendor = JvmVendorSpec.AZUL
         }
 
         description = "Runs the test suite on JDK $majorVersion"

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -78,7 +78,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[21,26].each { majorVersion ->
+[21, 26].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -78,7 +78,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[21].each { majorVersion ->
+[21,26].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -28,6 +28,13 @@ tasks.named("jacocoTestReport") {
     enabled = false
 }
 
+java.toolchain {
+    // We prefer toolchains that include jmod files for the Java standard library, like Azul Zulu,
+    // for better compatibility with WALA / JarInfer.
+    // Temurin does not include jmod files as of their JDK 24 builds.
+    vendor = JvmVendorSpec.AZUL
+}
+
 // Share sources folder with other projects for aggregated JaCoCo reports
 configurations.create('transitiveSourcesElements') {
     visible = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 asm = "9.3"
 check-framework = "4.0.0"
 support = "27.1.1"
-wala = "1.6.12"
+wala = "1.7.0"
 commons-cli = "1.4"
 auto-service = "1.1.1"
 google-java-format = "1.34.1"

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -56,7 +56,7 @@ tasks.withType(Test).configureEach { test ->
     dependsOn ':test-java-module:jar'
 }
 
-// Disable tasks for specific JDK versions; we only run on the recent JDK version specified above
+// Disable tasks for specific JDK versions; we only run on the recent JDK version specified above and newer
 tasks.getByName('testJdk17').configure {
     onlyIf { false }
 }

--- a/jdk-recent-unit-tests/build.gradle
+++ b/jdk-recent-unit-tests/build.gradle
@@ -51,6 +51,9 @@ tasks.withType(Test).configureEach { test ->
         // Used by com.uber.nullaway.jdk17.NullAwayModuleInfoTests
         "-Dtest.module.path=${configurations.testModulePath.asPath}"
     ]
+    // The test module jar is consumed via the synthetic module path above, so every
+    // JDK-specific Test task needs it built before execution.
+    dependsOn ':test-java-module:jar'
 }
 
 // Disable tasks for specific JDK versions; we only run on the recent JDK version specified above
@@ -59,9 +62,4 @@ tasks.getByName('testJdk17').configure {
 }
 tasks.getByName('testJdk21').configure {
     onlyIf { false }
-}
-
-tasks.getByName('test').configure {
-    // we need this since we don't have an implementation / api dependence on test-java-module
-    dependsOn ':test-java-module:jar'
 }


### PR DESCRIPTION
Partially addresses #1525.  We update WALA to get JDK 26 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running tests on JDK 26 in addition to JDK 21.

* **Chores**
  * Updated WALA library to version 1.7.0.
  * Standardized the Java toolchain to use Azul for test runs.
  * Ensured the test module JAR is built before any JDK-specific test executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->