### PR TITLE
Update to WALA 1.7.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 25
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Build and test
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 25
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Publish to Maven Local

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -82,10 +82,6 @@ test {
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)
-            // We prefer toolchains that include jmod files for the Java standard library, like Azul Zulu,
-            // for better compatibility with WALA / JarInfer.
-            // Temurin does not include jmod files as of their JDK 24 builds.
-            vendor = JvmVendorSpec.AZUL
         }
 
         description = "Runs the test suite on JDK $majorVersion"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 asm = "9.3"
 check-framework = "4.0.0"
 support = "27.1.1"
-wala = "1.7.0"
+wala = "1.7.1"
 commons-cli = "1.4"
 auto-service = "1.1.1"
 google-java-format = "1.34.1"


### PR DESCRIPTION
WALA no longer relies on running on a JDK distribution that includes `jmod` files, so this will make running JarInfer easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use Temurin JDK distribution for improved compatibility
  * Simplified JDK toolchain configuration
  * Updated WALA dependency to version 1.7.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->