### PR TITLE
Test on JDK 27 EA

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,12 @@ jobs:
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v6
-      - name: 'Set up JDKs'
+      - name: 'Set up JDK 27 EA from jdk.java.net'
+        uses: oracle-actions/setup-java@v1
+        with:
+          website: jdk.java.net
+          release: 27
+      - name: 'Set up Default JDK'
         uses: actions/setup-java@v5
         with:
           java-version: 25

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -19,17 +19,8 @@ plugins {
     id 'jacoco'
 }
 
-repositories {
-    maven {
-        url = uri('https://central.sonatype.com/repository/maven-snapshots/')
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
-}
-
 jacoco {
-    toolVersion = "0.8.15-SNAPSHOT"
+    toolVersion = "0.8.14"
 }
 
 // Do not generate reports for individual projects

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -19,8 +19,17 @@ plugins {
     id 'jacoco'
 }
 
+repositories {
+    maven {
+        url = uri('https://central.sonatype.com/repository/maven-snapshots/')
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+
 jacoco {
-    toolVersion = "0.8.14"
+    toolVersion = "0.8.15-SNAPSHOT"
 }
 
 // Do not generate reports for individual projects
@@ -78,7 +87,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[21, 26].each { majorVersion ->
+[21, 26, 27].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -50,4 +50,8 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }
 
+tasks.getByName('testJdk27').configure {
+    // Won't work until WALA supports JDK 27
+    onlyIf { false }
+}
 apply plugin: 'com.vanniktech.maven.publish'

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -162,11 +162,12 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Element element = param.getElement();
       Nullness assumed;
       // we treat lambda parameters differently; they "inherit" the nullability of the
-      // corresponding functional interface parameter, unless they are explicitly annotated
+      // corresponding functional interface parameter, unless they are explicitly annotated.
+      //
       // We look for explicit @Nullable annotations on the symbol.  In JDK 27+, sometimes
-      // javac will add a @Nullable annotation to the Type of param based on generics, but
-      // we don't want to consider that here (it is considered in the type stored in
-      // fiArgumentNullness)
+      // javac will add a @Nullable annotation to the Type of element based on its own generic
+      // inference.  We don't want to consider that here (it is handled in the type stored in
+      // fiArgumentNullness), so we only look at the annotations directly on element
       if (Nullness.hasNullableAnnotation(
           ((Symbol) element).getAnnotationMirrors().stream(), config)) {
         assumed = NULLABLE;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -163,6 +163,10 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Nullness assumed;
       // we treat lambda parameters differently; they "inherit" the nullability of the
       // corresponding functional interface parameter, unless they are explicitly annotated
+      // We look for explicit @Nullable annotations on the symbol.  In JDK 27+, sometimes
+      // javac will add a @Nullable annotation to the Type of param based on generics, but
+      // we don't want to consider that here (it is considered in the type stored in
+      // fiArgumentNullness)
       if (Nullness.hasNullableAnnotation(
           ((Symbol) element).getAnnotationMirrors().stream(), config)) {
         assumed = NULLABLE;

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/CoreNullnessStoreInitializer.java
@@ -163,7 +163,8 @@ class CoreNullnessStoreInitializer extends NullnessStoreInitializer {
       Nullness assumed;
       // we treat lambda parameters differently; they "inherit" the nullability of the
       // corresponding functional interface parameter, unless they are explicitly annotated
-      if (Nullness.hasNullableAnnotation((Symbol) element, config)) {
+      if (Nullness.hasNullableAnnotation(
+          ((Symbol) element).getAnnotationMirrors().stream(), config)) {
         assumed = NULLABLE;
       } else if (!NullabilityUtil.lambdaParamIsImplicitlyTyped(variableTree)) {
         // the parameter has a declared type with no @Nullable annotation


### PR DESCRIPTION
Run our tests on the latest JDK 27 EA build.  

Also fixes our check for explicit `@Nullable` annotations on lambda parameters, handling a change in the types `javac` provides in JDK 27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended CI/CD testing to include JDK 27 Early Access in addition to existing versions, ensuring compatibility across a wider range of Java environments.

* **Refactor**
  * Improved detection of explicit nullability annotations on lambda parameters for more accurate analysis with newer JDK releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->