### PR TITLE
Fix crash on JDK 27

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -407,7 +407,8 @@ public class NullabilityUtil {
           if (position.onLambda != null) {
             com.sun.tools.javac.util.List<JCTree.JCVariableDecl> lambdaParams =
                 position.onLambda.params;
-            return parameterIndex < lambdaParams.size()
+            return parameterIndex >= 0
+                && parameterIndex < lambdaParams.size()
                 && lambdaParams.get(parameterIndex).sym.equals(sym);
           } else {
             return ((Symbol.MethodSymbol) sym.owner).getParameters().indexOf(sym) == parameterIndex;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1042,6 +1042,44 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** Reduced from a crash observed when building JUnit on JDK 27; testing that we do not crash */
+  @Test
+  public void crasherOnJdk27() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Repro.java",
+            """
+            package repro;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Repro {
+                void f(C c) {
+                    E e = c.e();
+                    g((B b, B.I<@Nullable Void> i) -> {
+                        b.f(i, e);
+                        return null;
+                    });
+                }
+                static <T extends @Nullable Object> void g(A<T> a) {
+                }
+                interface A<T extends @Nullable Object> {
+                    T f(B b, B.I<T> i);
+                }
+                interface B {
+                    void f(I<@Nullable Void> i, E e);
+                    interface I<T extends @Nullable Object> {
+                    }
+                }
+                interface C {
+                    E e();
+                }
+                interface E {
+                }
+            }""")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
It seems that in certain cases for annotations on lambda parameters, the `parameter_index` field of a `TypePosition` can be negative on JDK 27.  This was causing a crash; fix by checking for a negative index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lambda parameter matching validation to properly guard against edge cases with invalid parameter indexes.

* **Tests**
  * Added test case for JDK 27 compatibility with generic method and lambda inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->