### PR TITLE
Add Spring MockBean/SpyBean/MockitoBean/MockitoSpyBean as default external init annotations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -170,7 +170,13 @@ final class ErrorProneCLIFlagsConfig implements Config {
           "org.springframework.beans.factory.annotation.Autowired");
   // + Anything with @Initializer as its "simple name"
 
-  static final ImmutableSet<String> DEFAULT_EXTERNAL_INIT_ANNOT = ImmutableSet.of("lombok.Builder");
+  static final ImmutableSet<String> DEFAULT_EXTERNAL_INIT_ANNOT =
+      ImmutableSet.of(
+          "lombok.Builder",
+          "org.springframework.boot.test.mock.mockito.MockBean",
+          "org.springframework.boot.test.mock.mockito.SpyBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoSpyBean");
 
   static final ImmutableSet<String> DEFAULT_CONTRACT_ANNOT =
       ImmutableSet.of("org.jetbrains.annotations.Contract");


### PR DESCRIPTION
## What does this PR do?

Spring Boot's `@MockBean` and `@SpyBean` annotations (and their Spring
Framework 6.2 replacements `@MockitoBean` and `@MockitoSpyBean`) inject
fields into test classes before any test method runs. NullAway was
raising false positive initialization errors on fields annotated with
these, because it did not recognize them as externally initialized.

This PR adds all four annotations to `DEFAULT_EXTERNAL_INIT_ANNOT` in
`ErrorProneCLIFlagsConfig`, so NullAway treats them as externally
initialized out of the box — without requiring users to manually
configure `ExternalInitAnnotations`.

## Motivation

Users running NullAway on Spring Boot test classes would see errors like:
[NullAway] @NonNull field mock not initialized

on fields that Spring's test framework always initializes before use.
This is a false positive that forces users to either suppress the warning
or manually add these annotations to their NullAway config.

The pattern is the same as the recently merged support for
`@InjectWireMock` (#1391).

## Changes

- `ErrorProneCLIFlagsConfig.java`: Added 4 Spring test annotations to
  `DEFAULT_EXTERNAL_INIT_ANNOT`
  - `org.springframework.boot.test.mock.mockito.MockBean`
  - `org.springframework.boot.test.mock.mockito.SpyBean`
  - `org.springframework.test.context.bean.override.mockito.MockitoBean`
  - `org.springframework.test.context.bean.override.mockito.MockitoSpyBean`

## Testing

Existing test `FrameworkTests.springTestAutowiredFieldTest` covers all
four annotations and passes with this change. Test data stub files for
all four annotations were already present in
`testdata/springboot-annotations/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded recognition of external initializer annotations to include Spring test framework annotations (MockBean, SpyBean) and Mockito-related annotations, enhancing support for code using these testing libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->