### PR TITLE
Handle subtype checking for wildcard super bounds

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -306,7 +306,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     jspecifyMode = flags.getBoolean(FL_JSPECIFY_MODE).orElse(false);
-    handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(true);
+    handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -306,7 +306,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     jspecifyMode = flags.getBoolean(FL_JSPECIFY_MODE).orElse(false);
-    handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
+    handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(true);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -1,5 +1,7 @@
 package com.uber.nullaway.generics;
 
+import static com.uber.nullaway.NullabilityUtil.castToNonNull;
+
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
@@ -180,7 +182,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * {@code S <: T}, interpreted with NullAway's nullability-aware subtype relation.
    */
   private boolean superWildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
-    Type lhsBound = lhsWildcard.getSuperBound();
+    // caller must ensure that lhsWildcard has a super bound
+    Type lhsBound = castToNonNull(lhsWildcard.getSuperBound());
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
       Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
       if (rhsWildcard.kind != BoundKind.SUPER) {
@@ -188,7 +191,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
         // support.
         return true;
       }
-      Type rhsBound = rhsWildcard.getSuperBound();
+      Type rhsBound = castToNonNull(rhsWildcard.getSuperBound());
       return typeArgumentSubtype(rhsBound, lhsBound);
     }
     return typeArgumentSubtype(rhsTypeArgument, lhsBound);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -125,8 +125,12 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       return wildcardContains((Type.WildcardType) lhsTypeArgument, rhsTypeArgument);
     }
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
-      // TODO: Add proper support for the remaining case where the formal type argument is not a
-      // wildcard but the actual type argument is a wildcard.
+      // This case should only arise when generic method invocation inference / capture conversion
+      // lets a wildcard actual argument flow into a non-wildcard formal type argument, e.g.,
+      // passing Foo<? extends T> to <U> void m(Foo<U>). We do not yet support wildcard inference.
+      // For non-inference assignment / return / parameter checks, javac rejects these conversions
+      // before NullAway runs.
+      // TODO: Add proper support when inference for wildcards is implemented.
       return true;
     }
     boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsTypeArgument);
@@ -142,9 +146,9 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * type arguments. In particular, for a formal argument {@code ? extends S}, we accept either a
    * concrete actual argument {@code T} or a wildcard actual argument {@code ? extends T} whenever
    * {@code T <: S}, using NullAway's nullability-aware subtype check in place of plain Java
-   * subtyping. This covers the JLS cases behind both {@code T <= ? extends S} and {@code ? extends
-   * T <= ? extends S}. For now, this method intentionally leaves {@code super} wildcards and other
-   * more complex cases to existing fallback behavior.
+   * subtyping. For a formal argument {@code ? super S}, we accept either a concrete actual argument
+   * {@code T} or a wildcard actual argument {@code ? super T} whenever {@code S <: T}. For now,
+   * this method intentionally leaves other more complex cases to existing fallback behavior.
    */
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     if (lhsWildcard.kind == BoundKind.UNBOUND) {
@@ -153,9 +157,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       // https://jspecify.dev/docs/user-guide/#wildcard-bounds
       return true;
     }
-    if (lhsWildcard.kind != BoundKind.EXTENDS) {
-      // Treat non-extends wildcards as accepted here until we add more complete support.
-      return true;
+    if (lhsWildcard.kind == BoundKind.SUPER) {
+      return superWildcardContains(lhsWildcard, rhsTypeArgument);
     }
     Type lhsBound = lhsWildcard.getExtendsBound();
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
@@ -169,6 +172,26 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       return typeArgumentSubtype(lhsBound, rhsBound);
     }
     return typeArgumentSubtype(lhsBound, rhsTypeArgument);
+  }
+
+  /**
+   * Returns whether a formal {@code ? super S} contains the actual type argument on the right. For
+   * concrete actuals {@code T} and wildcard actuals {@code ? super T}, containment holds when
+   * {@code S <: T}, interpreted with NullAway's nullability-aware subtype relation.
+   */
+  private boolean superWildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
+    Type lhsBound = lhsWildcard.getSuperBound();
+    if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
+      Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
+      if (rhsWildcard.kind != BoundKind.SUPER) {
+        // Treat non-super wildcard actual arguments as accepted here until we add more complete
+        // support.
+        return true;
+      }
+      Type rhsBound = rhsWildcard.getSuperBound();
+      return typeArgumentSubtype(rhsBound, lhsBound);
+    }
+    return typeArgumentSubtype(rhsTypeArgument, lhsBound);
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -248,10 +248,10 @@ public class WildcardTests extends NullAwayTestsBase {
                 Foo<? super String> nonnullSuperLocal = nullableObjectFoo;
                 Foo<? super @Nullable String> nullableSuperLocal = nullableObjectFoo;
                 Foo<? super @Nullable String> nullableSuperLocal2 = nullableStringFoo;
-                // BUG: Diagnostic contains: incompatible types:
+                // BUG: Diagnostic contains: incompatible types: Test.Foo<Object> cannot be converted to Test.Foo<? super @Nullable String>
                 Foo<? super @Nullable String> nullableSuperLocal3 = objectFoo;
                 Foo<? super String> nonnullSuperFromNullableSuper = nullableSuperFoo;
-                // BUG: Diagnostic contains: incompatible types:
+                // BUG: Diagnostic contains: incompatible types: Test.Foo<? super String> cannot be converted to Test.Foo<? super @Nullable String>
                 Foo<? super @Nullable String> nullableSuperFromNonnullSuper = nonnullSuperFoo;
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -229,6 +229,36 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void wildcardSuperFormalNoInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              class Foo<T extends @Nullable Object> {}
+              void testLocals(
+                  Foo<Object> objectFoo,
+                  Foo<@Nullable Object> nullableObjectFoo,
+                  Foo<@Nullable String> nullableStringFoo,
+                  Foo<? super String> nonnullSuperFoo,
+                  Foo<? super @Nullable String> nullableSuperFoo) {
+                Foo<? super String> nonnullSuperLocal2 = nullableObjectFoo;
+                Foo<? super @Nullable String> nullableSuperLocal = nullableObjectFoo;
+                Foo<? super @Nullable String> nullableSuperLocal2 = nullableStringFoo;
+                // BUG: Diagnostic contains: incompatible types:
+                Foo<? super @Nullable String> nullableSuperLocal3 = objectFoo;
+                Foo<? super String> nonnullSuperFromNullableSuper = nullableSuperFoo;
+                // BUG: Diagnostic contains: incompatible types:
+                Foo<? super @Nullable String> nullableSuperFromNonnullSuper = nonnullSuperFoo;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Ignore("bad interaction between wildcard support and generic method inference")
   @Test
   public void wildcardSuperBoundsAndInference() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -245,7 +245,7 @@ public class WildcardTests extends NullAwayTestsBase {
                   Foo<@Nullable String> nullableStringFoo,
                   Foo<? super String> nonnullSuperFoo,
                   Foo<? super @Nullable String> nullableSuperFoo) {
-                Foo<? super String> nonnullSuperLocal2 = nullableObjectFoo;
+                Foo<? super String> nonnullSuperLocal = nullableObjectFoo;
                 Foo<? super @Nullable String> nullableSuperLocal = nullableObjectFoo;
                 Foo<? super @Nullable String> nullableSuperLocal2 = nullableStringFoo;
                 // BUG: Diagnostic contains: incompatible types:

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -459,7 +459,7 @@ public class CustomLibraryModelsTests {
                 NestedAnnots.wildcardUpper(t);
               }
               void testLower(NestedAnnots<String> t) {
-                // TODO report an error here when we support wildcards
+                // BUG: Diagnostic contains: incompatible types: NestedAnnots<String> cannot be converted to NestedAnnots<? super @Nullable String>
                 NestedAnnots.wildcardLower(t);
               }
             }


### PR DESCRIPTION
Add one more case of containment checking, handling super-bounded wildcards (`? super T`).  Also, update a comment for another case, which we'll need to handle alongside inference support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Significantly improved type nullability checking for complex generic type parameter patterns, enabling more precise detection and reporting of type assignment incompatibilities in your codebase.

* **Tests**
  * Added comprehensive test coverage for various wildcard generic type parameter edge cases and scenarios.
  * Updated test expectations to align with the improved type compatibility diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->