### PR TITLE
Handle most remaining wildcard subtyping / containment cases

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -199,8 +199,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
       Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
       if (rhsWildcard.kind != BoundKind.SUPER) {
-        // Treat non-super wildcard actual arguments as accepted here until we add more complete
-        // support.
+        // This case cannot occur outside of inference: if the rhs is ? extends T, that is never
+        // assignable to ? super S, since the rhs could be an arbitrary subtype of T (which may be a
+        // subtype of S).
+        // TODO handle when we implement inference
         return true;
       }
       Type rhsBound = castToNonNull(rhsWildcard.getSuperBound());

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -11,7 +11,6 @@ import com.uber.nullaway.Config;
 import java.util.List;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Visitor that checks for identical nullability annotations at all nesting levels within two types.
@@ -155,13 +154,11 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    */
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     return switch (lhsWildcard.kind) {
-      case UNBOUND -> {
+      case UNBOUND, EXTENDS -> {
         Type lhsBound = wildcardUpperBound(lhsWildcard);
-        yield lhsBound == null || extendsBoundContains(lhsBound, rhsTypeArgument);
+        yield extendsBoundContains(lhsBound, rhsTypeArgument);
       }
-      case EXTENDS -> extendsBoundContains(lhsWildcard.getExtendsBound(), rhsTypeArgument);
       case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
-      default -> throw new RuntimeException("Unexpected wildcard bound kind: " + lhsWildcard.kind);
     };
   }
 
@@ -170,7 +167,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
       if (rhsWildcard.kind != BoundKind.EXTENDS) {
         Type rhsUpperBound = wildcardUpperBound(rhsWildcard);
-        return rhsUpperBound == null || typeArgumentSubtype(lhsBound, rhsUpperBound);
+        return typeArgumentSubtype(lhsBound, rhsUpperBound);
       }
       Type rhsBound = rhsWildcard.getExtendsBound();
       return typeArgumentSubtype(lhsBound, rhsBound);
@@ -182,13 +179,13 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * Returns the effective upper bound of a wildcard, using the corresponding type variable's upper
    * bound for unbounded wildcards and {@code super} wildcards.
    */
-  private @Nullable Type wildcardUpperBound(Type.WildcardType wildcardType) {
+  private Type wildcardUpperBound(Type.WildcardType wildcardType) {
     if (wildcardType.kind == BoundKind.EXTENDS) {
       return wildcardType.getExtendsBound();
     }
     // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
     // field. The upper bound of that type variable is the wildcard's effective upper bound.
-    return wildcardType.bound == null ? null : wildcardType.bound.getUpperBound();
+    return wildcardType.bound.getUpperBound();
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -11,6 +11,7 @@ import com.uber.nullaway.Config;
 import java.util.List;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Visitor that checks for identical nullability annotations at all nesting levels within two types.
@@ -153,27 +154,41 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * this method intentionally leaves other more complex cases to existing fallback behavior.
    */
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
-    if (lhsWildcard.kind == BoundKind.UNBOUND) {
-      // TODO: For unbounded wildcards, we need to find the bound of the corresponding type
-      // variable rather than accepting outright; see
-      // https://jspecify.dev/docs/user-guide/#wildcard-bounds
-      return true;
-    }
-    if (lhsWildcard.kind == BoundKind.SUPER) {
-      return superWildcardContains(lhsWildcard, rhsTypeArgument);
-    }
-    Type lhsBound = lhsWildcard.getExtendsBound();
+    return switch (lhsWildcard.kind) {
+      case UNBOUND -> {
+        Type lhsBound = wildcardUpperBound(lhsWildcard);
+        yield lhsBound == null || extendsBoundContains(lhsBound, rhsTypeArgument);
+      }
+      case EXTENDS -> extendsBoundContains(lhsWildcard.getExtendsBound(), rhsTypeArgument);
+      case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
+      default -> throw new RuntimeException("Unexpected wildcard bound kind: " + lhsWildcard.kind);
+    };
+  }
+
+  private boolean extendsBoundContains(Type lhsBound, Type rhsTypeArgument) {
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
       Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
       if (rhsWildcard.kind != BoundKind.EXTENDS) {
-        // Treat non-extends wildcard actual arguments as accepted here until we add more complete
-        // support.
-        return true;
+        Type rhsUpperBound = wildcardUpperBound(rhsWildcard);
+        return rhsUpperBound == null || typeArgumentSubtype(lhsBound, rhsUpperBound);
       }
       Type rhsBound = rhsWildcard.getExtendsBound();
       return typeArgumentSubtype(lhsBound, rhsBound);
     }
     return typeArgumentSubtype(lhsBound, rhsTypeArgument);
+  }
+
+  /**
+   * Returns the effective upper bound of a wildcard, using the corresponding type variable's upper
+   * bound for unbounded wildcards and {@code super} wildcards.
+   */
+  private @Nullable Type wildcardUpperBound(Type.WildcardType wildcardType) {
+    if (wildcardType.kind == BoundKind.EXTENDS) {
+      return wildcardType.getExtendsBound();
+    }
+    // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
+    // field. The upper bound of that type variable is the wildcard's effective upper bound.
+    return wildcardType.bound == null ? null : wildcardType.bound.getUpperBound();
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -123,8 +123,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       // Preserve the pre-flag behavior of skipping wildcard-aware checks entirely.
       return true;
     }
-    if (lhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
-      return wildcardContains((Type.WildcardType) lhsTypeArgument, rhsTypeArgument);
+    if (lhsTypeArgument instanceof Type.WildcardType lhsWildcard) {
+      return wildcardContains(lhsWildcard, rhsTypeArgument);
     }
     if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
       // This case should only arise when generic method invocation inference / capture conversion
@@ -144,33 +144,30 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   }
 
   /**
-   * Handles a narrow slice of the JLS type-argument containment rules from JLS 4.5.1 for wildcard
-   * type arguments. In particular, for a formal argument {@code ? extends S}, we accept either a
-   * concrete actual argument {@code T} or a wildcard actual argument {@code ? extends T} whenever
-   * {@code T <: S}, using NullAway's nullability-aware subtype check in place of plain Java
-   * subtyping. For a formal argument {@code ? super S}, we accept either a concrete actual argument
-   * {@code T} or a wildcard actual argument {@code ? super T} whenever {@code S <: T}. For now,
-   * this method intentionally leaves other more complex cases to existing fallback behavior.
+   * Handles JLS 4.5.1 type-argument containment for wildcard formal type arguments, using
+   * NullAway's nullability-aware subtype relation in place of plain Java subtyping. A formal {@code
+   * ? extends S} contains actual arguments whose effective upper bound is a subtype of {@code S}; a
+   * formal {@code ? super S} contains concrete actuals {@code T} and wildcard actuals {@code ?
+   * super T} when {@code S <: T}; and a formal {@code ?} is treated as {@code ? extends B}, where
+   * {@code B} is the corresponding type variable's upper bound.
    */
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     return switch (lhsWildcard.kind) {
-      case UNBOUND, EXTENDS -> {
-        Type lhsBound = wildcardUpperBound(lhsWildcard);
-        yield extendsBoundContains(lhsBound, rhsTypeArgument);
-      }
+      case UNBOUND, EXTENDS ->
+          extendsBoundContains(wildcardUpperBound(lhsWildcard), rhsTypeArgument);
       case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
     };
   }
 
+  /**
+   * Returns whether a formal {@code ? extends S} contains the actual type argument on the right.
+   * For concrete actuals {@code T}, wildcard actuals {@code ? extends T}, and non-extends wildcard
+   * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}.
+   */
   private boolean extendsBoundContains(Type lhsBound, Type rhsTypeArgument) {
-    if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
-      Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
-      if (rhsWildcard.kind != BoundKind.EXTENDS) {
-        Type rhsUpperBound = wildcardUpperBound(rhsWildcard);
-        return typeArgumentSubtype(lhsBound, rhsUpperBound);
-      }
-      Type rhsBound = rhsWildcard.getExtendsBound();
-      return typeArgumentSubtype(lhsBound, rhsBound);
+    if (rhsTypeArgument instanceof Type.WildcardType rhsWildcard) {
+      Type rhsUpperBound = wildcardUpperBound(rhsWildcard);
+      return typeArgumentSubtype(lhsBound, rhsUpperBound);
     }
     return typeArgumentSubtype(lhsBound, rhsTypeArgument);
   }
@@ -196,8 +193,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private boolean superWildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     // caller must ensure that lhsWildcard has a super bound
     Type lhsBound = castToNonNull(lhsWildcard.getSuperBound());
-    if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
-      Type.WildcardType rhsWildcard = (Type.WildcardType) rhsTypeArgument;
+    if (rhsTypeArgument instanceof Type.WildcardType rhsWildcard) {
       if (rhsWildcard.kind != BoundKind.SUPER) {
         // This case cannot occur outside of inference: if the rhs is ? extends T, that is never
         // assignable to ? super S, since the rhs could be an arbitrary subtype of T (which may be a

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -260,7 +260,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void wildcardExtendsTopFormalWithNonExtendsActualNoInference() {
+  public void superOrUnboundedWildcardAssignedToExtendsBoundedWildcard() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -289,7 +289,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void unboundedWildcardFormalWithNonNullTypeParameterBoundNoInference() {
+  public void unboundedWildcardFormalWithNonNullTypeParameterBound() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -315,7 +315,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void unboundedWildcardFormalWithNullableTypeParameterBoundNoInference() {
+  public void unboundedWildcardFormalWithNullableTypeParameterBound() {
     makeHelper()
         .addSourceLines(
             "Test.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -259,6 +259,88 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void wildcardExtendsTopFormalWithNonExtendsActualNoInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              class Foo<T extends @Nullable Object> {}
+              void testLocals(
+                  Foo<? super String> nonnullSuperFoo,
+                  Foo<? super @Nullable String> nullableSuperFoo,
+                  Foo<?> unboundedFoo) {
+                Foo<? extends @Nullable Object> fromNonnullSuper = nonnullSuperFoo;
+                Foo<? extends @Nullable Object> fromNullableSuper = nullableSuperFoo;
+                Foo<? extends @Nullable Object> fromUnbounded = unboundedFoo;
+                // BUG: Diagnostic contains: incompatible types: Test.Foo<? super String> cannot be converted to Test.Foo<? extends Object>
+                Foo<? extends Object> badFromNonnullSuper = nonnullSuperFoo;
+                // BUG: Diagnostic contains: incompatible types: Test.Foo<? super @Nullable String> cannot be converted to Test.Foo<? extends Object>
+                Foo<? extends Object> badFromNullableSuper = nullableSuperFoo;
+                // BUG: Diagnostic contains: incompatible types: Test.Foo<?> cannot be converted to Test.Foo<? extends Object>
+                Foo<? extends Object> badFromUnbounded = unboundedFoo;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unboundedWildcardFormalWithNonNullTypeParameterBoundNoInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              class NonNullBoundFoo<T extends Object> {}
+              void testLocals(
+                  NonNullBoundFoo<Object> nonnullObjectFoo,
+                  NonNullBoundFoo<? extends Object> nonnullExtendsObjectFoo,
+                  NonNullBoundFoo<? extends @Nullable Object> nullableExtendsObjectWithNonnullBoundFoo,
+                  NonNullBoundFoo<? super String> nonnullSuperStringFoo) {
+                NonNullBoundFoo<?> fromNonnull = nonnullObjectFoo;
+                NonNullBoundFoo<?> fromNonnullExtends = nonnullExtendsObjectFoo;
+                // BUG: Diagnostic contains: incompatible types: Test.NonNullBoundFoo<? extends @Nullable Object> cannot be converted to Test.NonNullBoundFoo<?>
+                NonNullBoundFoo<?> fromNullableExtends = nullableExtendsObjectWithNonnullBoundFoo;
+                NonNullBoundFoo<?> fromSuper = nonnullSuperStringFoo;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unboundedWildcardFormalWithNullableTypeParameterBoundNoInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              class NullableBoundFoo<T extends @Nullable Object> {}
+              void testLocals(
+                  NullableBoundFoo<Object> nonnullObjectWithNullableBoundFoo,
+                  NullableBoundFoo<@Nullable Object> nullableObjectFoo,
+                  NullableBoundFoo<? extends Object> nonnullExtendsObjectWithNullableBoundFoo,
+                  NullableBoundFoo<? extends @Nullable Object> nullableExtendsObjectFoo,
+                  NullableBoundFoo<? super String> nullableBoundSuperStringFoo) {
+                NullableBoundFoo<?> fromNonnull = nonnullObjectWithNullableBoundFoo;
+                NullableBoundFoo<?> fromNullable = nullableObjectFoo;
+                NullableBoundFoo<?> fromNonnullExtends = nonnullExtendsObjectWithNullableBoundFoo;
+                NullableBoundFoo<?> fromNullableExtends = nullableExtendsObjectFoo;
+                NullableBoundFoo<?> fromSuper = nullableBoundSuperStringFoo;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Ignore("bad interaction between wildcard support and generic method inference")
   @Test
   public void wildcardSuperBoundsAndInference() {


### PR DESCRIPTION
We now handle unbounded wildcards (which have an implicit upper bound identical to the corresponding type variable), and cases where a `? super S` wildcard is assigned to a `? extends T` wildcard.  The remaining unhandled cases can only arise in the context of generic type variables and inference, which we will handle later.

Also refactor the code a bit and document a bit better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced wildcard type variance handling in null-checking, improving accuracy for extends-bounded, super-bounded, and unbounded wildcards in generic types.

* **Tests**
  * Added test coverage for wildcard type parameters with various nullable and non-nullable bound scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->