### PR TITLE
Initial inference for wildcards

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -5,7 +5,6 @@ import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.Config;
@@ -155,7 +154,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     return switch (lhsWildcard.kind) {
       case UNBOUND, EXTENDS ->
-          extendsBoundContains(wildcardUpperBound(lhsWildcard), rhsTypeArgument);
+          extendsBoundContains(
+              GenericsUtils.wildcardUpperBound(lhsWildcard, state), rhsTypeArgument);
       case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
     };
   }
@@ -166,36 +166,12 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}.
    */
   private boolean extendsBoundContains(Type lhsBound, Type rhsTypeArgument) {
-    if (rhsTypeArgument instanceof Type.WildcardType rhsWildcard) {
-      Type rhsUpperBound = wildcardUpperBound(rhsWildcard);
+    Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
+    if (rhsWildcard != null) {
+      Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state);
       return typeArgumentSubtype(lhsBound, rhsUpperBound);
     }
     return typeArgumentSubtype(lhsBound, rhsTypeArgument);
-  }
-
-  /**
-   * Returns the effective upper bound of a wildcard, using the corresponding type variable's upper
-   * bound for unbounded wildcards and {@code super} wildcards.
-   */
-  private Type wildcardUpperBound(Type.WildcardType wildcardType) {
-    Type upperBound;
-    if (wildcardType.kind == BoundKind.EXTENDS) {
-      upperBound = wildcardType.getExtendsBound();
-    } else {
-      // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
-      // field. The upper bound of that type variable is the wildcard's effective upper bound.
-      upperBound =
-          wildcardType.bound == null
-              ? Symtab.instance(state.context).objectType
-              : wildcardType.bound.getUpperBound();
-    }
-    if (upperBound instanceof Type.WildcardType nestedWildcard) {
-      return wildcardUpperBound(nestedWildcard);
-    }
-    if (upperBound instanceof Type.CapturedType capturedType && capturedType.wildcard != null) {
-      return wildcardUpperBound(capturedType.wildcard);
-    }
-    return upperBound;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -5,6 +5,7 @@ import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.Config;
@@ -183,7 +184,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     } else {
       // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
       // field. The upper bound of that type variable is the wildcard's effective upper bound.
-      upperBound = wildcardType.bound.getUpperBound();
+      upperBound =
+          wildcardType.bound == null
+              ? Symtab.instance(state.context).objectType
+              : wildcardType.bound.getUpperBound();
     }
     if (upperBound instanceof Type.WildcardType nestedWildcard) {
       return wildcardUpperBound(nestedWildcard);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -177,12 +177,21 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * bound for unbounded wildcards and {@code super} wildcards.
    */
   private Type wildcardUpperBound(Type.WildcardType wildcardType) {
+    Type upperBound;
     if (wildcardType.kind == BoundKind.EXTENDS) {
-      return wildcardType.getExtendsBound();
+      upperBound = wildcardType.getExtendsBound();
+    } else {
+      // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
+      // field. The upper bound of that type variable is the wildcard's effective upper bound.
+      upperBound = wildcardType.bound.getUpperBound();
     }
-    // For ? and ? super L, javac stores the wildcard's corresponding type variable in the `bound`
-    // field. The upper bound of that type variable is the wildcard's effective upper bound.
-    return wildcardType.bound.getUpperBound();
+    if (upperBound instanceof Type.WildcardType nestedWildcard) {
+      return wildcardUpperBound(nestedWildcard);
+    }
+    if (upperBound instanceof Type.CapturedType capturedType && capturedType.wildcard != null) {
+      return wildcardUpperBound(capturedType.wildcard);
+    }
+    return upperBound;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -221,6 +221,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
             if (subtypeWildcard.kind == BoundKind.SUPER) {
               supertypeLowerBound.accept(this, castToNonNull(subtypeWildcard.getSuperBound()));
             }
+            // the subtype wildcard could have an extends bound, but as far as I know we do not
+            // need to generate constraints for this case
+            // TODO revisit if needed
           } else {
             supertypeLowerBound.accept(this, subtypeTypeArg);
           }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -8,7 +8,6 @@ import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
@@ -166,18 +165,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         constrainWildcardToSupertype(subtype, supertype);
       }
       return null;
-    }
-
-    @Override
-    public @Nullable Void visitCapturedType(CapturedType subtype, Type supertype) {
-      if (!localVariableType) {
-        directlyConstrainTypePair(subtype, supertype);
-      }
-      if (config.handleWildcardGenerics()) {
-        constrainWildcardToSupertype(subtype.wildcard, supertype);
-        return null;
-      }
-      return visitType(subtype, supertype);
     }
 
     /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -199,6 +199,13 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       supertypeTypeArg.accept(this, subtypeTypeArg);
     }
 
+    /**
+     * Adds constraints for type-argument containment where the formal argument is a wildcard. For
+     * {@code ? extends S} and {@code ?}, containment requires the actual argument's effective upper
+     * bound to be a subtype of {@code S}. For {@code ? super S}, concrete actual arguments require
+     * {@code S <: subtypeTypeArg}; {@code ? super T} actual arguments require {@code S <: T}. Other
+     * actual wildcard forms place no useful nullability constraint.
+     */
     private void constrainContainedByWildcard(Type subtypeTypeArg, WildcardType supertypeWildcard) {
       switch (supertypeWildcard.kind) {
         case UNBOUND, EXTENDS -> {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -164,10 +164,8 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (config.handleWildcardGenerics()) {
         Verify.verify(!localVariableType, "A wildcard type cannot be assigned to a local variable");
         constrainWildcardToSupertype(subtype, supertype);
-        return null;
-      } else {
-        return visitType(subtype, supertype);
       }
+      return null;
     }
 
     /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -100,12 +100,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
           return null;
         }
       }
-      // handle flow into a type variable.  the check for !(subtype instanceof TypeVar) is a
+      // handle flow into a type variable. The check for !(subtype instanceof TypeVar) is a
       // small optimization, as that case should be handled in visitTypeVar.
-      if (!localVariableType
-          && (supertype instanceof TypeVar)
-          && !(subtype instanceof TypeVar)
-          && !(subtype instanceof WildcardType)) {
+      if (!localVariableType && (supertype instanceof TypeVar) && !(subtype instanceof TypeVar)) {
         directlyConstrainTypePair(subtype, supertype);
       }
       return null;
@@ -135,7 +132,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         }
       }
       // if supertype is not a ClassType, we still call visitType to handle the case where
-      // supertype is a TypeVar
+      // supertype is a TypeVar or a wildcard
       return visitType(subtype, supertype);
     }
 
@@ -150,7 +147,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         subtypeComponentType.accept(this, superComponentType);
       }
       // if supertype is not an ArrayType, we still call visitType to handle the case where
-      // supertype is a TypeVar
+      // supertype is a TypeVar or a wildcard
       return visitType(subtype, supertype);
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -77,9 +77,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   /* All variables seen so far. */
   private final Map<Element, VarState> vars = new HashMap<>();
 
-  /* Captured type variables for which we have already added bound constraints. */
-  private final Set<Element> capturesWithBoundConstraints = new HashSet<>();
-
   /* ───────────────────── public API ───────────────────── */
 
   @Override
@@ -330,9 +327,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   private void directlyConstrainTypePair(Type s, Type t) throws UnsatisfiableConstraintsException {
-    addCaptureBoundConstraints(s);
-    addCaptureBoundConstraints(t);
-
     /* variable-to-variable edge */
     if (isTypeVariable(s) && isTypeVariable(t)) {
       TypeVariable sv = (TypeVariable) s;
@@ -402,24 +396,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
           && !Nullness.hasNonNullAnnotation(tv.getAnnotationMirrors().stream(), config);
     } else {
       return false;
-    }
-  }
-
-  private void addCaptureBoundConstraints(Type type) {
-    if (!(type instanceof CapturedType capturedType) || !isTypeVariable(capturedType)) {
-      return;
-    }
-    Element captureElement = capturedType.asElement();
-    if (!capturesWithBoundConstraints.add(captureElement)) {
-      return;
-    }
-    Type lowerBound = capturedType.getLowerBound();
-    if (lowerBound != null && !(lowerBound instanceof NullType)) {
-      lowerBound.accept(new AddSubtypeConstraintsVisitor(false), capturedType);
-    }
-    Type upperBound = capturedType.getUpperBound();
-    if (upperBound != null) {
-      capturedType.accept(new AddSubtypeConstraintsVisitor(false), upperBound);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -183,6 +183,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       return visitType(subtype, supertype);
     }
 
+    /**
+     * Adds nullability constraints for containment of one type argument by another during generic
+     * class/interface subtyping. For non-wildcard arguments, NullAway requires identical
+     * nullability. When either side is a wildcard, containment is reduced to constraints between
+     * the wildcard bound and the opposing argument.
+     */
     private void constrainTypeArgumentContainment(Type subtypeTypeArg, Type supertypeTypeArg) {
       if (!config.handleWildcardGenerics()) {
         equateTypeArguments(subtypeTypeArg, supertypeTypeArg);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -5,10 +5,13 @@ import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import com.google.common.base.Verify;
 import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.TypeVar;
+import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
@@ -73,6 +76,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   /* All variables seen so far. */
   private final Map<Element, VarState> vars = new HashMap<>();
 
+  /* Captured type variables for which we have already added bound constraints. */
+  private final Set<Element> capturesWithBoundConstraints = new HashSet<>();
+
   /* ───────────────────── public API ───────────────────── */
 
   @Override
@@ -92,7 +98,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     public @Nullable Void visitType(Type subtype, Type supertype) {
       // handle flow into a type variable.  the check for !(subtype instanceof TypeVar) is a
       // small optimization, as that case should be handled in visitTypeVar.
-      if (!localVariableType && (supertype instanceof TypeVar) && !(subtype instanceof TypeVar)) {
+      if (!localVariableType
+          && (supertype instanceof TypeVar)
+          && !(subtype instanceof TypeVar)
+          && !(subtype instanceof WildcardType)) {
         directlyConstrainTypePair(subtype, supertype);
       }
       return null;
@@ -116,13 +125,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         int numTypeArgs = supertypeTypeArguments.size();
         Verify.verify(numTypeArgs == subtypeTypeArguments.size());
         for (int i = 0; i < numTypeArgs; i++) {
-          Type rhsTypeArg = supertypeTypeArguments.get(i);
-          Type lhsTypeArg = subtypeTypeArguments.get(i);
-          // constrain in both directions
-          // TODO should we have a more optimized way to equate two types?  this just makes each
-          //  type a subtype of the other
-          lhsTypeArg.accept(this, rhsTypeArg);
-          rhsTypeArg.accept(this, lhsTypeArg);
+          Type supertypeTypeArg = supertypeTypeArguments.get(i);
+          Type subtypeTypeArg = subtypeTypeArguments.get(i);
+          constrainTypeArgumentContainment(subtypeTypeArg, supertypeTypeArg);
         }
       }
       // if supertype is not a ClassType, we still call visitType to handle the case where
@@ -151,6 +156,92 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         directlyConstrainTypePair(subtype, supertype);
       }
       return visitType(subtype, supertype);
+    }
+
+    private void constrainTypeArgumentContainment(Type subtypeTypeArg, Type supertypeTypeArg) {
+      if (!config.handleWildcardGenerics()) {
+        equateTypeArguments(subtypeTypeArg, supertypeTypeArg);
+        return;
+      }
+      WildcardType supertypeWildcard = asWildcard(supertypeTypeArg);
+      if (supertypeWildcard != null) {
+        constrainContainedByWildcard(subtypeTypeArg, supertypeWildcard);
+        return;
+      }
+      WildcardType subtypeWildcard = asWildcard(subtypeTypeArg);
+      if (subtypeWildcard != null) {
+        constrainWildcardContainedByConcrete(subtypeWildcard, supertypeTypeArg);
+        return;
+      }
+      equateTypeArguments(subtypeTypeArg, supertypeTypeArg);
+    }
+
+    private void equateTypeArguments(Type subtypeTypeArg, Type supertypeTypeArg) {
+      // constrain in both directions
+      // TODO should we have a more optimized way to equate two types?  this just makes each
+      //  type a subtype of the other
+      subtypeTypeArg.accept(this, supertypeTypeArg);
+      supertypeTypeArg.accept(this, subtypeTypeArg);
+    }
+
+    private void constrainContainedByWildcard(Type subtypeTypeArg, WildcardType supertypeWildcard) {
+      switch (supertypeWildcard.kind) {
+        case UNBOUND, EXTENDS -> {
+          Type subtypeUpperBound = effectiveWildcardUpperBound(subtypeTypeArg);
+          subtypeUpperBound.accept(this, wildcardUpperBound(supertypeWildcard));
+        }
+        case SUPER -> {
+          Type supertypeLowerBound = castToNonNull(supertypeWildcard.getSuperBound());
+          WildcardType subtypeWildcard = asWildcard(subtypeTypeArg);
+          if (subtypeWildcard != null) {
+            if (subtypeWildcard.kind == BoundKind.SUPER) {
+              supertypeLowerBound.accept(this, castToNonNull(subtypeWildcard.getSuperBound()));
+            }
+          } else {
+            supertypeLowerBound.accept(this, subtypeTypeArg);
+          }
+        }
+      }
+    }
+
+    private void constrainWildcardContainedByConcrete(
+        WildcardType subtypeWildcard, Type supertypeTypeArg) {
+      if (subtypeWildcard.kind == BoundKind.SUPER) {
+        castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertypeTypeArg);
+      } else {
+        wildcardUpperBound(subtypeWildcard).accept(this, supertypeTypeArg);
+      }
+    }
+
+    private Type effectiveWildcardUpperBound(Type typeArg) {
+      WildcardType wildcardType = asWildcard(typeArg);
+      return wildcardType == null ? typeArg : wildcardUpperBound(wildcardType);
+    }
+
+    private Type wildcardUpperBound(WildcardType wildcardType) {
+      Type upperBound;
+      if (wildcardType.kind == BoundKind.EXTENDS) {
+        upperBound = wildcardType.getExtendsBound();
+      } else {
+        upperBound = wildcardType.bound.getUpperBound();
+      }
+      if (upperBound instanceof WildcardType nestedWildcard) {
+        return wildcardUpperBound(nestedWildcard);
+      }
+      if (upperBound instanceof CapturedType capturedType && capturedType.wildcard != null) {
+        return wildcardUpperBound(capturedType.wildcard);
+      }
+      return upperBound;
+    }
+
+    private @Nullable WildcardType asWildcard(Type typeArg) {
+      if (typeArg instanceof WildcardType wildcardType) {
+        return wildcardType;
+      }
+      if (typeArg instanceof CapturedType capturedType) {
+        return capturedType.wildcard;
+      }
+      return null;
     }
   }
 
@@ -209,6 +300,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   private void directlyConstrainTypePair(Type s, Type t) throws UnsatisfiableConstraintsException {
+    addCaptureBoundConstraints(s);
+    addCaptureBoundConstraints(t);
+
     /* variable-to-variable edge */
     if (isTypeVariable(s) && isTypeVariable(t)) {
       TypeVariable sv = (TypeVariable) s;
@@ -272,13 +366,30 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
 
   private boolean isTypeVariable(Type t) {
     if (t instanceof TypeVar tv) {
-      // For now ignore capture variables, like "capture#1 of ? extends X".  Also, only treat as a
-      // type variable if it _doesn't_ have an explicit @Nullable or @NonNull annotation.
-      return !tv.isCaptured()
-          && !Nullness.hasNullableAnnotation(tv.getAnnotationMirrors().stream(), config)
+      // Only treat as a type variable if it _doesn't_ have an explicit @Nullable or @NonNull
+      // annotation.
+      return !Nullness.hasNullableAnnotation(tv.getAnnotationMirrors().stream(), config)
           && !Nullness.hasNonNullAnnotation(tv.getAnnotationMirrors().stream(), config);
     } else {
       return false;
+    }
+  }
+
+  private void addCaptureBoundConstraints(Type type) {
+    if (!(type instanceof CapturedType capturedType) || !isTypeVariable(capturedType)) {
+      return;
+    }
+    Element captureElement = capturedType.asElement();
+    if (!capturesWithBoundConstraints.add(captureElement)) {
+      return;
+    }
+    Type lowerBound = capturedType.getLowerBound();
+    if (lowerBound != null && !(lowerBound instanceof NullType)) {
+      lowerBound.accept(new AddSubtypeConstraintsVisitor(false), capturedType);
+    }
+    Type upperBound = capturedType.getUpperBound();
+    if (upperBound != null) {
+      capturedType.accept(new AddSubtypeConstraintsVisitor(false), upperBound);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -96,6 +96,18 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
 
     @Override
     public @Nullable Void visitType(Type subtype, Type supertype) {
+      if (config.handleWildcardGenerics()) {
+        WildcardType supertypeWildcard = asWildcard(supertype);
+        if (supertypeWildcard != null) {
+          constrainSubtypeToWildcard(subtype, supertypeWildcard);
+          return null;
+        }
+        WildcardType subtypeWildcard = asWildcard(subtype);
+        if (subtypeWildcard != null) {
+          constrainWildcardToSupertype(subtypeWildcard, supertype);
+          return null;
+        }
+      }
       // handle flow into a type variable.  the check for !(subtype instanceof TypeVar) is a
       // small optimization, as that case should be handled in visitTypeVar.
       if (!localVariableType
@@ -210,6 +222,20 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertypeTypeArg);
       } else {
         wildcardUpperBound(subtypeWildcard).accept(this, supertypeTypeArg);
+      }
+    }
+
+    private void constrainSubtypeToWildcard(Type subtype, WildcardType supertypeWildcard) {
+      if (supertypeWildcard.kind != BoundKind.SUPER) {
+        subtype.accept(this, wildcardUpperBound(supertypeWildcard));
+      }
+    }
+
+    private void constrainWildcardToSupertype(WildcardType subtypeWildcard, Type supertype) {
+      if (subtypeWildcard.kind == BoundKind.SUPER) {
+        castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertype);
+      } else {
+        wildcardUpperBound(subtypeWildcard).accept(this, supertype);
       }
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -96,6 +96,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (config.handleWildcardGenerics()) {
         WildcardType supertypeWildcard = GenericsUtils.asWildcard(supertype);
         if (supertypeWildcard != null) {
+          Verify.verify(!localVariableType, "A local variable should not have a wildcard type");
           constrainSubtypeToWildcard(subtype, supertypeWildcard);
           return null;
         }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -164,8 +164,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (config.handleWildcardGenerics()) {
         Verify.verify(!localVariableType, "A wildcard type cannot be assigned to a local variable");
         constrainWildcardToSupertype(subtype, supertype);
+        return null;
+      } else {
+        return visitType(subtype, supertype);
       }
-      return null;
     }
 
     /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -174,11 +174,8 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         directlyConstrainTypePair(subtype, supertype);
       }
       if (config.handleWildcardGenerics()) {
-        WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtype);
-        if (subtypeWildcard != null) {
-          constrainWildcardToSupertype(subtypeWildcard, supertype);
-          return null;
-        }
+        constrainWildcardToSupertype(subtype.wildcard, supertype);
+        return null;
       }
       return visitType(subtype, supertype);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -213,6 +213,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       }
     }
 
+    /**
+     * Adds constraints for type-argument containment where the actual argument is a wildcard and
+     * the formal argument is concrete. For {@code ? extends S} and {@code ?}, containment requires
+     * {@code S <: supertypeTypeArg}. For {@code ? super S}, use the lower bound and require {@code
+     * S <: supertypeTypeArg}.
+     */
     private void constrainWildcardContainedByConcrete(
         WildcardType subtypeWildcard, Type supertypeTypeArg) {
       if (subtypeWildcard.kind == BoundKind.SUPER) {
@@ -222,12 +228,22 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       }
     }
 
+    /**
+     * Adds constraints for a top-level subtype relation {@code subtype <: supertypeWildcard}. For
+     * {@code ? extends S} and {@code ?}, this reduces to {@code subtype <: S}. A {@code ? super S}
+     * supertype places no useful nullability constraint on {@code subtype}.
+     */
     private void constrainSubtypeToWildcard(Type subtype, WildcardType supertypeWildcard) {
       if (supertypeWildcard.kind != BoundKind.SUPER) {
         subtype.accept(this, GenericsUtils.wildcardUpperBound(supertypeWildcard, state));
       }
     }
 
+    /**
+     * Adds constraints for a top-level subtype relation {@code subtypeWildcard <: supertype}. For
+     * {@code ? extends S} and {@code ?}, this reduces to {@code S <: supertype}. For {@code ? super
+     * S}, use the lower bound and reduce to {@code S <: supertype}.
+     */
     private void constrainWildcardToSupertype(WildcardType subtypeWildcard, Type supertype) {
       if (subtypeWildcard.kind == BoundKind.SUPER) {
         castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertype);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -162,6 +162,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     @Override
     public @Nullable Void visitWildcardType(WildcardType subtype, Type supertype) {
       if (config.handleWildcardGenerics()) {
+        Verify.verify(!localVariableType, "A wildcard type cannot be assigned to a local variable");
         constrainWildcardToSupertype(subtype, supertype);
       }
       return null;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -8,6 +8,7 @@ import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
@@ -98,11 +99,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
           constrainSubtypeToWildcard(subtype, supertypeWildcard);
           return null;
         }
-        WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtype);
-        if (subtypeWildcard != null) {
-          constrainWildcardToSupertype(subtypeWildcard, supertype);
-          return null;
-        }
       }
       // handle flow into a type variable.  the check for !(subtype instanceof TypeVar) is a
       // small optimization, as that case should be handled in visitTypeVar.
@@ -162,6 +158,29 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     public @Nullable Void visitTypeVar(TypeVar subtype, Type supertype) {
       if (!localVariableType) {
         directlyConstrainTypePair(subtype, supertype);
+      }
+      return visitType(subtype, supertype);
+    }
+
+    @Override
+    public @Nullable Void visitWildcardType(WildcardType subtype, Type supertype) {
+      if (config.handleWildcardGenerics()) {
+        constrainWildcardToSupertype(subtype, supertype);
+      }
+      return null;
+    }
+
+    @Override
+    public @Nullable Void visitCapturedType(CapturedType subtype, Type supertype) {
+      if (!localVariableType) {
+        directlyConstrainTypePair(subtype, supertype);
+      }
+      if (config.handleWildcardGenerics()) {
+        WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtype);
+        if (subtypeWildcard != null) {
+          constrainWildcardToSupertype(subtypeWildcard, supertype);
+          return null;
+        }
       }
       return visitType(subtype, supertype);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -7,9 +7,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
@@ -95,12 +93,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     @Override
     public @Nullable Void visitType(Type subtype, Type supertype) {
       if (config.handleWildcardGenerics()) {
-        WildcardType supertypeWildcard = asWildcard(supertype);
+        WildcardType supertypeWildcard = GenericsUtils.asWildcard(supertype);
         if (supertypeWildcard != null) {
           constrainSubtypeToWildcard(subtype, supertypeWildcard);
           return null;
         }
-        WildcardType subtypeWildcard = asWildcard(subtype);
+        WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtype);
         if (subtypeWildcard != null) {
           constrainWildcardToSupertype(subtypeWildcard, supertype);
           return null;
@@ -173,12 +171,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         equateTypeArguments(subtypeTypeArg, supertypeTypeArg);
         return;
       }
-      WildcardType supertypeWildcard = asWildcard(supertypeTypeArg);
+      WildcardType supertypeWildcard = GenericsUtils.asWildcard(supertypeTypeArg);
       if (supertypeWildcard != null) {
         constrainContainedByWildcard(subtypeTypeArg, supertypeWildcard);
         return;
       }
-      WildcardType subtypeWildcard = asWildcard(subtypeTypeArg);
+      WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtypeTypeArg);
       if (subtypeWildcard != null) {
         constrainWildcardContainedByConcrete(subtypeWildcard, supertypeTypeArg);
         return;
@@ -197,12 +195,13 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     private void constrainContainedByWildcard(Type subtypeTypeArg, WildcardType supertypeWildcard) {
       switch (supertypeWildcard.kind) {
         case UNBOUND, EXTENDS -> {
-          Type subtypeUpperBound = effectiveWildcardUpperBound(subtypeTypeArg);
-          subtypeUpperBound.accept(this, wildcardUpperBound(supertypeWildcard));
+          Type subtypeUpperBound = GenericsUtils.effectiveWildcardUpperBound(subtypeTypeArg, state);
+          subtypeUpperBound.accept(
+              this, GenericsUtils.wildcardUpperBound(supertypeWildcard, state));
         }
         case SUPER -> {
           Type supertypeLowerBound = castToNonNull(supertypeWildcard.getSuperBound());
-          WildcardType subtypeWildcard = asWildcard(subtypeTypeArg);
+          WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtypeTypeArg);
           if (subtypeWildcard != null) {
             if (subtypeWildcard.kind == BoundKind.SUPER) {
               supertypeLowerBound.accept(this, castToNonNull(subtypeWildcard.getSuperBound()));
@@ -219,13 +218,13 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (subtypeWildcard.kind == BoundKind.SUPER) {
         castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertypeTypeArg);
       } else {
-        wildcardUpperBound(subtypeWildcard).accept(this, supertypeTypeArg);
+        GenericsUtils.wildcardUpperBound(subtypeWildcard, state).accept(this, supertypeTypeArg);
       }
     }
 
     private void constrainSubtypeToWildcard(Type subtype, WildcardType supertypeWildcard) {
       if (supertypeWildcard.kind != BoundKind.SUPER) {
-        subtype.accept(this, wildcardUpperBound(supertypeWildcard));
+        subtype.accept(this, GenericsUtils.wildcardUpperBound(supertypeWildcard, state));
       }
     }
 
@@ -233,42 +232,8 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (subtypeWildcard.kind == BoundKind.SUPER) {
         castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertype);
       } else {
-        wildcardUpperBound(subtypeWildcard).accept(this, supertype);
+        GenericsUtils.wildcardUpperBound(subtypeWildcard, state).accept(this, supertype);
       }
-    }
-
-    private Type effectiveWildcardUpperBound(Type typeArg) {
-      WildcardType wildcardType = asWildcard(typeArg);
-      return wildcardType == null ? typeArg : wildcardUpperBound(wildcardType);
-    }
-
-    private Type wildcardUpperBound(WildcardType wildcardType) {
-      Type upperBound;
-      if (wildcardType.kind == BoundKind.EXTENDS) {
-        upperBound = wildcardType.getExtendsBound();
-      } else {
-        upperBound =
-            wildcardType.bound == null
-                ? Symtab.instance(state.context).objectType
-                : wildcardType.bound.getUpperBound();
-      }
-      if (upperBound instanceof WildcardType nestedWildcard) {
-        return wildcardUpperBound(nestedWildcard);
-      }
-      if (upperBound instanceof CapturedType capturedType && capturedType.wildcard != null) {
-        return wildcardUpperBound(capturedType.wildcard);
-      }
-      return upperBound;
-    }
-
-    private @Nullable WildcardType asWildcard(Type typeArg) {
-      if (typeArg instanceof WildcardType wildcardType) {
-        return wildcardType;
-      }
-      if (typeArg instanceof CapturedType capturedType) {
-        return capturedType.wildcard;
-      }
-      return null;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -7,6 +7,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
@@ -249,7 +250,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       if (wildcardType.kind == BoundKind.EXTENDS) {
         upperBound = wildcardType.getExtendsBound();
       } else {
-        upperBound = wildcardType.bound.getUpperBound();
+        upperBound =
+            wildcardType.bound == null
+                ? Symtab.instance(state.context).objectType
+                : wildcardType.bound.getUpperBound();
       }
       if (upperBound instanceof WildcardType nestedWildcard) {
         return wildcardUpperBound(nestedWildcard);
@@ -435,9 +439,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     }
     // first, check if library model overrides the upper bound nullability
     Element enclosingElement = typeVarElement.getEnclosingElement();
-    if (enclosingElement instanceof Symbol.MethodSymbol methodSymbol) {
-      int typeVarIndex =
-          methodSymbol.getTypeParameters().indexOf((Symbol.TypeVariableSymbol) typeVarElement);
+    if (enclosingElement instanceof Symbol.MethodSymbol methodSymbol
+        && typeVarElement instanceof Symbol.TypeVariableSymbol typeVariableSymbol) {
+      int typeVarIndex = methodSymbol.getTypeParameters().indexOf(typeVariableSymbol);
       // TODO typeVarIndex is -1 in some cases; see test
       //  com.uber.nullaway.jspecify.GenericMethodTests.instanceGenericMethodWithMethodRefArgument.
       //  Investigate further.
@@ -445,9 +449,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
           && handler.onOverrideMethodTypeVariableUpperBound(methodSymbol, typeVarIndex, state)) {
         return true;
       }
-    } else if (enclosingElement instanceof Symbol.ClassSymbol classSymbol) {
-      int typeVarIndex =
-          classSymbol.getTypeParameters().indexOf((Symbol.TypeVariableSymbol) typeVarElement);
+    } else if (enclosingElement instanceof Symbol.ClassSymbol classSymbol
+        && typeVarElement instanceof Symbol.TypeVariableSymbol typeVariableSymbol) {
+      int typeVarIndex = classSymbol.getTypeParameters().indexOf(typeVariableSymbol);
       if (typeVarIndex >= 0
           && handler.onOverrideClassTypeVariableUpperBound(classSymbol.toString(), typeVarIndex)) {
         return true;
@@ -461,8 +465,11 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   private boolean fromUnannotatedMethod(Element typeVarElement) {
-    Symbol enclosingElement = (Symbol) typeVarElement.getEnclosingElement();
-    return enclosingElement != null
-        && codeAnnotationInfo.isSymbolUnannotated(enclosingElement, config, handler);
+    Element enclosingElement = typeVarElement.getEnclosingElement();
+    if (!(enclosingElement instanceof Symbol.MethodSymbol)
+        && !(enclosingElement instanceof Symbol.ClassSymbol)) {
+      return false;
+    }
+    return codeAnnotationInfo.isSymbolUnannotated((Symbol) enclosingElement, config, handler);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -186,7 +186,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       }
       WildcardType subtypeWildcard = GenericsUtils.asWildcard(subtypeTypeArg);
       if (subtypeWildcard != null) {
-        constrainWildcardContainedByConcrete(subtypeWildcard, supertypeTypeArg);
+        constrainWildcardToSupertype(subtypeWildcard, supertypeTypeArg);
         return;
       }
       equateTypeArguments(subtypeTypeArg, supertypeTypeArg);
@@ -228,21 +228,6 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
             supertypeLowerBound.accept(this, subtypeTypeArg);
           }
         }
-      }
-    }
-
-    /**
-     * Adds constraints for type-argument containment where the actual argument is a wildcard and
-     * the formal argument is concrete. For {@code ? extends S} and {@code ?}, containment requires
-     * {@code S <: supertypeTypeArg}. For {@code ? super S}, use the lower bound and require {@code
-     * S <: supertypeTypeArg}.
-     */
-    private void constrainWildcardContainedByConcrete(
-        WildcardType subtypeWildcard, Type supertypeTypeArg) {
-      if (subtypeWildcard.kind == BoundKind.SUPER) {
-        castToNonNull(subtypeWildcard.getSuperBound()).accept(this, supertypeTypeArg);
-      } else {
-        GenericsUtils.wildcardUpperBound(subtypeWildcard, state).accept(this, supertypeTypeArg);
       }
     }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -4,12 +4,17 @@ import com.google.common.base.Verify;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MemberReferenceTree;
+import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.CapturedType;
+import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
 import com.uber.nullaway.NullabilityUtil;
 import javax.lang.model.type.TypeKind;
+import org.jspecify.annotations.Nullable;
 
 /** Utility methods for doing generics-related checking */
 public class GenericsUtils {
@@ -20,6 +25,49 @@ public class GenericsUtils {
   enum MethodRefTypeRelationKind {
     RETURN,
     PARAMETER
+  }
+
+  /**
+   * Returns the effective upper bound of {@code typeArg}. For concrete type arguments, returns the
+   * type itself. For wildcards and captured wildcards, returns the wildcard's upper bound,
+   * recursing through nested wildcards and captures produced by javac.
+   */
+  static Type effectiveWildcardUpperBound(Type typeArg, VisitorState state) {
+    WildcardType wildcardType = asWildcard(typeArg);
+    return wildcardType == null ? typeArg : wildcardUpperBound(wildcardType, state);
+  }
+
+  /**
+   * Returns the effective upper bound of a wildcard, using the corresponding type variable's upper
+   * bound for unbounded wildcards and {@code super} wildcards.
+   */
+  static Type wildcardUpperBound(WildcardType wildcardType, VisitorState state) {
+    Type upperBound;
+    if (wildcardType.kind == BoundKind.EXTENDS) {
+      upperBound = wildcardType.getExtendsBound();
+    } else {
+      upperBound =
+          wildcardType.bound == null
+              ? Symtab.instance(state.context).objectType
+              : wildcardType.bound.getUpperBound();
+    }
+    if (upperBound instanceof WildcardType nestedWildcard) {
+      return wildcardUpperBound(nestedWildcard, state);
+    }
+    if (upperBound instanceof CapturedType capturedType && capturedType.wildcard != null) {
+      return wildcardUpperBound(capturedType.wildcard, state);
+    }
+    return upperBound;
+  }
+
+  static @Nullable WildcardType asWildcard(Type typeArg) {
+    if (typeArg instanceof WildcardType wildcardType) {
+      return wildcardType;
+    }
+    if (typeArg instanceof CapturedType capturedType) {
+      return capturedType.wildcard;
+    }
+    return null;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -46,10 +46,16 @@ public class GenericsUtils {
     if (wildcardType.kind == BoundKind.EXTENDS) {
       upperBound = wildcardType.getExtendsBound();
     } else {
+      // We have an unbound wildcard or a wildcard with just a lower bound.  In such cases, if
+      // present, we use the upper bound of the formal type variable to which the wildcard is being
+      // passed (confusingly stored in the `bound` field).  E.g., if we have class Foo<T extends
+      // @Nullable Object>, and then see Foo<? super String>, we use @Nullable Object as the upper
+      // bound.  If not present, default to Object.
+      Type.TypeVar formalTypeVar = wildcardType.bound;
       upperBound =
-          wildcardType.bound == null
+          formalTypeVar == null
               ? Symtab.instance(state.context).objectType
-              : wildcardType.bound.getUpperBound();
+              : formalTypeVar.getUpperBound();
     }
     if (upperBound instanceof WildcardType nestedWildcard) {
       return wildcardUpperBound(nestedWildcard, state);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -299,6 +299,9 @@ public class TypeSubstitutionUtils {
         // TODO revisit this decision when we add fuller support for inference and wildcards.
         return visit(t, wt.getExtendsBound());
       }
+      if (other instanceof Type.WildcardType wt && wt.kind == BoundKind.SUPER) {
+        return visit(t, wt.getSuperBound());
+      }
 
       Type updated = updateDirectNullabilityAnnotationsForType(t, other);
       if (!(other instanceof Type.ClassType)) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -293,16 +293,15 @@ public class TypeSubstitutionUtils {
 
     @Override
     public Type visitClassType(Type.ClassType t, Type other) {
-      if (other instanceof Type.WildcardType wt && wt.kind == BoundKind.EXTENDS) {
-        // As a temporary measure, we restore nullability annotations from the upper bound of the
-        // wildcard.
-        // TODO revisit this decision when we add fuller support for inference and wildcards.
-        return visit(t, wt.getExtendsBound());
+      if (other instanceof Type.WildcardType wt) {
+        // When the other type is a wildcard, restore nullability annotations from the bound that
+        // determines the functional interface type.
+        if (wt.kind == BoundKind.EXTENDS) {
+          return visit(t, wt.getExtendsBound());
+        } else if (wt.kind == BoundKind.SUPER) {
+          return visit(t, wt.getSuperBound());
+        }
       }
-      if (other instanceof Type.WildcardType wt && wt.kind == BoundKind.SUPER) {
-        return visit(t, wt.getSuperBound());
-      }
-
       Type updated = updateDirectNullabilityAnnotationsForType(t, other);
       if (!(other instanceof Type.ClassType)) {
         return updated;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -426,6 +426,40 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * Tests inference for {@code Stream.collect} when the stream element type comes from a captured
+   * wildcard. In this case javac creates a captured type variable for the {@code ? extends
+   * TypeMirror} bound with no method or class owner. This covers the solver path that treats such
+   * ownerless captured variables as annotated code rather than asking {@code CodeAnnotationInfo}
+   * whether their owner is unannotated.
+   */
+  @Test
+  public void streamCollectJoiningWithCapturedWildcardAccumulator() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import java.util.stream.Collectors;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              interface TypeMirror {
+                String accept(Object visitor, Object arg);
+              }
+              interface BoundContainer {
+                List<? extends TypeMirror> getBounds();
+              }
+              String test(BoundContainer b) {
+                return b.getBounds().stream()
+                    .map(bound -> ((TypeMirror) bound).accept(this, this))
+                    .collect(Collectors.joining(" & "));
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Test
   public void genericMethodLambdaArgWildCard() {
     makeHelperWithInferenceFailureWarning()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -443,6 +443,7 @@ public class WildcardTests extends NullAwayTestsBase {
                     // legal, should infer R -> Object but then the type of the lambda as
                     //  Function<Object, @Nullable Object> via wildcard upper bound
                     Object x = invokeWithReturn(t -> null);
+                    x.hashCode();
                 }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -370,6 +370,36 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void superWildcardToConcreteTypeVariable() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Box<T extends @Nullable Object> {}
+              static <T extends @Nullable Object> void take(Box<T> box) {}
+              static <T extends @Nullable Object> T get(Box<T> box) {
+                throw new RuntimeException();
+              }
+              Object field = new Object();
+              void test(Box<? super @Nullable String> nullableBox, Box<? super String> nonNullBox) {
+                take(nullableBox);
+                take(nonNullBox);
+                // TODO we need to report an additional error besides inference failure here
+                // See https://github.com/uber/NullAway/issues/1551
+                // BUG: Diagnostic contains: Failed to infer type argument nullability
+                field = get(nullableBox);
+                field = get(nonNullBox);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void genericMethodLambdaArgWildCard() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -426,40 +426,6 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  /**
-   * Tests inference for {@code Stream.collect} when the stream element type comes from a captured
-   * wildcard. In this case javac creates a captured type variable for the {@code ? extends
-   * TypeMirror} bound with no method or class owner. This covers the solver path that treats such
-   * ownerless captured variables as annotated code rather than asking {@code CodeAnnotationInfo}
-   * whether their owner is unannotated.
-   */
-  @Test
-  public void streamCollectJoiningWithCapturedWildcardAccumulator() {
-    makeHelperWithInferenceFailureWarning()
-        .addSourceLines(
-            "Test.java",
-            """
-            import java.util.List;
-            import java.util.stream.Collectors;
-            import org.jspecify.annotations.NullMarked;
-            @NullMarked
-            class Test {
-              interface TypeMirror {
-                String accept(Object visitor, Object arg);
-              }
-              interface BoundContainer {
-                List<? extends TypeMirror> getBounds();
-              }
-              String test(BoundContainer b) {
-                return b.getBounds().stream()
-                    .map(bound -> ((TypeMirror) bound).accept(this, this))
-                    .collect(Collectors.joining(" & "));
-              }
-            }
-            """)
-        .doTest();
-  }
-
   @Test
   public void genericMethodLambdaArgWildCard() {
     makeHelperWithInferenceFailureWarning()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -400,6 +400,33 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void methodRefParameterExtendsWildcardToConcreteParameter() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Consumer<T extends @Nullable Object> {
+                void accept(T t);
+              }
+              static void acceptNullable(@Nullable String s) {}
+              static void acceptNonNull(String s) {}
+              static <T extends @Nullable Object> void use(Consumer<? extends T> consumer) {}
+              static void useNullable(Consumer<? extends @Nullable String> consumer) {}
+              void test() {
+                use(Test::acceptNullable);
+                // BUG: Diagnostic contains: parameter s of referenced method is @NonNull
+                useNullable(Test::acceptNonNull);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void genericMethodLambdaArgWildCard() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -4,6 +4,7 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class WildcardTests extends NullAwayTestsBase {
@@ -460,6 +461,30 @@ public class WildcardTests extends NullAwayTestsBase {
                         s.hashCode();
                     });
                 }
+            }""")
+        .doTest();
+  }
+
+  @Ignore("https://github.com/uber/NullAway/issues/1500")
+  @Test
+  public void issue1500() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                public static <T extends @Nullable Object> Foo<T> of(Foo<? super T> foo) {
+                    return new Foo<>();
+                }
+
+                public Foo<T> or(Foo<? super T> other) {
+                    return this;
+                }
+              }
+              static final Foo<@Nullable Void> FOO = Foo.of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
             }""")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -392,6 +392,31 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Ignore("https://github.com/uber/NullAway/issues/1522")
+  @Test
+  public void issue1522() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            import java.util.function.Function;
+            import java.util.Optional;
+            @NullMarked
+            class Test {
+              static class Foo<T> {
+                public final <V> Foo<V> mapNotNull(Function<? super T, ? extends @Nullable V> mapper) {
+                  throw new RuntimeException();
+                }
+              }
+              static <T> Foo<T> after(Foo<Optional<T>> foo) {
+                return foo.mapNotNull(x -> x.orElse(null));
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /**
    * Extracted from Caffeine; exposed some subtle bugs in substitutions involving identity of {@code
    * Type} objects

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -428,6 +428,42 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void mapStreamValuesToNullable() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+                interface List<T extends @Nullable Object> {
+                    Stream<T> stream();
+                }
+                interface Stream<T extends @Nullable Object> {
+                    <R extends @Nullable Object> Stream<R> map(Function<? super T, ? extends R> mapper);
+                    void forEach(Consumer<? super T> action);
+                }
+                interface Function<T extends @Nullable Object, R extends @Nullable Object> {
+                    R apply(T t);
+                }
+                interface Consumer<T extends @Nullable Object> {
+                    void accept(T t);
+                }
+                static @Nullable String mapToNull(String s) {
+                    return null;
+                }
+                static void test(List<String> list) {
+                    // legal, should infer R -> @Nullable String
+                    list.stream().map(Test::mapToNull).forEach(s -> {
+                        // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                        s.hashCode();
+                    });
+                }
+            }""")
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -537,12 +537,14 @@ public class WildcardTests extends NullAwayTestsBase {
                 static @Nullable String mapToNull(String s) {
                     return null;
                 }
+                static void callHashCode(Object o) { o.hashCode(); }
                 static void test(List<String> list) {
-                    // legal, should infer R -> @Nullable String
                     list.stream().map(Test::mapToNull).forEach(s -> {
                         // BUG: Diagnostic contains: dereferenced expression s is @Nullable
                         s.hashCode();
                     });
+                    // TODO we should report an error here (https://github.com/uber/NullAway/issues/1552)
+                    list.stream().map(Test::mapToNull).forEach(Test::callHashCode);
                 }
             }""")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -4,7 +4,6 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class WildcardTests extends NullAwayTestsBase {
@@ -341,7 +340,6 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore("bad interaction between wildcard support and generic method inference")
   @Test
   public void wildcardSuperBoundsAndInference() {
     makeHelperWithInferenceFailureWarning()
@@ -370,7 +368,6 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore("https://github.com/uber/NullAway/issues/1350")
   @Test
   public void genericMethodLambdaArgWildCard() {
     makeHelperWithInferenceFailureWarning()


### PR DESCRIPTION
This is an initial (incomplete) implementation of extending our generic method inference to handle wildcard types.  It has known bugs and incompleteness (#1522, #1500, #1551, #1552), but we'll handle those in follow-up PRs to keep this one at a reasonable size.  This support is also behind a flag and off by default.

The key changes here are in `ConstraintSolverImpl`.  When constraining one class type `C` to be a subtype of another class type `S`, we now constrain their type arguments using "containment" (JLS 4.5.1 + the JSpecify spec) for wildcard type arguments.  Containment has various cases depending on whether we have `extends` or `super` bounds.  Also, when one type is constraint to be a subtype of a wildcard type, we use the wildcard's bound to generate the constraint.

Beyond the above:

* We refactor some common logic between wildcard subtype checking and wildcard constraint generation into `GenericsUtils`
* We extend a substitution case in `TypeSubstitutionUtils` to handle both `extends` and `super` bounds

See the new test cases in `WildcardTests`, including some that are ignored with follow-up issues.  Beyond addressing those follow ups, I plan to also go through any new reports from this support in our integration test subjects (junit, spring-framework, caffeine) and check their validity in order to make the inference more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wildcard generics handling: effective upper-bound computation, wildcard-aware subtype/containment constraints, and broader restoration of nullability for both extends and super bounds—resulting in more precise nullability analysis and inference.

* **Tests**
  * Re-enabled and added wildcard inference, method-reference, lambda, and stream mapping tests; introduced active and regression cases to validate wildcard/nullability behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->