### PR TITLE
Use Jacoco 0.8.15 snapshot

### DIFF
--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -19,8 +19,24 @@ plugins {
     id 'jacoco'
 }
 
+// we pull in the snapshot version of Jacoco to support running on JDK 27 early access builds
+// This repositories declaration is scoped so we can only pull in a snapshot version of Jacoco
+// from the snapshots repo, not any other dependency
+repositories {
+    maven {
+        name = "SonatypeSnapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            snapshotsOnly()
+        }
+        content {
+            includeGroup("org.jacoco")
+        }
+    }
+}
+
 jacoco {
-    toolVersion = "0.8.14"
+    toolVersion = "0.8.15-SNAPSHOT"
 }
 
 // Do not generate reports for individual projects


### PR DESCRIPTION
This is to support running tests on JDK 27 ea builds.  Without this, Jacoco crashes for such tests.  The tests still pass, but seeing the stack traces in the console is annoying and slows down the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure and code quality verification tooling to enhance development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->