### PR TITLE
Add Spring Boot as an integration test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,8 @@ jobs:
             url: https://github.com/spring-projects/spring-framework.git
           - project: junit-framework
             url: https://github.com/junit-team/junit-framework.git
+          - project: spring-boot
+            url: https://github.com/spring-projects/spring-boot.git
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to include Spring Boot in the external project compatibility testing matrix, alongside caffeine, spring-framework, and junit-framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->