### PR TITLE
Fix nullability for return and parameter wildcards

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -30,6 +30,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.TargetType;
@@ -1801,7 +1802,7 @@ public final class GenericsChecks {
         overriddenMethodType instanceof ExecutableType,
         "expected ExecutableType but instead got %s",
         overriddenMethodType.getClass());
-    return getTypeNullness(overriddenMethodType.getReturnType());
+    return getReturnTypeNullness(overriddenMethodType.getReturnType(), state);
   }
 
   /**
@@ -2198,7 +2199,8 @@ public final class GenericsChecks {
       // type variables declared on the enclosing class
       if (substitutedParamTypes != null
           && Objects.equals(
-              getParameterTypeNullness(substitutedParamTypes.get(paramIndex), isVarargsParam),
+              getParameterTypeNullness(
+                  substitutedParamTypes.get(paramIndex), isVarargsParam, state),
               Nullness.NULLABLE)) {
         return Nullness.NULLABLE;
       }
@@ -2335,7 +2337,7 @@ public final class GenericsChecks {
     Type methodType =
         TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, method, config);
     Type paramType = methodType.getParameterTypes().get(parameterIndex);
-    return getParameterTypeNullness(paramType, isVarargsParam);
+    return getParameterTypeNullness(paramType, isVarargsParam, state);
   }
 
   /**
@@ -2402,7 +2404,7 @@ public final class GenericsChecks {
    * @param isVarargsParam true if the parameter is a varargs parameter
    * @return The nullness of the parameter type
    */
-  private Nullness getParameterTypeNullness(Type type, boolean isVarargsParam) {
+  private Nullness getParameterTypeNullness(Type type, boolean isVarargsParam, VisitorState state) {
     if (isVarargsParam) {
       // type better be an array type
       verify(
@@ -2412,9 +2414,12 @@ public final class GenericsChecks {
       // use the component type to determine nullness
       Type.ArrayType arrayType = (Type.ArrayType) type;
       Type componentType = arrayType.getComponentType();
-      return getTypeNullness(componentType);
+      return getParameterTypeNullness(componentType, false, state);
     } else {
-      // For non-varargs, we just check the type itself
+      Type.WildcardType wildcardType = GenericsUtils.asWildcard(type);
+      if (wildcardType != null && wildcardType.kind == BoundKind.SUPER) {
+        return getTypeNullness(castToNonNull(wildcardType.getSuperBound()));
+      }
       return getTypeNullness(type);
     }
   }
@@ -2428,6 +2433,33 @@ public final class GenericsChecks {
         Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
     if (hasNullableAnnotation) {
       return Nullness.NULLABLE;
+    }
+    return Nullness.NONNULL;
+  }
+
+  /**
+   * Returns the nullness of a return type. For wildcard and javac captured wildcard types, use the
+   * effective upper bound: a read from {@code Foo<? extends @Nullable Object>} or {@code Foo<?
+   * super String>} can produce any value permitted by the capture's upper bound.
+   */
+  private Nullness getReturnTypeNullness(Type type, VisitorState state) {
+    return getReturnTypeNullness(type, state, false);
+  }
+
+  private Nullness getReturnTypeNullness(
+      Type type, VisitorState state, boolean followTypeVarUpperBound) {
+    if (getTypeNullness(type).equals(Nullness.NULLABLE)) {
+      return Nullness.NULLABLE;
+    }
+    if (GenericsUtils.asWildcard(type) != null) {
+      Type effectiveUpperBound = GenericsUtils.effectiveWildcardUpperBound(type, state);
+      return getReturnTypeNullness(effectiveUpperBound, state, true);
+    }
+    if (followTypeVarUpperBound && type instanceof Type.TypeVar typeVar) {
+      Type upperBound = typeVar.getUpperBound();
+      if (upperBound != null) {
+        return getReturnTypeNullness(upperBound, state, true);
+      }
     }
     return Nullness.NONNULL;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2416,9 +2416,11 @@ public final class GenericsChecks {
       Type componentType = arrayType.getComponentType();
       return getParameterTypeNullness(componentType, false, state);
     } else {
-      Type.WildcardType wildcardType = GenericsUtils.asWildcard(type);
-      if (wildcardType != null && wildcardType.kind == BoundKind.SUPER) {
-        return getTypeNullness(castToNonNull(wildcardType.getSuperBound()));
+      if (config.handleWildcardGenerics()) {
+        Type.WildcardType wildcardType = GenericsUtils.asWildcard(type);
+        if (wildcardType != null && wildcardType.kind == BoundKind.SUPER) {
+          return getTypeNullness(castToNonNull(wildcardType.getSuperBound()));
+        }
       }
       return getTypeNullness(type);
     }
@@ -2451,7 +2453,7 @@ public final class GenericsChecks {
     if (getTypeNullness(type).equals(Nullness.NULLABLE)) {
       return Nullness.NULLABLE;
     }
-    if (GenericsUtils.asWildcard(type) != null) {
+    if (config.handleWildcardGenerics() && GenericsUtils.asWildcard(type) != null) {
       Type effectiveUpperBound = GenericsUtils.effectiveWildcardUpperBound(type, state);
       return getReturnTypeNullness(effectiveUpperBound, state, true);
     }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -437,6 +437,43 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void wildcardCaptureLocals() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                T get() { throw new RuntimeException(); }
+              }
+              static void testNullableExtendsBound(Foo<? extends @Nullable Object> f) {
+                Object x = f.get();
+                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                x.hashCode();
+              }
+              static void testNonNullExtendsBound(Foo<? extends Object> f) {
+                Object x = f.get();
+                // this is legal
+                x.hashCode();
+              }
+              static void testNullableSuperBound(Foo<? super @Nullable String> f) {
+                Object x = f.get();
+                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                x.hashCode();
+              }
+              static void testNonNullSuperBound(Foo<? super String> f) {
+                Object x = f.get();
+                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                x.hashCode();
+              }
+            }""")
+        .doTest();
+  }
+
+  @Test
   public void wildcardSuperBoundsAndInference() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -342,6 +342,101 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void wildcardCaptureParameters() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                void set(T t) {}
+              }
+              static void testNullableExtendsBound(Foo<? extends @Nullable Object> f) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                f.set(null);
+              }
+              static void testNonNullExtendsBound(Foo<? extends Object> f) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                f.set(null);
+              }
+              static void testNullableSuperBound(Foo<? super @Nullable String> f) {
+                // this is legal
+                f.set(null);
+              }
+              static void testNonNullSuperBound(Foo<? super String> f) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                f.set(null);
+              }
+            }""")
+        .doTest();
+  }
+
+  @Test
+  public void wildcardCaptureReturns() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                T get() { throw new RuntimeException(); }
+              }
+              static void testNullableExtendsBound(Foo<? extends @Nullable Object> f) {
+                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                f.get().hashCode();
+              }
+              static void testNonNullExtendsBound(Foo<? extends Object> f) {
+                // this is legal
+                f.get().hashCode();
+              }
+              static void testNullableSuperBound(Foo<? super @Nullable String> f) {
+                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                f.get().hashCode();
+              }
+              static void testNonNullSuperBound(Foo<? super String> f) {
+                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                f.get().hashCode();
+              }
+            }""")
+        .doTest();
+  }
+
+  @Test
+  public void wildcardCaptureReturnWithTypeVariableUpperBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                T get() { throw new RuntimeException(); }
+              }
+              static class NullableBound<U extends @Nullable Object> {
+                void test(Foo<? extends U> f) {
+                  // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                  f.get().hashCode();
+                }
+              }
+              static class NonNullBound<U> {
+                void test(Foo<? extends U> f) {
+                  // this is legal
+                  f.get().hashCode();
+                }
+              }
+            }""")
+        .doTest();
+  }
+
+  @Test
   public void wildcardSuperBoundsAndInference() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(


### PR DESCRIPTION
See the new test cases.  Use upper and lower bounds to reason about the nullability of accessed values of wildcard type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced null-checking accuracy for Java generic types with improved wildcard support
  * Better nullness analysis for method parameters, return values, and type-variable bounds in generic declarations
  * Improved handling of complex wildcard scenarios

* **Tests**
  * Added test coverage for wildcard generic capture behavior across parameters, returns, and local variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->