### PR TITLE
Enable test for issue 1500 and add comment

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -719,7 +719,7 @@ public class WildcardTests extends NullAwayTestsBase {
               // This works due to the explicit type argument
               static final Foo<@Nullable Void> FOO2 = Foo.<@Nullable Void>of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
 
-              static final Foo<@Nullable Void> TMP = Foo.ofNoWildcard(new Foo<@Nullable Void>());
+              // This works since ofNoWildcard does not use a lower-bounded wildcard in its parameter type
               static final Foo<@Nullable Void> FOO3 = Foo.ofNoWildcard(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
             }""")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -703,6 +703,10 @@ public class WildcardTests extends NullAwayTestsBase {
                     return new Foo<>();
                 }
 
+                public static <T extends @Nullable Object> Foo<T> ofNoWildcard(Foo<T> foo) {
+                    return new Foo<>();
+                }
+
                 public Foo<T> or(Foo<? super T> other) {
                     return this;
                 }
@@ -714,6 +718,9 @@ public class WildcardTests extends NullAwayTestsBase {
 
               // This works due to the explicit type argument
               static final Foo<@Nullable Void> FOO2 = Foo.<@Nullable Void>of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
+
+              static final Foo<@Nullable Void> TMP = Foo.ofNoWildcard(new Foo<@Nullable Void>());
+              static final Foo<@Nullable Void> FOO3 = Foo.ofNoWildcard(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
             }""")
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -689,7 +689,6 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore("https://github.com/uber/NullAway/issues/1500")
   @Test
   public void issue1500() {
     makeHelperWithInferenceFailureWarning()
@@ -708,6 +707,9 @@ public class WildcardTests extends NullAwayTestsBase {
                     return this;
                 }
               }
+              // We report an error here since we do not infer Foo<@Nullable Void> as the type of the Foo.of call;
+              // javac itself has a similar inference limitation, see https://godbolt.org/z/Y875ahYMx
+              // BUG: Diagnostic contains: incompatible types: Foo<Void> cannot be converted to Foo<@Nullable Void>
               static final Foo<@Nullable Void> FOO = Foo.of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
             }""")
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -711,6 +711,9 @@ public class WildcardTests extends NullAwayTestsBase {
               // javac itself has a similar inference limitation, see https://godbolt.org/z/Y875ahYMx
               // BUG: Diagnostic contains: incompatible types: Foo<Void> cannot be converted to Foo<@Nullable Void>
               static final Foo<@Nullable Void> FOO = Foo.of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
+
+              // This works due to the explicit type argument
+              static final Foo<@Nullable Void> FOO2 = Foo.<@Nullable Void>of(new Foo<@Nullable Void>()).or(new Foo<@Nullable Void>());
             }""")
         .doTest();
   }


### PR DESCRIPTION
Fixes #1500

NullAway behaves correctly for this case.  Test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Re-enabled previously skipped test for wildcard type handling in generic declarations. Expanded test coverage with additional scenarios to validate null-safety analysis behavior across different generic type parameter patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->