### PR TITLE
Enable generic bytecode tests on JDK 17

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,6 +34,7 @@ jobs:
             21
             25
           distribution: 'temurin'
+          check-latest: 'true'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: List toolchains

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Build and test
-        run: ./gradlew build
+        run: ./gradlew javaToolchains build
       - name: Run shellcheck
         run: ./gradlew shellcheck
         if: runner.os == 'Linux'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           website: jdk.java.net
           release: 27
-      # Use Zulu for JDK 17, as Temurin build of 17.0.19 is still not released
+      # Use Zulu for JDK 17 on Windows, as Temurin build of 17.0.19 is still not released
       - name: 'Set up Zulu JDK 17 on Windows'
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,12 +29,17 @@ jobs:
       - name: 'Set up Default JDK'
         uses: actions/setup-java@v5
         with:
-          java-version: 25
+          java-version: |
+            17
+            21
+            25
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+      - name: List toolchains
+        run: ./gradlew javaToolchains
       - name: Build and test
-        run: ./gradlew javaToolchains build
+        run: ./gradlew build
       - name: Run shellcheck
         run: ./gradlew shellcheck
         if: runner.os == 'Linux'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           website: jdk.java.net
           release: 27
-      # Use Zulu for JDK 17, as Windows Temurin build of 17.0.19 is still not released
+      # Use Zulu for JDK 17, as Temurin build of 17.0.19 is still not released
       - name: 'Set up Zulu JDK 17 on Windows'
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,12 +27,20 @@ jobs:
           website: jdk.java.net
           release: 27
       # Use Zulu for JDK 17, as Windows Temurin build of 17.0.19 is still not released
-      - name: 'Set up Zulu JDK 17'
+      - name: 'Set up Zulu JDK 17 on Windows'
         uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
           check-latest: 'true'
+        if: runner.os == 'Windows'
+      - name: 'Set up Temurin JDK 17'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          check-latest: 'true'
+        if: runner.os != 'Windows'
       - name: 'Set up JDKs'
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,11 +26,17 @@ jobs:
         with:
           website: jdk.java.net
           release: 27
-      - name: 'Set up Default JDK'
+      # Use Zulu for JDK 17, as Windows Temurin build of 17.0.19 is still not released
+      - name: 'Set up Zulu JDK 17'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          check-latest: 'true'
+      - name: 'Set up JDKs'
         uses: actions/setup-java@v5
         with:
           java-version: |
-            17
             21
             25
           distribution: 'temurin'

--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -26,7 +26,6 @@ import com.uber.nullaway.NullAway;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,8 +85,6 @@ public class NullAwayGuavaParametricNullnessTests {
 
   @Test
   public void jspecifyFutureCallback() {
-    // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -134,8 +131,6 @@ public class NullAwayGuavaParametricNullnessTests {
 
   @Test
   public void jspecifyIterables() {
-    // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -164,8 +159,6 @@ public class NullAwayGuavaParametricNullnessTests {
 
   @Test
   public void jspecifyComparators() {
-    // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
@@ -246,8 +239,6 @@ public class NullAwayGuavaParametricNullnessTests {
 
   @Test
   public void newHashSetPassingNullable() {
-    // to ensure javac reads proper generic types from the Guava jar
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -4,7 +4,6 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.List;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class BytecodeGenericsTests extends NullAwayTestsBase {
@@ -83,8 +82,6 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
 
   @Test
   public void genericsChecksForFieldAssignments() {
-    // to read annotations properly from bytecode
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -110,9 +107,6 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
 
   @Test
   public void genericsChecksForParamPassingAndReturns() {
-    // to read annotations properly from bytecode
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
-
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -245,8 +239,6 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
 
   @Test
   public void callMethodTakingJavaUtilFunction() {
-    // to read annotations properly from bytecode
-    Assume.assumeTrue(Runtime.version().feature() >= 21);
     makeHelper()
         .addSourceLines(
             "Test.java",


### PR DESCRIPTION
These tests work on JDK 17 with the `-XDaddTypeAnnotationsToSymbol=true` flag, after the JDK 17.0.19 release, due to backported support.  We have to modify our CI config a bit to install the right version of JDK 17 across platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed Java-version gating from jspecify-related nullness and generics tests so they run unconditionally, ensuring those checks execute in all CI and local runs.

* **Chores**
  * CI now installs multiple Java toolchains (including newer and LTS JDKs) and adds a step to list configured toolchains before building and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->