### PR TITLE
Use text blocks for addInputLines and addOutputLines calls

### DIFF
--- a/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
+++ b/guava-recent-unit-tests/src/test/java/com/uber/nullaway/guava/NullAwayGuavaParametricNullnessTests.java
@@ -63,23 +63,25 @@ public class NullAwayGuavaParametricNullnessTests {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.google.common.util.concurrent.FutureCallback;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "    public static <T> FutureCallback<T> wrapFutureCallback(FutureCallback<T> futureCallback) {",
-            "        return new FutureCallback<T>() {",
-            "            @Override",
-            "            public void onSuccess(@Nullable T result) {",
-            "                futureCallback.onSuccess(result);",
-            "            }",
-            "            @Override",
-            "            public void onFailure(Throwable throwable) {",
-            "                futureCallback.onFailure(throwable);",
-            "            }",
-            "        };",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import com.google.common.util.concurrent.FutureCallback;
+            import javax.annotation.Nullable;
+            class Test {
+                public static <T> FutureCallback<T> wrapFutureCallback(FutureCallback<T> futureCallback) {
+                    return new FutureCallback<T>() {
+                        @Override
+                        public void onSuccess(@Nullable T result) {
+                            futureCallback.onSuccess(result);
+                        }
+                        @Override
+                        public void onFailure(Throwable throwable) {
+                            futureCallback.onFailure(throwable);
+                        }
+                    };
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -88,23 +90,25 @@ public class NullAwayGuavaParametricNullnessTests {
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
-            "import com.google.common.util.concurrent.FutureCallback;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Test {",
-            "    public static <T> FutureCallback<@Nullable T> wrapFutureCallback(FutureCallback<@Nullable T> futureCallback) {",
-            "        return new FutureCallback<@Nullable T>() {",
-            "            @Override",
-            "            public void onSuccess(@Nullable T result) {",
-            "                futureCallback.onSuccess(result);",
-            "            }",
-            "            @Override",
-            "            public void onFailure(Throwable throwable) {",
-            "                futureCallback.onFailure(throwable);",
-            "            }",
-            "        };",
-            "    }",
-            "}")
+            """
+            import com.google.common.util.concurrent.FutureCallback;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+                public static <T> FutureCallback<@Nullable T> wrapFutureCallback(FutureCallback<@Nullable T> futureCallback) {
+                    return new FutureCallback<@Nullable T>() {
+                        @Override
+                        public void onSuccess(@Nullable T result) {
+                            futureCallback.onSuccess(result);
+                        }
+                        @Override
+                        public void onFailure(Throwable throwable) {
+                            futureCallback.onFailure(throwable);
+                        }
+                    };
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -113,19 +117,21 @@ public class NullAwayGuavaParametricNullnessTests {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.google.common.collect.ImmutableList;",
-            "import com.google.common.collect.Iterables;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "    public static String test1() {",
-            "        // BUG: Diagnostic contains: returning @Nullable expression",
-            "        return Iterables.getFirst(ImmutableList.<String>of(), null);",
-            "    }",
-            "    public static @Nullable String test2() {",
-            "        return Iterables.getFirst(ImmutableList.<String>of(), null);",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import com.google.common.collect.ImmutableList;
+            import com.google.common.collect.Iterables;
+            import javax.annotation.Nullable;
+            class Test {
+                public static String test1() {
+                    // BUG: Diagnostic contains: returning @Nullable expression
+                    return Iterables.getFirst(ImmutableList.<String>of(), null);
+                }
+                public static @Nullable String test2() {
+                    return Iterables.getFirst(ImmutableList.<String>of(), null);
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -134,26 +140,28 @@ public class NullAwayGuavaParametricNullnessTests {
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
-            "import com.google.common.collect.ImmutableList;",
-            "import com.google.common.collect.Iterables;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Test {",
-            "    public static String test1() {",
-            "        // BUG: Diagnostic contains: returning @Nullable expression",
-            "        return Iterables.<@Nullable String>getFirst(ImmutableList.<String>of(), null);",
-            "    }",
-            "    public static @Nullable String test2() {",
-            "        return Iterables.<@Nullable String>getFirst(ImmutableList.<String>of(), null);",
-            "    }",
-            "    public static String test3() {",
-            "        return Iterables.getOnlyElement(ImmutableList.of(\"hi\"));",
-            "    }",
-            "    public static String test4() {",
-            "        // BUG: Diagnostic contains: returning @Nullable expression",
-            "        return Iterables.<@Nullable String>getOnlyElement(ImmutableList.of(\"hi\"));",
-            "    }",
-            "}")
+            """
+            import com.google.common.collect.ImmutableList;
+            import com.google.common.collect.Iterables;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+                public static String test1() {
+                    // BUG: Diagnostic contains: returning @Nullable expression
+                    return Iterables.<@Nullable String>getFirst(ImmutableList.<String>of(), null);
+                }
+                public static @Nullable String test2() {
+                    return Iterables.<@Nullable String>getFirst(ImmutableList.<String>of(), null);
+                }
+                public static String test3() {
+                    return Iterables.getOnlyElement(ImmutableList.of("hi"));
+                }
+                public static String test4() {
+                    // BUG: Diagnostic contains: returning @Nullable expression
+                    return Iterables.<@Nullable String>getOnlyElement(ImmutableList.of("hi"));
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -162,19 +170,21 @@ public class NullAwayGuavaParametricNullnessTests {
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
-            "import com.google.common.collect.Comparators;",
-            "import java.util.Comparator;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Test {",
-            "    public static String test1(String t1, String t2, Comparator<? super String> cmp) {",
-            "        return Comparators.min(t1, t2, cmp);",
-            "    }",
-            "    public static String test2(@Nullable String t1, @Nullable String t2, Comparator<? super @Nullable String> cmp) {",
-            "        // BUG: Diagnostic contains: returning @Nullable expression",
-            "        return Comparators.<@Nullable String>min(t1, t2, cmp);",
-            "    }",
-            "}")
+            """
+            import com.google.common.collect.Comparators;
+            import java.util.Comparator;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+                public static String test1(String t1, String t2, Comparator<? super String> cmp) {
+                    return Comparators.min(t1, t2, cmp);
+                }
+                public static String test2(@Nullable String t1, @Nullable String t2, Comparator<? super @Nullable String> cmp) {
+                    // BUG: Diagnostic contains: returning @Nullable expression
+                    return Comparators.<@Nullable String>min(t1, t2, cmp);
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -183,26 +193,28 @@ public class NullAwayGuavaParametricNullnessTests {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.google.common.io.Closer;",
-            "import java.io.Closeable;",
-            "import java.io.FileInputStream;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "    public static FileInputStream test1(Closer closer, FileInputStream fis1) {",
-            "        // safe: non-null arg to non-null return",
-            "        return closer.register(fis1);",
-            "    }",
-            "    @Nullable",
-            "    public static FileInputStream test2(Closer closer, @Nullable FileInputStream fis2) {",
-            "        // safe: nullable arg to nullable return",
-            "        return closer.register(fis2);",
-            "    }",
-            "    public static FileInputStream test3(Closer closer, @Nullable FileInputStream fis3) {",
-            "        // BUG: Diagnostic contains: returning @Nullable expression",
-            "        return closer.register(fis3);",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import com.google.common.io.Closer;
+            import java.io.Closeable;
+            import java.io.FileInputStream;
+            import javax.annotation.Nullable;
+            class Test {
+                public static FileInputStream test1(Closer closer, FileInputStream fis1) {
+                    // safe: non-null arg to non-null return
+                    return closer.register(fis1);
+                }
+                @Nullable
+                public static FileInputStream test2(Closer closer, @Nullable FileInputStream fis2) {
+                    // safe: nullable arg to nullable return
+                    return closer.register(fis2);
+                }
+                public static FileInputStream test3(Closer closer, @Nullable FileInputStream fis3) {
+                    // BUG: Diagnostic contains: returning @Nullable expression
+                    return closer.register(fis3);
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -211,29 +223,31 @@ public class NullAwayGuavaParametricNullnessTests {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.google.common.base.Function;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "    public static void testFunctionOverride() {",
-            "        Function<Object, Object> f = new Function<Object, Object>() {",
-            "            @Override",
-            "            public Object apply(Object input) {",
-            "                return input;",
-            "             }",
-            "        };",
-            "    }",
-            "    public static void testFunctionOverrideNullableReturn() {",
-            "        Function<Object, Object> f = new Function<Object, Object>() {",
-            "            @Override",
-            "            @Nullable",
-            "            // BUG: Diagnostic contains: method returns @Nullable, but superclass method",
-            "            public Object apply(Object input) {",
-            "                return null;",
-            "             }",
-            "        };",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import com.google.common.base.Function;
+            import javax.annotation.Nullable;
+            class Test {
+                public static void testFunctionOverride() {
+                    Function<Object, Object> f = new Function<Object, Object>() {
+                        @Override
+                        public Object apply(Object input) {
+                            return input;
+                         }
+                    };
+                }
+                public static void testFunctionOverrideNullableReturn() {
+                    Function<Object, Object> f = new Function<Object, Object>() {
+                        @Override
+                        @Nullable
+                        // BUG: Diagnostic contains: method returns @Nullable, but superclass method
+                        public Object apply(Object input) {
+                            return null;
+                         }
+                    };
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -242,15 +256,17 @@ public class NullAwayGuavaParametricNullnessTests {
     jspecifyCompilationHelper
         .addSourceLines(
             "Test.java",
-            "import com.google.common.collect.Sets;",
-            "import java.util.Set;",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Test {",
-            "  public static void test(@Nullable String s) {",
-            "    Set<@Nullable String> params = Sets.newHashSet(s);",
-            "  }",
-            "}")
+            """
+            import com.google.common.collect.Sets;
+            import java.util.Set;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              public static void test(@Nullable String s) {
+                Set<@Nullable String> params = Sets.newHashSet(s);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
+++ b/jar-infer/nullaway-integration-test/src/test/java/com/uber/nullaway/jarinfer/JarInferIntegrationTest.java
@@ -32,15 +32,17 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1(@Nullable String s) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 's'",
-            "    Toys.test1(s, \"let's\", \"try\");",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1(@Nullable String s) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 's'
+                Toys.test1(s, "let's", "try");
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -56,15 +58,17 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1(Object @Nullable [] o) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'o'",
-            "    Toys.testArray(o);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1(Object @Nullable [] o) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'o'
+                Toys.testArray(o);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -80,19 +84,21 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1(Toys.Generic<String> g) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    g.getString(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.genericParam(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.nestedGenericParam(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1(Toys.Generic<String> g) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                g.getString(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.genericParam(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.nestedGenericParam(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -108,24 +114,26 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.genericWildcard(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.nestedGenericWildcard(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.genericWildcardUpper(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.genericWildcardLower(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys.doubleGenericWildcard(\"\", null);",
-            "    Toys.doubleGenericWildcardNullOk(\"\", null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.genericWildcard(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.nestedGenericWildcard(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.genericWildcardUpper(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.genericWildcardLower(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys.doubleGenericWildcard("", null);
+                Toys.doubleGenericWildcardNullOk("", null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -141,15 +149,17 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Toys t = new Toys(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Toys t = new Toys(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -165,15 +175,17 @@ public class JarInferIntegrationTest {
                 "-XepOpt:NullAway:JarInferEnabled=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import com.uber.nullaway.jarinfer.toys.unannotated.Toys;",
-            "class Test {",
-            "  void test1(@Nullable String s) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'Toys.getString(false, s)'",
-            "    Toys.test1(Toys.getString(false, s), \"let's\", \"try\");",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import com.uber.nullaway.jarinfer.toys.unannotated.Toys;
+            class Test {
+              void test1(@Nullable String s) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'Toys.getString(false, s)'
+                Toys.test1(Toys.getString(false, s), "let's", "try");
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -196,19 +208,23 @@ public class JarInferIntegrationTest {
         // modelled as having a @Nullable parameter
         .addSourceLines(
             "SpannableStringBuilder.java",
-            "package android.text;",
-            "public class SpannableStringBuilder {",
-            "  public SpannableStringBuilder append(CharSequence text) { return this; }",
-            "}")
+            """
+            package android.text;
+            public class SpannableStringBuilder {
+              public SpannableStringBuilder append(CharSequence text) { return this; }
+            }
+            """)
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "class Test {",
-            "  void test1(android.text.SpannableStringBuilder builder) {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    builder.append(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class Test {
+              void test1(android.text.SpannableStringBuilder builder) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                builder.append(null);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-annotations/astubx-generator/src/test/java/com/uber/nullaway/jdkannotations/AstubxTest.java
+++ b/jdk-annotations/astubx-generator/src/test/java/com/uber/nullaway/jdkannotations/AstubxTest.java
@@ -54,19 +54,21 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "AnnotationExample.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class AnnotationExample {",
-            "    @Nullable",
-            "    public String makeUpperCase(String inputString) {",
-            "        if (inputString == null || inputString.isEmpty()) {",
-            "            return null;",
-            "        } else {",
-            "            return inputString.toUpperCase();",
-            "        }",
-            "    }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class AnnotationExample {
+                @Nullable
+                public String makeUpperCase(String inputString) {
+                    if (inputString == null || inputString.isEmpty()) {
+                        return null;
+                    } else {
+                        return inputString.toUpperCase();
+                    }
+                }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -84,18 +86,20 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NullableUpperBound.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class NullableUpperBound<T extends @Nullable Object> {",
-            "        T nullableObject;",
-            "        public T getNullable() {",
-            "            return nullableObject;",
-            "        }",
-            "        public @Nullable T withAnnotation() {",
-            "            return nullableObject;",
-            "        }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class NullableUpperBound<T extends @Nullable Object> {
+                    T nullableObject;
+                    public T getNullable() {
+                        return nullableObject;
+                    }
+                    public @Nullable T withAnnotation() {
+                        return nullableObject;
+                    }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -116,20 +120,22 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "ReturnAnnotation.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class ReturnAnnotation {",
-            "  public static class UpperBoundExample<T extends @Nullable Object> {",
-            "    T nullableObject;",
-            "    public T getNullable() {",
-            "      return nullableObject;",
-            "    }",
-            "    public @Nullable T withAnnotation() {",
-            "        return nullableObject;",
-            "    }",
-            "  }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class ReturnAnnotation {
+              public static class UpperBoundExample<T extends @Nullable Object> {
+                T nullableObject;
+                public T getNullable() {
+                  return nullableObject;
+                }
+                public @Nullable T withAnnotation() {
+                    return nullableObject;
+                }
+              }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -150,11 +156,13 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NullMarkedClass.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "public class NullMarkedClass {",
-            "  public static class Nested {}",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            public class NullMarkedClass {
+              public static class Nested {}
+            }
+            """)
         .doTest();
     runTest(ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of("NullMarkedClass"));
   }
@@ -164,10 +172,12 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NotNullMarked.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "public class NotNullMarked {",
-            "  public static class Nested {}",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            public class NotNullMarked {
+              public static class Nested {}
+            }
+            """)
         .doTest();
     runTest(ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of());
   }
@@ -177,18 +187,20 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NullableParameters.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class NullableParameters{",
-            " public static Object getNewObjectIfNull(@Nullable Object object) {",
-            "   if (object == null) {",
-            "     return new Object();",
-            "   } else {",
-            "     return object;",
-            "   }",
-            " }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class NullableParameters{
+             public static Object getNewObjectIfNull(@Nullable Object object) {
+               if (object == null) {
+                 return new Object();
+               } else {
+                 return object;
+               }
+             }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -206,17 +218,19 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NullUnmarked.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "public class NullUnmarked{",
-            " public static Object getNewObjectIfNull(@Nullable Object object) {",
-            "   if (object == null) {",
-            "     return new Object();",
-            "   } else {",
-            "     return object;",
-            "   }",
-            " }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            public class NullUnmarked{
+             public static Object getNewObjectIfNull(@Nullable Object object) {
+               if (object == null) {
+                 return new Object();
+               } else {
+                 return object;
+               }
+             }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -234,19 +248,21 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "NullableParameters.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "import java.util.Arrays;",
-            "@NullMarked",
-            "public class NullableParameters{",
-            " public static Object[] getNewObjectArrayIfNull(Object @Nullable [] objectArray) {",
-            "   if (Arrays.stream(objectArray).allMatch(e -> e == null)) {",
-            "     return new Object[]{new Object(),new Object()};",
-            "   } else {",
-            "     return objectArray;",
-            "   }",
-            " }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            import java.util.Arrays;
+            @NullMarked
+            public class NullableParameters{
+             public static Object[] getNewObjectArrayIfNull(Object @Nullable [] objectArray) {
+               if (Arrays.stream(objectArray).allMatch(e -> e == null)) {
+                 return new Object[]{new Object(),new Object()};
+               } else {
+                 return objectArray;
+               }
+             }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -264,14 +280,16 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "ArrayParameters.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class ArrayParameters {",
-            "  public static void arrayNullable(String @Nullable [] arr) {}",
-            "  public static void elementsNullable(@Nullable String[] arr) {}",
-            "  public static void bothNullable(@Nullable String @Nullable [] arr) {}",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class ArrayParameters {
+              public static void arrayNullable(String @Nullable [] arr) {}
+              public static void elementsNullable(@Nullable String[] arr) {}
+              public static void bothNullable(@Nullable String @Nullable [] arr) {}
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -309,14 +327,16 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "Generic.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class Generic<T> {",
-            " public String getString(@Nullable T t) {",
-            "   return t.toString();",
-            " }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Generic<T> {
+             public String getString(@Nullable T t) {
+               return t.toString();
+             }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -334,22 +354,24 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "ParameterizedTypeArray.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "import java.util.List;",
-            "import java.util.ArrayList;",
-            "@NullMarked",
-            "public class ParameterizedTypeArray {",
-            "  public List<String>[] identity(List<String>[] listArray) {",
-            "    return listArray;",
-            "  }",
-            "  public List<@Nullable String>[] nullableIdentity(List<@Nullable String>[] listArray) {",
-            "    return listArray;",
-            "  }",
-            "  public List<? extends @Nullable String> wildcardIdentity(List<? super @Nullable String> listArray) {",
-            "    return null;",
-            "  }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            import java.util.List;
+            import java.util.ArrayList;
+            @NullMarked
+            public class ParameterizedTypeArray {
+              public List<String>[] identity(List<String>[] listArray) {
+                return listArray;
+              }
+              public List<@Nullable String>[] nullableIdentity(List<@Nullable String>[] listArray) {
+                return listArray;
+              }
+              public List<? extends @Nullable String> wildcardIdentity(List<? super @Nullable String> listArray) {
+                return null;
+              }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -397,17 +419,19 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "PrimitiveType.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class PrimitiveType {",
-            "    public int multiply(@Nullable Integer num1, @Nullable Integer num2) {",
-            "       if(num1!=null && num2!=null){",
-            "           return num1*num2;",
-            "       }",
-            "       return -1;",
-            "    }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class PrimitiveType {
+                public int multiply(@Nullable Integer num1, @Nullable Integer num2) {
+                   if(num1!=null && num2!=null){
+                       return num1*num2;
+                   }
+                   return -1;
+                }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -425,16 +449,18 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "VoidReturn.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "public class VoidReturn {",
-            "    public void printMultiply(@Nullable Integer num1, @Nullable Integer num2) {",
-            "       if(num1!=null && num2!=null){",
-            "           System.out.println(num1*num2);",
-            "       }",
-            "    }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class VoidReturn {
+                public void printMultiply(@Nullable Integer num1, @Nullable Integer num2) {
+                   if(num1!=null && num2!=null){
+                       System.out.println(num1*num2);
+                   }
+                }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -452,12 +478,14 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  <K, T extends @Nullable Object> void nullableTypeVar(K k, T t) {}",
-            "  <T> void nonNullTypeVar() {}",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              <K, T extends @Nullable Object> void nullableTypeVar(K k, T t) {}
+              <T> void nonNullTypeVar() {}
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -475,11 +503,13 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  public static int varargs(Object @Nullable ... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              public static int varargs(Object @Nullable ... args) { return 0; }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -497,11 +527,13 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  public static int varargs(@Nullable Object... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              public static int varargs(@Nullable Object... args) { return 0; }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(
@@ -523,11 +555,13 @@ public class AstubxTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Test {",
-            "  public static int varargs(@Nullable Object @Nullable ... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              public static int varargs(@Nullable Object @Nullable ... args) { return 0; }
+            }
+            """)
         .doTest();
     ImmutableMap<String, MethodAnnotationsRecord> expectedMethodRecords =
         ImmutableMap.of(

--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -31,22 +31,24 @@ public class JDKIntegrationTest {
                 "-XepOpt:NullAway:JarInferEnabled=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static ReturnAnnotation returnAnnotation = new ReturnAnnotation();",
-            "  static void test(String value){",
-            "  }",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'returnAnnotation.makeUpperCase(\"nullaway\")'",
-            "    test(returnAnnotation.makeUpperCase(\"nullaway\"));",
-            "  }",
-            "  static void testNegative() {",
-            "    // no error since nullReturn is annotated with javax.annotation.Nullable,",
-            "    // which is not considered when generating stubx files",
-            "    test(returnAnnotation.nullReturn());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static ReturnAnnotation returnAnnotation = new ReturnAnnotation();
+              static void test(String value){
+              }
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'returnAnnotation.makeUpperCase("nullaway")'
+                test(returnAnnotation.makeUpperCase("nullaway"));
+              }
+              static void testNegative() {
+                // no error since nullReturn is annotated with javax.annotation.Nullable,
+                // which is not considered when generating stubx files
+                test(returnAnnotation.nullReturn());
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -61,17 +63,19 @@ public class JDKIntegrationTest {
                 "-XepOpt:NullAway:JarInferEnabled=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static ReturnAnnotation returnAnnotation = new ReturnAnnotation();",
-            "  static void test(Integer[] value){",
-            "  }",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'returnAnnotation.generateIntArray(7)'",
-            "    test(returnAnnotation.generateIntArray(7));",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static ReturnAnnotation returnAnnotation = new ReturnAnnotation();
+              static void test(Integer[] value){
+              }
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'returnAnnotation.generateIntArray(7)'
+                test(returnAnnotation.generateIntArray(7));
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -85,17 +89,19 @@ public class JDKIntegrationTest {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static ReturnAnnotation returnAnnotation = new ReturnAnnotation();",
-            "  static void test(String value){",
-            "  }",
-            "  static void testNegative() {",
-            "    // Since the JarInferEnabled flag is not set, we don't get an error here",
-            "    test(returnAnnotation.makeUpperCase(\"nullaway\"));",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static ReturnAnnotation returnAnnotation = new ReturnAnnotation();
+              static void test(String value){
+              }
+              static void testNegative() {
+                // Since the JarInferEnabled flag is not set, we don't get an error here
+                test(returnAnnotation.makeUpperCase("nullaway"));
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -110,16 +116,18 @@ public class JDKIntegrationTest {
                 "-XepOpt:NullAway:JarInferEnabled=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static ReturnAnnotation.InnerExample innerExample = new ReturnAnnotation.InnerExample();",
-            "  static void test(String value){}",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'innerExample.returnNull()'",
-            "    test(innerExample.returnNull());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static ReturnAnnotation.InnerExample innerExample = new ReturnAnnotation.InnerExample();
+              static void test(String value){}
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'innerExample.returnNull()'
+                test(innerExample.returnNull());
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -135,18 +143,20 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static ReturnAnnotation.UpperBoundExample<@Nullable Object> upperBoundExample = new ReturnAnnotation.UpperBoundExample<@Nullable Object>();",
-            "  static void test(Object value){",
-            "  }",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'upperBoundExample.getNullable()'",
-            "    test(upperBoundExample.getNullable());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static ReturnAnnotation.UpperBoundExample<@Nullable Object> upperBoundExample = new ReturnAnnotation.UpperBoundExample<@Nullable Object>();
+              static void test(Object value){
+              }
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'upperBoundExample.getNullable()'
+                test(upperBoundExample.getNullable());
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -161,13 +171,15 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  // BUG: Diagnostic contains: Generic type parameter cannot be @Nullable",
-            "  static ReturnAnnotation.UpperBoundExample<@Nullable Object> upperBoundExample = new ReturnAnnotation.UpperBoundExample<@Nullable Object>();",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              // BUG: Diagnostic contains: Generic type parameter cannot be @Nullable
+              static ReturnAnnotation.UpperBoundExample<@Nullable Object> upperBoundExample = new ReturnAnnotation.UpperBoundExample<@Nullable Object>();
+            }
+            """)
         .doTest();
   }
 
@@ -183,15 +195,17 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static ParameterAnnotation parameterAnnotation = new ParameterAnnotation();",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    parameterAnnotation.add(5,null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static ParameterAnnotation parameterAnnotation = new ParameterAnnotation();
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                parameterAnnotation.add(5,null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -207,18 +221,20 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static ParameterAnnotation parameterAnnotation = new ParameterAnnotation();",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    parameterAnnotation.printObjectString(null);",
-            "  }",
-            "  static void testNegative() {",
-            "    parameterAnnotation.getNewObjectIfNull(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static ParameterAnnotation parameterAnnotation = new ParameterAnnotation();
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                parameterAnnotation.printObjectString(null);
+              }
+              static void testNegative() {
+                parameterAnnotation.getNewObjectIfNull(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -234,17 +250,19 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ParameterAnnotation.takesNonNullArray(null);",
-            "  }",
-            "  static void testNegative() {",
-            "    ParameterAnnotation.takesNullArray(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ParameterAnnotation.takesNonNullArray(null);
+              }
+              static void testNegative() {
+                ParameterAnnotation.takesNullArray(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -260,33 +278,35 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  String[] nonNullArray = new String[] {\"value\"};",
-            "  @Nullable String[] nullableElements = new String[] {\"value\", null};",
-            "  String @Nullable [] nullableArray = null;",
-            "  @Nullable String @Nullable [] nullableArrayAndElements = new String[] {\"value\", null};",
-            "  void testCall() {",
-            "    ParameterAnnotation.takesNullableArray(nonNullArray);",
-            "    ParameterAnnotation.takesNullableArray(nullableArray);",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    ParameterAnnotation.takesNullableArray(nullableElements);",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    ParameterAnnotation.takesNullableArray(nullableArrayAndElements);",
-            "    ParameterAnnotation.takesNullableElements(nonNullArray);",
-            "    ParameterAnnotation.takesNullableElements(nullableElements);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'nullableArray' where @NonNull is required",
-            "    ParameterAnnotation.takesNullableElements(nullableArray);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'nullableArrayAndElements' where @NonNull is required",
-            "    ParameterAnnotation.takesNullableElements(nullableArrayAndElements);",
-            "    ParameterAnnotation.takesNullableArrayAndElements(nonNullArray);",
-            "    ParameterAnnotation.takesNullableArrayAndElements(nullableElements);",
-            "    ParameterAnnotation.takesNullableArrayAndElements(nullableArray);",
-            "    ParameterAnnotation.takesNullableArrayAndElements(nullableArrayAndElements);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              String[] nonNullArray = new String[] {"value"};
+              @Nullable String[] nullableElements = new String[] {"value", null};
+              String @Nullable [] nullableArray = null;
+              @Nullable String @Nullable [] nullableArrayAndElements = new String[] {"value", null};
+              void testCall() {
+                ParameterAnnotation.takesNullableArray(nonNullArray);
+                ParameterAnnotation.takesNullableArray(nullableArray);
+                // BUG: Diagnostic contains: incompatible types
+                ParameterAnnotation.takesNullableArray(nullableElements);
+                // BUG: Diagnostic contains: incompatible types
+                ParameterAnnotation.takesNullableArray(nullableArrayAndElements);
+                ParameterAnnotation.takesNullableElements(nonNullArray);
+                ParameterAnnotation.takesNullableElements(nullableElements);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'nullableArray' where @NonNull is required
+                ParameterAnnotation.takesNullableElements(nullableArray);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'nullableArrayAndElements' where @NonNull is required
+                ParameterAnnotation.takesNullableElements(nullableArrayAndElements);
+                ParameterAnnotation.takesNullableArrayAndElements(nonNullArray);
+                ParameterAnnotation.takesNullableArrayAndElements(nullableElements);
+                ParameterAnnotation.takesNullableArrayAndElements(nullableArray);
+                ParameterAnnotation.takesNullableArrayAndElements(nullableArrayAndElements);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -302,20 +322,22 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ParameterAnnotation.takesNonNullGenericArray(null);",
-            "    // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericArray()",
-            "    ReturnAnnotation.returnNullableGenericArray().hashCode();",
-            "  }",
-            "  static void testNegative() {",
-            "    ParameterAnnotation.takesNullGenericArray(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ParameterAnnotation.takesNonNullGenericArray(null);
+                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericArray()
+                ReturnAnnotation.returnNullableGenericArray().hashCode();
+              }
+              static void testNegative() {
+                ParameterAnnotation.takesNullGenericArray(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -331,17 +353,19 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "class Test {",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericContainingNullable()",
-            "    ReturnAnnotation.returnNullableGenericContainingNullable().hashCode();",
-            "  }",
-            "  static void testNegative() {",
-            "    ReturnAnnotation.returnNonNullGenericContainingNullable().hashCode();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            class Test {
+              static void testPositive() {
+                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericContainingNullable()
+                ReturnAnnotation.returnNullableGenericContainingNullable().hashCode();
+              }
+              static void testNegative() {
+                ReturnAnnotation.returnNonNullGenericContainingNullable().hashCode();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -357,18 +381,20 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static ParameterAnnotation.Generic<String> ex = new ParameterAnnotation.Generic<>();",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ex.printObjectString(null);",
-            "  }",
-            "  static void testNegative() {",
-            "    ex.getString(null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static ParameterAnnotation.Generic<String> ex = new ParameterAnnotation.Generic<>();
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ex.printObjectString(null);
+              }
+              static void testNegative() {
+                ex.getString(null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -384,18 +410,20 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter '(Object) null' where @NonNull is required",
-            "    ParameterAnnotation.varargsArrayNullable((Object) null);",
-            "  }",
-            "  static void testNegative() {",
-            "    Object[] args = null;",
-            "    ParameterAnnotation.varargsArrayNullable(args);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter '(Object) null' where @NonNull is required
+                ParameterAnnotation.varargsArrayNullable((Object) null);
+              }
+              static void testNegative() {
+                Object[] args = null;
+                ParameterAnnotation.varargsArrayNullable(args);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -411,18 +439,20 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static void testPositive() {",
-            "    Object[] args = null;",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'args' where @NonNull is required",
-            "    ParameterAnnotation.varargsElementsNullable(args);",
-            "  }",
-            "  static void testNegative() {",
-            "    ParameterAnnotation.varargsElementsNullable(null, null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static void testPositive() {
+                Object[] args = null;
+                // BUG: Diagnostic contains: passing @Nullable parameter 'args' where @NonNull is required
+                ParameterAnnotation.varargsElementsNullable(args);
+              }
+              static void testNegative() {
+                ParameterAnnotation.varargsElementsNullable(null, null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -438,15 +468,17 @@ public class JDKIntegrationTest {
                     "-XepOpt:NullAway:JarInferEnabled=true")))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "class Test {",
-            "  static void testNegative() {",
-            "    ParameterAnnotation.varargs(null, null);",
-            "    Object[] args = null;",
-            "    ParameterAnnotation.varargs(args);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            class Test {
+              static void testNegative() {
+                ParameterAnnotation.varargs(null, null);
+                Object[] args = null;
+                ParameterAnnotation.varargs(args);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -461,16 +493,18 @@ public class JDKIntegrationTest {
                 "-XepOpt:NullAway:JarInferEnabled=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "import java.util.List;",
-            "class Test<T> {",
-            "  void testCall() {",
-            "    // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.getList(6, null) is @Nullable",
-            "    ReturnAnnotation.getList(6, null).isEmpty();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            import java.util.List;
+            class Test<T> {
+              void testCall() {
+                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.getList(6, null) is @Nullable
+                ReturnAnnotation.getList(6, null).isEmpty();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -487,25 +521,27 @@ public class JDKIntegrationTest {
                 "-XDaddTypeAnnotationsToSymbol=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "import java.util.List;",
-            "class Test {",
-            "  void testCall() {",
-            "    // BUG: Diagnostic contains: dereferenced expression ParameterAnnotation.nullableTypeParam(1, null) is @Nullable",
-            "    ParameterAnnotation.nullableTypeParam(1, null).toString();",
-            "    ParameterAnnotation.nullableTypeParam(1, \"string\").toString();",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ParameterAnnotation.nullableTypeParam(null, \"string\");",
-            "    ParameterAnnotation.nonNullTypeParam(1);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required",
-            "    ParameterAnnotation.nonNullTypeParam(null);",
-            "    Object x = ParameterAnnotation.twoNullableTypeParam(null, \"string\");",
-            "    // BUG: Diagnostic contains: dereferenced expression x is @Nullable",
-            "    x.toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            import java.util.List;
+            class Test {
+              void testCall() {
+                // BUG: Diagnostic contains: dereferenced expression ParameterAnnotation.nullableTypeParam(1, null) is @Nullable
+                ParameterAnnotation.nullableTypeParam(1, null).toString();
+                ParameterAnnotation.nullableTypeParam(1, "string").toString();
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ParameterAnnotation.nullableTypeParam(null, "string");
+                ParameterAnnotation.nonNullTypeParam(1);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                ParameterAnnotation.nonNullTypeParam(null);
+                Object x = ParameterAnnotation.twoNullableTypeParam(null, "string");
+                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                x.toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -522,32 +558,34 @@ public class JDKIntegrationTest {
                 "-XDaddTypeAnnotationsToSymbol=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ReturnAnnotation;",
-            "import java.util.*;",
-            "class Test {",
-            "  void testCall() {",
-            "    // -- Type argument nullability",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    List<String> typeArg1 = ReturnAnnotation.nestedAnnotTypeArg();",
-            "    List<@Nullable String> typeArg2 = ReturnAnnotation.nestedAnnotTypeArg();",
-            "    // -- Array Element nullability",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    String[] arrayElement1 = ReturnAnnotation.nestedAnnotArrayElement();",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    String @Nullable [] arrayElement2 = ReturnAnnotation.nestedAnnotArrayElement();",
-            "    @Nullable String [] arrayElement3 = ReturnAnnotation.nestedAnnotArrayElement();",
-            "    // -- mixed type nullability",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    List<Integer>[] mixed1 = ReturnAnnotation.nestedAnnotMixed();",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    @Nullable List<Integer>[] mixed2 = ReturnAnnotation.nestedAnnotMixed();",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    List<@Nullable Integer>[] mixed3 = ReturnAnnotation.nestedAnnotMixed();",
-            "    @Nullable List<@Nullable Integer>[] mixed4 = ReturnAnnotation.nestedAnnotMixed();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ReturnAnnotation;
+            import java.util.*;
+            class Test {
+              void testCall() {
+                // -- Type argument nullability
+                // BUG: Diagnostic contains: incompatible types
+                List<String> typeArg1 = ReturnAnnotation.nestedAnnotTypeArg();
+                List<@Nullable String> typeArg2 = ReturnAnnotation.nestedAnnotTypeArg();
+                // -- Array Element nullability
+                // BUG: Diagnostic contains: incompatible types
+                String[] arrayElement1 = ReturnAnnotation.nestedAnnotArrayElement();
+                // BUG: Diagnostic contains: incompatible types
+                String @Nullable [] arrayElement2 = ReturnAnnotation.nestedAnnotArrayElement();
+                @Nullable String [] arrayElement3 = ReturnAnnotation.nestedAnnotArrayElement();
+                // -- mixed type nullability
+                // BUG: Diagnostic contains: incompatible types
+                List<Integer>[] mixed1 = ReturnAnnotation.nestedAnnotMixed();
+                // BUG: Diagnostic contains: incompatible types
+                @Nullable List<Integer>[] mixed2 = ReturnAnnotation.nestedAnnotMixed();
+                // BUG: Diagnostic contains: incompatible types
+                List<@Nullable Integer>[] mixed3 = ReturnAnnotation.nestedAnnotMixed();
+                @Nullable List<@Nullable Integer>[] mixed4 = ReturnAnnotation.nestedAnnotMixed();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -564,39 +602,41 @@ public class JDKIntegrationTest {
                 "-XDaddTypeAnnotationsToSymbol=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "import com.uber.nullaway.jdkannotations.ParameterAnnotation;",
-            "import java.util.*;",
-            "class Test {",
-            "  void testCall() {",
-            "    // -- Type argument",
-            "    List<@Nullable String> nullableTypeArg = new ArrayList<>();",
-            "    nullableTypeArg.add(\"string\");",
-            "    nullableTypeArg.add(null);",
-            "    List<String> nonNullTypeArg = new ArrayList<>(2);",
-            "    // -- Array type",
-            "    @Nullable String[] nullableArray = new String[] {\"populated\", \"value\", null};",
-            "    String[] nonNullArray = new String[] {\"populated\", \"value\"};",
-            "    // -- Multiple nested annotations",
-            "    List<@Nullable Integer> innerList = new ArrayList<>();",
-            "    innerList.add(null);",
-            "    innerList.add(4);",
-            "    @Nullable List<@Nullable Integer>[] nullableMixed = (@Nullable List<@Nullable Integer>[]) new List<?>[3];",
-            "    nullableMixed[0] = innerList;",
-            "    nullableMixed[0] = null;",
-            "    List<@Nullable Integer>[] nonNullArrayMixed = (List<@Nullable Integer>[]) new List<?>[3];",
-            "    @Nullable List<Integer>[] nonNullTypeArgMixed = (@Nullable List<Integer>[]) new List<?>[3];",
-            "    // === test calls",
-            "    ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nullableMixed);",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    ParameterAnnotation.nestedAnnotations(nonNullTypeArg, nullableArray, nullableMixed);",
-            "    ParameterAnnotation.nestedAnnotations(nullableTypeArg, nonNullArray, nullableMixed);",
-            "    ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nonNullArrayMixed);",
-            "    // BUG: Diagnostic contains: incompatible types",
-            "    ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nonNullTypeArgMixed);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import com.uber.nullaway.jdkannotations.ParameterAnnotation;
+            import java.util.*;
+            class Test {
+              void testCall() {
+                // -- Type argument
+                List<@Nullable String> nullableTypeArg = new ArrayList<>();
+                nullableTypeArg.add("string");
+                nullableTypeArg.add(null);
+                List<String> nonNullTypeArg = new ArrayList<>(2);
+                // -- Array type
+                @Nullable String[] nullableArray = new String[] {"populated", "value", null};
+                String[] nonNullArray = new String[] {"populated", "value"};
+                // -- Multiple nested annotations
+                List<@Nullable Integer> innerList = new ArrayList<>();
+                innerList.add(null);
+                innerList.add(4);
+                @Nullable List<@Nullable Integer>[] nullableMixed = (@Nullable List<@Nullable Integer>[]) new List<?>[3];
+                nullableMixed[0] = innerList;
+                nullableMixed[0] = null;
+                List<@Nullable Integer>[] nonNullArrayMixed = (List<@Nullable Integer>[]) new List<?>[3];
+                @Nullable List<Integer>[] nonNullTypeArgMixed = (@Nullable List<Integer>[]) new List<?>[3];
+                // === test calls
+                ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nullableMixed);
+                // BUG: Diagnostic contains: incompatible types
+                ParameterAnnotation.nestedAnnotations(nonNullTypeArg, nullableArray, nullableMixed);
+                ParameterAnnotation.nestedAnnotations(nullableTypeArg, nonNullArray, nullableMixed);
+                ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nonNullArrayMixed);
+                // BUG: Diagnostic contains: incompatible types
+                ParameterAnnotation.nestedAnnotations(nullableTypeArg, nullableArray, nonNullTypeArgMixed);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-javac-plugin/src/test/java/com/uber/nullaway/javacplugin/NullnessAnnotationSerializerTest.java
+++ b/jdk-javac-plugin/src/test/java/com/uber/nullaway/javacplugin/NullnessAnnotationSerializerTest.java
@@ -69,9 +69,11 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "class Foo {}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Foo {}
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -86,18 +88,22 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "module-info.java",
-            "module com.example {",
-            "    requires java.base;",
-            "    requires org.jspecify;",
-            "}")
+            """
+            module com.example {
+                requires java.base;
+                requires org.jspecify;
+            }
+            """)
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "class Foo {",
-            "  public @Nullable String NullableReturn(@Nullable Integer i) { return null;}",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Foo {
+              public @Nullable String NullableReturn(@Nullable Integer i) { return null;}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -126,13 +132,15 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
-            "class Foo {",
-            "  void publicMethod(@Nullable String s) {}",
-            "  private void privateMethod(@Nullable String s) {}",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Foo {
+              void publicMethod(@Nullable String s) {}
+              private void privateMethod(@Nullable String s) {}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -161,16 +169,18 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Foo {",
-            "  @NullUnmarked",
-            "  class Inner { }",
-            "  private class PrivateInner<T extends @Nullable Object> { }",
-            "  void method() {",
-            "    Runnable r = new Runnable() { public void run() {} };",
-            "  }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Foo {
+              @NullUnmarked
+              class Inner { }
+              private class PrivateInner<T extends @Nullable Object> { }
+              void method() {
+                Runnable r = new Runnable() { public void run() {} };
+              }
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -187,11 +197,13 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Foo<T extends @Nullable Object> {",
-            "  public <U extends @Nullable Object> U make(U u) { throw new RuntimeException(); }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Foo<T extends @Nullable Object> {
+              public <U extends @Nullable Object> U make(U u) { throw new RuntimeException(); }
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -220,11 +232,13 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Foo {",
-            "  public static int hash(Object @Nullable ... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Foo {
+              public static int hash(Object @Nullable ... args) { return 0; }
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -253,11 +267,13 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Foo {",
-            "  public static int hash(@Nullable Object... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Foo {
+              public static int hash(@Nullable Object... args) { return 0; }
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -293,11 +309,13 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Foo {",
-            "  public static int hash(@Nullable Object @Nullable... args) { return 0; }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Foo {
+              public static int hash(@Nullable Object @Nullable... args) { return 0; }
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -333,13 +351,15 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class Foo {",
-            "  public static void arrayNullable(String @Nullable [] arr) {}",
-            "  public static void elementsNullable(@Nullable String[] arr) {}",
-            "  public static void bothNullable(@Nullable String @Nullable [] arr) {}",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Foo {
+              public static void arrayNullable(String @Nullable [] arr) {}
+              public static void elementsNullable(@Nullable String[] arr) {}
+              public static void bothNullable(@Nullable String @Nullable [] arr) {}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -396,15 +416,17 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Foo {",
-            "  class NoAnnotation { void noAnnotMethod() {} }",
-            "  class Inner {",
-            "    void annotatedMethod(@Nullable String s) {}",
-            "  }",
-            "  class AnnotatedGeneric<T extends @Nullable Object> {}",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Foo {
+              class NoAnnotation { void noAnnotMethod() {} }
+              class Inner {
+                void annotatedMethod(@Nullable String s) {}
+              }
+              class AnnotatedGeneric<T extends @Nullable Object> {}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -441,14 +463,16 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "class Foo {",
-            "  void noAnnotation() {}",
-            "  <T extends @Nullable Object> void annotatedTypeArgument() {}",
-            "  @Nullable String annotatedReturnType() { throw new RuntimeException(); }",
-            "  void annotatedParameter(@Nullable String s) {}",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Foo {
+              void noAnnotation() {}
+              <T extends @Nullable Object> void annotatedTypeArgument() {}
+              @Nullable String annotatedReturnType() { throw new RuntimeException(); }
+              void annotatedParameter(@Nullable String s) {}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -491,17 +515,19 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "import java.util.List;",
-            "@NullMarked",
-            "public class Foo {",
-            "  interface Bar {}",
-            "  public void arrayType(String @Nullable [] arr) {}",
-            "  public void wildcard(List<? super @Nullable Integer> list) {}",
-            "  public <U extends @Nullable Object> void typeVariable(U u) {}",
-            "  public <T extends @Nullable String & Bar> void intersection(T t) {}",
-            "  public <T> void nullableOnTypeVar(List<@Nullable T> list) {}",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            import java.util.List;
+            @NullMarked
+            public class Foo {
+              interface Bar {}
+              public void arrayType(String @Nullable [] arr) {}
+              public void wildcard(List<? super @Nullable Integer> list) {}
+              public <U extends @Nullable Object> void typeVariable(U u) {}
+              public <T extends @Nullable String & Bar> void intersection(T t) {}
+              public <T> void nullableOnTypeVar(List<@Nullable T> list) {}
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)
@@ -574,16 +600,18 @@ public class NullnessAnnotationSerializerTest {
     compilationTestHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.annotations.*;",
-            "import java.util.*;",
-            "@NullMarked",
-            "public abstract class Foo {",
-            "  public abstract <E extends @Nullable Object> Collection<E> checkedCollection(Collection<E> c, Class<@NonNull E> type);",
-            "  public abstract List<@Nullable String> nestedReturnType();",
-            "  public abstract void nestedParameterType(@Nullable String [] arr, List<@NonNull String>[] s);",
-            "  public abstract List<? extends @Nullable String> wildcardUpperBound();",
-            "  public abstract List<List<String @Nullable []>> nestedArrayType();",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            import java.util.*;
+            @NullMarked
+            public abstract class Foo {
+              public abstract <E extends @Nullable Object> Collection<E> checkedCollection(Collection<E> c, Class<@NonNull E> type);
+              public abstract List<@Nullable String> nestedReturnType();
+              public abstract void nestedParameterType(@Nullable String [] arr, List<@NonNull String>[] s);
+              public abstract List<? extends @Nullable String> wildcardUpperBound();
+              public abstract List<List<String @Nullable []>> nestedArrayType();
+            }
+            """)
         .doTest();
     Map<String, List<ClassInfo>> moduleClasses = getParsedJSON();
     assertThat(moduleClasses)

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
@@ -30,18 +30,20 @@ public class InstanceOfBindingTests {
     defaultCompilationHelper
         .addSourceLines(
             "InstanceOfBinding.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class InstanceOfBinding {",
-            "  public void testInstanceOfBinding(@Nullable Object o) {",
-            "    if (o instanceof String s) {",
-            "      s.toString();",
-            "      o.toString();",
-            "    }",
-            "    // BUG: Diagnostic contains: dereferenced expression o",
-            "    o.toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class InstanceOfBinding {
+              public void testInstanceOfBinding(@Nullable Object o) {
+                if (o instanceof String s) {
+                  s.toString();
+                  o.toString();
+                }
+                // BUG: Diagnostic contains: dereferenced expression o
+                o.toString();
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
@@ -35,13 +35,15 @@ public class ModuleInfoTests {
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",
-            "@SuppressWarnings(\"some-warning-name\")",
-            "module com.uber.mymodule {",
-            "  // Important: two-level deep module tests matching of identifier `java` as base expression;",
-            "  // see further discussion at https://github.com/uber/NullAway/pull/544#discussion_r780829467",
-            "  requires java.base;",
-            "  requires static org.checkerframework.checker.qual;",
-            "}")
+            """
+            @SuppressWarnings("some-warning-name")
+            module com.uber.mymodule {
+              // Important: two-level deep module tests matching of identifier `java` as base expression;
+              // see further discussion at https://github.com/uber/NullAway/pull/544#discussion_r780829467
+              requires java.base;
+              requires static org.checkerframework.checker.qual;
+            }
+            """)
         .doTest();
   }
 
@@ -50,23 +52,27 @@ public class ModuleInfoTests {
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "module com.example.myapp {",
-            "    exports com.example.myapp;",
-            "    requires java.base;",
-            "    requires org.jspecify;",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            module com.example.myapp {
+                exports com.example.myapp;
+                requires java.base;
+                requires org.jspecify;
+            }
+            """)
         .addSourceLines(
             "com/example/myapp/Test.java",
-            "package com.example.myapp;",
-            "public class Test {",
-            "  public static void main(String[] args) {",
-            "    String s = null;",
-            "    // BUG: Diagnostic contains: dereferenced expression s is @Nullable",
-            "    s.hashCode();",
-            "  }",
-            "}")
+            """
+            package com.example.myapp;
+            public class Test {
+              public static void main(String[] args) {
+                String s = null;
+                // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                s.hashCode();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -75,27 +81,33 @@ public class ModuleInfoTests {
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "module com.example.myapp {",
-            "    exports com.example.myapp;",
-            "    requires java.base;",
-            "    requires org.jspecify;",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            module com.example.myapp {
+                exports com.example.myapp;
+                requires java.base;
+                requires org.jspecify;
+            }
+            """)
         .addSourceLines(
             "com/example/myapp/package-info.java",
-            "@NullUnmarked package com.example.myapp;",
-            "import org.jspecify.annotations.NullUnmarked;")
+            """
+            @NullUnmarked package com.example.myapp;
+            import org.jspecify.annotations.NullUnmarked;
+            """)
         .addSourceLines(
             "com/example/myapp/Test.java",
-            "package com.example.myapp;",
-            "public class Test {",
-            "  public static void main(String[] args) {",
-            "    String s = null;",
-            "    // no error since @NullUnmarked is in effect",
-            "    s.hashCode();",
-            "  }",
-            "}")
+            """
+            package com.example.myapp;
+            public class Test {
+              public static void main(String[] args) {
+                String s = null;
+                // no error since @NullUnmarked is in effect
+                s.hashCode();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -104,28 +116,32 @@ public class ModuleInfoTests {
     defaultCompilationHelper
         .addSourceLines(
             "module-info.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "module com.example.myapp {",
-            "    requires java.base;",
-            "    requires org.jspecify;",
-            "    requires com.uber.test.java.module;",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            module com.example.myapp {
+                requires java.base;
+                requires org.jspecify;
+                requires com.uber.test.java.module;
+            }
+            """)
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.NullMarked;",
-            "import com.example.nullmarked.NullMarkedFromModule;",
-            "import com.example.nullunmarked.NullUnmarkedFromPackage;",
-            "@NullMarked",
-            "class Test {",
-            "  void testPositive() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter",
-            "    NullMarkedFromModule.takesNonNull(null);",
-            "  }",
-            "  void testNegative() {",
-            "    NullUnmarkedFromPackage.takesAny(null);",
-            "  }",
-            "}")
+            """
+            import org.jspecify.annotations.NullMarked;
+            import com.example.nullmarked.NullMarkedFromModule;
+            import com.example.nullunmarked.NullUnmarkedFromPackage;
+            @NullMarked
+            class Test {
+              void testPositive() {
+                // BUG: Diagnostic contains: passing @Nullable parameter
+                NullMarkedFromModule.takesNonNull(null);
+              }
+              void testNegative() {
+                NullUnmarkedFromPackage.takesAny(null);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/OptionalEmptyTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/OptionalEmptyTests.java
@@ -33,36 +33,38 @@ public class OptionalEmptyTests {
     compilationTestHelper
         .addSourceLines(
             "TestNegative.java",
-            "package com.uber;",
-            "import java.util.Optional;",
-            "import javax.annotation.Nullable;",
-            "import com.google.common.base.Function;",
-            "public class TestNegative {",
-            "  void foo() {",
-            "    Optional<Object> a = Optional.empty();",
-            "      // no error since a.isEmpty() is called",
-            "      if(!a.isEmpty()){",
-            "         a.get().toString();",
-            "       }",
-            "    }",
-            "  void foo2() {",
-            "    Optional<Object> a = Optional.empty();",
-            "      // no error since a.isEmpty() is called",
-            "      if(a.isEmpty()){",
-            "      } else {",
-            "         a.get().toString();",
-            "       }",
-            "    }",
-            "   public void lambdaConsumer(Function a){",
-            "        return;",
-            "   }",
-            "  void bar() {",
-            "     Optional<Object> b = Optional.empty();",
-            "      if(!b.isEmpty()){",
-            "          lambdaConsumer(v -> b.get().toString());",
-            "       }",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import java.util.Optional;
+            import javax.annotation.Nullable;
+            import com.google.common.base.Function;
+            public class TestNegative {
+              void foo() {
+                Optional<Object> a = Optional.empty();
+                  // no error since a.isEmpty() is called
+                  if(!a.isEmpty()){
+                     a.get().toString();
+                   }
+                }
+              void foo2() {
+                Optional<Object> a = Optional.empty();
+                  // no error since a.isEmpty() is called
+                  if(a.isEmpty()){
+                  } else {
+                     a.get().toString();
+                   }
+                }
+               public void lambdaConsumer(Function a){
+                    return;
+               }
+              void bar() {
+                 Optional<Object> b = Optional.empty();
+                  if(!b.isEmpty()){
+                      lambdaConsumer(v -> b.get().toString());
+                   }
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -71,29 +73,31 @@ public class OptionalEmptyTests {
     compilationTestHelper
         .addSourceLines(
             "TestPositive.java",
-            "package com.uber;",
-            "import java.util.Optional;",
-            "import javax.annotation.Nullable;",
-            "import com.google.common.base.Function;",
-            "public class TestPositive {",
-            "  void foo() {",
-            "    Optional<Object> a = Optional.empty();",
-            "    if (a.isEmpty()) {",
-            "      // BUG: Diagnostic contains: Invoking get() on possibly empty Optional a",
-            "      a.get().toString();",
-            "    }",
-            "  }",
-            "   public void lambdaConsumer(Function a){",
-            "        return;",
-            "   }",
-            "  void bar() {",
-            "     Optional<Object> b = Optional.empty();",
-            "     if (b.isEmpty()) {",
-            "       // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b",
-            "       lambdaConsumer(v -> b.get().toString());",
-            "     }",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import java.util.Optional;
+            import javax.annotation.Nullable;
+            import com.google.common.base.Function;
+            public class TestPositive {
+              void foo() {
+                Optional<Object> a = Optional.empty();
+                if (a.isEmpty()) {
+                  // BUG: Diagnostic contains: Invoking get() on possibly empty Optional a
+                  a.get().toString();
+                }
+              }
+               public void lambdaConsumer(Function a){
+                    return;
+               }
+              void bar() {
+                 Optional<Object> b = Optional.empty();
+                 if (b.isEmpty()) {
+                   // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b
+                   lambdaConsumer(v -> b.get().toString());
+                 }
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -108,20 +112,22 @@ public class OptionalEmptyTests {
                 "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import java.util.Optional;",
-            "import com.google.common.truth.Truth;",
-            "",
-            "public class Test {",
-            "  void truthAssertThatIsEmptyIsFalse() {",
-            "    Optional<Object> b = Optional.empty();",
-            "    Truth.assertThat(b.isEmpty()).isTrue();  // no impact",
-            "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b",
-            "    b.get().toString();",
-            "    Truth.assertThat(b.isEmpty()).isFalse();",
-            "    b.get().toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import java.util.Optional;
+            import com.google.common.truth.Truth;
+
+            public class Test {
+              void truthAssertThatIsEmptyIsFalse() {
+                Optional<Object> b = Optional.empty();
+                Truth.assertThat(b.isEmpty()).isTrue();  // no impact
+                // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b
+                b.get().toString();
+                Truth.assertThat(b.isEmpty()).isFalse();
+                b.get().toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -136,20 +142,22 @@ public class OptionalEmptyTests {
                 "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import java.util.Optional;",
-            "import org.assertj.core.api.Assertions;",
-            "",
-            "public class Test {",
-            "  void assertJAssertThatIsEmptyIsFalse() {",
-            "    Optional<Object> b = Optional.empty();",
-            "    Assertions.assertThat(b.isEmpty()).isTrue();  // no impact",
-            "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b",
-            "    b.get().toString();",
-            "    Assertions.assertThat(b.isEmpty()).isFalse();",
-            "    b.get().toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import java.util.Optional;
+            import org.assertj.core.api.Assertions;
+
+            public class Test {
+              void assertJAssertThatIsEmptyIsFalse() {
+                Optional<Object> b = Optional.empty();
+                Assertions.assertThat(b.isEmpty()).isTrue();  // no impact
+                // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b
+                b.get().toString();
+                Assertions.assertThat(b.isEmpty()).isFalse();
+                b.get().toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -164,30 +172,32 @@ public class OptionalEmptyTests {
                 "-XepOpt:NullAway:HandleTestAssertionLibraries=true"))
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import java.util.Optional;",
-            "import org.junit.Assert;",
-            "import org.junit.jupiter.api.Assertions;",
-            "",
-            "public class Test {",
-            "  void junit4AssertFalseIsEmpty() {",
-            "    Optional<Object> b = Optional.empty();",
-            "    Assert.assertTrue(b.isEmpty());  // no impact",
-            "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b",
-            "    b.get().toString();",
-            "    Assert.assertFalse(\"errormsg\", b.isEmpty());",
-            "    b.get().toString();",
-            "  }",
-            "",
-            "  void junit5AssertFalseIsEmpty() {",
-            "    Optional<Object> d = Optional.empty();",
-            "    Assertions.assertTrue(d.isEmpty());  // no impact",
-            "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional d",
-            "    d.get().toString();",
-            "    Assertions.assertFalse(d.isEmpty(), \"errormsg\");",
-            "    d.get().toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import java.util.Optional;
+            import org.junit.Assert;
+            import org.junit.jupiter.api.Assertions;
+
+            public class Test {
+              void junit4AssertFalseIsEmpty() {
+                Optional<Object> b = Optional.empty();
+                Assert.assertTrue(b.isEmpty());  // no impact
+                // BUG: Diagnostic contains: Invoking get() on possibly empty Optional b
+                b.get().toString();
+                Assert.assertFalse("errormsg", b.isEmpty());
+                b.get().toString();
+              }
+
+              void junit5AssertFalseIsEmpty() {
+                Optional<Object> d = Optional.empty();
+                Assertions.assertTrue(d.isEmpty());  // no impact
+                // BUG: Diagnostic contains: Invoking get() on possibly empty Optional d
+                d.get().toString();
+                Assertions.assertFalse(d.isEmpty(), "errormsg");
+                d.get().toString();
+              }
+            }
+            """)
         .doTest();
   }
 

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
@@ -30,16 +30,18 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) { }",
-            "  public void testRecordConstructors() {",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Rec rec1 = new Rec(null, null);",
-            "    Rec rec2 = new Rec(new Object(), null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) { }
+              public void testRecordConstructors() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Rec rec1 = new Rec(null, null);
+                Rec rec2 = new Rec(new Object(), null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -48,17 +50,19 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) { }",
-            "  public void testRecordConstructors() {",
-            "    Rec rec = new Rec(new Object(), null);",
-            "    rec.first().toString();",
-            "    // BUG: Diagnostic contains: dereferenced expression rec.second()",
-            "    rec.second().toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) { }
+              public void testRecordConstructors() {
+                Rec rec = new Rec(new Object(), null);
+                rec.first().toString();
+                // BUG: Diagnostic contains: dereferenced expression rec.second()
+                rec.second().toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -67,24 +71,26 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) {",
-            "    Object m1() {",
-            "      // BUG: Diagnostic contains: returning @Nullable expression from method",
-            "      return second();",
-            "    }",
-            "    Object m2() {",
-            "      return first();",
-            "    }",
-            "    void derefs() {",
-            "      first().toString();",
-            "      // BUG: Diagnostic contains: dereferenced expression second()",
-            "      second().toString();",
-            "    }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) {
+                Object m1() {
+                  // BUG: Diagnostic contains: returning @Nullable expression from method
+                  return second();
+                }
+                Object m2() {
+                  return first();
+                }
+                void derefs() {
+                  first().toString();
+                  // BUG: Diagnostic contains: dereferenced expression second()
+                  second().toString();
+                }
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -93,24 +99,26 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) {",
-            "    Object m1() {",
-            "      // BUG: Diagnostic contains: returning @Nullable expression from method",
-            "      return second;",
-            "    }",
-            "    Object m2() {",
-            "      return first;",
-            "    }",
-            "    void derefs() {",
-            "      first.toString();",
-            "      // BUG: Diagnostic contains: dereferenced expression second",
-            "      second.toString();",
-            "    }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) {
+                Object m1() {
+                  // BUG: Diagnostic contains: returning @Nullable expression from method
+                  return second;
+                }
+                Object m2() {
+                  return first;
+                }
+                void derefs() {
+                  first.toString();
+                  // BUG: Diagnostic contains: dereferenced expression second
+                  second.toString();
+                }
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -119,17 +127,19 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) {",
-            "    Rec {",
-            "      first.toString();",
-            "      // BUG: Diagnostic contains: dereferenced expression second",
-            "      second.toString();",
-            "    }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) {
+                Rec {
+                  first.toString();
+                  // BUG: Diagnostic contains: dereferenced expression second
+                  second.toString();
+                }
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -138,26 +148,28 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  interface I1 { Object m1(); }",
-            "  interface I2 { void m2(@Nullable Object x); }",
-            "  record Rec1(Object first, @Nullable Object second) implements I1 {",
-            "    // BUG: Diagnostic contains: method returns @Nullable, but superclass method",
-            "    @Nullable public Object m1() { return second(); }",
-            "  }",
-            "  record Rec2(Object first, @Nullable Object second) implements I1 {",
-            "    public Object m1() { return first(); }",
-            "  }",
-            "  record Rec3(Object first, @Nullable Object second) implements I2 {",
-            "    // BUG: Diagnostic contains: parameter x is @NonNull, but parameter in superclass",
-            "    public void m2(Object x) { x.toString(); }",
-            "  }",
-            "  record Rec4(Object first, @Nullable Object second) implements I2 {",
-            "    public void m2(@Nullable Object x) { if (x != null) { x.toString(); } }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              interface I1 { Object m1(); }
+              interface I2 { void m2(@Nullable Object x); }
+              record Rec1(Object first, @Nullable Object second) implements I1 {
+                // BUG: Diagnostic contains: method returns @Nullable, but superclass method
+                @Nullable public Object m1() { return second(); }
+              }
+              record Rec2(Object first, @Nullable Object second) implements I1 {
+                public Object m1() { return first(); }
+              }
+              record Rec3(Object first, @Nullable Object second) implements I2 {
+                // BUG: Diagnostic contains: parameter x is @NonNull, but parameter in superclass
+                public void m2(Object x) { x.toString(); }
+              }
+              record Rec4(Object first, @Nullable Object second) implements I2 {
+                public void m2(@Nullable Object x) { if (x != null) { x.toString(); } }
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -166,16 +178,18 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  public void testLocalRecord() {",
-            "    record Rec(Object first, @Nullable Object second) { }",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    Rec rec1 = new Rec(null, null);",
-            "    Rec rec2 = new Rec(new Object(), null);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              public void testLocalRecord() {
+                record Rec(Object first, @Nullable Object second) { }
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                Rec rec1 = new Rec(null, null);
+                Rec rec2 = new Rec(new Object(), null);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -184,30 +198,32 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  public void recordEqualsNull() {",
-            "    record Rec() {",
-            "      void print(Object o) { System.out.println(o.toString()); }",
-            "      void equals(Integer i1, Integer i2) { }",
-            "      boolean equals(String i1, String i2) { return false; }",
-            "      boolean equals(Long l1) { return false; }",
-            "    }",
-            "    Object o = null;",
-            "    // null can be passed to the generated equals() method taking an Object parameter",
-            "    new Rec().equals(o);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    new Rec().print(null);",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    new Rec().equals(null, Integer.valueOf(100));",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'null'",
-            "    new Rec().equals(\"hello\", null);",
-            "    Long l = null;",
-            "    // BUG: Diagnostic contains: passing @Nullable parameter 'l'",
-            "    new Rec().equals(l);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              public void recordEqualsNull() {
+                record Rec() {
+                  void print(Object o) { System.out.println(o.toString()); }
+                  void equals(Integer i1, Integer i2) { }
+                  boolean equals(String i1, String i2) { return false; }
+                  boolean equals(Long l1) { return false; }
+                }
+                Object o = null;
+                // null can be passed to the generated equals() method taking an Object parameter
+                new Rec().equals(o);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                new Rec().print(null);
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                new Rec().equals(null, Integer.valueOf(100));
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null'
+                new Rec().equals("hello", null);
+                Long l = null;
+                // BUG: Diagnostic contains: passing @Nullable parameter 'l'
+                new Rec().equals(l);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -216,19 +232,21 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) { }",
-            "  void recordDeconstructionInstanceOf(Object obj) {",
-            "    if (obj instanceof Rec(Object f, @Nullable Object s)) {",
-            "      f.toString();",
-            "      // TODO: NullAway should report a warning here!",
-            "      // See https://github.com/uber/NullAway/issues/840",
-            "      s.toString();",
-            "    }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) { }
+              void recordDeconstructionInstanceOf(Object obj) {
+                if (obj instanceof Rec(Object f, @Nullable Object s)) {
+                  f.toString();
+                  // TODO: NullAway should report a warning here!
+                  // See https://github.com/uber/NullAway/issues/840
+                  s.toString();
+                }
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -237,19 +255,21 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "Records.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Records {",
-            "  record Rec(Object first, @Nullable Object second) { }",
-            "  int recordDeconstructionSwitchCase(Object obj) {",
-            "    return switch (obj) {",
-            "      // TODO: NullAway should report a warning here!",
-            "      // See https://github.com/uber/NullAway/issues/840",
-            "      case Rec(Object f, @Nullable Object s) -> s.toString().length();",
-            "      default -> 0;",
-            "    };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Records {
+              record Rec(Object first, @Nullable Object second) { }
+              int recordDeconstructionSwitchCase(Object obj) {
+                return switch (obj) {
+                  // TODO: NullAway should report a warning here!
+                  // See https://github.com/uber/NullAway/issues/840
+                  case Rec(Object f, @Nullable Object s) -> s.toString().length();
+                  default -> 0;
+                };
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -258,21 +278,23 @@ public class RecordTests {
     defaultCompilationHelper
         .addSourceLines(
             "BarEntity.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.NonNull;",
-            "import org.jspecify.annotations.Nullable;",
-            "public class BarEntity {",
-            "  public interface Identifiable<ID> {",
-            "    @Nullable",
-            "    ID id();",
-            "  }",
-            "  public static class Id {}",
-            "  public record NameChanged(BarEntity.Id id, Class<BarEntity> type) implements Identifiable<@NonNull Id> {",
-            "    public NameChanged(BarEntity.Id id) {",
-            "      this(id, BarEntity.class);",
-            "    }",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            public class BarEntity {
+              public interface Identifiable<ID> {
+                @Nullable
+                ID id();
+              }
+              public static class Id {}
+              public record NameChanged(BarEntity.Id id, Class<BarEntity> type) implements Identifiable<@NonNull Id> {
+                public NameChanged(BarEntity.Id id) {
+                  this(id, BarEntity.class);
+                }
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -52,17 +52,19 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "class SwitchExpr {",
-            "  public void testSwitchExpressionAssign(int i) {",
-            "    Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };",
-            "    // BUG: Diagnostic contains: dereferenced expression o is @Nullable",
-            "    o.toString();",
-            "    Object o2 = switch (i) { case 3, 4, 5 -> new Object(); default -> \"hello\"; };",
-            "    // This dereference is safe",
-            "    o2.toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class SwitchExpr {
+              public void testSwitchExpressionAssign(int i) {
+                Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };
+                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                o.toString();
+                Object o2 = switch (i) { case 3, 4, 5 -> new Object(); default -> "hello"; };
+                // This dereference is safe
+                o2.toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -71,15 +73,17 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "class SwitchExpr {",
-            "  public void testDirectlyDerefedSwitchExpr(int i) {",
-            "    // BUG: Diagnostic contains: dereferenced expression (switch",
-            "    (switch (i) { case 3, 4, 5 -> new Object(); default -> null; }).toString();",
-            "    // This deference is safe",
-            "    (switch (i) { case 3, 4, 5 -> new Object(); default -> \"hello\"; }).toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class SwitchExpr {
+              public void testDirectlyDerefedSwitchExpr(int i) {
+                // BUG: Diagnostic contains: dereferenced expression (switch
+                (switch (i) { case 3, 4, 5 -> new Object(); default -> null; }).toString();
+                // This deference is safe
+                (switch (i) { case 3, 4, 5 -> new Object(); default -> "hello"; }).toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -88,16 +92,18 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "class SwitchExpr {",
-            "  private void takesNonNull(Object o) {}",
-            "  public void testSwitchExpr3(int i) {",
-            "    // BUG: Diagnostic contains: passing",
-            "    takesNonNull(switch (i) { case 3, 4, 5 -> new Object(); default -> null; });",
-            "    // This call is safe",
-            "    takesNonNull(switch (i) { case 3, 4, 5 -> new Object(); default -> new Object(); });",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class SwitchExpr {
+              private void takesNonNull(Object o) {}
+              public void testSwitchExpr3(int i) {
+                // BUG: Diagnostic contains: passing
+                takesNonNull(switch (i) { case 3, 4, 5 -> new Object(); default -> null; });
+                // This call is safe
+                takesNonNull(switch (i) { case 3, 4, 5 -> new Object(); default -> new Object(); });
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -106,32 +112,34 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "class SwitchExpr {",
-            "  public void testSwitchStmtArrowCase(int i) {",
-            "    Object o = null;",
-            "    switch (i) {",
-            "      case 3, 4, 5 -> { o = new Object(); }",
-            "      default -> { o = null; }",
-            "    }",
-            "    // BUG: Diagnostic contains: dereferenced expression o is @Nullable",
-            "    o.toString();",
-            "    Object o2 = null;",
-            "    switch (i) {",
-            "      case 3, 4, 5 -> { o2 = null; }",
-            "      default -> { o2 = new Object(); }",
-            "    }",
-            "    // BUG: Diagnostic contains: dereferenced expression o2 is @Nullable",
-            "    o2.toString();",
-            "    Object o3 = null;",
-            "    switch (i) {",
-            "      case 3, 4, 5 -> { o3 = new Object(); }",
-            "      default -> { o3 = new Object(); }",
-            "    }",
-            "    // This dereference is safe",
-            "    o3.toString();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class SwitchExpr {
+              public void testSwitchStmtArrowCase(int i) {
+                Object o = null;
+                switch (i) {
+                  case 3, 4, 5 -> { o = new Object(); }
+                  default -> { o = null; }
+                }
+                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                o.toString();
+                Object o2 = null;
+                switch (i) {
+                  case 3, 4, 5 -> { o2 = null; }
+                  default -> { o2 = new Object(); }
+                }
+                // BUG: Diagnostic contains: dereferenced expression o2 is @Nullable
+                o2.toString();
+                Object o3 = null;
+                switch (i) {
+                  case 3, 4, 5 -> { o3 = new Object(); }
+                  default -> { o3 = new Object(); }
+                }
+                // This dereference is safe
+                o3.toString();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -140,19 +148,21 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "class SwitchExpr {",
-            "  public void testSwitchExprUnbox() {",
-            "    Integer i = null;",
-            "    // BUG: Diagnostic contains: switch selector expression i is @Nullable",
-            "    Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };",
-            "    int j1 = 0;",
-            "    // BUG: Diagnostic contains: unboxing of a @Nullable value",
-            "    int j2 = 3 + (switch (j1) { case 3, 4, 5 -> Integer.valueOf(4); default -> null; });",
-            "    // This is safe",
-            "    int j3 = 3 + (switch (j1) { case 3, 4, 5 -> Integer.valueOf(4); default -> Integer.valueOf(6); });",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class SwitchExpr {
+              public void testSwitchExprUnbox() {
+                Integer i = null;
+                // BUG: Diagnostic contains: switch selector expression i is @Nullable
+                Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };
+                int j1 = 0;
+                // BUG: Diagnostic contains: unboxing of a @Nullable value
+                int j2 = 3 + (switch (j1) { case 3, 4, 5 -> Integer.valueOf(4); default -> null; });
+                // This is safe
+                int j3 = 3 + (switch (j1) { case 3, 4, 5 -> Integer.valueOf(4); default -> Integer.valueOf(6); });
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -161,16 +171,18 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "import java.util.function.Function;",
-            "class SwitchExpr {",
-            "  int i;",
-            "  public void testSwitchExprLambda() {",
-            "    // Here we just test to make sure there is no crash.  We need better",
-            "    // generics support to do a more substantive test.",
-            "    Function<SwitchExpr,Object> f = (s) -> switch (s.i) { case 3, 4, 5 -> new Object(); default -> \"hello\"; };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import java.util.function.Function;
+            class SwitchExpr {
+              int i;
+              public void testSwitchExprLambda() {
+                // Here we just test to make sure there is no crash.  We need better
+                // generics support to do a more substantive test.
+                Function<SwitchExpr,Object> f = (s) -> switch (s.i) { case 3, 4, 5 -> new Object(); default -> "hello"; };
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -179,28 +191,30 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchExpr.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class SwitchExpr {",
-            "  public enum NullableEnum {",
-            "    A,",
-            "    B,",
-            "  }",
-            "  static Object handleNullableEnum(@Nullable NullableEnum nullableEnum) {",
-            "    return switch (nullableEnum) {",
-            "      case A -> new Object();",
-            "      case B -> new Object();",
-            "      case null -> throw new IllegalArgumentException(\"NullableEnum parameter is required\");",
-            "    };",
-            "  }",
-            "  static Object handleNullableEnumNoCaseNull(@Nullable NullableEnum nullableEnum) {",
-            "    // BUG: Diagnostic contains: switch selector expression nullableEnum is @Nullable",
-            "    return switch (nullableEnum) {",
-            "      case A -> new Object();",
-            "      case B -> new Object();",
-            "    };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class SwitchExpr {
+              public enum NullableEnum {
+                A,
+                B,
+              }
+              static Object handleNullableEnum(@Nullable NullableEnum nullableEnum) {
+                return switch (nullableEnum) {
+                  case A -> new Object();
+                  case B -> new Object();
+                  case null -> throw new IllegalArgumentException("NullableEnum parameter is required");
+                };
+              }
+              static Object handleNullableEnumNoCaseNull(@Nullable NullableEnum nullableEnum) {
+                // BUG: Diagnostic contains: switch selector expression nullableEnum is @Nullable
+                return switch (nullableEnum) {
+                  case A -> new Object();
+                  case B -> new Object();
+                };
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -209,36 +223,38 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "SwitchNullCase.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class SwitchNullCase {",
-            "  public enum NullableEnum {",
-            "    A,",
-            "    B,",
-            "  }",
-            "  static Object testPositive1(@Nullable NullableEnum nullableEnum) {",
-            "    return switch (nullableEnum) {",
-            "      case A -> new Object();",
-            "      // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable",
-            "      case null -> nullableEnum.hashCode();",
-            "      default -> nullableEnum.toString();",
-            "    };",
-            "  }",
-            "  static Object testPositive2(@Nullable NullableEnum nullableEnum) {",
-            "    return switch (nullableEnum) {",
-            "      case A -> new Object();",
-            "      // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable",
-            "      case null, default -> nullableEnum.toString();",
-            "    };",
-            "  }",
-            "  static Object testNegative(@Nullable NullableEnum nullableEnum) {",
-            "    return switch (nullableEnum) {",
-            "      case A, B -> nullableEnum.hashCode();",
-            "      case null -> new Object();",
-            "      default -> nullableEnum.toString();",
-            "    };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class SwitchNullCase {
+              public enum NullableEnum {
+                A,
+                B,
+              }
+              static Object testPositive1(@Nullable NullableEnum nullableEnum) {
+                return switch (nullableEnum) {
+                  case A -> new Object();
+                  // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable
+                  case null -> nullableEnum.hashCode();
+                  default -> nullableEnum.toString();
+                };
+              }
+              static Object testPositive2(@Nullable NullableEnum nullableEnum) {
+                return switch (nullableEnum) {
+                  case A -> new Object();
+                  // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable
+                  case null, default -> nullableEnum.toString();
+                };
+              }
+              static Object testNegative(@Nullable NullableEnum nullableEnum) {
+                return switch (nullableEnum) {
+                  case A, B -> nullableEnum.hashCode();
+                  case null -> new Object();
+                  default -> nullableEnum.toString();
+                };
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -247,21 +263,23 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "public class Test {",
-            "    public enum NullableEnum {",
-            "        VALUE1, VALUE2;",
-            "    }",
-            "    static Object handleNullableEnumCaseNullDefaultStatement(@Nullable NullableEnum nullableEnum) {",
-            "        Object result;",
-            "        switch (nullableEnum) {",
-            "            case null -> result = new Object();",
-            "            default -> result = nullableEnum.toString();",
-            "        }",
-            "        return result;",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            public class Test {
+                public enum NullableEnum {
+                    VALUE1, VALUE2;
+                }
+                static Object handleNullableEnumCaseNullDefaultStatement(@Nullable NullableEnum nullableEnum) {
+                    Object result;
+                    switch (nullableEnum) {
+                        case null -> result = new Object();
+                        default -> result = nullableEnum.toString();
+                    }
+                    return result;
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -270,21 +288,23 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "TestCase.java",
-            "import java.io.IOException;",
-            "import org.jspecify.annotations.NullMarked;",
-            "@NullMarked",
-            "public class TestCase {",
-            "    boolean hasRelevantMessage(IOException ioException)",
-            "    {",
-            "        String message = ioException.getMessage();",
-            "        return switch (message)",
-            "        {",
-            "            case null -> false;",
-            "            case \"Operation timed out\", \"Connection reset by peer\", \"Premature EOF\", \"Error writing to server\" -> true;",
-            "            default -> message.contains(\"GOAWAY received\");",
-            "        };",
-            "    }",
-            "}")
+            """
+            import java.io.IOException;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            public class TestCase {
+                boolean hasRelevantMessage(IOException ioException)
+                {
+                    String message = ioException.getMessage();
+                    return switch (message)
+                    {
+                        case null -> false;
+                        case "Operation timed out", "Connection reset by peer", "Premature EOF", "Error writing to server" -> true;
+                        default -> message.contains("GOAWAY received");
+                    };
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -293,18 +313,20 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "NullAwayDiscardError.java",
-            "package com.uber;",
-            "public class NullAwayDiscardError {",
-            "    public sealed interface IntOrBool {}",
-            "    public record WrappedInt(int a) implements IntOrBool {}",
-            "    public record WrappedBoolean(boolean b) implements IntOrBool {}",
-            "    public static void unwrap(IntOrBool i) {",
-            "        switch(i) {",
-            "            case WrappedInt(_) -> {}",
-            "            case WrappedBoolean(_) -> {}",
-            "        }",
-            "    }",
-            "}")
+            """
+            package com.uber;
+            public class NullAwayDiscardError {
+                public sealed interface IntOrBool {}
+                public record WrappedInt(int a) implements IntOrBool {}
+                public record WrappedBoolean(boolean b) implements IntOrBool {}
+                public static void unwrap(IntOrBool i) {
+                    switch(i) {
+                        case WrappedInt(_) -> {}
+                        case WrappedBoolean(_) -> {}
+                    }
+                }
+            }
+            """)
         .doTest();
   }
 
@@ -313,29 +335,31 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "ExceptionUtil.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class ExceptionUtil {",
-            "   static class BusinessException extends Exception {",
-            "       public BusinessException(String message) {",
-            "           super(message);",
-            "       }",
-            "   }",
-            "   static class BusinessExceptionUnauthenticated extends BusinessException {",
-            "       public BusinessExceptionUnauthenticated(String message) {",
-            "           super(message);",
-            "       }",
-            "   }",
-            "   private static @Nullable String test(Throwable t) {",
-            "       if (!(t instanceof RuntimeException rte) || !(rte.getCause() instanceof BusinessException bException)) {",
-            "           return \"\"; ",
-            "       }",
-            "       return switch (bException) {",
-            "           case BusinessExceptionUnauthenticated e -> { e.toString(); bException.toString(); yield \"\"; } ",
-            "           default -> bException.getMessage();",
-            "       };",
-            "   }",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class ExceptionUtil {
+               static class BusinessException extends Exception {
+                   public BusinessException(String message) {
+                       super(message);
+                   }
+               }
+               static class BusinessExceptionUnauthenticated extends BusinessException {
+                   public BusinessExceptionUnauthenticated(String message) {
+                       super(message);
+                   }
+               }
+               private static @Nullable String test(Throwable t) {
+                   if (!(t instanceof RuntimeException rte) || !(rte.getCause() instanceof BusinessException bException)) {
+                       return "";
+                   }
+                   return switch (bException) {
+                       case BusinessExceptionUnauthenticated e -> { e.toString(); bException.toString(); yield ""; }
+                       default -> bException.getMessage();
+                   };
+               }
+            }
+            """)
         .doTest();
   }
 
@@ -344,26 +368,28 @@ public class SwitchTests {
     defaultCompilationHelper
         .addSourceLines(
             "ExceptionUtil.java",
-            "import org.jspecify.annotations.*;",
-            "@NullMarked",
-            "public class ExceptionUtil {",
-            "   static class BusinessException extends Exception {",
-            "       public BusinessException(String message) {",
-            "           super(message);",
-            "       }",
-            "   }",
-            "   static class BusinessExceptionUnauthenticated extends BusinessException {",
-            "       public BusinessExceptionUnauthenticated(String message) {",
-            "           super(message);",
-            "       }",
-            "   }",
-            "   private static @Nullable String test(Throwable t) {",
-            "       if (!(t instanceof RuntimeException rte) || !(rte.getCause() instanceof BusinessException bException)) {",
-            "           return \"\"; ",
-            "       }",
-            "       return bException.getMessage();",
-            "   };",
-            "}")
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class ExceptionUtil {
+               static class BusinessException extends Exception {
+                   public BusinessException(String message) {
+                       super(message);
+                   }
+               }
+               static class BusinessExceptionUnauthenticated extends BusinessException {
+                   public BusinessExceptionUnauthenticated(String message) {
+                       super(message);
+                   }
+               }
+               private static @Nullable String test(Throwable t) {
+                   if (!(t instanceof RuntimeException rte) || !(rte.getCause() instanceof BusinessException bException)) {
+                       return "";
+                   }
+                   return bException.getMessage();
+               };
+            }
+            """)
         .doTest();
   }
 }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -387,7 +387,7 @@ public class SwitchTests {
                        return "";
                    }
                    return bException.getMessage();
-               };
+               }
             }
             """)
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/AutoSuggestNoCastTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AutoSuggestNoCastTest.java
@@ -58,20 +58,25 @@ public class AutoSuggestNoCastTest {
     makeTestHelperWithSuppressionComment()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "class Test {",
-            "  Object test1() {",
-            "    return null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class Test {
+              Object test1() {
+                return null;
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "class Test {", // Can we actually check comments?
-            "  @SuppressWarnings(\"NullAway\") /* PR #000000 */ Object test1() {",
-            "    return null;",
-            "  }",
-            "}")
+            // Can we actually check comments?
+            """
+            package com.uber;
+            class Test {
+              @SuppressWarnings("NullAway") /* PR #000000 */ Object test1() {
+                return null;
+              }
+            }
+            """)
         .doTest(); // Yes we can!
   }
 
@@ -80,20 +85,24 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "class Test {",
-            "  Object test1() {",
-            "    return null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class Test {
+              Object test1() {
+                return null;
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "class Test {",
-            "  @SuppressWarnings(\"NullAway\") Object test1() {",
-            "    return null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            class Test {
+              @SuppressWarnings("NullAway") Object test1() {
+                return null;
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -102,27 +111,31 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Object foo;",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      foo.toString();",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Object foo;
+              private final Runnable runnable =
+                () -> {
+                  foo.toString();
+                };
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Object foo;",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      foo.toString();",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Object foo;
+              @SuppressWarnings("NullAway")
+              private final Runnable runnable =
+                () -> {
+                  foo.toString();
+                };
+            }
+            """)
         .doTest();
   }
 
@@ -131,29 +144,33 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  static int id(int x) { return x; }",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      id(foo);",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              static int id(int x) { return x; }
+              private final Runnable runnable =
+                () -> {
+                  id(foo);
+                };
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  static int id(int x) { return x; }",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      id(foo);",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              static int id(int x) { return x; }
+              @SuppressWarnings("NullAway")
+              private final Runnable runnable =
+                () -> {
+                  id(foo);
+                };
+            }
+            """)
         .doTest();
   }
 
@@ -162,29 +179,33 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  static int id(int x) { return x; }",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      int x = foo + 1;",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              static int id(int x) { return x; }
+              private final Runnable runnable =
+                () -> {
+                  int x = foo + 1;
+                };
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  static int id(int x) { return x; }",
-            "  private final Runnable runnable =",
-            "    () -> {",
-            "      @SuppressWarnings(\"NullAway\")",
-            "      int x = foo + 1;",
-            "    };",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              static int id(int x) { return x; }
+              private final Runnable runnable =
+                () -> {
+                  @SuppressWarnings("NullAway")
+                  int x = foo + 1;
+                };
+            }
+            """)
         .doTest();
   }
 
@@ -193,34 +214,38 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  @Nullable private java.util.function.Function<Object, Integer> f;",
-            "  void m1() {",
-            "    f = (x) -> { return foo + 1; };",
-            "  }",
-            "  void m2() {",
-            "    java.util.function.Function<Object,Integer> g = (x) -> { return foo + 1; };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              @Nullable private java.util.function.Function<Object, Integer> f;
+              void m1() {
+                f = (x) -> { return foo + 1; };
+              }
+              void m2() {
+                java.util.function.Function<Object,Integer> g = (x) -> { return foo + 1; };
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable private Integer foo;",
-            "  @Nullable private java.util.function.Function<Object, Integer> f;",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  void m1() {",
-            "    f = (x) -> { return foo + 1; };",
-            "  }",
-            "  void m2() {",
-            "    @SuppressWarnings(\"NullAway\")",
-            "    java.util.function.Function<Object,Integer> g = (x) -> { return foo + 1; };",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable private Integer foo;
+              @Nullable private java.util.function.Function<Object, Integer> f;
+              @SuppressWarnings("NullAway")
+              void m1() {
+                f = (x) -> { return foo + 1; };
+              }
+              void m2() {
+                @SuppressWarnings("NullAway")
+                java.util.function.Function<Object,Integer> g = (x) -> { return foo + 1; };
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -229,33 +254,37 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  static interface I {",
-            "    public void foo(@Nullable Object o);",
-            "  }",
-            "  static void biz(Object p) {}",
-            "  static void callFoo(I i) { i.foo(null); }",
-            "  static void bar() {",
-            "    callFoo(Test::biz);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              static interface I {
+                public void foo(@Nullable Object o);
+              }
+              static void biz(Object p) {}
+              static void callFoo(I i) { i.foo(null); }
+              static void bar() {
+                callFoo(Test::biz);
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  static interface I {",
-            "    public void foo(@Nullable Object o);",
-            "  }",
-            "  static void biz(Object p) {}",
-            "  static void callFoo(I i) { i.foo(null); }",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  static void bar() {",
-            "    callFoo(Test::biz);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              static interface I {
+                public void foo(@Nullable Object o);
+              }
+              static void biz(Object p) {}
+              static void callFoo(I i) { i.foo(null); }
+              @SuppressWarnings("NullAway")
+              static void bar() {
+                callFoo(Test::biz);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -264,35 +293,39 @@ public class AutoSuggestNoCastTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  static interface I {",
-            "    public Object foo();",
-            "  }",
-            "  @Nullable",
-            "  static Object biz() { return null; }",
-            "  static void callFoo(I i) { i.foo(); }",
-            "  static void bar() {",
-            "    callFoo(Test::biz);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              static interface I {
+                public Object foo();
+              }
+              @Nullable
+              static Object biz() { return null; }
+              static void callFoo(I i) { i.foo(); }
+              static void bar() {
+                callFoo(Test::biz);
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  static interface I {",
-            "    public Object foo();",
-            "  }",
-            "  @Nullable",
-            "  static Object biz() { return null; }",
-            "  static void callFoo(I i) { i.foo(); }",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  static void bar() {",
-            "    callFoo(Test::biz);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              static interface I {
+                public Object foo();
+              }
+              @Nullable
+              static Object biz() { return null; }
+              static void callFoo(I i) { i.foo(); }
+              @SuppressWarnings("NullAway")
+              static void bar() {
+                callFoo(Test::biz);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/AutoSuggestTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AutoSuggestTest.java
@@ -51,14 +51,16 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "class Test {",
-            "  Object test1(@Nullable Object o) {",
-            "    return castToNonNull(o);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              Object test1(@Nullable Object o) {
+                return castToNonNull(o);
+              }
+            }
+            """)
         .expectUnchanged()
         .doTest();
   }
@@ -68,25 +70,29 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable Object o;",
-            "  Object test1() {",
-            "    return o;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable Object o;
+              Object test1() {
+                return o;
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable Object o;",
-            "  Object test1() {",
-            "    return castToNonNull(o);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable Object o;
+              Object test1() {
+                return castToNonNull(o);
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -99,45 +105,49 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object f = new Object();",
-            "  Object test1(@Nullable Object o) {",
-            "    return o;",
-            "  }",
-            "  Object test2() {",
-            "    return null;",
-            "  }",
-            "  void test3() {",
-            "    f = null;",
-            "  }",
-            "  @Nullable Object m() { return null; }",
-            "  Object shouldAddCast() {",
-            "    return m();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              Object f = new Object();
+              Object test1(@Nullable Object o) {
+                return o;
+              }
+              Object test2() {
+                return null;
+              }
+              void test3() {
+                f = null;
+              }
+              @Nullable Object m() { return null; }
+              Object shouldAddCast() {
+                return m();
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object f = new Object();",
-            "  @SuppressWarnings(\"NullAway\") Object test1(@Nullable Object o) {",
-            "    return o;",
-            "  }",
-            "  @SuppressWarnings(\"NullAway\") Object test2() {",
-            "    return null;",
-            "  }",
-            "  @SuppressWarnings(\"NullAway\") void test3() {",
-            "    f = null;",
-            "  }",
-            "  @Nullable Object m() { return null; }",
-            "  Object shouldAddCast() {",
-            "    return castToNonNull(m());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            import javax.annotation.Nullable;
+            class Test {
+              Object f = new Object();
+              @SuppressWarnings("NullAway") Object test1(@Nullable Object o) {
+                return o;
+              }
+              @SuppressWarnings("NullAway") Object test2() {
+                return null;
+              }
+              @SuppressWarnings("NullAway") void test3() {
+                f = null;
+              }
+              @Nullable Object m() { return null; }
+              Object shouldAddCast() {
+                return castToNonNull(m());
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -146,24 +156,28 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "class Test {",
-            "  Object test1(Object o) {",
-            "    return castToNonNull(o);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              Object test1(Object o) {
+                return castToNonNull(o);
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "class Test {",
-            "  Object test1(Object o) {",
-            "    return o;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              Object test1(Object o) {
+                return o;
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -172,30 +186,34 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "class Test {",
-            "  static class Foo { Object getObj() { return new Object(); } }",
-            "  Object test1(Foo f) {",
-            "    return castToNonNull(f",
-            "                         // comment that should not be deleted",
-            "                         .getObj());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              static class Foo { Object getObj() { return new Object(); } }
+              Object test1(Foo f) {
+                return castToNonNull(f
+                                     // comment that should not be deleted
+                                     .getObj());
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "class Test {",
-            "  static class Foo { Object getObj() { return new Object(); } }",
-            "  Object test1(Foo f) {",
-            "    return f",
-            "        // comment that should not be deleted",
-            "        .getObj();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              static class Foo { Object getObj() { return new Object(); } }
+              Object test1(Foo f) {
+                return f
+                    // comment that should not be deleted
+                    .getObj();
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -204,40 +222,44 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  public @Nullable Object doReturnNullable() {",
-            "    return null;",
-            "  }",
-            "  public static void takesNonNull(Object o) { ",
-            "    System.out.println(o.toString());",
-            "  }",
-            "  public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {",
-            "    return f.apply(this);",
-            "  }",
-            "  void test() throws Exception {",
-            "    takesNonNull(execute(Test::doReturnNullable));",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              public @Nullable Object doReturnNullable() {
+                return null;
+              }
+              public static void takesNonNull(Object o) {
+                System.out.println(o.toString());
+              }
+              public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {
+                return f.apply(this);
+              }
+              void test() throws Exception {
+                takesNonNull(execute(Test::doReturnNullable));
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  public @Nullable Object doReturnNullable() {",
-            "    return null;",
-            "  }",
-            "  public static void takesNonNull(Object o) { ",
-            "    System.out.println(o.toString());",
-            "  }",
-            "  public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {",
-            "    return f.apply(this);",
-            "  }",
-            "  @SuppressWarnings(\"NullAway\") void test() throws Exception {",
-            "    takesNonNull(execute(Test::doReturnNullable));",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              public @Nullable Object doReturnNullable() {
+                return null;
+              }
+              public static void takesNonNull(Object o) {
+                System.out.println(o.toString());
+              }
+              public <R> R execute(io.reactivex.functions.Function<Test,R> f) throws Exception {
+                return f.apply(this);
+              }
+              @SuppressWarnings("NullAway") void test() throws Exception {
+                takesNonNull(execute(Test::doReturnNullable));
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -246,44 +268,48 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object x = new Object();",
-            "  static class Foo { @Nullable Object getObj() { return null; } }",
-            "  Object test1(Foo f) {",
-            "    return f",
-            "           // comment that should not be deleted",
-            "           .getObj();",
-            "  }",
-            "  void test2(Foo f) {",
-            "    x = f.getObj(); // comment that should not be deleted",
-            "  }",
-            "  Object test3(Foo f) {",
-            "    return f./* keep this comment */getObj();",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              Object x = new Object();
+              static class Foo { @Nullable Object getObj() { return null; } }
+              Object test1(Foo f) {
+                return f
+                       // comment that should not be deleted
+                       .getObj();
+              }
+              void test2(Foo f) {
+                x = f.getObj(); // comment that should not be deleted
+              }
+              Object test3(Foo f) {
+                return f./* keep this comment */getObj();
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object x = new Object();",
-            "  static class Foo { @Nullable Object getObj() { return null; } }",
-            "  Object test1(Foo f) {",
-            "    return castToNonNull(f",
-            "           // comment that should not be deleted",
-            "           .getObj());",
-            "  }",
-            "  void test2(Foo f) {",
-            "    x = castToNonNull(f.getObj()); // comment that should not be deleted",
-            "  }",
-            "  Object test3(Foo f) {",
-            "    return castToNonNull(f./* keep this comment */getObj());",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+
+            import javax.annotation.Nullable;
+            class Test {
+              Object x = new Object();
+              static class Foo { @Nullable Object getObj() { return null; } }
+              Object test1(Foo f) {
+                return castToNonNull(f
+                       // comment that should not be deleted
+                       .getObj());
+              }
+              void test2(Foo f) {
+                x = castToNonNull(f.getObj()); // comment that should not be deleted
+              }
+              Object test3(Foo f) {
+                return castToNonNull(f./* keep this comment */getObj());
+              }
+            }
+            """)
         .doTest();
   }
 
@@ -292,22 +318,26 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object f;",
-            "  Object g;",
-            "  Test() {}",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              Object f;
+              Object g;
+              Test() {}
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object f;",
-            "  Object g;",
-            "  @SuppressWarnings(\"NullAway.Init\") Test() {}",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              Object f;
+              Object g;
+              @SuppressWarnings("NullAway.Init") Test() {}
+            }
+            """)
         .doTest();
   }
 
@@ -316,18 +346,22 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  Object f;",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              Object f;
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @SuppressWarnings(\"NullAway.Init\") Object f;",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @SuppressWarnings("NullAway.Init") Object f;
+            }
+            """)
         .doTest();
   }
 
@@ -336,18 +370,22 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @SuppressWarnings(\"unused\") Object f;",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @SuppressWarnings("unused") Object f;
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @SuppressWarnings({\"unused\",\"NullAway.Init\"}) Object f;",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @SuppressWarnings({"unused","NullAway.Init"}) Object f;
+            }
+            """)
         .doTest();
   }
 
@@ -356,31 +394,35 @@ public class AutoSuggestTest {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable Integer i;",
-            "  int test1() {",
-            "    return i;",
-            "  }",
-            "  void test2() {",
-            "    int x = i;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable Integer i;
+              int test1() {
+                return i;
+              }
+              void test2() {
+                int x = i;
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import static com.uber.nullaway.testdata.Util.castToNonNull;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  @Nullable Integer i;",
-            "  int test1() {",
-            "    return castToNonNull(i);",
-            "  }",
-            "  void test2() {",
-            "    int x = castToNonNull(i);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            import javax.annotation.Nullable;
+            class Test {
+              @Nullable Integer i;
+              int test1() {
+                return castToNonNull(i);
+              }
+              void test2() {
+                int x = castToNonNull(i);
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/SuggestedFixesTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/SuggestedFixesTests.java
@@ -32,25 +32,29 @@ public class SuggestedFixesTests {
     makeTestHelper()
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "class Test {",
-            "  void test() {",
-            "    Object[] arr = new Object[1];",
-            "    arr[0] = null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              void test() {
+                Object[] arr = new Object[1];
+                arr[0] = null;
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import org.jspecify.annotations.Nullable;",
-            "class Test {",
-            "  @SuppressWarnings(\"NullAway\")",
-            "  void test() {",
-            "    Object[] arr = new Object[1];",
-            "    arr[0] = null;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              @SuppressWarnings("NullAway")
+              void test() {
+                Object[] arr = new Object[1];
+                arr[0] = null;
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/scripts/convert_line_helper_textblocks.py
+++ b/scripts/convert_line_helper_textblocks.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 """
-Convert CompilationTestHelper.addSourceLines(...) calls in a single Java file to use text blocks.
+Convert line-based test helper calls in a single Java file to use text blocks.
 
 Assumptions:
 - Each argument is on its own line.
 - The first argument is the filename string literal.
 - Subsequent arguments are string literals representing source lines, with optional // or /* */ comments
-  on their own line or trailing after a string literal.
+  on their own line. Trailing Java comments after string literal arguments are preserved before the
+  generated text block.
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
-from typing import Iterable, Iterator, List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
+
+METHOD_NAMES = ("addSourceLines", "addInputLines", "addOutputLines")
 
 
-def find_add_source_lines_calls(src: str) -> List[Tuple[int, int]]:
-    """Return (open_paren_idx, close_paren_idx) pairs for addSourceLines calls."""
+def find_line_helper_calls(src: str) -> List[Tuple[int, int]]:
+    """Return (open_paren_idx, close_paren_idx) pairs for supported line-helper calls."""
     calls = []
     i = 0
     n = len(src)
@@ -35,12 +38,15 @@ def find_add_source_lines_calls(src: str) -> List[Tuple[int, int]]:
             elif c == "/" and i + 1 < n and src[i + 1] == "*":
                 state = "block_comment"
                 i += 1
-            elif src.startswith("addSourceLines(", i):
-                open_idx = i + len("addSourceLines")
-                close_idx = find_matching_paren(src, open_idx)
-                if close_idx is not None:
-                    calls.append((open_idx, close_idx))
-                    i = close_idx
+            else:
+                for method_name in METHOD_NAMES:
+                    if src.startswith(f"{method_name}(", i):
+                        open_idx = i + len(method_name)
+                        close_idx = find_matching_paren(src, open_idx)
+                        if close_idx is not None:
+                            calls.append((open_idx, close_idx))
+                            i = close_idx
+                        break
         elif state == "string":
             if c == "\\":
                 i += 1
@@ -139,11 +145,12 @@ def transform_args_text(args_text: str) -> Optional[str]:
     if not lines:
         return None
 
-    items: List[Tuple[str, str, str, Optional[str]]] = []
+    items: List[Tuple[str, str]] = []
     arg_line_indices: List[int] = []
     filename_line_idx = None
     filename_line = None
     arg_indent = None
+    java_comments: List[str] = []
 
     for idx, line in enumerate(lines):
         if not line.strip():
@@ -166,11 +173,9 @@ def transform_args_text(args_text: str) -> Optional[str]:
                 default=-1,
             )
             comment = None
-            spacing = ""
             rest_prefix = rest_no_nl
             if idx_comment != -1:
                 comment = rest_no_nl[idx_comment:]
-                spacing = rest_no_nl[:idx_comment].replace(",", "")
                 rest_prefix = rest_no_nl[:idx_comment]
             if rest_prefix.strip().strip(","):
                 return None
@@ -179,8 +184,10 @@ def transform_args_text(args_text: str) -> Optional[str]:
                 filename_line = line
                 arg_indent = indent
             else:
-                items.append(("string", content, spacing, comment))
+                items.append(("string", content))
                 arg_line_indices.append(idx)
+                if comment:
+                    java_comments.append(comment)
         elif body.lstrip().startswith("//") or body.lstrip().startswith("/*"):
             if filename_line_idx is None:
                 return None
@@ -190,7 +197,7 @@ def transform_args_text(args_text: str) -> Optional[str]:
                 comment_body = line[len(arg_indent) :].rstrip("\r\n")
             else:
                 comment_body = line.lstrip().rstrip("\r\n")
-            items.append(("comment", comment_body, "", None))
+            items.append(("comment", comment_body))
             arg_line_indices.append(idx)
         else:
             return None
@@ -210,11 +217,9 @@ def transform_args_text(args_text: str) -> Optional[str]:
             break
 
     content_lines: List[str] = []
-    for kind, content, spacing, comment in items:
+    for kind, content in items:
         if kind == "string":
             line = unescape_for_text_block(content)
-            if comment:
-                line += f"{spacing}{comment}"
             content_lines.append(line)
         else:
             content_lines.append(content)
@@ -228,6 +233,8 @@ def transform_args_text(args_text: str) -> Optional[str]:
         new_lines.append(filename_line)
     else:
         new_lines.append(filename_line + line_ending)
+    for comment in java_comments:
+        new_lines.append(f"{arg_indent}{comment}{line_ending}")
     new_lines.append(f'{arg_indent}"""{line_ending}')
     for content_line in content_lines:
         new_lines.append(f"{arg_indent}{content_line}{line_ending}")
@@ -237,7 +244,7 @@ def transform_args_text(args_text: str) -> Optional[str]:
 
 
 def transform_source(src: str) -> Tuple[str, int]:
-    calls = find_add_source_lines_calls(src)
+    calls = find_line_helper_calls(src)
     if not calls:
         return src, 0
 
@@ -261,7 +268,7 @@ def transform_source(src: str) -> Tuple[str, int]:
 
 def main(argv: Optional[Iterable[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Convert addSourceLines calls to text blocks in a single Java file."
+        description="Convert line-based test helper calls to text blocks in a single Java file."
     )
     parser.add_argument("path", help="Path to a .java file")
     parser.add_argument(
@@ -294,7 +301,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         print(f"Failed to write {path}: {exc}", file=sys.stderr)
         return 1
 
-    print(f"Updated {changes} addSourceLines call(s) in {path}", file=sys.stderr)
+    print(f"Updated {changes} line-helper call(s) in {path}", file=sys.stderr)
     return 0
 
 

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -510,34 +510,38 @@ public class CustomLibraryModelsTests {
     testHelper
         .addInputLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  public static <T> T castToNonNull(String reason, T value, int line) {",
-            "    if (value == null) {",
-            "      throw new NullPointerException(reason + \" at line \" + line);",
-            "    }",
-            "    return value;",
-            "  }",
-            "  Object test1(Object o) {",
-            "    return Test.castToNonNull(\"CAST_REASON\",o,42);",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              public static <T> T castToNonNull(String reason, T value, int line) {
+                if (value == null) {
+                  throw new NullPointerException(reason + " at line " + line);
+                }
+                return value;
+              }
+              Object test1(Object o) {
+                return Test.castToNonNull("CAST_REASON",o,42);
+              }
+            }
+            """)
         .addOutputLines(
             "out/Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "class Test {",
-            "  public static <T> T castToNonNull(String reason, T value, int line) {",
-            "    if (value == null) {",
-            "      throw new NullPointerException(reason + \" at line \" + line);",
-            "    }",
-            "    return value;",
-            "  }",
-            "  Object test1(Object o) {",
-            "    return o;",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              public static <T> T castToNonNull(String reason, T value, int line) {
+                if (value == null) {
+                  throw new NullPointerException(reason + " at line " + line);
+                }
+                return value;
+              }
+              Object test1(Object o) {
+                return o;
+              }
+            }
+            """)
         .doTest();
   }
 }


### PR DESCRIPTION
Extend our script to apply to calls to `addInputLines` and `addOutputLines` and apply across tests.