### PR TITLE
Use Temurin JDK 17 always in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,25 +26,11 @@ jobs:
         with:
           website: jdk.java.net
           release: 27
-      # Use Zulu for JDK 17 on Windows, as Temurin build of 17.0.19 is still not released
-      - name: 'Set up Zulu JDK 17 on Windows'
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: 'zulu'
-          check-latest: 'true'
-        if: runner.os == 'Windows'
-      - name: 'Set up Temurin JDK 17'
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          check-latest: 'true'
-        if: runner.os != 'Windows'
       - name: 'Set up JDKs'
         uses: actions/setup-java@v5
         with:
           java-version: |
+            17
             21
             25
           distribution: 'temurin'


### PR DESCRIPTION
Temurin 17.0.19 for Windows [has been released](https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.19%2B10), so we no longer need to install the Zulu distribution just for Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow Java toolchain setup to use a unified configuration approach, simplifying the build pipeline setup across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->