### PR TITLE
Test case for trick to assert chain of accesses is non-null 

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
@@ -246,6 +246,9 @@ public class SuppressionTests extends NullAwayTestsBase {
                 f.next.hashCode();
                 f.next.next.hashCode();
                 f.next.next.next.hashCode();
+                // one too many
+                // BUG: Diagnostic contains: dereferenced expression f.next.next.next.next is @Nullable
+                f.next.next.next.next.hashCode();
               }
 
               static void testCalls(Foo f) {
@@ -254,6 +257,9 @@ public class SuppressionTests extends NullAwayTestsBase {
                 f.getNext().hashCode();
                 f.getNext().getNext().hashCode();
                 f.getNext().getNext().getNext().hashCode();
+                // one too many
+                // BUG: Diagnostic contains: dereferenced expression f.getNext().getNext().getNext().getNext() is @Nullable
+                f.getNext().getNext().getNext().getNext().hashCode();
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
@@ -237,14 +237,23 @@ public class SuppressionTests extends NullAwayTestsBase {
             class Test {
               static class Foo {
                 @Nullable Foo next;
+                @Nullable Foo getNext() { return next; }
               }
 
-              static void test(Foo f) {
+              static void testFields(Foo f) {
                 @SuppressWarnings("NullAway")
                 var unused = Objects.requireNonNull(f.next.next.next);
                 f.next.hashCode();
                 f.next.next.hashCode();
                 f.next.next.next.hashCode();
+              }
+
+              static void testCalls(Foo f) {
+                @SuppressWarnings("NullAway")
+                var unused = Objects.requireNonNull(f.getNext().getNext().getNext());
+                f.getNext().hashCode();
+                f.getNext().getNext().hashCode();
+                f.getNext().getNext().getNext().hashCode();
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
@@ -216,4 +216,38 @@ public class SuppressionTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  /**
+   * Test showing a trick for asserting that all {@code @Nullable} levels of a nested access path
+   * are in fact non-null using a warning suppression.
+   */
+  @Test
+  public void suppressNestedInRequireNonNull() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            import java.util.Objects;
+            class Test {
+              static class Foo {
+                @Nullable Foo next;
+              }
+
+              static void test(Foo f) {
+                @SuppressWarnings("NullAway")
+                var unused = Objects.requireNonNull(f.next.next.next);
+                f.next.hashCode();
+                f.next.next.hashCode();
+                f.next.next.next.hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
See #1529 

This test case shows how to use a `@SuppressWarnings` and `requireNonNull` to assert that an entire chain of field accesses is non-null.  Also works for method calls.  Test-only change, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying suppression of NullAway warnings for nested nullable access paths when wrapped with Objects.requireNonNull().
  * Covers both direct field chaining and method/accessor chaining scenarios to ensure suppression behaves consistently.
  * Also asserts that an extra/over-extended dereference still produces a NullAway diagnostic as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->