### PR TITLE
Improve inference failure error message

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
@@ -19,8 +19,15 @@ public interface ConstraintSolver {
    * exceptions.
    */
   class UnsatisfiableConstraintsException extends RuntimeException {
-    public UnsatisfiableConstraintsException(String message) {
-      super(message);
+    /** Type variable on which the contradiction was detected */
+    private final Element typeVariable;
+
+    public UnsatisfiableConstraintsException(Element typeVariable) {
+      this.typeVariable = typeVariable;
+    }
+
+    public Element getTypeVariable() {
+      return typeVariable;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -317,7 +317,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         s,
         t);
     /* variable-to-variable edge */
-    if (isTypeVariable(s) && isTypeVariable(t)) {
+    if (treatAsTypeVariableForInference(s) && treatAsTypeVariableForInference(t)) {
       TypeVariable sv = (TypeVariable) s;
       TypeVariable tv = (TypeVariable) t;
       getState(sv.asElement()).supertypes.add(tv.asElement());
@@ -362,11 +362,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
    */
   private void constrainAsNullable(Type t, Type knownNullableType)
       throws UnsatisfiableConstraintsException {
-    if (isTypeVariable(t)) {
+    if (treatAsTypeVariableForInference(t)) {
       updateNullness(t.asElement(), NullnessState.NULLABLE);
     } else if (isKnownNonNull(t)) {
-      Verify.verify(knownNullableType instanceof TypeVariable);
-      throw new UnsatisfiableConstraintsException(knownNullableType.asElement());
+      TypeVariable typeVar =
+          knownNullableType instanceof TypeVariable typeVariable ? typeVariable : (TypeVariable) t;
+      throw new UnsatisfiableConstraintsException(typeVar.asElement());
     }
   }
 
@@ -374,16 +375,16 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
    * Constrain a type to be @NonNull due to its being a subtype of some known @NonNull type
    *
    * @param t the type to constrain
-   * @param knownNonNullType the known non-null type
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
    */
   private void constrainAsNonNull(Type t, Type knownNonNullType)
       throws UnsatisfiableConstraintsException {
-    if (isTypeVariable(t)) {
+    if (treatAsTypeVariableForInference(t)) {
       updateNullness(t.asElement(), NullnessState.NONNULL);
     } else if (isKnownNullable(t)) {
-      Verify.verify(knownNonNullType instanceof TypeVariable);
-      throw new UnsatisfiableConstraintsException(knownNonNullType.asElement());
+      TypeVariable typeVar =
+          t instanceof TypeVariable typeVariable ? typeVariable : (TypeVariable) knownNonNullType;
+      throw new UnsatisfiableConstraintsException(typeVar.asElement());
     }
   }
 
@@ -393,7 +394,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     return vars.computeIfAbsent(typeVarElement, v -> new VarState(upperBoundIsNullable(v)));
   }
 
-  private boolean isTypeVariable(Type t) {
+  private boolean treatAsTypeVariableForInference(Type t) {
     if (t instanceof TypeVar tv) {
       // Only treat as a type variable if it _doesn't_ have an explicit @Nullable or @NonNull
       // annotation.
@@ -411,7 +412,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
 
   /** Everything non-nullable *and* non-variable counts as @NonNull. */
   private boolean isKnownNonNull(Type t) {
-    return !isKnownNullable(t) && !isTypeVariable(t);
+    return !isKnownNullable(t) && !treatAsTypeVariableForInference(t);
   }
 
   private boolean upperBoundIsNullable(Element typeVarElement) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -311,6 +311,11 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   private void directlyConstrainTypePair(Type s, Type t) throws UnsatisfiableConstraintsException {
+    Verify.verify(
+        s instanceof TypeVariable || t instanceof TypeVariable,
+        "At least one argument must be a type variable but got %s and %s",
+        s,
+        t);
     /* variable-to-variable edge */
     if (isTypeVariable(s) && isTypeVariable(t)) {
       TypeVariable sv = (TypeVariable) s;
@@ -321,10 +326,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
 
     /* top-level nullability rules */
     if (isKnownNonNull(t)) {
-      requireNonNull(s);
+      constrainAsNonNull(s, t);
     }
     if (isKnownNullable(s)) {
-      requireNullable(t);
+      constrainAsNullable(t, s);
     }
   }
 
@@ -348,19 +353,37 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     return true;
   }
 
-  private void requireNullable(Type t) throws UnsatisfiableConstraintsException {
+  /**
+   * Constrain a type to be @Nullable due to its being a supertype of some known @Nullable type
+   *
+   * @param t the type to constrain
+   * @param knownNullableType the known nullable type
+   * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
+   */
+  private void constrainAsNullable(Type t, Type knownNullableType)
+      throws UnsatisfiableConstraintsException {
     if (isTypeVariable(t)) {
       updateNullness(t.asElement(), NullnessState.NULLABLE);
     } else if (isKnownNonNull(t)) {
-      throw new UnsatisfiableConstraintsException(t.asElement());
+      Verify.verify(knownNullableType instanceof TypeVariable);
+      throw new UnsatisfiableConstraintsException(knownNullableType.asElement());
     }
   }
 
-  private void requireNonNull(Type t) throws UnsatisfiableConstraintsException {
+  /**
+   * Constrain a type to be @NonNull due to its being a subtype of some known @NonNull type
+   *
+   * @param t the type to constrain
+   * @param knownNonNullType the known non-null type
+   * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
+   */
+  private void constrainAsNonNull(Type t, Type knownNonNullType)
+      throws UnsatisfiableConstraintsException {
     if (isTypeVariable(t)) {
       updateNullness(t.asElement(), NullnessState.NONNULL);
     } else if (isKnownNullable(t)) {
-      throw new UnsatisfiableConstraintsException(t.asElement());
+      Verify.verify(knownNonNullType instanceof TypeVariable);
+      throw new UnsatisfiableConstraintsException(knownNonNullType.asElement());
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -339,12 +339,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
       return false;
     }
     if (st.nullness != NullnessState.UNKNOWN) {
-      throw new UnsatisfiableConstraintsException(
-          "Contradictory nullability for " + typeVarElement + ": " + st.nullness + " vs. " + n);
+      throw new UnsatisfiableConstraintsException(typeVarElement);
     }
     if (n == NullnessState.NULLABLE && !st.nullableAllowed) {
-      throw new UnsatisfiableConstraintsException(
-          typeVarElement + " cannot be @Nullable (upper bound is @NonNull)");
+      throw new UnsatisfiableConstraintsException(typeVarElement);
     }
     st.nullness = n;
     return true;
@@ -354,7 +352,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     if (isTypeVariable(t)) {
       updateNullness(t.asElement(), NullnessState.NULLABLE);
     } else if (isKnownNonNull(t)) {
-      throw new UnsatisfiableConstraintsException("Cannot treat @NonNull type as @Nullable: " + t);
+      throw new UnsatisfiableConstraintsException(t.asElement());
     }
   }
 
@@ -362,7 +360,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     if (isTypeVariable(t)) {
       updateNullness(t.asElement(), NullnessState.NONNULL);
     } else if (isKnownNullable(t)) {
-      throw new UnsatisfiableConstraintsException("Cannot treat @Nullable type as @NonNull: " + t);
+      throw new UnsatisfiableConstraintsException(t.asElement());
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -939,19 +939,17 @@ public final class GenericsChecks {
       }
       return successResult;
     } catch (UnsatisfiableConstraintsException e) {
+      String inferenceFailureMessage = inferenceFailureMessage(e);
       if (config.warnOnGenericInferenceFailure()) {
         ErrorBuilder errorBuilder = analysis.getErrorBuilder();
         ErrorMessage errorMessage =
             new ErrorMessage(
-                ErrorMessage.MessageTypes.GENERIC_INFERENCE_FAILURE,
-                String.format(
-                    "Failed to infer type argument nullability for call %s: %s",
-                    state.getSourceForNode(invocationTree), e.getMessage()));
+                ErrorMessage.MessageTypes.GENERIC_INFERENCE_FAILURE, inferenceFailureMessage);
         state.reportMatch(
             errorBuilder.createErrorDescription(
                 errorMessage, analysis.buildDescription(invocationTree), state, null));
       }
-      InferenceFailure failureResult = new InferenceFailure(e.getMessage());
+      InferenceFailure failureResult = new InferenceFailure(inferenceFailureMessage);
       // don't cache result if we were called from dataflow, since the result may rely on dataflow
       // facts that do not reflect the fixed point
       if (!calledFromDataflow) {
@@ -961,6 +959,12 @@ public final class GenericsChecks {
       }
       return failureResult;
     }
+  }
+
+  private String inferenceFailureMessage(UnsatisfiableConstraintsException e) {
+    return String.format(
+        "inference failure: type variable %s constrained to be both @NonNull and @Nullable",
+        e.getTypeVariable());
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -901,6 +901,29 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void nullableTypeVarToNonNullField() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+                static <T extends @Nullable Object> @Nullable T f(T t) {
+                    return null;
+                }
+                String field = "hello";
+                void testField() {
+                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                    field = f("hello");
+                }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void dataflowAndLoops() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -882,7 +882,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 String field = "hello";
                 void testField() {
                     String s = null;
-                    // BUG: Diagnostic contains: Failed to infer type argument nullability
+                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
                     field = id(s);
                 }
                 @Nullable String field2 = null;
@@ -1206,7 +1206,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                     return Optional.ofNullable(value);
                 }
                 public static <U extends @Nullable Object> Optional<U> optionalResultPositive1(@Nullable U value) {
-                    // BUG: Diagnostic contains: Failed to infer type argument nullability
+                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
                     return Optional.of(value);
                 }
                 // identical to above, testing the other error message

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -520,9 +520,7 @@ public class WildcardTests extends NullAwayTestsBase {
               void test(Box<? super @Nullable String> nullableBox, Box<? super String> nonNullBox) {
                 take(nullableBox);
                 take(nonNullBox);
-                // TODO we need to report an additional error besides inference failure here
-                // See https://github.com/uber/NullAway/issues/1551
-                // BUG: Diagnostic contains: Failed to infer type argument nullability
+                // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
                 field = get(nullableBox);
                 field = get(nonNullBox);
               }


### PR DESCRIPTION
We now print a simple and consistent message indicating which type variable was discovered to have contradictory nullability constraints.  We may eventually want to give more diagnostic information on _where_ the contradiction came from, but this is simple and an improvement over what we had before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for generic method type inference failures: messages now identify the specific type variable constrained to both @NonNull and @Nullable and are standardized.

* **Refactor**
  * Exception handling around constraint contradictions reorganized to enable more precise diagnostic text tied to the problematic type variable.

* **Tests**
  * Updated tests to expect the new, more specific inference-failure diagnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->