### PR TITLE
Enable inference failure warnings by default

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -313,12 +313,4 @@ public interface Config {
 
   /** Should wildcard-aware generic nullability checks be enabled? */
   boolean handleWildcardGenerics();
-
-  /**
-   * Checks if a warning should be issued when generic type inference fails to infer a type
-   * argument's nullability.
-   *
-   * @return true if a warning should be issued when generic type inference fails
-   */
-  boolean warnOnGenericInferenceFailure();
 }

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -228,9 +228,4 @@ public class DummyOptionsConfig implements Config {
   public boolean handleWildcardGenerics() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
-
-  @Override
-  public boolean warnOnGenericInferenceFailure() {
-    throw new IllegalStateException(ERROR_MESSAGE);
-  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -101,9 +101,6 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_FIX_SERIALIZATION_CONFIG_PATH =
       EP_FL_NAMESPACE + ":FixSerializationConfigPath";
 
-  static final String FL_WARN_ON_GENERIC_INFERENCE_FAILURE =
-      EP_FL_NAMESPACE + ":WarnOnGenericInferenceFailure";
-
   static final String FL_HANDLE_WILDCARD_GENERICS = EP_FL_NAMESPACE + ":HandleWildcardGenerics";
 
   static final String ANNOTATED_PACKAGES_ONLY_NULLMARKED_ERROR_MSG =
@@ -234,7 +231,6 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final boolean acknowledgeAndroidRecent;
   private final boolean jspecifyMode;
   private final boolean handleWildcardGenerics;
-  private final boolean warnOnInferenceFailure;
   private final ImmutableSet<MethodClassAndName> knownInitializers;
   private final ImmutableSet<String> excludedClassAnnotations;
   private final ImmutableSet<String> generatedCodeAnnotations;
@@ -315,7 +311,6 @@ final class ErrorProneCLIFlagsConfig implements Config {
         getPackagePattern(
             getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT, DEFAULT_EXCLUDED_FIELD_ANNOT));
     castToNonNullMethod = flags.get(FL_CTNN_METHOD).orElse(null);
-    warnOnInferenceFailure = flags.getBoolean(FL_WARN_ON_GENERIC_INFERENCE_FAILURE).orElse(false);
     autofixSuppressionComment = flags.get(FL_SUPPRESS_COMMENT).orElse("");
     optionalClassPaths =
         new ImmutableSet.Builder<String>()
@@ -617,11 +612,6 @@ final class ErrorProneCLIFlagsConfig implements Config {
   @Override
   public boolean handleWildcardGenerics() {
     return handleWildcardGenerics;
-  }
-
-  @Override
-  public boolean warnOnGenericInferenceFailure() {
-    return warnOnInferenceFailure;
   }
 
   record MethodClassAndName(String enclosingClass, String methodName) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1152,15 +1152,13 @@ public final class GenericsChecks {
       return successResult;
     } catch (UnsatisfiableConstraintsException e) {
       String inferenceFailureMessage = inferenceFailureMessage(e);
-      if (config.warnOnGenericInferenceFailure()) {
-        ErrorBuilder errorBuilder = analysis.getErrorBuilder();
-        ErrorMessage errorMessage =
-            new ErrorMessage(
-                ErrorMessage.MessageTypes.GENERIC_INFERENCE_FAILURE, inferenceFailureMessage);
-        state.reportMatch(
-            errorBuilder.createErrorDescription(
-                errorMessage, analysis.buildDescription(invocationTree), state, null));
-      }
+      ErrorBuilder errorBuilder = analysis.getErrorBuilder();
+      ErrorMessage errorMessage =
+          new ErrorMessage(
+              ErrorMessage.MessageTypes.GENERIC_INFERENCE_FAILURE, inferenceFailureMessage);
+      state.reportMatch(
+          errorBuilder.createErrorDescription(
+              errorMessage, analysis.buildDescription(invocationTree), state, null));
       InferenceFailure failureResult = new InferenceFailure(inferenceFailureMessage);
       // don't cache result if we were called from dataflow, since the result may rely on dataflow
       // facts that do not reflect the fixed point

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
@@ -10,7 +10,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void wildcard() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -34,7 +34,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void genericMethodCallInOneArm() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -60,7 +60,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void genericMethodCallInBothArms() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -88,7 +88,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void nestedConditionalExpressions() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -116,7 +116,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalAsMethodArgument() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -142,7 +142,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalInfersGenericTypeArguments() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -167,7 +167,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void varConditionalDoesNotProvideTargetTypeForGenericMethodInference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -200,7 +200,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void nestedConditionalInfersGenericTypeArguments() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -228,7 +228,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalInfersDiamondTypeArguments() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -255,7 +255,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void varConditionalDoesNotProvideTargetTypeForDiamondInference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -291,7 +291,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void nestedConditionalInfersDiamondTypeArguments() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -324,7 +324,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalGenericMethodInferenceWithDataflow() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -352,7 +352,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalGenericTypeArgumentInferenceWithDataflow() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -379,7 +379,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
 
   @Test
   public void conditionalGenericMethodInferenceDataflowAndLoops() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -426,11 +426,8 @@ public class ConditionalExprTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
+  private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
-        JSpecifyJavacConfig.withJSpecifyModeArgs(
-            List.of(
-                "-XepOpt:NullAway:OnlyNullMarked=true",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
+        JSpecifyJavacConfig.withJSpecifyModeArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=true")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
@@ -246,8 +246,6 @@ public class GenericDiamondTests extends NullAwayTestsBase {
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
+            Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -11,7 +11,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaReturnsGenericMethodCall() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -66,7 +66,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void issue1294_lambdaArguments() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -94,7 +94,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void supplierLambdaInference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -123,7 +123,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaConditionalExprBody() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -146,7 +146,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaWithReturnStmtNullable() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -169,7 +169,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaReturnEnclosingLocal() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -193,7 +193,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaAccessingNonFinalField() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -221,7 +221,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void nestedLambdaFromSpring() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -258,7 +258,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaWithRawType() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -281,7 +281,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefWithMatchingReturnNullability() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -308,7 +308,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefWithDifferentReturnNullability() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -346,7 +346,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefWithArgument() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -380,7 +380,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void inferFromUnboundMethodRef() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -419,7 +419,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void issue1431_methodRefTypesIntegratedWithGenericInference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -453,7 +453,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void issue1431_methodRefTypesIntegratedWithGenericInference_multipleArgs() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -486,7 +486,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefsAndGenericInferenceNested() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -528,7 +528,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefsAndGenericInferenceNestedReturn() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -561,7 +561,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void inferFromBoundMethodRefReturn() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -602,7 +602,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void inferFromBoundMethodRefParam() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -643,7 +643,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void inferFromStaticMethodRefParam() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -684,7 +684,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void refToMethodTakingArray() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -728,7 +728,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void refToVarargsPassingArray() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -772,7 +772,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void refToVarargsPassIndividualArgs() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -823,7 +823,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void varargsDifferentFunctionalInterfaceArities() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -867,7 +867,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   @Ignore("we need to handle interactions between inference and unmarked code; TODO open issue")
   @Test
   public void inferFromMethodRefToUnmarked() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -902,7 +902,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void inferFromGenericInstanceMethodRef() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -941,7 +941,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
    */
   @Test
   public void mapStream() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -965,7 +965,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void issue1528() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1007,7 +1007,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void genericMethodLambdaArgWildCard() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1030,7 +1030,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   @Ignore("https://github.com/uber/NullAway/issues/1462")
   @Test
   public void streamMapNullableTest() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1065,7 +1065,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void genericMethodMethodRefWildCard() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1087,7 +1087,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   /** Reduced from a crash observed when building JUnit on JDK 27; testing that we do not crash */
   @Test
   public void crasherOnJdk27() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Repro.java",
             """
@@ -1124,7 +1124,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void lambdaReturnUsesNullableInvocationTargetType() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1150,11 +1150,9 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
+  private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
+            Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -791,7 +791,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void firstOrDefaultSelfContained() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -857,7 +857,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void localsWithTypesFromDataflow() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -902,7 +902,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void nullableTypeVarToNonNullField() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -925,7 +925,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void dataflowAndLoops() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -974,7 +974,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void otherExprsWithTypesFromDataflow() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1173,7 +1173,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
    */
   @Test
   public void rowMapperTest() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "TestRowMapper.java",
             """
@@ -1206,7 +1206,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void selfContainedOptional() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1248,7 +1248,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
    */
   @Test
   public void reassignLocal() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1365,7 +1365,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
   /** Self-contained test for https://github.com/uber/NullAway/issues/1157. */
   @Test
   public void atomicReferenceFieldUpdaterSelfContained() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1385,7 +1385,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void atomicReferenceFieldUpdaterFromJDK() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1402,7 +1402,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void inferenceFromReceiverPassing() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1432,7 +1432,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void typeOfParameterWithInferredLambda() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1553,7 +1553,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void issue1455() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Foo.java",
             """
@@ -1635,7 +1635,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
   @Ignore("https://github.com/uber/NullAway/issues/1493")
   @Test
   public void issue1493() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1654,7 +1654,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void nestedReceivers() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1691,7 +1691,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void caffeineNestedArgToGenericMethod() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1724,7 +1724,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void nestedGenericMethodRepairPreservesTopLevelNullability() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -1747,13 +1747,5 @@ public class GenericMethodTests extends NullAwayTestsBase {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
-  }
-
-  private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
-    return makeTestHelperWithArgs(
-        JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -46,6 +46,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
             @NullMarked
             class Test {
               Optional<String> ofNullableAcceptsNullable(@Nullable String value) {
+                // BUG: Diagnostic contains: inference failure
                 return Optional.ofNullable(value);
               }
 
@@ -125,6 +126,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
                     @NullMarked
                     class Test {
                       static Optional<String> getKey(@Nullable String key) {
+                        // BUG: Diagnostic contains: inference failure
                         return Optional.ofNullable(key).or(() -> Optional.ofNullable(System.getenv("DEFAULT_KEY")));
                       }
                     }
@@ -144,6 +146,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
             @NullMarked
             public record Repro(@Nullable String name) {
               public Optional<String> getNameOpt() {
+                // BUG: Diagnostic contains: inference failure
                 return Optional.ofNullable(name).filter(it -> true);
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -269,8 +269,6 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
+            Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -474,7 +474,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void wildcardSuperBoundsAndInference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -502,7 +502,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void superWildcardToConcreteTypeVariable() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -530,7 +530,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void methodRefParameterExtendsWildcardToConcreteParameter() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -557,7 +557,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void genericMethodLambdaArgWildCard() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -581,7 +581,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void issue1522() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -605,7 +605,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void issue1522SelfContained() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -635,7 +635,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void issue1522SelfContainedWithMethodReference() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -668,7 +668,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void groundTargetTypePreservesNestedWildcards() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -733,7 +733,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void groundTargetTypePreservesNestedWildcardsForMethodReferences() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -766,7 +766,7 @@ public class WildcardTests extends NullAwayTestsBase {
    */
   @Test
   public void nullableWildcardFromCaffeine() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -799,7 +799,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void mapStreamValuesToNullable() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -846,7 +846,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void issue1500() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -882,7 +882,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void unboundWildcardTypeVarUnmarked() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -905,7 +905,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void nullableOnWildcard() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -937,13 +937,5 @@ public class WildcardTests extends NullAwayTestsBase {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));
-  }
-
-  private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
-    return makeTestHelperWithArgs(
-        JSpecifyJavacConfig.withJSpecifyModeArgs(
-            Arrays.asList(
-                "-XepOpt:NullAway:OnlyNullMarked=true",
-                "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
   }
 }


### PR DESCRIPTION
Fixes #1551.  Unfortunately this leads to too many new warnings on real-world benchmarks to just enable it.  I think we need to get better wildcards support into place, and possibly more JDK modeling, and then we can try to land this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy annotation location configuration handling.

* **Changes**
  * Generic type inference failures are now unconditionally reported as errors in all cases, changing from the previous behavior where reporting was optional based on configuration.
  * Removed the `WarnOnGenericInferenceFailure` configuration option from available settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->