### PR TITLE
Add Contract annotation to nullaway-annotations

### DIFF
--- a/annotations/src/main/java/com/uber/nullaway/annotations/Contract.java
+++ b/annotations/src/main/java/com/uber/nullaway/annotations/Contract.java
@@ -1,0 +1,43 @@
+package com.uber.nullaway.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies method or constructor behavior depending on the arguments.
+ *
+ * <p>This annotation is inspired by {@code org.jetbrains.annotations.Contract} and follows the same
+ * contract-string semantics. It is provided in the {@code com.uber.nullaway.annotations} package so
+ * users can depend directly on NullAway's annotations artifact.
+ *
+ * <p>The contract string has the following grammar:
+ *
+ * <pre>{@code
+ * contract ::= (clause ';')* clause
+ * clause ::= args '->' effect
+ * args ::= ((arg ',')* arg)?
+ * arg ::= value-constraint
+ * value-constraint ::= '_' | 'null' | '!null' | 'false' | 'true'
+ * effect ::= value-constraint | 'fail' | 'this' | 'new' | 'param<N>'
+ * }</pre>
+ *
+ * <p>For example, {@code "null -> fail"} describes a method that throws if the argument is {@code
+ * null}, and {@code "!null -> !null"} describes a method that returns a non-null value when passed
+ * a non-null value.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface Contract {
+
+  /**
+   * Contains the contract clauses describing relationships between call arguments and the returned
+   * value or exceptional behavior.
+   *
+   * @return the contract string
+   */
+  String value();
+}

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -1120,34 +1120,34 @@ public class ContractsTests extends NullAwayTestsBase {
         .addSourceLines(
             "NullnessChecker.java",
             """
-                    package com.uber;
+            package com.uber;
 
-                    import com.uber.nullaway.annotations.Contract;
-                    import javax.annotation.Nullable;
+            import com.uber.nullaway.annotations.Contract;
+            import javax.annotation.Nullable;
 
-                    public class NullnessChecker {
-                      @Contract("null -> fail")
-                      static void assertNonNull(@Nullable Object o) {
-                        if (o == null) {
-                          throw new IllegalArgumentException();
-                        }
-                      }
-                    }
-                    """)
+            public class NullnessChecker {
+              @Contract("null -> fail")
+              static void assertNonNull(@Nullable Object o) {
+                if (o == null) {
+                  throw new IllegalArgumentException();
+                }
+              }
+            }
+            """)
         .addSourceLines(
             "Test.java",
             """
-                    package com.uber;
+            package com.uber;
 
-                    import javax.annotation.Nullable;
+            import javax.annotation.Nullable;
 
-                    class Test {
-                      String test(@Nullable Object o) {
-                        NullnessChecker.assertNonNull(o);
-                        return o.toString();
-                      }
-                    }
-                    """)
+            class Test {
+              String test(@Nullable Object o) {
+                NullnessChecker.assertNonNull(o);
+                return o.toString();
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -1109,4 +1109,45 @@ public class ContractsTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void nullAwayContractAnnotation() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "NullnessChecker.java",
+            """
+                    package com.uber;
+
+                    import com.uber.nullaway.annotations.Contract;
+                    import javax.annotation.Nullable;
+
+                    public class NullnessChecker {
+                      @Contract("null -> fail")
+                      static void assertNonNull(@Nullable Object o) {
+                        if (o == null) {
+                          throw new IllegalArgumentException();
+                        }
+                      }
+                    }
+                    """)
+        .addSourceLines(
+            "Test.java",
+            """
+                    package com.uber;
+
+                    import javax.annotation.Nullable;
+
+                    class Test {
+                      String test(@Nullable Object o) {
+                        NullnessChecker.assertNonNull(o);
+                        return o.toString();
+                      }
+                    }
+                    """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
Fixes #1543.

This PR adds `com.uber.nullaway.annotations.Contract` to the `nullaway-annotations` artifact.

NullAway already recognizes annotations whose simple name is `Contract`, so this provides a NullAway-owned annotation users can depend on directly.

Changes:
- Add `@Contract` annotation under `com.uber.nullaway.annotations`
- Use `RetentionPolicy.CLASS`
- Support `METHOD` and `CONSTRUCTOR` targets
- Add Javadoc for `value()` and `pure()`

Tested with:
- `./gradlew :annotations:build`
- `./gradlew :annotations:javadoc`
- `./gradlew spotlessCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `@Contract` annotation for methods and constructors with a required contract string; it's documented and retained in compiled classes, with Javadoc describing the contract grammar and examples.
* **Tests**
  * Added a test confirming the `@Contract` annotation is recognized and influences nullness reasoning at call sites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->