### PR TITLE
Adjust more TreePaths to have correct leaf before calling getTreeType

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -751,13 +751,8 @@ public class NullabilityUtil {
       ExpressionTree expr, VisitorState state) {
     TreePath path = state.getPath();
     if (path.getLeaf() != expr) {
-      // if the expression is not the leaf of the path, we can't update the path to point to the
-      // stripped expression, so we just return the original expression and state
-      // TODO fix all cases where this happens and remove this fallback case
-      //  Tracked in https://github.com/uber/NullAway/issues/1479
       throw new RuntimeException(
           String.format("Wrong leaf %s in path to %s", path.getLeaf(), expr));
-      //      return new ExprTreeAndState(expr, state);
     }
     ExpressionTree resultExpr = expr;
     while (resultExpr instanceof ParenthesizedTree) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -755,6 +755,10 @@ public class NullabilityUtil {
       // stripped expression, so we just return the original expression and state
       // TODO fix all cases where this happens and remove this fallback case
       //  Tracked in https://github.com/uber/NullAway/issues/1479
+      if (true) {
+        throw new RuntimeException(
+            String.format("Wrong leaf %s in path to %s", path.getLeaf(), expr));
+      }
       return new ExprTreeAndState(expr, state);
     }
     ExpressionTree resultExpr = expr;

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -755,11 +755,9 @@ public class NullabilityUtil {
       // stripped expression, so we just return the original expression and state
       // TODO fix all cases where this happens and remove this fallback case
       //  Tracked in https://github.com/uber/NullAway/issues/1479
-      if (true) {
-        throw new RuntimeException(
-            String.format("Wrong leaf %s in path to %s", path.getLeaf(), expr));
-      }
-      return new ExprTreeAndState(expr, state);
+      throw new RuntimeException(
+          String.format("Wrong leaf %s in path to %s", path.getLeaf(), expr));
+      //      return new ExprTreeAndState(expr, state);
     }
     ExpressionTree resultExpr = expr;
     while (resultExpr instanceof ParenthesizedTree) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1551,9 +1551,9 @@ public final class GenericsChecks {
 
     Type condExprType = getConditionalExpressionType(tree, state);
     Type truePartType =
-        getTreeType(truePartTree, state.withPath(new TreePath(state.getPath(), truePartTree)));
+        getTreeType(truePartTree, state.withPath(pathWithLeaf(state.getPath(), truePartTree)));
     Type falsePartType =
-        getTreeType(falsePartTree, state.withPath(new TreePath(state.getPath(), falsePartTree)));
+        getTreeType(falsePartTree, state.withPath(pathWithLeaf(state.getPath(), falsePartTree)));
     // The condExpr type should be the least-upper bound of the true and false part types.  To check
     // the nullability annotations, we check that the true and false parts are assignable to the
     // type of the whole expression
@@ -1671,7 +1671,7 @@ public final class GenericsChecks {
               if (inferredPolyType != null) {
                 actualParameterType = inferredPolyType;
               } else {
-                TreePath pathToActualParam = new TreePath(state.getPath(), currentActualParam);
+                TreePath pathToActualParam = pathWithLeaf(state.getPath(), currentActualParam);
                 actualParameterType =
                     getTreeType(currentActualParam, state.withPath(pathToActualParam));
               }
@@ -1679,7 +1679,7 @@ public final class GenericsChecks {
                 if (isGenericCallNeedingInference(currentActualParam)) {
                   // infer the type of the method call based on the assignment context
                   // and the formal parameter type
-                  TreePath pathToParam = new TreePath(state.getPath(), currentActualParam);
+                  TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
                   actualParameterType =
                       inferGenericMethodCallType(
                           state.withPath(pathToParam),
@@ -2020,10 +2020,7 @@ public final class GenericsChecks {
     com.sun.tools.javac.util.List<Type> callSiteParamTypes =
         methodTypeAtCallSite.getParameterTypes();
     List<? extends ExpressionTree> actualParams = invocationTree.getArguments();
-    TreePath pathToInvocation = state.getPath();
-    if (!state.getPath().getLeaf().equals(invocationTree)) {
-      pathToInvocation = new TreePath(pathToInvocation, invocationTree);
-    }
+    TreePath pathToInvocation = pathWithLeaf(state.getPath(), invocationTree);
     // use this map to store repaired substitutions for method type variables, to ensure we use the
     // same repaired substitution for all occurrences of the same type variable
     Map<Symbol.TypeVariableSymbol, Type> repairedTopLevelSubstitutions = new HashMap<>();
@@ -2047,7 +2044,7 @@ public final class GenericsChecks {
         } else { // need to compute the substitution
           ExpressionTree actualParam = actualParams.get(i);
           Type actualArgType =
-              getTreeType(actualParam, state.withPath(new TreePath(pathToInvocation, actualParam)));
+              getTreeType(actualParam, state.withPath(pathWithLeaf(pathToInvocation, actualParam)));
           // only handle cases of non-raw actual parameter types that have the same base type as the
           // inferred parameter type at the call site
           if (actualArgType != null
@@ -2193,8 +2190,8 @@ public final class GenericsChecks {
     Preconditions.checkArgument(
         assignment instanceof AssignmentTree || assignment instanceof VariableTree);
     TreePath path = state.getPath();
-    if (!path.getLeaf().equals(assignment)) {
-      state = state.withPath(new TreePath(path, assignment));
+    if (path.getLeaf() != assignment) {
+      state = state.withPath(pathWithLeaf(path, assignment));
     }
     Type treeType = getTreeType(assignment, state);
     return new InvocationAndContext(invocation, treeType, isAssignmentToLocalVariable(assignment));
@@ -2301,7 +2298,7 @@ public final class GenericsChecks {
       } else if (methodSelect instanceof MemberSelectTree memberSelectTree) {
         ExpressionTree receiver = ASTHelpers.stripParentheses(memberSelectTree.getExpression());
         TreePath curPath = path != null ? path : state.getPath();
-        TreePath receiverPath = new TreePath(curPath, receiver);
+        TreePath receiverPath = pathWithLeaf(curPath, receiver);
         if (isGenericCallNeedingInference(receiver)) {
           enclosingType =
               inferGenericMethodCallType(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1328,6 +1328,10 @@ public final class GenericsChecks {
     return updateTypeWithNullness(state, exprType, refinedNullness);
   }
 
+  /**
+   * Returns an updated version of {@code path} with {@code leaf} as the leaf, if needed. If {@code
+   * leaf} is already the leaf of {@code path}, just return {@code path} unmodified.
+   */
   private static TreePath pathWithLeaf(TreePath path, Tree leaf) {
     return path.getLeaf() == leaf ? path : new TreePath(path, leaf);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1005,9 +1005,16 @@ public final class GenericsChecks {
     // then, handle parameters
     new InvocationArguments(methodInvocationTree, methodType)
         .forEach(
-            (argument, argPos, formalParamType, unused) ->
-                generateConstraintsForPseudoAssignment(
-                    state, path, solver, allInvocations, argument, formalParamType));
+            (argument, argPos, formalParamType, unused) -> {
+              TreePath pathToArgument = new TreePath(path, argument);
+              generateConstraintsForPseudoAssignment(
+                  state.withPath(pathToArgument),
+                  pathToArgument,
+                  solver,
+                  allInvocations,
+                  argument,
+                  formalParamType);
+            });
   }
 
   /**
@@ -1651,11 +1658,12 @@ public final class GenericsChecks {
                 if (isGenericCallNeedingInference(currentActualParam)) {
                   // infer the type of the method call based on the assignment context
                   // and the formal parameter type
+                  TreePath pathToParam = new TreePath(state.getPath(), currentActualParam);
                   actualParameterType =
                       inferGenericMethodCallType(
-                          state,
+                          state.withPath(pathToParam),
                           (MethodInvocationTree) currentActualParam,
-                          null,
+                          pathToParam,
                           formalParameter,
                           false,
                           false);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2009,7 +2009,10 @@ public final class GenericsChecks {
     com.sun.tools.javac.util.List<Type> callSiteParamTypes =
         methodTypeAtCallSite.getParameterTypes();
     List<? extends ExpressionTree> actualParams = invocationTree.getArguments();
-
+    TreePath pathToInvocation = state.getPath();
+    if (!state.getPath().getLeaf().equals(invocationTree)) {
+      pathToInvocation = new TreePath(pathToInvocation, invocationTree);
+    }
     // use this map to store repaired substitutions for method type variables, to ensure we use the
     // same repaired substitution for all occurrences of the same type variable
     Map<Symbol.TypeVariableSymbol, Type> repairedTopLevelSubstitutions = new HashMap<>();
@@ -2031,7 +2034,9 @@ public final class GenericsChecks {
             callSiteParamType = repairedSubstitution;
           }
         } else { // need to compute the substitution
-          Type actualArgType = getTreeType(actualParams.get(i), state);
+          ExpressionTree actualParam = actualParams.get(i);
+          Type actualArgType =
+              getTreeType(actualParam, state.withPath(new TreePath(pathToInvocation, actualParam)));
           // only handle cases of non-raw actual parameter types that have the same base type as the
           // inferred parameter type at the call site
           if (actualArgType != null

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -786,7 +786,12 @@ public final class GenericsChecks {
       if (isGenericCallNeedingInference(rhsTree)) {
         rhsType =
             inferGenericMethodCallType(
-                state, (MethodInvocationTree) rhsTree, null, lhsType, assignedToLocal, false);
+                state.withPath(pathToRhs),
+                (MethodInvocationTree) rhsTree,
+                pathToRhs,
+                lhsType,
+                assignedToLocal,
+                false);
       }
       boolean isAssignmentValid = subtypeParameterNullability(lhsType, rhsType, state);
       if (!isAssignmentValid) {
@@ -1003,11 +1008,12 @@ public final class GenericsChecks {
           methodType.getReturnType(), typeFromAssignmentContext, assignedToLocal);
     }
     // then, handle parameters
+    TreePath pathToInvocation =
+        path != null ? path : pathWithLeaf(state.getPath(), methodInvocationTree);
     new InvocationArguments(methodInvocationTree, methodType)
         .forEach(
             (argument, argPos, formalParamType, unused) -> {
-              TreePath pathToArgument =
-                  new TreePath(path == null ? state.getPath() : path, argument);
+              TreePath pathToArgument = new TreePath(pathToInvocation, argument);
               generateConstraintsForPseudoAssignment(
                   state.withPath(pathToArgument),
                   pathToArgument,
@@ -1093,12 +1099,9 @@ public final class GenericsChecks {
             .asMethodType();
     Type fiReturnType = fiMethodTypeAsMember.getReturnType();
     Tree body = lambda.getBody();
-    // augment our current TreePath so that the lambda is the leaf, in case dataflow analysis needs
-    // to be run within it
-    if (path == null) {
-      path = state.getPath();
-    }
-    TreePath lambdaPath = new TreePath(path, lambda);
+    // Ensure our current TreePath has the lambda as the leaf, in case dataflow analysis needs to be
+    // run within it.
+    TreePath lambdaPath = pathWithLeaf(path != null ? path : state.getPath(), lambda);
     if (body instanceof ExpressionTree returnedExpression) {
       // Case 1: Expression body, e.g., () -> null
       TreePath returnedExpressionPath = new TreePath(lambdaPath, returnedExpression);
@@ -1287,14 +1290,13 @@ public final class GenericsChecks {
     if (!shouldRunDataflowForExpression(exprType, expr)) {
       return exprType;
     }
-    TreePath currentPath = path != null ? path : state.getPath();
     // We need a TreePath whose leaf is the expression, as the calls to `getNullness` /
     // `getNullnessFromRunning` below return the nullness of the leaf of the path.
-    // Just appending expr to currentPath is a bit sketchy, as it may not actually be the valid
-    // tree path to the expression.  However, all we need the path for (beyond the leaf) is to
+    // Just appending expr to the current path is a bit sketchy, as it may not actually be the
+    // valid tree path to the expression. However, all we need the path for (beyond the leaf) is to
     // discover the enclosing method/lambda/initializer, and for that purpose this should be
-    // sufficient.
-    TreePath exprPath = new TreePath(currentPath, expr);
+    // sufficient. pathWithLeaf avoids appending expr when the provided path is already at expr.
+    TreePath exprPath = pathWithLeaf(path != null ? path : state.getPath(), expr);
     TreePath enclosingPath = NullabilityUtil.findEnclosingMethodOrLambdaOrInitializer(exprPath);
     if (enclosingPath == null) {
       return exprType;
@@ -1324,6 +1326,10 @@ public final class GenericsChecks {
       return exprType;
     }
     return updateTypeWithNullness(state, exprType, refinedNullness);
+  }
+
+  private static TreePath pathWithLeaf(TreePath path, Tree leaf) {
+    return path.getLeaf() == leaf ? path : new TreePath(path, leaf);
   }
 
   /**
@@ -1444,7 +1450,12 @@ public final class GenericsChecks {
       if (isGenericCallNeedingInference(retExpr)) {
         returnExpressionType =
             inferGenericMethodCallType(
-                state, (MethodInvocationTree) retExpr, null, formalReturnType, false, false);
+                state.withPath(pathToRetExpr),
+                (MethodInvocationTree) retExpr,
+                pathToRetExpr,
+                formalReturnType,
+                false,
+                false);
       }
       boolean isReturnTypeValid =
           subtypeParameterNullability(formalReturnType, returnExpressionType, state);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1516,8 +1516,10 @@ public final class GenericsChecks {
     Tree falsePartTree = tree.getFalseExpression();
 
     Type condExprType = getConditionalExpressionType(tree, state);
-    Type truePartType = getTreeType(truePartTree, state);
-    Type falsePartType = getTreeType(falsePartTree, state);
+    Type truePartType =
+        getTreeType(truePartTree, state.withPath(new TreePath(state.getPath(), truePartTree)));
+    Type falsePartType =
+        getTreeType(falsePartTree, state.withPath(new TreePath(state.getPath(), falsePartTree)));
     // The condExpr type should be the least-upper bound of the true and false part types.  To check
     // the nullability annotations, we check that the true and false parts are assignable to the
     // type of the whole expression
@@ -1771,7 +1773,7 @@ public final class GenericsChecks {
             && newClassTree.getClassBody() != null) {
           Type newClassType = ASTHelpers.getType(newClassTree);
           if (newClassType != null && newClassType.tsym.equals(symbol)) {
-            Type typeFromTree = getTreeType(newClassTree, state);
+            Type typeFromTree = getTreeType(newClassTree, state.withPath(path));
             if (typeFromTree != null) {
               verify(
                   state.getTypes().isAssignable(symbol.type, typeFromTree),

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1586,7 +1586,7 @@ public final class GenericsChecks {
       parent = parentPath.getLeaf();
     }
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
-      return getTreeType(parent, state);
+      return getTreeType(parent, state.withPath(parentPath));
     }
     return getTreeType(tree, state);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1662,7 +1662,8 @@ public final class GenericsChecks {
                 return;
               }
 
-              Type actualParameterType = null;
+              TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
+              Type actualParameterType;
               if (currentActualParam instanceof LambdaExpressionTree) {
                 maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter);
               }
@@ -1670,15 +1671,12 @@ public final class GenericsChecks {
               if (inferredPolyType != null) {
                 actualParameterType = inferredPolyType;
               } else {
-                TreePath pathToActualParam = pathWithLeaf(state.getPath(), currentActualParam);
-                actualParameterType =
-                    getTreeType(currentActualParam, state.withPath(pathToActualParam));
+                actualParameterType = getTreeType(currentActualParam, state.withPath(pathToParam));
               }
               if (actualParameterType != null) {
                 if (isGenericCallNeedingInference(currentActualParam)) {
                   // infer the type of the method call based on the assignment context
                   // and the formal parameter type
-                  TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
                   actualParameterType =
                       inferGenericMethodCallType(
                           state.withPath(pathToParam),
@@ -2121,7 +2119,8 @@ public final class GenericsChecks {
       parent = parentPath.getLeaf();
     }
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
-      return getInvocationInferenceInfoForAssignment(parent, invocation, state);
+      return getInvocationInferenceInfoForAssignment(
+          parent, invocation, state.withPath(parentPath));
     } else if (parent instanceof ReturnTree) {
       // find the enclosing method and return its return type
       TreePath enclosingMethodOrLambda =
@@ -2142,7 +2141,8 @@ public final class GenericsChecks {
           // this is the case of a nested generic call, e.g., id(id(x)) where id is generic
           // we want to find the outermost invocation that requires inference, since that is
           // the one whose assignment context is relevant
-          return getInvocationAndContextForInference(parentPath, state, calledFromDataflow);
+          return getInvocationAndContextForInference(
+              parentPath, state.withPath(parentPath), calledFromDataflow);
         }
         // the generic invocation is either a regular parameter to the parent call, or the
         // receiver expression
@@ -2166,7 +2166,7 @@ public final class GenericsChecks {
                       ASTHelpers.getSymbol(parentInvocation),
                       parentInvocation,
                       parentPath,
-                      state,
+                      state.withPath(parentPath),
                       calledFromDataflow);
             } else {
               throw new RuntimeException(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -28,7 +28,7 @@ import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreeScanner;
+import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
@@ -1111,10 +1111,19 @@ public final class GenericsChecks {
           fiReturnType);
     } else if (body instanceof BlockTree) {
       // Case 2: Block body, e.g., () -> { return null; }
-      List<ExpressionTree> returnExpressions = ReturnFinder.findReturnExpressions(body);
-      for (ExpressionTree returnExpr : returnExpressions) {
+      TreePath bodyPath = new TreePath(lambdaPath, body);
+      List<TreePath> returnPaths = ReturnFinder.findReturnPaths(bodyPath);
+      for (TreePath returnPath : returnPaths) {
+        ReturnTree returnTree = (ReturnTree) returnPath.getLeaf();
+        ExpressionTree returnExpr = castToNonNull(returnTree.getExpression());
+        TreePath returnExprPath = new TreePath(returnPath, returnExpr);
         generateConstraintsForPseudoAssignment(
-            state, lambdaPath, solver, allInvocations, returnExpr, fiReturnType);
+            state.withPath(returnExprPath),
+            returnExprPath,
+            solver,
+            allInvocations,
+            returnExpr,
+            fiReturnType);
       }
     }
   }
@@ -1196,8 +1205,8 @@ public final class GenericsChecks {
   }
 
   /**
-   * A visitor that scans a {@link Tree} (typically a lambda or method body) to find all {@code
-   * return} statements and collect their expressions.
+   * A visitor that scans a {@link TreePath} (typically to a lambda or method body) to find all
+   * {@code return} statements and collect their paths.
    *
    * <p>This scanner is specifically designed to be "shallow." It will <b>not</b> descend into
    * nested lambdas, local classes, or anonymous classes, ensuring it only finds {@code return}
@@ -1207,32 +1216,33 @@ public final class GenericsChecks {
    *
    * <pre>
    * Tree lambdaBody = myLambda.getBody();
-   * List<ExpressionTree> returns = ReturnFinder.findReturnExpressions(lambdaBody);
+   * TreePath lambdaBodyPath = new TreePath(lambdaPath, lambdaBody);
+   * List<TreePath> returns = ReturnFinder.findReturnPaths(lambdaBodyPath);
    * </pre>
    */
-  static class ReturnFinder extends TreeScanner<@Nullable Void, @Nullable Void> {
+  static class ReturnFinder extends TreePathScanner<@Nullable Void, @Nullable Void> {
 
-    private final List<ExpressionTree> returnExpressions = new ArrayList<>();
+    private final List<TreePath> returnPaths = new ArrayList<>();
 
     /**
-     * Scans the given tree and returns all found return expressions.
+     * Scans the given path and returns all found paths to return statements with expressions.
      *
-     * @param tree The tree (e.g., a lambda body) to scan.
-     * @return A list of all return expressions found.
+     * @param path The path to a tree (e.g., a lambda body) to scan.
+     * @return A list of all paths to return statements with expressions found.
      */
-    public static List<ExpressionTree> findReturnExpressions(Tree tree) {
+    public static List<TreePath> findReturnPaths(TreePath path) {
       ReturnFinder finder = new ReturnFinder();
-      finder.scan(tree, null);
-      return finder.getReturnExpressions();
+      finder.scan(path, null);
+      return finder.getReturnPaths();
     }
 
     /**
-     * Gets the list of return expressions found by this visitor.
+     * Gets the list of return statement paths found by this visitor.
      *
-     * @return The list of return expressions.
+     * @return The list of return statement paths.
      */
-    public List<ExpressionTree> getReturnExpressions() {
-      return returnExpressions;
+    public List<TreePath> getReturnPaths() {
+      return returnPaths;
     }
 
     @Override
@@ -1255,9 +1265,8 @@ public final class GenericsChecks {
 
     @Override
     public @Nullable Void visitReturn(ReturnTree node, @Nullable Void p) {
-      ExpressionTree expression = node.getExpression();
-      if (expression != null) {
-        returnExpressions.add(expression);
+      if (node.getExpression() != null) {
+        returnPaths.add(getCurrentPath());
       }
       // We've processed this return, don't scan its children
       return null;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1039,12 +1039,15 @@ public final class GenericsChecks {
    */
   private void generateConstraintsForPseudoAssignment(
       VisitorState state,
-      @Nullable TreePath path,
+      @SuppressWarnings("unused") @Nullable TreePath path,
       ConstraintSolver solver,
       Set<MethodInvocationTree> allInvocations,
       ExpressionTree rhsExpr,
       Type lhsType) {
-    rhsExpr = ASTHelpers.stripParentheses(rhsExpr);
+    NullabilityUtil.ExprTreeAndState exprTreeAndState =
+        NullabilityUtil.stripParensAndUpdateTreePath(rhsExpr, state);
+    rhsExpr = exprTreeAndState.expr();
+    state = exprTreeAndState.state();
     // if the parameter is itself a generic call requiring inference, generate constraints for
     // that call
     if (isGenericCallNeedingInference(rhsExpr)) {
@@ -1052,9 +1055,10 @@ public final class GenericsChecks {
       Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(invTree);
       allInvocations.add(invTree);
       generateConstraintsForCall(
-          state, path, lhsType, false, solver, symbol, invTree, allInvocations);
+          state, state.getPath(), lhsType, false, solver, symbol, invTree, allInvocations);
     } else if (rhsExpr instanceof LambdaExpressionTree lambda) {
-      handleLambdaInGenericMethodInference(state, path, solver, allInvocations, lhsType, lambda);
+      handleLambdaInGenericMethodInference(
+          state, state.getPath(), solver, allInvocations, lhsType, lambda);
     } else if (rhsExpr instanceof MemberReferenceTree memberReferenceTree) {
       handleMethodRefInGenericMethodInference(state, solver, lhsType, memberReferenceTree);
     } else { // all other cases
@@ -1063,7 +1067,7 @@ public final class GenericsChecks {
         // bail out of any checking involving raw types for now
         return;
       }
-      argumentType = refineArgumentTypeWithDataflow(argumentType, rhsExpr, state, path);
+      argumentType = refineArgumentTypeWithDataflow(argumentType, rhsExpr, state, state.getPath());
       solver.addSubtypeConstraint(argumentType, lhsType, false);
     }
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1016,7 +1016,6 @@ public final class GenericsChecks {
               TreePath pathToArgument = new TreePath(pathToInvocation, argument);
               generateConstraintsForPseudoAssignment(
                   state.withPath(pathToArgument),
-                  pathToArgument,
                   solver,
                   allInvocations,
                   argument,
@@ -1029,7 +1028,6 @@ public final class GenericsChecks {
    * (parameter passing or return).
    *
    * @param state the visitor state
-   * @param path the tree path to {@code rhsExpr} if available
    * @param solver the constraint solver
    * @param allInvocations a set of all method invocations that require inference, including nested
    *     ones. This is an output parameter that gets mutated while generating the constraints to add
@@ -1039,7 +1037,6 @@ public final class GenericsChecks {
    */
   private void generateConstraintsForPseudoAssignment(
       VisitorState state,
-      @SuppressWarnings("unused") @Nullable TreePath path,
       ConstraintSolver solver,
       Set<MethodInvocationTree> allInvocations,
       ExpressionTree rhsExpr,
@@ -1111,7 +1108,6 @@ public final class GenericsChecks {
       TreePath returnedExpressionPath = new TreePath(lambdaPath, returnedExpression);
       generateConstraintsForPseudoAssignment(
           state.withPath(returnedExpressionPath),
-          returnedExpressionPath,
           solver,
           allInvocations,
           returnedExpression,
@@ -1125,12 +1121,7 @@ public final class GenericsChecks {
         ExpressionTree returnExpr = castToNonNull(returnTree.getExpression());
         TreePath returnExprPath = new TreePath(returnPath, returnExpr);
         generateConstraintsForPseudoAssignment(
-            state.withPath(returnExprPath),
-            returnExprPath,
-            solver,
-            allInvocations,
-            returnExpr,
-            fiReturnType);
+            state.withPath(returnExprPath), solver, allInvocations, returnExpr, fiReturnType);
       }
     }
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1093,8 +1093,14 @@ public final class GenericsChecks {
     TreePath lambdaPath = new TreePath(path, lambda);
     if (body instanceof ExpressionTree returnedExpression) {
       // Case 1: Expression body, e.g., () -> null
+      TreePath returnedExpressionPath = new TreePath(lambdaPath, returnedExpression);
       generateConstraintsForPseudoAssignment(
-          state, lambdaPath, solver, allInvocations, returnedExpression, fiReturnType);
+          state.withPath(returnedExpressionPath),
+          returnedExpressionPath,
+          solver,
+          allInvocations,
+          returnedExpression,
+          fiReturnType);
     } else if (body instanceof BlockTree) {
       // Case 2: Block body, e.g., () -> { return null; }
       List<ExpressionTree> returnExpressions = ReturnFinder.findReturnExpressions(body);
@@ -2256,8 +2262,9 @@ public final class GenericsChecks {
         }
       } else if (methodSelect instanceof MemberSelectTree memberSelectTree) {
         ExpressionTree receiver = ASTHelpers.stripParentheses(memberSelectTree.getExpression());
+        TreePath curPath = path != null ? path : state.getPath();
+        TreePath receiverPath = new TreePath(curPath, receiver);
         if (isGenericCallNeedingInference(receiver)) {
-          var receiverPath = path == null ? null : new TreePath(path, receiver);
           enclosingType =
               inferGenericMethodCallType(
                   state,
@@ -2267,7 +2274,7 @@ public final class GenericsChecks {
                   false,
                   calledFromDataflow);
         } else {
-          enclosingType = getTreeType(receiver, state);
+          enclosingType = getTreeType(receiver, state.withPath(receiverPath));
         }
       }
     } else {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -613,7 +613,7 @@ public final class GenericsChecks {
       parent = parentPath.getLeaf();
     }
     if (parent instanceof VariableTree || parent instanceof AssignmentTree) {
-      return getTreeType(parent, state);
+      return getTreeType(parent, state.withPath(parentPath));
     }
     if (parent instanceof ReturnTree) {
       TreePath enclosingMethodOrLambda =

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1006,7 +1006,8 @@ public final class GenericsChecks {
     new InvocationArguments(methodInvocationTree, methodType)
         .forEach(
             (argument, argPos, formalParamType, unused) -> {
-              TreePath pathToArgument = new TreePath(path, argument);
+              TreePath pathToArgument =
+                  new TreePath(path == null ? state.getPath() : path, argument);
               generateConstraintsForPseudoAssignment(
                   state.withPath(pathToArgument),
                   pathToArgument,

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2167,6 +2167,10 @@ public final class GenericsChecks {
       Tree assignment, MethodInvocationTree invocation, VisitorState state) {
     Preconditions.checkArgument(
         assignment instanceof AssignmentTree || assignment instanceof VariableTree);
+    TreePath path = state.getPath();
+    if (!path.getLeaf().equals(assignment)) {
+      state = state.withPath(new TreePath(path, assignment));
+    }
     Type treeType = getTreeType(assignment, state);
     return new InvocationAndContext(invocation, treeType, isAssignmentToLocalVariable(assignment));
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -3,7 +3,9 @@ package com.uber.nullaway.generics;
 import com.google.common.base.Verify;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
@@ -122,8 +124,11 @@ public class GenericsUtils {
     }
     Type qualifierType = null;
     if (!referencedMethod.isStatic()) {
+      ExpressionTree qualifierExpression = memberReferenceTree.getQualifierExpression();
       qualifierType =
-          genericsChecks.getTreeType(memberReferenceTree.getQualifierExpression(), state);
+          genericsChecks.getTreeType(
+              qualifierExpression,
+              state.withPath(new TreePath(state.getPath(), qualifierExpression)));
     }
 
     // now, get the type of the corresponding functional interface method, as a member of targetType


### PR DESCRIPTION
Fixes #1479 

Now the `stripParensAndUpdateTreePath` utility method will throw if the leaf of the `TreePath` passed in doesn't match `expr`.  This is a good invariant to enforce.  There are a lot of code changes here, but they are all related to manipulating `TreePath`s rather than core logic, and the new `throw` will guard against getting this wrong in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of nullability analysis for generic method invocations, lambdas, returns and method references by ensuring the correct expression context is used.
  * Added fail-fast validation to detect and surface mismatched analysis state earlier.

* **Improvements**
  * Propagated precise, path-aware context throughout inference and constraint generation to strengthen dataflow refinement and type resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->