### PR TITLE
Run inference for generic method calls nested inside receivers

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -553,9 +553,12 @@ public final class GenericsChecks {
       } else {
         result = ASTHelpers.getType(tree);
         if (result != null) {
-          // for method invocations and field reads, there may be annotations on type variables in
-          // the return / field type that need to be restored
           if (tree instanceof MethodInvocationTree invocationTree) {
+            // for a call to an instance method, we may need to run inference on a nested call
+            // inside the receiver in order to figure out the proper nullability of the receiver's
+            // type arguments.  we invoke getEnclosingTypeForCallExpression, which will run
+            // inference if needed, and then recompute the type as a member of the returned
+            // enclosing type
             Symbol.MethodSymbol symbol = castToNonNull(ASTHelpers.getSymbol(invocationTree));
             Type invokedMethodType = symbol.type;
             Type enclosingType =
@@ -567,6 +570,7 @@ public final class GenericsChecks {
             }
             Type.MethodType methodType =
                 handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
+            // restore explicit annotations from the return type
             Type returnType = methodType.getReturnType();
             result =
                 TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
@@ -574,6 +578,7 @@ public final class GenericsChecks {
           } else if (tree instanceof MemberSelectTree memberSelectTree) {
             Symbol memberSelectSymbol = ASTHelpers.getSymbol(memberSelectTree);
             if (memberSelectSymbol != null && memberSelectSymbol.getKind().isField()) {
+              // restore explicit annotations from the field's declared type
               Type fieldType = memberSelectSymbol.type;
               result =
                   TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -551,6 +551,8 @@ public final class GenericsChecks {
           result = ASTHelpers.getType(assignmentTree);
         }
       } else {
+        // TODO for a method invocation we may need to recurse through the receivers to do inference
+        //  for any generic method calls, and then bubble those types back up
         result = ASTHelpers.getType(tree);
         if (result != null) {
           // for method invocations and field reads, there may be annotations on type variables in

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -551,16 +551,22 @@ public final class GenericsChecks {
           result = ASTHelpers.getType(assignmentTree);
         }
       } else {
-        // TODO for a method invocation we may need to recurse through the receivers to do inference
-        //  for any generic method calls, and then bubble those types back up
         result = ASTHelpers.getType(tree);
         if (result != null) {
           // for method invocations and field reads, there may be annotations on type variables in
           // the return / field type that need to be restored
           if (tree instanceof MethodInvocationTree invocationTree) {
             Symbol.MethodSymbol symbol = castToNonNull(ASTHelpers.getSymbol(invocationTree));
+            Type invokedMethodType = symbol.type;
+            Type enclosingType =
+                getEnclosingTypeForCallExpression(
+                    symbol, invocationTree, state.getPath(), state, false);
+            if (enclosingType != null) {
+              invokedMethodType =
+                  TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
+            }
             Type.MethodType methodType =
-                handler.onOverrideMethodType(symbol, symbol.type.asMethodType(), state);
+                handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
             Type returnType = methodType.getReturnType();
             result =
                 TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -556,7 +556,10 @@ public final class GenericsChecks {
           if (tree instanceof MethodInvocationTree invocationTree) {
             // for a call to an instance method, we may need to run inference on a nested call
             // inside the receiver in order to figure out the proper nullability of the receiver's
-            // type arguments.  we invoke getEnclosingTypeForCallExpression, which will run
+            // type arguments.  E.g., for a call `foo(x,y).bar().baz()`, where `foo` is a generic
+            // method, we need to run inference on the call to `foo` to determine the receiver type
+            // of the `bar()` call, which could in turn impact the receiver type of the `baz()`
+            // call.  We invoke getEnclosingTypeForCallExpression, which will run
             // inference if needed, and then recompute the type as a member of the returned
             // enclosing type
             Symbol.MethodSymbol symbol = castToNonNull(ASTHelpers.getSymbol(invocationTree));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1654,7 +1654,6 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             """
-            import java.util.Objects;
             import org.jspecify.annotations.NullMarked;
             import org.jspecify.annotations.Nullable;
             @NullMarked
@@ -1676,6 +1675,11 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 Foo.of(new Foo<@Nullable String>())
                   .or(new Foo<@Nullable String>())
                   .or(new Foo<@Nullable String>());
+
+              // a true positive case
+              // BUG: Diagnostic contains: incompatible types: Foo<@Nullable String> cannot be converted to Foo<String>
+              static Foo<String> WRONG =
+                Foo.of(new Foo<@Nullable String>()).or(new Foo<@Nullable String>());
             }
             """)
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1665,8 +1665,13 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 }
                 Foo<T> or(Foo<T> other) { return this; }
               }
+              // infer Foo<@Nullable String> as the type of the Foo.of() call via
+              // its parameter, and use that type to determine the return type of
+              // the or() call is Foo<@Nullable String>
               static Foo<@Nullable String> FOO =
                 Foo.of(new Foo<@Nullable String>()).or(new Foo<@Nullable String>());
+
+              // like the case above, but more deeply nested
               static Foo<@Nullable String> FOO2 =
                 Foo.of(new Foo<@Nullable String>())
                   .or(new Foo<@Nullable String>())

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1648,6 +1648,30 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void nestedReceivers() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Objects;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {
+                static <U extends @Nullable Object> Foo<U> of(Foo<U> other) {
+                  throw new RuntimeException();
+                }
+                Foo<T> or(Foo<T> other) { return this; }
+              }
+              static Foo<@Nullable String> FOO =
+                Foo.of(new Foo<@Nullable String>()).or(new Foo<@Nullable String>());
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1667,6 +1667,10 @@ public class GenericMethodTests extends NullAwayTestsBase {
               }
               static Foo<@Nullable String> FOO =
                 Foo.of(new Foo<@Nullable String>()).or(new Foo<@Nullable String>());
+              static Foo<@Nullable String> FOO2 =
+                Foo.of(new Foo<@Nullable String>())
+                  .or(new Foo<@Nullable String>())
+                  .or(new Foo<@Nullable String>());
             }
             """)
         .doTest();


### PR DESCRIPTION
Discovered this issue while investigating #1500.  When computing the type of an invocation, we may need to run inference for a generic method call nested within its receiver in order to compute its proper type.

This change exposed a couple of other issues, which are fixed in PRs stack on top of this one.  The integration test failures are expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety analysis for chained generic method calls by using the actual call receiver context when resolving invoked method types, yielding more accurate nullability results in complex generic scenarios and reducing false positives/negatives.

* **Tests**
  * Added a unit test validating nested chained receiver behavior to exercise generic type inference and guard against regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->