### PR TITLE
Use ground target types when handling lambdas and method refs passed to generic methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -829,7 +829,7 @@ public final class GenericsChecks {
     if (!assignedToLocal
         && (rhsTree instanceof LambdaExpressionTree || rhsTree instanceof MemberReferenceTree)
         && isAssignmentToField(tree)) {
-      maybeStorePolyExpressionTypeFromTarget(rhsTree, lhsType);
+      maybeStorePolyExpressionTypeFromTarget(rhsTree, lhsType, state);
     }
     boolean varLocalDeclaration =
         tree instanceof VariableTree varTree && isVarLocalVariableDeclaration(varTree);
@@ -1081,9 +1081,15 @@ public final class GenericsChecks {
                       || argument instanceof MemberReferenceTree) {
                     Type polyExprTreeType = ASTHelpers.getType(argument);
                     if (polyExprTreeType != null) {
+                      Type formalParamGroundTargetType =
+                          GenericsUtils.groundTargetTypeForPolyExpression(formalParamType, state);
                       Type typeWithInferredNullability =
                           TypeSubstitutionUtils.updateTypeWithInferredNullability(
-                              polyExprTreeType, formalParamType, typeVarNullability, state, config);
+                              polyExprTreeType,
+                              formalParamGroundTargetType,
+                              typeVarNullability,
+                              state,
+                              config);
                       inferredPolyExpressionTypes.put(argument, typeWithInferredNullability);
                     }
                   }
@@ -1255,10 +1261,11 @@ public final class GenericsChecks {
     Symbol.MethodSymbol fiMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(lambda, state.getTypes());
 
+    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(lhsType, state);
     // get the return type of the functional interface method, viewed as a member of the lhs
     // type, so the generic method's type variables are substituted in
     Type.MethodType fiMethodTypeAsMember =
-        TypeSubstitutionUtils.memberType(state.getTypes(), lhsType, fiMethod, config)
+        TypeSubstitutionUtils.memberType(state.getTypes(), groundTargetType, fiMethod, config)
             .asMethodType();
     Type fiReturnType = fiMethodTypeAsMember.getReturnType();
     Tree body = lambda.getBody();
@@ -1308,9 +1315,10 @@ public final class GenericsChecks {
       ConstraintSolver solver,
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
+    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(lhsType, state);
     GenericsUtils.processMethodRefTypeRelations(
         this,
-        lhsType,
+        groundTargetType,
         memberReferenceTree,
         state,
         (subtype, supertype, unused) -> {
@@ -1799,12 +1807,14 @@ public final class GenericsChecks {
               }
 
               if (currentActualParam instanceof MemberReferenceTree memberReferenceTree) {
+                Type groundFormalParameter =
+                    GenericsUtils.groundTargetTypeForPolyExpression(formalParameter, state);
                 // the type of the method reference tree provided by javac may not capture
                 // nullability of nested types. So, do explicit type checks based on the return and
                 // parameter types of the referenced method
                 GenericsUtils.processMethodRefTypeRelations(
                     this,
-                    formalParameter,
+                    groundFormalParameter,
                     memberReferenceTree,
                     state,
                     (subtype, supertype, relationKind) -> {
@@ -1818,14 +1828,14 @@ public final class GenericsChecks {
                         }
                       }
                     });
-                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter);
+                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter, state);
                 return;
               }
 
               TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
               Type actualParameterType;
               if (currentActualParam instanceof LambdaExpressionTree) {
-                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter);
+                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter, state);
               }
               Type inferredPolyType = inferredPolyExpressionTypes.get(currentActualParam);
               if (inferredPolyType != null) {
@@ -2683,7 +2693,8 @@ public final class GenericsChecks {
    * <p>This is used to compensate for javac dropping annotations on type variables in poly
    * expression target types, so later checks use the correctly annotated functional interface type.
    */
-  private void maybeStorePolyExpressionTypeFromTarget(Tree polyExpressionTree, Type targetType) {
+  private void maybeStorePolyExpressionTypeFromTarget(
+      Tree polyExpressionTree, Type targetType, VisitorState state) {
     if (targetType.isRaw() || inferredPolyExpressionTypes.containsKey(polyExpressionTree)) {
       return;
     }
@@ -2691,9 +2702,10 @@ public final class GenericsChecks {
     if (polyExpressionType == null) {
       return;
     }
+    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(targetType, state);
     Type polyExpressionTypeWithTargetAnnotations =
         TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-            targetType, polyExpressionType, config, Collections.emptyMap());
+            groundTargetType, polyExpressionType, config, Collections.emptyMap());
     inferredPolyExpressionTypes.put(polyExpressionTree, polyExpressionTypeWithTargetAnnotations);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1082,7 +1082,8 @@ public final class GenericsChecks {
                     Type polyExprTreeType = ASTHelpers.getType(argument);
                     if (polyExprTreeType != null) {
                       Type formalParamGroundTargetType =
-                          GenericsUtils.groundTargetTypeForPolyExpression(formalParamType, state);
+                          GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
+                              formalParamType, state);
                       Type typeWithInferredNullability =
                           TypeSubstitutionUtils.updateTypeWithInferredNullability(
                               polyExprTreeType,
@@ -1261,7 +1262,8 @@ public final class GenericsChecks {
     Symbol.MethodSymbol fiMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(lambda, state.getTypes());
 
-    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(lhsType, state);
+    Type groundTargetType =
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state);
     // get the return type of the functional interface method, viewed as a member of the lhs
     // type, so the generic method's type variables are substituted in
     Type.MethodType fiMethodTypeAsMember =
@@ -1315,7 +1317,8 @@ public final class GenericsChecks {
       ConstraintSolver solver,
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
-    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(lhsType, state);
+    Type groundTargetType =
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state);
     GenericsUtils.processMethodRefTypeRelations(
         this,
         groundTargetType,
@@ -1808,7 +1811,8 @@ public final class GenericsChecks {
 
               if (currentActualParam instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
-                    GenericsUtils.groundTargetTypeForPolyExpression(formalParameter, state);
+                    GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
+                        formalParameter, state);
                 // the type of the method reference tree provided by javac may not capture
                 // nullability of nested types. So, do explicit type checks based on the return and
                 // parameter types of the referenced method
@@ -2702,7 +2706,8 @@ public final class GenericsChecks {
     if (polyExpressionType == null) {
       return;
     }
-    Type groundTargetType = GenericsUtils.groundTargetTypeForPolyExpression(targetType, state);
+    Type groundTargetType =
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(targetType, state);
     Type polyExpressionTypeWithTargetAnnotations =
         TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
             groundTargetType, polyExpressionType, config, Collections.emptyMap());

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1083,7 +1083,7 @@ public final class GenericsChecks {
                     if (polyExprTreeType != null) {
                       Type formalParamGroundTargetType =
                           GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
-                              formalParamType, state);
+                              formalParamType, state, config);
                       Type typeWithInferredNullability =
                           TypeSubstitutionUtils.updateTypeWithInferredNullability(
                               polyExprTreeType,
@@ -1263,7 +1263,7 @@ public final class GenericsChecks {
         NullabilityUtil.getFunctionalInterfaceMethod(lambda, state.getTypes());
 
     Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state);
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state, config);
     // get the return type of the functional interface method, viewed as a member of the lhs
     // type, so the generic method's type variables are substituted in
     Type.MethodType fiMethodTypeAsMember =
@@ -1318,7 +1318,7 @@ public final class GenericsChecks {
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
     Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state);
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state, config);
     GenericsUtils.processMethodRefTypeRelations(
         this,
         groundTargetType,
@@ -1812,7 +1812,7 @@ public final class GenericsChecks {
               if (currentActualParam instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
                     GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
-                        formalParameter, state);
+                        formalParameter, state, config);
                 // the type of the method reference tree provided by javac may not capture
                 // nullability of nested types. So, do explicit type checks based on the return and
                 // parameter types of the referenced method
@@ -2707,7 +2707,8 @@ public final class GenericsChecks {
       return;
     }
     Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(targetType, state);
+        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
+            targetType, state, config);
     Type polyExpressionTypeWithTargetAnnotations =
         TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
             groundTargetType, polyExpressionType, config, Collections.emptyMap());

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1082,8 +1082,7 @@ public final class GenericsChecks {
                     Type polyExprTreeType = ASTHelpers.getType(argument);
                     if (polyExprTreeType != null) {
                       Type formalParamGroundTargetType =
-                          GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
-                              formalParamType, state, config);
+                          GenericsUtils.groundTargetType(formalParamType, state, config);
                       Type typeWithInferredNullability =
                           TypeSubstitutionUtils.updateTypeWithInferredNullability(
                               polyExprTreeType,
@@ -1262,8 +1261,7 @@ public final class GenericsChecks {
     Symbol.MethodSymbol fiMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(lambda, state.getTypes());
 
-    Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state, config);
+    Type groundTargetType = GenericsUtils.groundTargetType(lhsType, state, config);
     // get the return type of the functional interface method, viewed as a member of the lhs
     // type, so the generic method's type variables are substituted in
     Type.MethodType fiMethodTypeAsMember =
@@ -1317,8 +1315,7 @@ public final class GenericsChecks {
       ConstraintSolver solver,
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
-    Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(lhsType, state, config);
+    Type groundTargetType = GenericsUtils.groundTargetType(lhsType, state, config);
     GenericsUtils.processMethodRefTypeRelations(
         this,
         groundTargetType,
@@ -1811,8 +1808,7 @@ public final class GenericsChecks {
 
               if (currentActualParam instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
-                    GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
-                        formalParameter, state, config);
+                    GenericsUtils.groundTargetType(formalParameter, state, config);
                 // the type of the method reference tree provided by javac may not capture
                 // nullability of nested types. So, do explicit type checks based on the return and
                 // parameter types of the referenced method
@@ -2706,9 +2702,7 @@ public final class GenericsChecks {
     if (polyExpressionType == null) {
       return;
     }
-    Type groundTargetType =
-        GenericsUtils.groundFunctionalInterfaceTargetTypeForPolyExpression(
-            targetType, state, config);
+    Type groundTargetType = GenericsUtils.groundTargetType(targetType, state, config);
     Type polyExpressionTypeWithTargetAnnotations =
         TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
             groundTargetType, polyExpressionType, config, Collections.emptyMap());

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -11,9 +11,12 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.CapturedType;
+import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
 import com.uber.nullaway.NullabilityUtil;
 import javax.lang.model.type.TypeKind;
 import org.jspecify.annotations.Nullable;
@@ -76,6 +79,48 @@ public class GenericsUtils {
       return capturedType.wildcard;
     }
     return null;
+  }
+
+  /**
+   * Returns a wildcard-free target type for lambda and method-reference checking. For a wildcard
+   * type argument, use the bound that determines the functional interface descriptor.
+   */
+  @SuppressWarnings("ReferenceEquality")
+  static Type groundTargetTypeForPolyExpression(Type targetType, VisitorState state) {
+    if (!(targetType instanceof ClassType classType) || targetType.isRaw()) {
+      return targetType;
+    }
+    List<Type> typeArguments = classType.getTypeArguments();
+    Type enclosingType = classType.getEnclosingType();
+    Type groundedEnclosingType = groundTargetTypeForPolyExpression(enclosingType, state);
+    if (typeArguments.isEmpty()) {
+      return groundedEnclosingType == enclosingType
+          ? targetType
+          : TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(
+              targetType, groundedEnclosingType, typeArguments);
+    }
+    ListBuffer<Type> groundedTypeArguments = new ListBuffer<>();
+    boolean changed = groundedEnclosingType != enclosingType;
+    for (Type typeArgument : typeArguments) {
+      Type groundedTypeArgument = groundTypeArgumentForPolyExpression(typeArgument, state);
+      groundedTypeArguments.append(groundedTypeArgument);
+      changed |= groundedTypeArgument != typeArgument;
+    }
+    return changed
+        ? TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(
+            targetType, groundedEnclosingType, groundedTypeArguments.toList())
+        : targetType;
+  }
+
+  private static Type groundTypeArgumentForPolyExpression(Type typeArgument, VisitorState state) {
+    WildcardType wildcardType = asWildcard(typeArgument);
+    if (wildcardType == null) {
+      return groundTargetTypeForPolyExpression(typeArgument, state);
+    }
+    if (wildcardType.kind == BoundKind.SUPER) {
+      return wildcardType.getSuperBound();
+    }
+    return wildcardUpperBound(wildcardType, state);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -1,5 +1,7 @@
 package com.uber.nullaway.generics;
 
+import static com.uber.nullaway.NullabilityUtil.castToNonNull;
+
 import com.google.common.base.Verify;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
@@ -119,7 +121,7 @@ public class GenericsUtils {
       return typeArgument;
     }
     if (wildcardType.kind == BoundKind.SUPER) {
-      return wildcardType.getSuperBound();
+      return castToNonNull(wildcardType.getSuperBound());
     }
     return wildcardUpperBound(wildcardType, state);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -82,25 +82,22 @@ public class GenericsUtils {
   }
 
   /**
-   * Returns a wildcard-free target type for lambda and method-reference checking. For a wildcard
-   * type argument, use the bound that determines the functional interface descriptor.
+   * Returns a non-wildcard functional interface parameterization for lambda and method-reference
+   * checking. For immediate wildcard type arguments, use the bound that determines the functional
+   * interface descriptor, preserving wildcards in nested type positions.
    */
   @SuppressWarnings("ReferenceEquality")
-  static Type groundTargetTypeForPolyExpression(Type targetType, VisitorState state) {
+  static Type groundFunctionalInterfaceTargetTypeForPolyExpression(
+      Type targetType, VisitorState state) {
     if (!(targetType instanceof ClassType classType) || targetType.isRaw()) {
       return targetType;
     }
     List<Type> typeArguments = classType.getTypeArguments();
-    Type enclosingType = classType.getEnclosingType();
-    Type groundedEnclosingType = groundTargetTypeForPolyExpression(enclosingType, state);
     if (typeArguments.isEmpty()) {
-      return groundedEnclosingType == enclosingType
-          ? targetType
-          : TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(
-              targetType, groundedEnclosingType, typeArguments);
+      return targetType;
     }
     ListBuffer<Type> groundedTypeArguments = new ListBuffer<>();
-    boolean changed = groundedEnclosingType != enclosingType;
+    boolean changed = false;
     for (Type typeArgument : typeArguments) {
       Type groundedTypeArgument = groundTypeArgumentForPolyExpression(typeArgument, state);
       groundedTypeArguments.append(groundedTypeArgument);
@@ -108,14 +105,14 @@ public class GenericsUtils {
     }
     return changed
         ? TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(
-            targetType, groundedEnclosingType, groundedTypeArguments.toList())
+            targetType, classType.getEnclosingType(), groundedTypeArguments.toList())
         : targetType;
   }
 
   private static Type groundTypeArgumentForPolyExpression(Type typeArgument, VisitorState state) {
     WildcardType wildcardType = asWildcard(typeArgument);
     if (wildcardType == null) {
-      return groundTargetTypeForPolyExpression(typeArgument, state);
+      return typeArgument;
     }
     if (wildcardType.kind == BoundKind.SUPER) {
       return wildcardType.getSuperBound();

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -88,10 +88,17 @@ public class GenericsUtils {
    * Returns a non-wildcard functional interface parameterization for lambda and method-reference
    * checking. For immediate wildcard type arguments, use the bound that determines the functional
    * interface descriptor, preserving wildcards in nested type positions.
+   *
+   * <p>This implements the ground target type behavior used for lambda and method-reference target
+   * typing; see JLS <a
+   * href="https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.27.3">15.27.3</a>,
+   * JLS <a
+   * href="https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.13.2">15.13.2</a>,
+   * and the non-wildcard parameterization rules in JLS <a
+   * href="https://docs.oracle.com/javase/specs/jls/se21/html/jls-9.html#jls-9.9">9.9</a>.
    */
   @SuppressWarnings("ReferenceEquality")
-  static Type groundFunctionalInterfaceTargetTypeForPolyExpression(
-      Type targetType, VisitorState state, Config config) {
+  static Type groundTargetType(Type targetType, VisitorState state, Config config) {
     if (!config.handleWildcardGenerics()) {
       return targetType;
     }
@@ -105,7 +112,7 @@ public class GenericsUtils {
     ListBuffer<Type> groundedTypeArguments = new ListBuffer<>();
     boolean changed = false;
     for (Type typeArgument : typeArguments) {
-      Type groundedTypeArgument = groundTypeArgumentForPolyExpression(typeArgument, state);
+      Type groundedTypeArgument = groundTypeArgument(typeArgument, state);
       groundedTypeArguments.append(groundedTypeArgument);
       changed |= groundedTypeArgument != typeArgument;
     }
@@ -115,7 +122,12 @@ public class GenericsUtils {
         : targetType;
   }
 
-  private static Type groundTypeArgumentForPolyExpression(Type typeArgument, VisitorState state) {
+  /**
+   * Grounds one immediate wildcard type argument according to the non-wildcard parameterization
+   * rules for functional interface target types in JLS <a
+   * href="https://docs.oracle.com/javase/specs/jls/se21/html/jls-9.html#jls-9.9">9.9</a>.
+   */
+  private static Type groundTypeArgument(Type typeArgument, VisitorState state) {
     WildcardType wildcardType = asWildcard(typeArgument);
     if (wildcardType == null) {
       return typeArgument;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -17,6 +17,7 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
+import com.uber.nullaway.Config;
 import com.uber.nullaway.NullabilityUtil;
 import javax.lang.model.type.TypeKind;
 import org.jspecify.annotations.Nullable;
@@ -88,7 +89,10 @@ public class GenericsUtils {
    */
   @SuppressWarnings("ReferenceEquality")
   static Type groundFunctionalInterfaceTargetTypeForPolyExpression(
-      Type targetType, VisitorState state) {
+      Type targetType, VisitorState state, Config config) {
+    if (!config.handleWildcardGenerics()) {
+      return targetType;
+    }
     if (!(targetType instanceof ClassType classType) || targetType.isRaw()) {
       return targetType;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -4,7 +4,6 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class WildcardTests extends NullAwayTestsBase {
@@ -580,7 +579,6 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore("https://github.com/uber/NullAway/issues/1522")
   @Test
   public void issue1522() {
     makeHelperWithInferenceFailureWarning()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -605,6 +605,69 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1522SelfContained() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              interface Function<T extends @Nullable Object, U extends @Nullable Object> {
+                U apply(T t);
+              }
+              static class Optional<T> {
+                public @Nullable T orElse(@Nullable T other) {
+                    throw new RuntimeException();
+                }
+              }
+              static class Foo<T> {
+                public final <V> Foo<V> mapNotNull(Function<? super T, ? extends @Nullable V> mapper) {
+                  throw new RuntimeException();
+                }
+              }
+              static <T> Foo<T> after(Foo<Optional<T>> foo) {
+                return foo.mapNotNull(x -> x.orElse(null));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void issue1522SelfContainedMethodReference() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              interface Function<T extends @Nullable Object, U extends @Nullable Object> {
+                U apply(T t);
+              }
+              static class Optional<T> {
+                public @Nullable T orElse(@Nullable T other) {
+                    throw new RuntimeException();
+                }
+              }
+              static class Foo<T> {
+                public final <V> Foo<V> mapNotNull(Function<? super T, ? extends @Nullable V> mapper) {
+                  throw new RuntimeException();
+                }
+              }
+              static <T> @Nullable T orElseNull(Optional<T> optional) {
+                return optional.orElse(null);
+              }
+              static <T> Foo<T> after(Foo<Optional<T>> foo) {
+                return foo.mapNotNull(Test::orElseNull);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /**
    * Extracted from Caffeine; exposed some subtle bugs in substitutions involving identity of {@code
    * Type} objects

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -634,7 +634,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void issue1522SelfContainedMethodReference() {
+  public void issue1522SelfContainedWithMethodReference() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(
             "Test.java",
@@ -667,7 +667,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void polyExpressionGroundTargetPreservesNestedWildcards() {
+  public void groundTargetTypePreservesNestedWildcards() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(
             "Test.java",
@@ -722,7 +722,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void polyExpressionGroundTargetPreservesNestedWildcardsForMethodReferences() {
+  public void groundTargetTypePreservesNestedWildcardsForMethodReferences() {
     makeHelperWithInferenceFailureWarning()
         .addSourceLines(
             "Test.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -687,6 +687,10 @@ public class WildcardTests extends NullAwayTestsBase {
                   Function<Box<? super String>, R> mapper) {
                 throw new RuntimeException();
               }
+              static <R extends @Nullable Object> R invokeNestedWithUpperBound(
+                  Function<Box<? extends String>, R> mapper) {
+                throw new RuntimeException();
+              }
               static <R extends @Nullable Object> R invokeTopLevelWildcard(
                   Function<? super Box<? super String>, R> mapper) {
                 throw new RuntimeException();
@@ -698,6 +702,12 @@ public class WildcardTests extends NullAwayTestsBase {
               static void testNestedWildcard() {
                 invokeNested(box -> {
                   // BUG: Diagnostic contains: dereferenced expression box.get() is @Nullable
+                  box.get().hashCode();
+                  return null;
+                });
+                invokeNestedWithUpperBound(box -> {
+                  // safe since the upper bound of the Box type variable is @NonNull String,
+                  // so box.get() cannot be null
                   box.get().hashCode();
                   return null;
                 });

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -668,6 +668,90 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void polyExpressionGroundTargetPreservesNestedWildcards() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              interface Function<T extends @Nullable Object, R extends @Nullable Object> {
+                R apply(T t);
+              }
+              static class Box<T extends @Nullable Object> {
+                T get() {
+                  throw new RuntimeException();
+                }
+              }
+              static <R extends @Nullable Object> R invokeNested(
+                  Function<Box<? super String>, R> mapper) {
+                throw new RuntimeException();
+              }
+              static <R extends @Nullable Object> R invokeTopLevelWildcard(
+                  Function<? super Box<? super String>, R> mapper) {
+                throw new RuntimeException();
+              }
+              static <R extends @Nullable Object> R invokeArray(
+                  Function<Box<? super String>[], R> mapper) {
+                throw new RuntimeException();
+              }
+              static void testNestedWildcard() {
+                invokeNested(box -> {
+                  // BUG: Diagnostic contains: dereferenced expression box.get() is @Nullable
+                  box.get().hashCode();
+                  return null;
+                });
+              }
+              static void testTopLevelWildcardBound() {
+                invokeTopLevelWildcard(box -> {
+                  // BUG: Diagnostic contains: dereferenced expression box.get() is @Nullable
+                  box.get().hashCode();
+                  return null;
+                });
+              }
+              static void testArrayWithNestedWildcard() {
+                invokeArray(boxes -> {
+                  // BUG: Diagnostic contains: dereferenced expression boxes[0].get() is @Nullable
+                  boxes[0].get().hashCode();
+                  return null;
+                });
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void polyExpressionGroundTargetPreservesNestedWildcardsForMethodReferences() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              interface Function<T extends @Nullable Object, R extends @Nullable Object> {
+                R apply(T t);
+              }
+              static class Box<T extends @Nullable Object> {}
+              static <R extends @Nullable Object> R invokeExtendsNullable(
+                  Function<Box<? extends @Nullable String>, R> mapper) {
+                throw new RuntimeException();
+              }
+              static @Nullable Object needsBoxExtendsString(Box<? extends String> box) {
+                return null;
+              }
+              static void test() {
+                // BUG: Diagnostic contains: parameter type of referenced method is Box<? extends String>
+                invokeExtendsNullable(Test::needsBoxExtendsString);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /**
    * Extracted from Caffeine; exposed some subtle bugs in substitutions involving identity of {@code
    * Type} objects


### PR DESCRIPTION
Fixes #1522 

When handling lambdas and method references passed to a generic method, if the generic method's formal parameter type is a class type with wildcards at the top level, we need to compute the _ground target type_ for checking.  In the ground target type, wildcards are replaced with their lower bound if explicit, and otherwise replaced with their upper bound.  

So, for the test from #1522:
```java
@NullMarked
class Test {
  static class Foo<T> {
    public final <V> Foo<V> mapNotNull(Function<? super T, ? extends @Nullable V> mapper) {
      throw new RuntimeException();
    }
  }
  static <T> Foo<T> after(Foo<Optional<T>> foo) {
    return foo.mapNotNull(x -> x.orElse(null));
  }
}
```

We have a lambda passed to `mapNotNull`, whose parameter type is `Function<? super T, ? extends @Nullable V>`.  The ground target type for this parameter is `Function<T, @Nullable V>`, which should be used to infer types at the call site and check the lambda.  In this case, inference succeeds, and the return of `x.orElse(null)` from the lambda is fine since the return type is `@Nullable V`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved generic nullability inference for lambda expressions and method references by correctly grounding wildcard and parameterized types before applying nullability constraints.
  * Enhanced handling of complex nested wildcard type parameters in generic inference scenarios.

* **Tests**
  * Expanded test coverage for wildcard nullness behavior across lambdas, method references, and nested-wildcard type parameter scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->