### PR TITLE
Tell agents not to run multiple Gradle builds in parallel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ test class or method within that module, you can use the `--tests` flag. For exa
 ./gradlew :nullaway:test --tests "com.uber.nullaway.NullAwayTest"
 ```
 
-Do _not_ try to run multiple Gradle build commands in parallel; it it not supported and often leads to a failure.
+Do _not_ try to run multiple Gradle build commands in parallel; it is not supported and often leads to a failure.
 
 # Changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ test class or method within that module, you can use the `--tests` flag. For exa
 ./gradlew :nullaway:test --tests "com.uber.nullaway.NullAwayTest"
 ```
 
+Do _not_ try to run multiple Gradle build commands in parallel; it it not supported and often leads to a failure.
+
 # Changelog
 
 Our `CHANGELOG.md` file should be formatted as follows:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidelines to clarify build command execution: contributors are instructed not to run multiple Gradle build commands in parallel and to follow prescribed sequential steps to avoid intermittent build failures during testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->