### PR TITLE
Refactor hasAnyAnnotationMatching method

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -196,27 +196,19 @@ public class NullabilityUtil {
   }
 
   /**
-   * Check if any direct annotation a symbol matches a given predicate. Works for both source and
-   * bytecode.
+   * Check if any direct annotation a symbol matches a given predicate. Includes code for backward
+   * compatibility with older JDKs where javac did not place type-use annotations on Symbols from
+   * bytecodes.
    *
    * @param symbol the symbol
    * @param config NullAway configuration
    * @param predicate the predicate to match annotation names against
    * @return true if any annotation on the symbol matches the predicate, false otherwise
    */
-  public static boolean hasAnyAnnotationMatching(
+  public static boolean hasAnyAnnotationMatchingBackCompat(
       Symbol symbol, Config config, Predicate<String> predicate) {
-    // check for declaration annotations
-    for (AnnotationMirror annotationMirror : symbol.getAnnotationMirrors()) {
-      if (predicate.test(annotationMirror.getAnnotationType().toString())) {
-        return true;
-      }
-    }
-    // check for type use annotations
-    for (AnnotationMirror annotationMirror : symbol.type.getAnnotationMirrors()) {
-      if (predicate.test(annotationMirror.getAnnotationType().toString())) {
-        return true;
-      }
+    if (hasAnyAnnotationMatching(symbol, predicate)) {
+      return true;
     }
     // to handle bytecodes, also check direct type-use annotations stored in attributes
     Symbol typeAnnotationOwner =
@@ -227,6 +219,31 @@ public class NullabilityUtil {
         continue;
       }
       if (predicate.test(typeCompound.getAnnotationType().toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check if any direct annotation a symbol matches a given predicate. Includes code for backward
+   * compatibility with older JDKs where javac did not place type-use annotations on Symbols from
+   * bytecodes.
+   *
+   * @param symbol the symbol
+   * @param predicate the predicate to match annotation names against
+   * @return true if any annotation on the symbol matches the predicate, false otherwise
+   */
+  public static boolean hasAnyAnnotationMatching(Symbol symbol, Predicate<String> predicate) {
+    // check for declaration annotations
+    for (AnnotationMirror annotationMirror : symbol.getAnnotationMirrors()) {
+      if (predicate.test(annotationMirror.getAnnotationType().toString())) {
+        return true;
+      }
+    }
+    // check for type use annotations
+    for (AnnotationMirror annotationMirror : symbol.type.getAnnotationMirrors()) {
+      if (predicate.test(annotationMirror.getAnnotationType().toString())) {
         return true;
       }
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -239,8 +239,12 @@ public class NullabilityUtil {
         return true;
       }
     }
-    // check for type use annotations
-    for (AnnotationMirror annotationMirror : symbol.type.getAnnotationMirrors()) {
+    // check for type use annotations.  For MethodSymbols, look on the return type
+    Type annotatedType =
+        symbol instanceof Symbol.MethodSymbol methodSymbol
+            ? methodSymbol.getReturnType()
+            : symbol.type;
+    for (AnnotationMirror annotationMirror : annotatedType.getAnnotationMirrors()) {
       if (predicate.test(annotationMirror.getAnnotationType().toString())) {
         return true;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -226,9 +226,7 @@ public class NullabilityUtil {
   }
 
   /**
-   * Check if any direct annotation a symbol matches a given predicate. Includes code for backward
-   * compatibility with older JDKs where javac did not place type-use annotations on Symbols from
-   * bytecodes.
+   * Check if any direct annotation a symbol matches a given predicate.
    *
    * @param symbol the symbol
    * @param predicate the predicate to match annotation names against

--- a/nullaway/src/main/java/com/uber/nullaway/Nullness.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Nullness.java
@@ -69,7 +69,7 @@ public enum Nullness implements AbstractValue<Nullness> {
    * {@code symbol}. Used to reason whether a field may be null.
    */
   public static boolean hasNullableOrMonotonicNonNullAnnotation(Symbol symbol, Config config) {
-    return NullabilityUtil.hasAnyAnnotationMatching(
+    return NullabilityUtil.hasAnyAnnotationMatchingBackCompat(
         symbol,
         config,
         annot -> isNullableAnnotation(annot, config) || isMonotonicNonNullAnnotation(annot));
@@ -208,7 +208,7 @@ public enum Nullness implements AbstractValue<Nullness> {
    * Config)}
    */
   public static boolean hasNonNullAnnotation(Symbol symbol, Config config) {
-    return NullabilityUtil.hasAnyAnnotationMatching(
+    return NullabilityUtil.hasAnyAnnotationMatchingBackCompat(
         symbol, config, annot -> isNonNullAnnotation(annot, config));
   }
 
@@ -220,7 +220,7 @@ public enum Nullness implements AbstractValue<Nullness> {
    * Config)}
    */
   public static boolean hasNullableAnnotation(Symbol symbol, Config config) {
-    return NullabilityUtil.hasAnyAnnotationMatching(
+    return NullabilityUtil.hasAnyAnnotationMatchingBackCompat(
         symbol, config, annot -> isNullableAnnotation(annot, config));
   }
 


### PR DESCRIPTION
Make `hasAnyAnnotationMatching` a method that works on modern versions of `javac`, and rename the old method with backward compatibility code as `hasAnyAnnotationMatchingBackCompat`.  We'll use the new method in an upcoming PR.  No logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal annotation-matching to better handle both source and bytecode annotations, enhancing compatibility and maintainability.
* **Bug Fix**
  * More accurate nullable/non-null detection to reduce false positives/negatives in nullability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->