### PR TITLE
Enable HandleWildcardGenerics flag when building NullAway

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -246,9 +246,9 @@ tasks.register('buildWithNullAway', JavaCompile) {
         option("NullAway:AnnotatedPackages", "com.uber,org.checkerframework.nullaway,com.google.common")
         option("NullAway:CastToNonNullMethod", "com.uber.nullaway.NullabilityUtil.castToNonNull")
         option("NullAway:CheckOptionalEmptiness")
-        option("NullAway:AcknowledgeRestrictiveAnnotations")
         option("NullAway:CheckContracts")
         option("NullAway:JSpecifyMode")
+        option("NullAway:HandleWildcardGenerics")
     }
     // Make sure the jar has already been built
     dependsOn 'jar'


### PR DESCRIPTION
Wildcard generics checking is still too buggy to recommend to all, but we should run it on NullAway code to catch more issues with it.

Also remove `AcknowledgeRestrictiveAnnotations` as that is redundant with JSpecify mode.