### PR TITLE
Update Codecov action to v6

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
         continue-on-error: true
         if: runner.os == 'Linux' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./code-coverage-report/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Avoids issue with upcoming Node.js 20 deprecation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to use the latest version of the Codecov coverage reporting action for improved coverage tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uber/NullAway/pull/1587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->