### PR TITLE
Revert "Report error when @Initializer is used on a constructor (#1546)"

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -685,18 +685,6 @@ public class NullAway extends BugChecker
     // overridden method (if overridden method is in an annotated
     // package)
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
-    if (methodSymbol.isConstructor() && isInitializerMethod(state, methodSymbol)) {
-      String message =
-          "@Initializer annotation (or a configured initializer annotation) is not allowed "
-              + "on constructors, as NullAway already treats constructors as initializers "
-              + "by default.";
-      return errorBuilder.createErrorDescription(
-          new ErrorMessage(ErrorMessage.MessageTypes.ANNOTATION_VALUE_INVALID, message),
-          tree,
-          buildDescription(tree),
-          state,
-          null);
-    }
     handler.onMatchMethod(tree, new MethodAnalysisContext(this, state, methodSymbol));
     boolean isOverriding = ASTHelpers.hasAnnotation(methodSymbol, "java.lang.Override", state);
     boolean exhaustiveOverride = config.exhaustiveOverride();

--- a/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
@@ -242,44 +242,4 @@ public class InitializationTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
-
-  @Test
-  public void initializerAnnotationOnConstructor() {
-    makeTestHelperWithArgs(
-            Arrays.asList(
-                "-d",
-                temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:CustomInitializerAnnotations=com.uber.MyInitializer"))
-        .addSourceLines(
-            "MyInitializer.java",
-            """
-            package com.uber;
-            import java.lang.annotation.ElementType;
-            import java.lang.annotation.Retention;
-            import java.lang.annotation.RetentionPolicy;
-            import java.lang.annotation.Target;
-            @Retention(RetentionPolicy.CLASS)
-            @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
-            public @interface MyInitializer {}
-            """)
-        .addSourceLines(
-            "Test.java",
-            """
-            package com.uber;
-            class Test {
-              Object f;
-              @MyInitializer
-              // BUG: Diagnostic contains: @Initializer annotation (or a configured initializer annotation) is not allowed on constructors
-              public Test() {
-                this.f = new Object();
-              }
-              @MyInitializer
-              public void init() {
-                this.f = new Object();
-              }
-            }
-            """)
-        .doTest();
-  }
 }


### PR DESCRIPTION
This reverts commit 661f37443b0205102b23a99a994d409f9aa0cf14.

It turns out there are valid scenarios for `@Autowired` to be written on a constructor (to disambiguate when multiple constructors are present).  In general, we don't know what other purposes custom initializer annotations are being used for, beyond initialization semantics.  So, let's not warn when they are used on constructors.