### PR TITLE
Notes for 0.13.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-Version 0.13.5
+Version 0.13.6
 --------------
+
+(NOTE: originally these notes appeared with the 0.13.5 release, but that release was pushed
+incorrectly due to an error in our release process.)
 
 Includes various bug fixes, particularly in JSpecify mode.  Also, the nullaway-annotations
 artifact now includes a `@Contract` annotation.  NullAway also now has a built-in handler
@@ -47,6 +50,12 @@ has multiple known bugs, and we do not yet recommend enabling it.
   - Use Temurin JDK 17 always in CI (#1565)
   - Tell agents not to run multiple Gradle builds in parallel (#1582)
   - Update Codecov action to v6 (#1587)
+
+Version 0.13.5
+--------------
+
+DO NOT USE THIS RELEASE.  It was pushed incorrectly due to an error in our release process.
+Please use version 0.13.6 instead.
 
 Version 0.13.4
 --------------

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 GROUP=com.uber.nullaway
-VERSION_NAME=0.13.5-SNAPSHOT
+VERSION_NAME=0.13.6-SNAPSHOT
 
 POM_DESCRIPTION=A fast annotation-based null checker for Java
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to alert users that version 0.13.5 should not be used; version 0.13.6 is recommended.

* **Chores**
  * Bumped version to 0.13.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->