### PR TITLE
Draft: Prototype conditional nullness tracking for boolean variables (Fixes #98, #1060)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -527,6 +527,23 @@ public class AccessPathNullnessPropagation
       handleEnhancedForOverKeySet(localVariableNode, rhs, input, updates);
     }
 
+    if (target instanceof LocalVariableNode localVariableNode) {
+      com.sun.tools.javac.code.Type targetType = ASTHelpers.getType(target.getTree());
+      
+      // NullAway requires us to prove targetType is not null before using it!
+      if (targetType != null && targetType.getTag() == com.sun.tools.javac.code.TypeTag.BOOLEAN) {
+        NullnessStore thenStore = input.getThenStore();
+        NullnessStore elseStore = input.getElseStore();
+        
+        if (!thenStore.equals(elseStore)) {
+           AccessPath booleanAp = AccessPath.fromLocal(localVariableNode);
+           if (booleanAp != null) {
+               updates.setConditional(booleanAp, thenStore, elseStore);
+           }
+        }
+      }
+    }
+
     if (target instanceof ArrayAccessNode arrayAccessNode) {
       setNonnullIfAnalyzeable(updates, arrayAccessNode.getArray());
     }
@@ -1298,6 +1315,8 @@ public class AccessPathNullnessPropagation
     void set(MethodInvocationNode node, Nullness value);
 
     void set(AccessPath ap, Nullness value);
+
+    void setConditional(AccessPath booleanAp, NullnessStore ifTrue, NullnessStore ifFalse);
   }
 
   private final class ReadableUpdates implements Updates {
@@ -1337,6 +1356,11 @@ public class AccessPathNullnessPropagation
     @Override
     public void set(AccessPath ap, Nullness value) {
       values.put(checkNotNull(ap), value);
+    }
+
+    @Override
+    public void setConditional(AccessPath booleanAp, NullnessStore ifTrue, NullnessStore ifFalse) {
+      // Stub for conditional update extraction to be passed to the store builder
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -530,7 +530,7 @@ public class AccessPathNullnessPropagation
     if (target instanceof LocalVariableNode localVariableNode) {
       com.sun.tools.javac.code.Type targetType = ASTHelpers.getType(target.getTree());
       
-      // NullAway requires us to prove targetType is not null before using it!
+      // Check targetType is non-null since ASTHelpers.getType() may return null.
       if (targetType != null && targetType.getTag() == com.sun.tools.javac.code.TypeTag.BOOLEAN) {
         NullnessStore thenStore = input.getThenStore();
         NullnessStore elseStore = input.getElseStore();

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -42,12 +42,20 @@ import org.jspecify.annotations.Nullable;
  */
 public class NullnessStore implements Store<NullnessStore> {
 
-  private static final NullnessStore EMPTY = new NullnessStore(ImmutableMap.of());
+  private static final NullnessStore EMPTY = new NullnessStore(
+      ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
 
   private final ImmutableMap<AccessPath, Nullness> contents;
+  private final ImmutableMap<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfTrue;
+  private final ImmutableMap<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfFalse;
 
-  private NullnessStore(Map<AccessPath, Nullness> contents) {
+  private NullnessStore(
+      Map<AccessPath, Nullness> contents,
+      Map<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfTrue,
+      Map<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfFalse) {
     this.contents = ImmutableMap.copyOf(contents);
+    this.conditionalIfTrue = ImmutableMap.copyOf(conditionalIfTrue);
+    this.conditionalIfFalse = ImmutableMap.copyOf(conditionalIfFalse);
   }
 
   /**
@@ -193,7 +201,11 @@ public class NullnessStore implements Store<NullnessStore> {
         upperBoundContentsBuilder.put(ap, smallValue.leastUpperBound(largeValue));
       }
     }
-    return new NullnessStore(upperBoundContentsBuilder.build());
+    return new NullnessStore(
+        upperBoundContentsBuilder.build(), 
+        ImmutableMap.of(), 
+        ImmutableMap.of()
+    );
   }
 
   @Override
@@ -277,7 +289,9 @@ public class NullnessStore implements Store<NullnessStore> {
     return new NullnessStore(
         contents.entrySet().stream()
             .filter(e -> pred.test(e.getKey()))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+        this.conditionalIfTrue,
+        this.conditionalIfFalse);
   }
 
   /**
@@ -334,19 +348,27 @@ public class NullnessStore implements Store<NullnessStore> {
   /** class for building up instances of the store. */
   public static final class Builder {
     private final ImmutableMap.Builder<AccessPath, Nullness> contents;
+    private final ImmutableMap.Builder<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfTrue;
+    private final ImmutableMap.Builder<AccessPath, ImmutableMap<AccessPath, Nullness>> conditionalIfFalse;
 
     Builder(NullnessStore prototype) {
       contents = ImmutableMap.builder();
+      conditionalIfTrue = ImmutableMap.builder();
+      conditionalIfFalse = ImmutableMap.builder();
+
       if (!prototype.contents.isEmpty()) {
         contents.putAll(prototype.contents);
+      }
+      if (!prototype.conditionalIfTrue.isEmpty()) {
+        conditionalIfTrue.putAll(prototype.conditionalIfTrue);
+      }
+      if (!prototype.conditionalIfFalse.isEmpty()) {
+        conditionalIfFalse.putAll(prototype.conditionalIfFalse);
       }
     }
 
     /**
-     * Sets the value for the given variable. {@code element} must come from a call to {@link
-     * LocalVariableNode#getElement()} or {@link
-     * org.checkerframework.nullaway.javacutil.TreeUtils#elementFromDeclaration} ({@link
-     * org.checkerframework.nullaway.dataflow.cfg.node.VariableDeclarationNode#getTree()}).
+     * Sets the value for the given variable.
      *
      * @param ap relevant access path
      * @param value fact for access path
@@ -357,13 +379,26 @@ public class NullnessStore implements Store<NullnessStore> {
       return this;
     }
 
+    public NullnessStore.Builder setConditionalInformation(
+        AccessPath booleanAp, 
+        ImmutableMap<AccessPath, Nullness> ifTrue, 
+        ImmutableMap<AccessPath, Nullness> ifFalse) {
+      conditionalIfTrue.put(booleanAp, ifTrue);
+      conditionalIfFalse.put(booleanAp, ifFalse);
+      return this;
+    }
+
     /**
      * Construct the immutable NullnessStore instance.
      *
      * @return a store constructed from everything added to the builder
      */
     public NullnessStore build() {
-      return new NullnessStore(contents.buildKeepingLast());
+      return new NullnessStore(
+          contents.buildKeepingLast(),
+          conditionalIfTrue.buildKeepingLast(),
+          conditionalIfFalse.buildKeepingLast()
+      );
     }
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1295,4 +1295,27 @@ public class CoreTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void testConditionalNullnessBoolean() {
+    defaultCompilationHelper
+      .addSourceLines(
+        "Test.java",
+        "package com.uber;",
+        "import javax.annotation.Nullable;",
+        "public class Test {",
+        "  public double execute(int a) {",
+        "    Object x = (a > 0) ? new Object() : null;",
+        "    boolean triggered = (a > 6);",
+        "    if (triggered) { x = null; }",
+        "    else { triggered = false; }",
+        "    if (!triggered) {",
+        "      // BUG: Diagnostic contains: dereferenced expression",
+        "      return x.hashCode();",
+        "    }",
+        "    return 0.0;",
+        "  }",
+        "}")
+      .doTest();
+  }
 }


### PR DESCRIPTION
### Objective
Prototyping the core data structures to resolve false positives caused by boolean conditional nullability. This addresses #98 and #1060.

### Architectural Changes Made
* **`NullnessStore`**: Extended the state tracker to hold conditional nullness facts alongside absolute nullness states using immutable `conditionalIfTrue` and `conditionalIfFalse` maps.
* **`NullnessStore.Builder`**: Updated to properly hydrate the new conditional data structures during CFG traversal.
* **`AccessPathNullnessPropagation`**: Modified `visitAssignment` to safely evaluate boolean condition states and capture divergent `thenStore` and `elseStore` paths.
* **`CoreTests`**: Added `testConditionalNullnessBoolean` documenting the known diagnostic bug while the full CFG extraction remains a stub.

### Next Steps / Notes for Reviewers
I am opening this as a **Draft PR** to get early feedback on the `NullnessStore` architecture. Currently, `ReadableUpdates.setConditional` is left as a stub. Once the core architectural approach is approved, I plan to wire the full CFG extraction into the updates stream so it resolves the test case. 

Would love your thoughts on this direction, @msridhar!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced null-safety analysis to track conditional nullness based on boolean conditions and assignments
  * Improved propagation of nullness information through conditional branches

* **Tests**
  * Added a test validating conditional nullness handling for boolean-based control flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->