### PR TITLE
Add support for filtering null objects from streams

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -641,7 +641,8 @@ public final class GenericsChecks {
                   TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
             }
             Type.MethodType methodType =
-                handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
+                handler.onOverrideMethodType(
+                    symbol, invokedMethodType.asMethodType(), state, invocationTree);
             // restore explicit annotations from the return type
             Type returnType = methodType.getReturnType();
             result =
@@ -658,9 +659,6 @@ public final class GenericsChecks {
             }
           }
         }
-      }
-      if (tree instanceof ExpressionTree expressionTree && result != null) {
-        result = handler.onOverrideExpressionType(expressionTree, result, state);
       }
       return typeOrNullIfRaw(result);
     }
@@ -1195,7 +1193,8 @@ public final class GenericsChecks {
       boolean calledFromDataflow)
       throws UnsatisfiableConstraintsException {
     Type.MethodType methodType =
-        handler.onOverrideMethodType(methodSymbol, methodSymbol.type.asMethodType(), state);
+        handler.onOverrideMethodType(
+            methodSymbol, methodSymbol.type.asMethodType(), state, methodInvocationTree);
     // first, handle the return type flow
     if (typeFromAssignmentContext != null) {
       solver.addSubtypeConstraint(
@@ -1414,7 +1413,7 @@ public final class GenericsChecks {
       result = getInferredMethodTypeForGenericMethodReference(result, state);
     }
     // finally, run any handlers
-    return handler.onOverrideMethodType(overridingMethod, result, state);
+    return handler.onOverrideMethodType(overridingMethod, result, state, null);
   }
 
   /**
@@ -1837,7 +1836,13 @@ public final class GenericsChecks {
     }
 
     Type.MethodType finalMethodType =
-        handler.onOverrideMethodType(methodSymbol, invokedMethodType.asMethodType(), state);
+        handler.onOverrideMethodType(
+            methodSymbol,
+            invokedMethodType.asMethodType(),
+            state,
+            tree instanceof MethodInvocationTree methodInvocationTree
+                ? methodInvocationTree
+                : null);
     new InvocationArguments(tree, finalMethodType)
         .forEach(
             (currentActualParam, argPos, formalParameter, unused) -> {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -636,28 +636,17 @@ public final class GenericsChecks {
             Type enclosingType =
                 getEnclosingTypeForCallExpression(
                     symbol, invocationTree, state.getPath(), state, calledFromDataflow);
-            boolean recomputedMemberType = false;
+            // boolean recomputedMemberType = false;
             if (enclosingType != null) {
               invokedMethodType =
                   TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
-              recomputedMemberType = true;
             }
             Type.MethodType methodType =
                 handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
             Type returnType = methodType.getReturnType();
-            if (recomputedMemberType && !(invokedMethodType instanceof Type.ForAll)) {
-              // If the receiver type was recomputed above, the member return type is already the
-              // call-site return type. Using javac's expression type as the base can preserve stale
-              // nested annotations from before the receiver refinement.
-              result = returnType;
-            } else {
-              // For generic method calls, keep javac's expression type as the base because it
-              // contains call-site inference results for method type variables. Then restore any
-              // explicit annotations from the declared/recomputed return type.
-              result =
-                  TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-                      returnType, result, config, Collections.emptyMap());
-            }
+            result =
+                TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
+                    returnType, result, config, Collections.emptyMap());
           } else if (tree instanceof MemberSelectTree memberSelectTree) {
             Symbol memberSelectSymbol = ASTHelpers.getSymbol(memberSelectTree);
             if (memberSelectSymbol != null && memberSelectSymbol.getKind().isField()) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -636,13 +636,13 @@ public final class GenericsChecks {
             Type enclosingType =
                 getEnclosingTypeForCallExpression(
                     symbol, invocationTree, state.getPath(), state, calledFromDataflow);
-            // boolean recomputedMemberType = false;
             if (enclosingType != null) {
               invokedMethodType =
                   TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
             }
             Type.MethodType methodType =
                 handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
+            // restore explicit annotations from the return type
             Type returnType = methodType.getReturnType();
             result =
                 TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -636,17 +636,28 @@ public final class GenericsChecks {
             Type enclosingType =
                 getEnclosingTypeForCallExpression(
                     symbol, invocationTree, state.getPath(), state, calledFromDataflow);
+            boolean recomputedMemberType = false;
             if (enclosingType != null) {
               invokedMethodType =
                   TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
+              recomputedMemberType = true;
             }
             Type.MethodType methodType =
                 handler.onOverrideMethodType(symbol, invokedMethodType.asMethodType(), state);
-            // restore explicit annotations from the return type
             Type returnType = methodType.getReturnType();
-            result =
-                TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-                    returnType, result, config, Collections.emptyMap());
+            if (recomputedMemberType && !(invokedMethodType instanceof Type.ForAll)) {
+              // If the receiver type was recomputed above, the member return type is already the
+              // call-site return type. Using javac's expression type as the base can preserve stale
+              // nested annotations from before the receiver refinement.
+              result = returnType;
+            } else {
+              // For generic method calls, keep javac's expression type as the base because it
+              // contains call-site inference results for method type variables. Then restore any
+              // explicit annotations from the declared/recomputed return type.
+              result =
+                  TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
+                      returnType, result, config, Collections.emptyMap());
+            }
           } else if (tree instanceof MemberSelectTree memberSelectTree) {
             Symbol memberSelectSymbol = ASTHelpers.getSymbol(memberSelectTree);
             if (memberSelectSymbol != null && memberSelectSymbol.getKind().isField()) {
@@ -658,6 +669,9 @@ public final class GenericsChecks {
             }
           }
         }
+      }
+      if (tree instanceof ExpressionTree expressionTree && result != null) {
+        result = handler.onOverrideExpressionType(expressionTree, result, state);
       }
       return typeOrNullIfRaw(result);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -354,20 +354,13 @@ class CompositeHandler implements Handler {
 
   @Override
   public Type.MethodType onOverrideMethodType(
-      Symbol.MethodSymbol methodSymbol, Type.MethodType methodType, VisitorState state) {
+      Symbol.MethodSymbol methodSymbol,
+      Type.MethodType methodType,
+      VisitorState state,
+      @Nullable MethodInvocationTree invocationTree) {
     Type.MethodType currentType = methodType;
     for (Handler h : handlers) {
-      currentType = h.onOverrideMethodType(methodSymbol, currentType, state);
-    }
-    return currentType;
-  }
-
-  @Override
-  public Type onOverrideExpressionType(
-      ExpressionTree expressionTree, Type type, VisitorState state) {
-    Type currentType = type;
-    for (Handler h : handlers) {
-      currentType = h.onOverrideExpressionType(expressionTree, currentType, state);
+      currentType = h.onOverrideMethodType(methodSymbol, currentType, state, invocationTree);
     }
     return currentType;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -363,6 +363,16 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public Type onOverrideExpressionType(
+      ExpressionTree expressionTree, Type type, VisitorState state) {
+    Type currentType = type;
+    for (Handler h : handlers) {
+      currentType = h.onOverrideExpressionType(expressionTree, currentType, state);
+    }
+    return currentType;
+  }
+
+  @Override
   public boolean shouldSkipFieldInitializationCheck(
       Symbol.ClassSymbol classSymbol, Symbol fieldSymbol, VisitorState state) {
     for (Handler h : handlers) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -375,4 +375,15 @@ class CompositeHandler implements Handler {
     }
     return false;
   }
+
+  @Override
+  public boolean isSingleArgNullImpliesFalseMethod(
+      Symbol.MethodSymbol methodSymbol, VisitorState state) {
+    for (Handler h : handlers) {
+      if (h.isSingleArgNullImpliesFalseMethod(methodSymbol, state)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -511,8 +511,8 @@ public interface Handler {
   }
 
   /**
-   * Returns true if the given single-argument method is known to return {@code false} whenever its
-   * only argument is {@code null}.
+   * Returns true if the given method takes a single argument and returns {@code false} whenever the
+   * argument is {@code null}.
    */
   default boolean isSingleArgNullImpliesFalseMethod(
       Symbol.MethodSymbol methodSymbol, VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -511,6 +511,15 @@ public interface Handler {
   }
 
   /**
+   * Returns true if the given single-argument method is known to return {@code false} whenever its
+   * only argument is {@code null}.
+   */
+  default boolean isSingleArgNullImpliesFalseMethod(
+      Symbol.MethodSymbol methodSymbol, VisitorState state) {
+    return false;
+  }
+
+  /**
    * A three value enum for handlers implementing onDataflowVisitMethodInvocation to communicate
    * their knowledge of the method return nullability to the rest of NullAway.
    */

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -492,6 +492,19 @@ public interface Handler {
   }
 
   /**
+   * Method to override the type of an expression.
+   *
+   * @param expressionTree the expression tree
+   * @param type original expression type
+   * @param state The current visitor state.
+   * @return the possibly modified expression type
+   */
+  default Type onOverrideExpressionType(
+      ExpressionTree expressionTree, Type type, VisitorState state) {
+    return type;
+  }
+
+  /**
    * Method to determine whether a field should be treated as initialized externally (e.g. by a
    * framework), using the field and its enclosing class.
    *

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -484,24 +484,15 @@ public interface Handler {
    * @param methodSymbol symbol of the method
    * @param methodType original method type
    * @param state The current visitor state.
+   * @param invocationTree the invocation tree for the method, if available
    * @return the possibly modified method type
    */
   default Type.MethodType onOverrideMethodType(
-      Symbol.MethodSymbol methodSymbol, Type.MethodType methodType, VisitorState state) {
+      Symbol.MethodSymbol methodSymbol,
+      Type.MethodType methodType,
+      VisitorState state,
+      @Nullable MethodInvocationTree invocationTree) {
     return methodType;
-  }
-
-  /**
-   * Method to override the type of an expression.
-   *
-   * @param expressionTree the expression tree
-   * @param type original expression type
-   * @param state The current visitor state.
-   * @return the possibly modified expression type
-   */
-  default Type onOverrideExpressionType(
-      ExpressionTree expressionTree, Type type, VisitorState state) {
-    return type;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -60,7 +60,9 @@ public class Handlers {
     LibraryModelsHandler libraryModelsHandler = new LibraryModelsHandler(config);
     handlerListBuilder.add(libraryModelsHandler);
     handlerListBuilder.add(StreamNullabilityPropagatorFactory.getRxStreamNullabilityPropagator());
-    handlerListBuilder.add(StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator());
+    StreamNullabilityPropagator javaStreamNullabilityPropagator =
+        StreamNullabilityPropagatorFactory.getJavaStreamNullabilityPropagator();
+    handlerListBuilder.add(javaStreamNullabilityPropagator);
     handlerListBuilder.add(
         StreamNullabilityPropagatorFactory.fromSpecs(
             libraryModelsHandler.getStreamNullabilitySpecs()));
@@ -90,6 +92,7 @@ public class Handlers {
       restrictiveAnnotationHandler.initMainHandler(mainHandler);
     }
     libraryModelsHandler.initMainHandler(mainHandler);
+    javaStreamNullabilityPropagator.initMainHandler(mainHandler);
 
     return mainHandler;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -430,7 +430,10 @@ public class LibraryModelsHandler implements Handler {
   @Override
   @SuppressWarnings("ReferenceEquality")
   public Type.MethodType onOverrideMethodType(
-      Symbol.MethodSymbol methodSymbol, Type.MethodType methodType, VisitorState state) {
+      Symbol.MethodSymbol methodSymbol,
+      Type.MethodType methodType,
+      VisitorState state,
+      @Nullable MethodInvocationTree invocationTree) {
     OptimizedLibraryModels optimizedLibraryModels = getOptLibraryModels(state.context);
     ImmutableSetMultimap<Integer, NestedAnnotationInfo> nestedAnnotations =
         optimizedLibraryModels.nestedAnnotationsForMethods(methodSymbol);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -426,6 +426,13 @@ public class LibraryModelsHandler implements Handler {
     return libraryModels.nullMarkedClasses().contains(className);
   }
 
+  @Override
+  public boolean isSingleArgNullImpliesFalseMethod(
+      Symbol.MethodSymbol methodSymbol, VisitorState state) {
+    return methodSymbol.getParameters().size() == 1
+        && getOptLibraryModels(state.context).nullImpliesFalseParameters(methodSymbol).contains(0);
+  }
+
   /** Updates method types based on nested annotation information from library models. */
   @Override
   @SuppressWarnings("ReferenceEquality")

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -48,6 +48,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
+import com.uber.nullaway.annotations.Initializer;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathElement;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
@@ -190,9 +191,16 @@ class StreamNullabilityPropagator implements Handler {
 
   private @Nullable NullAway analysis;
 
+  private @Nullable Handler mainHandler;
+
   StreamNullabilityPropagator(ImmutableList<StreamTypeRecord> models) {
     super();
     this.models = models;
+  }
+
+  @Initializer
+  void initMainHandler(Handler mainHandler) {
+    this.mainHandler = mainHandler;
   }
 
   @Override
@@ -295,11 +303,12 @@ class StreamNullabilityPropagator implements Handler {
       Type.MethodType methodType,
       VisitorState state,
       @Nullable MethodInvocationTree invocationTree) {
-    if (analysis == null || invocationTree == null) {
+    if (invocationTree == null) {
       return methodType;
     }
     if (isNullRejectingFilterInvocation(invocationTree, state)) {
-      Type updatedReturnType = refineFilterExpressionType(methodType.getReturnType(), state);
+      Type returnType = methodType.getReturnType();
+      Type updatedReturnType = refineFilterExpressionType(returnType, state);
       return new Type.MethodType(
           methodType.argtypes, updatedReturnType, methodType.thrown, methodType.tsym);
     }
@@ -309,9 +318,13 @@ class StreamNullabilityPropagator implements Handler {
   private boolean isNullRejectingFilterInvocation(
       MethodInvocationTree invocationTree, VisitorState state) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
-    if (methodSymbol == null
-        || invocationTree.getArguments().size() != 1
-        || !isObjectsNonNullMethodReference(invocationTree.getArguments().get(0))) {
+    Handler handler = mainHandler;
+    if (methodSymbol == null || invocationTree.getArguments().size() != 1 || handler == null) {
+      return false;
+    }
+    Symbol predicateMethodSymbol = ASTHelpers.getSymbol(invocationTree.getArguments().get(0));
+    if (!(predicateMethodSymbol instanceof Symbol.MethodSymbol predicateMethod)
+        || !handler.isSingleArgNullImpliesFalseMethod(predicateMethod, state)) {
       return false;
     }
     Type receiverType = ASTHelpers.getReceiverType(invocationTree);
@@ -324,29 +337,6 @@ class StreamNullabilityPropagator implements Handler {
       }
     }
     return false;
-  }
-
-  private static boolean isObjectsNonNullMethodReference(ExpressionTree argTree) {
-    if (!(argTree instanceof MemberReferenceTree memberReferenceTree)
-        || !memberReferenceTree.getName().contentEquals("nonNull")
-        || !isJavaUtilObjects(memberReferenceTree.getQualifierExpression())) {
-      return false;
-    }
-    Symbol symbol = ASTHelpers.getSymbol(argTree);
-    return !(symbol instanceof Symbol.MethodSymbol methodSymbol)
-        || methodSymbol.getParameters().size() == 1;
-  }
-
-  private static boolean isJavaUtilObjects(ExpressionTree tree) {
-    Symbol symbol = ASTHelpers.getSymbol(tree);
-    if (symbol instanceof Symbol.ClassSymbol classSymbol
-        && classSymbol.getQualifiedName().contentEquals("java.util.Objects")) {
-      return true;
-    }
-    Type type = ASTHelpers.getType(tree);
-    return type != null
-        && type.tsym instanceof Symbol.ClassSymbol classSymbol
-        && classSymbol.getQualifiedName().contentEquals("java.util.Objects");
   }
 
   private Type refineFilterExpressionType(Type type, VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -290,15 +290,20 @@ class StreamNullabilityPropagator implements Handler {
   }
 
   @Override
-  public Type onOverrideExpressionType(
-      ExpressionTree expressionTree, Type type, VisitorState state) {
-    if (analysis == null || !(expressionTree instanceof MethodInvocationTree invocationTree)) {
-      return type;
+  public Type.MethodType onOverrideMethodType(
+      Symbol.MethodSymbol methodSymbol,
+      Type.MethodType methodType,
+      VisitorState state,
+      @Nullable MethodInvocationTree invocationTree) {
+    if (analysis == null || invocationTree == null) {
+      return methodType;
     }
     if (isNullRejectingFilterInvocation(invocationTree, state)) {
-      return refineFilterExpressionType(type, state);
+      Type updatedReturnType = refineFilterExpressionType(methodType.getReturnType(), state);
+      return new Type.MethodType(
+          methodType.argtypes, updatedReturnType, methodType.thrown, methodType.tsym);
     }
-    return type;
+    return methodType;
   }
 
   private boolean isNullRejectingFilterInvocation(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -52,11 +52,14 @@ import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathElement;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.NullnessStore;
+import com.uber.nullaway.generics.TypeMetadataBuilder;
+import com.uber.nullaway.generics.TypeSubstitutionUtils;
 import com.uber.nullaway.handlers.stream.CollectLikeMethodRecord;
 import com.uber.nullaway.handlers.stream.MapLikeMethodRecord;
 import com.uber.nullaway.handlers.stream.MapOrCollectLikeMethodRecord;
 import com.uber.nullaway.handlers.stream.MapOrCollectMethodToFilterInstanceRecord;
 import com.uber.nullaway.handlers.stream.StreamTypeRecord;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -68,6 +71,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.nullaway.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.nullaway.dataflow.cfg.node.LocalVariableNode;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This Handler transfers nullability info through chains of calls to methods of
@@ -183,6 +187,8 @@ class StreamNullabilityPropagator implements Handler {
       new LinkedHashMap<>();
   private final ImmutableList<StreamTypeRecord> models;
 
+  private @Nullable NullAway analysis;
+
   StreamNullabilityPropagator(ImmutableList<StreamTypeRecord> models) {
     super();
     this.models = models;
@@ -191,6 +197,7 @@ class StreamNullabilityPropagator implements Handler {
   @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+    this.analysis = analysis;
     // Clear compilation unit specific state
     this.filterMethodOrLambdaSet.clear();
     this.observableOuterCallInChain.clear();
@@ -279,6 +286,83 @@ class StreamNullabilityPropagator implements Handler {
     } else if (argTree instanceof MemberReferenceTree) {
       observableCallToInnerMethodOrLambda.put(tree, argTree);
     }
+  }
+
+  @Override
+  public Type onOverrideExpressionType(
+      ExpressionTree expressionTree, Type type, VisitorState state) {
+    if (analysis == null || !(expressionTree instanceof MethodInvocationTree invocationTree)) {
+      return type;
+    }
+    if (isNullRejectingFilterInvocation(invocationTree, state)) {
+      return refineFilterExpressionType(type);
+    }
+    return type;
+  }
+
+  private boolean isNullRejectingFilterInvocation(
+      MethodInvocationTree invocationTree, VisitorState state) {
+    Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
+    if (methodSymbol == null
+        || invocationTree.getArguments().size() != 1
+        || !isObjectsNonNullMethodReference(invocationTree.getArguments().get(0))) {
+      return false;
+    }
+    Type receiverType = ASTHelpers.getReceiverType(invocationTree);
+    if (receiverType == null) {
+      return false;
+    }
+    for (StreamTypeRecord streamType : models) {
+      if (streamType.matchesType(receiverType, state) && streamType.isFilterMethod(methodSymbol)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isObjectsNonNullMethodReference(ExpressionTree argTree) {
+    if (!(argTree instanceof MemberReferenceTree memberReferenceTree)
+        || !memberReferenceTree.getName().contentEquals("nonNull")
+        || !isJavaUtilObjects(memberReferenceTree.getQualifierExpression())) {
+      return false;
+    }
+    Symbol symbol = ASTHelpers.getSymbol(argTree);
+    return !(symbol instanceof Symbol.MethodSymbol methodSymbol)
+        || methodSymbol.getParameters().size() == 1;
+  }
+
+  private static boolean isJavaUtilObjects(ExpressionTree tree) {
+    Symbol symbol = ASTHelpers.getSymbol(tree);
+    if (symbol instanceof Symbol.ClassSymbol classSymbol
+        && classSymbol.getQualifiedName().contentEquals("java.util.Objects")) {
+      return true;
+    }
+    Type type = ASTHelpers.getType(tree);
+    return type != null
+        && type.tsym instanceof Symbol.ClassSymbol classSymbol
+        && classSymbol.getQualifiedName().contentEquals("java.util.Objects");
+  }
+
+  private Type refineFilterExpressionType(Type type) {
+    if (!(type instanceof Type.ClassType classType)) {
+      return type;
+    }
+    List<Type> typeArgs = classType.getTypeArguments();
+    if (typeArgs.size() != 1) {
+      return type;
+    }
+    Type streamElementType = typeArgs.get(0);
+    if (!Nullness.hasNullableAnnotation(
+        streamElementType.getAnnotationMirrors().stream(), castToNonNull(analysis).getConfig())) {
+      return type;
+    }
+    Type updatedElementType =
+        TypeSubstitutionUtils.removeNullableAnnotation(
+            streamElementType, castToNonNull(analysis).getConfig());
+    java.util.List<Type> updatedTypeArgs = new ArrayList<>(1);
+    updatedTypeArgs.add(updatedElementType);
+    return TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(
+        classType, classType.getEnclosingType(), updatedTypeArgs);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -295,7 +295,14 @@ class StreamNullabilityPropagator implements Handler {
     }
   }
 
+  /**
+   * If the invocation is a call of the form {@code s.filter(meth)}, where {@code s} has type {@code
+   * Stream<@Nullable Foo>} and {@code meth} is a null-filtering method like {@code
+   * Objects::nonNull}, updates the return type of the invocation to be {@code Stream<@NonNull
+   * Foo>}.
+   */
   @Override
+  @SuppressWarnings("ReferenceEquality") // reference equality check on types ok in this case
   public Type.MethodType onOverrideMethodType(
       Symbol.MethodSymbol methodSymbol,
       Type.MethodType methodType,
@@ -306,38 +313,43 @@ class StreamNullabilityPropagator implements Handler {
     }
     if (isNullRejectingFilterInvocation(invocationTree, state)) {
       Type returnType = methodType.getReturnType();
-      Type updatedReturnType = refineFilterExpressionType(returnType, state);
-      return new Type.MethodType(
-          methodType.argtypes, updatedReturnType, methodType.thrown, methodType.tsym);
+      Type updatedReturnType = updateFilterTypeArgToNonNull(returnType, state);
+      if (updatedReturnType != returnType) {
+        return new Type.MethodType(
+            methodType.argtypes, updatedReturnType, methodType.thrown, methodType.tsym);
+      }
     }
     return methodType;
   }
 
+  /**
+   * Checks if invocation tree is of the form {@code s.filter(meth)} where {@code s} has some type
+   * {@code Stream<@Nullable Foo>} and {@code meth} is a null-filtering method like {@code
+   * Objects::nonNull}
+   */
   private boolean isNullRejectingFilterInvocation(
       MethodInvocationTree invocationTree, VisitorState state) {
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
-    Handler handler = mainHandler;
-    if (methodSymbol == null || invocationTree.getArguments().size() != 1 || handler == null) {
-      return false;
-    }
-    Symbol predicateMethodSymbol = ASTHelpers.getSymbol(invocationTree.getArguments().get(0));
-    if (!(predicateMethodSymbol instanceof Symbol.MethodSymbol predicateMethod)
-        || !handler.isSingleArgNullImpliesFalseMethod(predicateMethod, state)) {
+    if (methodSymbol == null
+        || methodSymbol.isStatic()
+        || invocationTree.getArguments().size() != 1
+        || mainHandler == null) {
       return false;
     }
     Type receiverType = ASTHelpers.getReceiverType(invocationTree);
-    if (receiverType == null) {
-      return false;
-    }
     for (StreamTypeRecord streamType : models) {
       if (streamType.matchesType(receiverType, state) && streamType.isFilterMethod(methodSymbol)) {
-        return true;
+        Symbol predicateMethodSymbol = ASTHelpers.getSymbol(invocationTree.getArguments().get(0));
+        if (predicateMethodSymbol instanceof Symbol.MethodSymbol predicateMethod
+            && mainHandler.isSingleArgNullImpliesFalseMethod(predicateMethod, state)) {
+          return true;
+        }
       }
     }
     return false;
   }
 
-  private Type refineFilterExpressionType(Type type, VisitorState state) {
+  private Type updateFilterTypeArgToNonNull(Type type, VisitorState state) {
     if (!(type instanceof Type.ClassType classType)) {
       return type;
     }
@@ -351,7 +363,7 @@ class StreamNullabilityPropagator implements Handler {
       return type;
     }
     // Rather than just stripping the @Nullable annotation, use an explicit @NonNull annotation, as
-    // the explicit annotation will override @Nullable annotations placed by javac
+    // the explicit annotation will override other @Nullable annotations placed by javac
     Type updatedElementType =
         TypeSubstitutionUtils.typeWithAnnot(
             streamElementType, GenericsChecks.getSyntheticNonNullAnnotType(state));

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -52,6 +52,7 @@ import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathElement;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
 import com.uber.nullaway.dataflow.NullnessStore;
+import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.generics.TypeMetadataBuilder;
 import com.uber.nullaway.generics.TypeSubstitutionUtils;
 import com.uber.nullaway.handlers.stream.CollectLikeMethodRecord;
@@ -295,7 +296,7 @@ class StreamNullabilityPropagator implements Handler {
       return type;
     }
     if (isNullRejectingFilterInvocation(invocationTree, state)) {
-      return refineFilterExpressionType(type);
+      return refineFilterExpressionType(type, state);
     }
     return type;
   }
@@ -343,7 +344,7 @@ class StreamNullabilityPropagator implements Handler {
         && classSymbol.getQualifiedName().contentEquals("java.util.Objects");
   }
 
-  private Type refineFilterExpressionType(Type type) {
+  private Type refineFilterExpressionType(Type type, VisitorState state) {
     if (!(type instanceof Type.ClassType classType)) {
       return type;
     }
@@ -357,8 +358,10 @@ class StreamNullabilityPropagator implements Handler {
       return type;
     }
     Type updatedElementType =
-        TypeSubstitutionUtils.removeNullableAnnotation(
-            streamElementType, castToNonNull(analysis).getConfig());
+        TypeSubstitutionUtils.typeWithAnnot(
+            TypeSubstitutionUtils.removeNullableAnnotation(
+                streamElementType, castToNonNull(analysis).getConfig()),
+            GenericsChecks.getSyntheticNonNullAnnotType(state));
     java.util.List<Type> updatedTypeArgs = new ArrayList<>(1);
     updatedTypeArgs.add(updatedElementType);
     return TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -362,11 +362,11 @@ class StreamNullabilityPropagator implements Handler {
         streamElementType.getAnnotationMirrors().stream(), castToNonNull(analysis).getConfig())) {
       return type;
     }
+    // Rather than just stripping the @Nullable annotation, use an explicit @NonNull annotation, as
+    // the explicit annotation will override @Nullable annotations placed by javac
     Type updatedElementType =
         TypeSubstitutionUtils.typeWithAnnot(
-            TypeSubstitutionUtils.removeNullableAnnotation(
-                streamElementType, castToNonNull(analysis).getConfig()),
-            GenericsChecks.getSyntheticNonNullAnnotType(state));
+            streamElementType, GenericsChecks.getSyntheticNonNullAnnotType(state));
     java.util.List<Type> updatedTypeArgs = new ArrayList<>(1);
     updatedTypeArgs.add(updatedElementType);
     return TypeMetadataBuilder.TYPE_METADATA_BUILDER.createClassType(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -48,7 +48,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
-import com.uber.nullaway.annotations.Initializer;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathElement;
 import com.uber.nullaway.dataflow.AccessPathNullnessAnalysis;
@@ -198,7 +197,6 @@ class StreamNullabilityPropagator implements Handler {
     this.models = models;
   }
 
-  @Initializer
   void initMainHandler(Handler mainHandler) {
     this.mainHandler = mainHandler;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -98,6 +98,27 @@ public class ContractHandler implements Handler {
   }
 
   @Override
+  public boolean isSingleArgNullImpliesFalseMethod(
+      Symbol.MethodSymbol methodSymbol, VisitorState state) {
+    if (methodSymbol.getParameters().size() != 1) {
+      return false;
+    }
+    for (String clause : ContractUtils.getContractClauses(methodSymbol, config)) {
+      String[] parts = clause.split("->");
+      if (parts.length != 2) {
+        continue;
+      }
+      String[] antecedent = parts[0].trim().isEmpty() ? new String[0] : parts[0].split(",");
+      if (antecedent.length == 1
+          && antecedent[0].trim().equals("null")
+          && parts[1].trim().equals("false")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
   public void onMatchTopLevelClass(
       NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
     this.analysis = analysis;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -1,0 +1,102 @@
+package com.uber.nullaway.jspecify;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.NullAwayTestsBase;
+import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
+
+  @Test
+  public void filterObjectsNonNullRefinesStreamElementType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Arrays;
+            import java.util.List;
+            import java.util.Objects;
+            import java.util.Optional;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static Optional<Double> sumNumbersAsDoubles(@Nullable Number... numbers) {
+                return Arrays.stream(numbers)
+                    .filter(Objects::nonNull)
+                    .map(Number::doubleValue)
+                    .reduce(Double::sum);
+              }
+
+              static Optional<Double> sumDoubles(@Nullable Double... doubles) {
+                return Arrays.stream(doubles)
+                    .filter(Objects::nonNull)
+                    .reduce(Double::sum);
+              }
+
+              static Optional<Double> sumDoublesWithExplicitMap(@Nullable Double... doubles) {
+                return Arrays.stream(doubles)
+                    .filter(Objects::nonNull)
+                    .map(Objects::requireNonNull)
+                    .reduce(Double::sum);
+              }
+
+              static List<String> nullableStringsToNonNull(List<@Nullable String> values) {
+                return values.stream().filter(Objects::nonNull).toList();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unrelatedFilterDoesNotRefineStreamElementType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import java.util.Objects;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static List<String> filterDoesNotProveNonNull(List<@Nullable String> values) {
+                // BUG: Diagnostic contains: incompatible types
+                return values.stream().filter(value -> true).toList();
+              }
+
+              static @Nullable String maybeNull(String value) {
+                return null;
+              }
+
+              static List<@Nullable String> genericMapAfterNullRejectingFilterUsesCallSiteInference(
+                  List<@Nullable String> values) {
+                return values.stream()
+                    .filter(Objects::nonNull)
+                    .map(Test::maybeNull)
+                    .toList();
+              }
+
+              static List<String> mapAfterNullRejectingFilterCanStillReturnNullable(
+                  List<@Nullable String> values) {
+                return values.stream()
+                    .filter(Objects::nonNull)
+                    .map(Test::maybeNull)
+                    // BUG: Diagnostic contains: incompatible types
+                    .toList();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        JSpecifyJavacConfig.withJSpecifyModeArgs(
+            Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -64,7 +64,7 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
             "org/springframework/util/StringUtils.java",
             """
             package org.springframework.util;
-
+            // stub for Spring's StringUtils class for which we have a library model
             public final class StringUtils {
               public static boolean hasLength(String value) {
                 return value != null && !value.isEmpty();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -52,6 +52,64 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void filterLibraryModeledNullRejectingPredicateRefinesStreamElementType() {
+    makeHelper()
+        .addSourceLines(
+            "org/springframework/util/StringUtils.java",
+            """
+            package org.springframework.util;
+
+            public final class StringUtils {
+              public static boolean hasLength(String value) {
+                return value != null && !value.isEmpty();
+              }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            import org.springframework.util.StringUtils;
+
+            @NullMarked
+            class Test {
+              static List<String> nullableStringsToNonNull(List<@Nullable String> values) {
+                return values.stream().filter(StringUtils::hasLength).toList();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void filterContractNullRejectingPredicateRefinesStreamElementType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jetbrains.annotations.Contract;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              @Contract("null -> false")
+              static boolean hasLength(@Nullable String value) {
+                return value != null && !value.isEmpty();
+              }
+
+              static List<String> nullableStringsToNonNull(List<@Nullable String> values) {
+                return values.stream().filter(Test::hasLength).toList();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void unrelatedFilterDoesNotRefineStreamElementType() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
 
   @Test
-  public void filterObjectsNonNullRefinesStreamElementType() {
+  public void filterRefinesStreamElementType() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -36,6 +36,12 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
                     .reduce(Double::sum);
               }
 
+              static Optional<Double> sumDoublesMissingfilter(@Nullable Double... doubles) {
+                return Arrays.stream(doubles)
+                    // BUG: Diagnostic contains: incompatible types
+                    .reduce(Double::sum);
+              }
+
               static Optional<Double> sumDoublesWithExplicitMap(@Nullable Double... doubles) {
                 return Arrays.stream(doubles)
                     .filter(Objects::nonNull)
@@ -52,7 +58,7 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void filterLibraryModeledNullRejectingPredicateRefinesStreamElementType() {
+  public void filterWithStringUtilsHasLength() {
     makeHelper()
         .addSourceLines(
             "org/springframework/util/StringUtils.java",
@@ -84,7 +90,7 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void filterContractNullRejectingPredicateRefinesStreamElementType() {
+  public void filterWithContractMethod() {
     makeHelper()
         .addSourceLines(
             "Test.java",


### PR DESCRIPTION
Fixes #1578 
Fixes #1594 

Now, if we have a `Stream<@Nullable Foo>` `s` and the code invokes `s.filter(Objects::nonNull)`, the result type is `Stream<Foo>`.  This works for any method that has an appropriate library model or any method annotated `@Contract(null -> false)`.

This PR does not handle lambdas, e.g., `s.filter(x -> x != null)`; we can add such support in a follow-up if it comes up often.

Main support is in `StreamNullabilityPropagator.onOverrideMethodType`.  To identify filtering methods, we add a new `Handler` method `isSingleArgNullImpliesFalseMethod` and implement in `LibraryModelsHandler` and `ContractHandler`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream filter operations now refine element nullability when using null-rejecting predicates (including contract- or library-model-backed predicates).
  * Call-site invocation context is now propagated to nullability handlers, enabling more precise, site-aware inference and special-case detection of single-arg null->false methods.

* **Tests**
  * Added tests validating stream filter refinement, contract-based and library-model predicates, custom predicates, and non-refining filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->