### PR TITLE
Switch code coverage aggregation to use built-in jacoco plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,8 +135,10 @@ subprojects { project ->
     if (project.name != "jar-infer" && project.name != "library-model" && project.name != "jdk-annotations" && project.name != "nullaway-bom") {
         project.apply plugin: "com.diffplug.spotless"
         spotless {
-            java {
-                googleJavaFormat(libs.versions.google.java.format.get())
+            project.plugins.withId('java') {
+                java {
+                    googleJavaFormat(libs.versions.google.java.format.get())
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -132,13 +132,11 @@ subprojects { project ->
 
     // Spotless complains when applied to the folders containing projects
     // when they do not have a build.gradle file
-    if (project.name != "jar-infer" && project.name != "library-model" && project.name != "jdk-annotations" && project.name != "nullaway-bom") {
+    if (project.name != "jar-infer" && project.name != "library-model" && project.name != "jdk-annotations" && project.name != "nullaway-bom" && project.name != "code-coverage-report") {
         project.apply plugin: "com.diffplug.spotless"
         spotless {
-            project.plugins.withId('java') {
-                java {
-                    googleJavaFormat(libs.versions.google.java.format.get())
-                }
+            java {
+                googleJavaFormat(libs.versions.google.java.format.get())
             }
         }
     }

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -123,3 +123,21 @@ def epJdk17Test = tasks.register("testJdk17", Test) {
 tasks.named('check').configure {
     dependsOn(epJdk17Test)
 }
+
+// The built-in jacoco-report-aggregation plugin aggregates coverage per test suite,
+// matching the variant whose org.gradle.testsuite.name == "test". That auto-created
+// variant (coverageDataElementsForTest) only carries the default `test` task's exec
+// data. testJdk17/21/26/27 are plain Test tasks that re-run the `test` source set
+// under other JDKs, so without this their coverage is dropped from aggregation.
+// This attaches their exec files to the `test` suite's coverage variant and
+// replaces the old hand-rolled `coverageDataElements` configuration
+// See https://github.com/uber/NullAway/pull/1598#issuecomment-4693680548
+configurations.named('coverageDataElementsForTest') {
+    tasks.withType(Test).matching { it.name != 'test' }.each { testTask ->
+        // tasks.named(...).map { } keeps the exec-file reference lazy and carries the
+        // task dependency, so requesting the coverage data runs the JDK-specific tests.
+        outgoing.artifact(
+                tasks.named(testTask.name).map { t -> t.extensions.getByType(JacocoTaskExtension).destinationFile }
+        )
+    }
+}

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -137,7 +137,8 @@ configurations.named('coverageDataElementsForTest') {
         // tasks.named(...).map { } keeps the exec-file reference lazy and carries the
         // task dependency, so requesting the coverage data runs the JDK-specific tests.
         outgoing.artifact(
-                tasks.named(testTask.name).map { t -> t.extensions.getByType(JacocoTaskExtension).destinationFile }
-        )
+                tasks.named(testTask.name).map { t ->
+                    t.extensions.getByType(JacocoTaskExtension).destinationFile
+                })
     }
 }

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -44,23 +44,6 @@ tasks.named("jacocoTestReport") {
     enabled = false
 }
 
-// Share sources folder with other projects for aggregated JaCoCo reports
-configurations.create('transitiveSourcesElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
-    sourceSets.main.java.srcDirs.forEach {
-        outgoing.artifact(it)
-    }
-}
-
-
 configurations {
     // A configuration holding the jars for the Error Prone version to use when testing with JDK 17
     errorProneJdk17
@@ -139,23 +122,4 @@ def epJdk17Test = tasks.register("testJdk17", Test) {
 
 tasks.named('check').configure {
     dependsOn(epJdk17Test)
-}
-
-// Share the coverage data to be aggregated for the whole product
-configurations.create('coverageDataElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-    // This will cause the test tasks to run if the coverage data is requested by the aggregation task
-    tasks.withType(Test).forEach {task ->
-        // tasks.named(task.name) is a hack to introduce the right task dependence in Gradle.  We will fix this
-        // correctly when addressing https://github.com/uber/NullAway/issues/871
-        outgoing.artifact(tasks.named(task.name).map { t -> t.extensions.getByType(JacocoTaskExtension).destinationFile })
-    }
 }

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -19,10 +19,6 @@ plugins {
     id 'jacoco-report-aggregation'
 }
 
-// Use JDK 21 for this module, via a toolchain.  We need JDK 21 since this module
-// depends on jdk-recent-unit-tests.
-java.toolchain.languageVersion.set JavaLanguageVersion.of(21)
-
 repositories {
     mavenCentral()
     google()

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -19,11 +19,6 @@ plugins {
     id 'jacoco-report-aggregation'
 }
 
-repositories {
-    mavenCentral()
-    google()
-}
-
 dependencies {
     jacocoAggregation project(':annotations')
     jacocoAggregation project(':nullaway')

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -14,75 +14,38 @@
  * limitations under the License.
  */
 
-// Mostly taken from official Gradle sample: https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html
 plugins {
-    id 'java'
-    id 'jacoco'
+    id 'base'
+    id 'jacoco-report-aggregation'
 }
 
 // Use JDK 21 for this module, via a toolchain.  We need JDK 21 since this module
 // depends on jdk-recent-unit-tests.
-// We must null out sourceCompatibility and targetCompatibility to use toolchains.
-java.sourceCompatibility = null
-java.targetCompatibility = null
 java.toolchain.languageVersion.set JavaLanguageVersion.of(21)
 
-// A resolvable configuration to collect source code
-def sourcesPath = configurations.create("sourcesPath") {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
+repositories {
+    mavenCentral()
+    google()
 }
 
-// A resolvable configuration to collect JaCoCo coverage data
-def coverageDataPath = configurations.create("coverageDataPath") {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-}
-
-// Task to gather code coverage from multiple subprojects
-def codeCoverageReport = tasks.register('codeCoverageReport', JacocoReport) {
-    additionalClassDirs(configurations.runtimeClasspath.filter{it.path.contains(rootProject.name)  })
-    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
-
-    reports {
-        // xml is usually used to integrate code coverage with
-        // other tools like SonarQube, Coveralls or Codecov
-        xml.required = true
-
-        // HTML reports can be used to see code coverage
-        // without any external tools
-        html.required = true
-    }
-}
-
-// These dependencies indicate which projects have tests or tested code we want to include
-// when computing overall coverage.  We aim to measure coverage for all code that actually ships
-// in a Maven artifact (so, e.g., we do not measure coverage for the jmh module)
 dependencies {
-    implementation project(':annotations')
-    implementation project(':nullaway')
-    implementation project(':jar-infer:jar-infer-lib')
-    implementation project(':jar-infer:nullaway-integration-test')
-    implementation project(':guava-recent-unit-tests')
-    implementation project(':jdk-recent-unit-tests')
-    implementation project(':library-model:library-model-generator')
-    implementation project(':jdk-javac-plugin')
-    implementation project(':jdk-annotations:astubx-generator')
-    implementation project(':jdk-annotations:jdk-integration-test')
-    implementation project(':test-library-models')
+    jacocoAggregation project(':annotations')
+    jacocoAggregation project(':nullaway')
+    jacocoAggregation project(':jar-infer:jar-infer-lib')
+    jacocoAggregation project(':jar-infer:nullaway-integration-test')
+    jacocoAggregation project(':guava-recent-unit-tests')
+    jacocoAggregation project(':jdk-recent-unit-tests')
+    jacocoAggregation project(':library-model:library-model-generator')
+    jacocoAggregation project(':jdk-javac-plugin')
+    jacocoAggregation project(':jdk-annotations:astubx-generator')
+    jacocoAggregation project(':jdk-annotations:jdk-integration-test')
+    jacocoAggregation project(':test-library-models')
+}
+
+reporting {
+    reports {
+        codeCoverageReport(JacocoCoverageReport) {
+            testSuiteName = "test"
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/uber/NullAway/issues/871

Replace the custom jacoco aggregation logic in `code-coverage-report/build.gradle` with Gradle's built-in jacoco-report-aggregation plugin.

This gets rid of a lot of custom gradle code to manually create resolvable configurations, wiring up source directories, class directories, and execution data across subprojects.


  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [/] If applicable, unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to Gradle's built-in coverage aggregation for centralized module coverage reports.
  * Excluded the coverage-report module from automatic formatting to avoid applying the project-wide Java formatter.

* **Refactor**
  * Removed legacy custom coverage wiring and replaced it with the standard aggregation setup, simplifying how per-module test results are collected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->