### PR TITLE
Fix Optional factory method tracking (Partial fix for #889)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -547,6 +547,8 @@ public class AccessPathNullnessPropagation
       }
     }
 
+    handler.onDataflowVisitAssignment(node, state, apContext, values(input), input.getRegularStore(), updates);
+
     return updateRegularStore(value, input, updates);
   }
 
@@ -741,6 +743,7 @@ public class AccessPathNullnessPropagation
     if (isCatchVariable(node)) {
       updates.set(node, NONNULL);
     }
+
     /*
      * We can return whatever we want here because a variable declaration is not an expression and
      * thus no one can use its value directly. Any updates to the nullness of the variable are

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -372,4 +372,17 @@ class CompositeHandler implements Handler {
     }
     return false;
   }
+
+  @Override
+  public void onDataflowVisitAssignment(
+      org.checkerframework.nullaway.dataflow.cfg.node.AssignmentNode node,
+      com.google.errorprone.VisitorState state,
+      com.uber.nullaway.dataflow.AccessPath.AccessPathContext apContext,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.SubNodeValues inputs,
+      com.uber.nullaway.dataflow.NullnessStore store,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.Updates updates) {
+    for (Handler h : handlers) {
+      h.onDataflowVisitAssignment(node, state, apContext, inputs, store, updates);
+    }
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -387,6 +387,9 @@ class CompositeHandler implements Handler {
     for (Handler h : handlers) {
       h.onDataflowVisitAssignment(node, state, apContext, inputs, store, updates);
     }
+  }
+
+  @Override
   public boolean isSingleArgNullImpliesFalseMethod(
       Symbol.MethodSymbol methodSymbol, VisitorState state) {
     for (Handler h : handlers) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -279,6 +279,25 @@ public interface Handler {
   }
 
   /**
+   * Called when NullAway visits an assignment node during dataflow analysis.
+   *
+   * @param node The assignment node being visited.
+   * @param state The current visitor state.
+   * @param apContext The current access path context.
+   * @param store The current nullness store.
+   * @param updates The updates to be applied to the store.
+   */
+  default void onDataflowVisitAssignment(
+      org.checkerframework.nullaway.dataflow.cfg.node.AssignmentNode node,
+      com.google.errorprone.VisitorState state,
+      com.uber.nullaway.dataflow.AccessPath.AccessPathContext apContext,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.SubNodeValues inputs,
+      com.uber.nullaway.dataflow.NullnessStore store,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.Updates updates) {
+    // NoOp
+  }
+
+  /**
    * Called when the Dataflow analysis visits each field access.
    *
    * @param node The AST node for the field access.

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -130,6 +130,19 @@ public class OptionalEmptinessHandler implements Handler {
     } else if (optionalIsEmptyCall(symbol, types)) {
       updateNonNullAPsForOptionalContent(
           state.context, elseUpdates, node.getTarget().getReceiver(), apContext);
+    } else if (optionalOfCall(symbol, types)) {
+      // Optional.of(...) always yields a non-empty Optional
+      updateNonNullAPsForOptionalContent(
+          state.context, bothUpdates, node, apContext);
+    } else if (optionalOfNullableCall(symbol, types)) {
+      // Optional.ofNullable(...) yields a non-empty Optional ONLY if the argument is non-null
+      if (node.getArguments().size() == 1) {
+        Node arg = node.getArgument(0);
+        if (inputs.valueOfSubNode(arg) == Nullness.NONNULL) {
+          updateNonNullAPsForOptionalContent(
+              state.context, bothUpdates, node, apContext);
+        }
+      }
     } else if (config.handleTestAssertionLibraries()) {
       handleTestAssertions(state, apContext, bothUpdates, node, symbol);
     }
@@ -149,6 +162,85 @@ public class OptionalEmptinessHandler implements Handler {
           new ErrorMessage(ErrorMessage.MessageTypes.GET_ON_EMPTY_OPTIONAL, message));
     }
     return Optional.empty();
+  }
+
+  @Override
+  public void onDataflowVisitAssignment(
+      org.checkerframework.nullaway.dataflow.cfg.node.AssignmentNode node,
+      com.google.errorprone.VisitorState state,
+      com.uber.nullaway.dataflow.AccessPath.AccessPathContext apContext,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.SubNodeValues inputs,
+      com.uber.nullaway.dataflow.NullnessStore store,
+      com.uber.nullaway.dataflow.AccessPathNullnessPropagation.Updates updates) {
+
+    org.checkerframework.nullaway.dataflow.cfg.node.Node rhs = node.getExpression();
+    org.checkerframework.nullaway.dataflow.cfg.node.Node lhs = node.getTarget();
+
+    // Peel back any type cast, null check, widening or narrowing conversion nodes using shaded paths
+    while (rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.TypeCastNode
+        || rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.NullChkNode
+        || rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.WideningConversionNode
+        || rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.NarrowingConversionNode) {
+      if (rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.TypeCastNode) {
+        rhs = ((org.checkerframework.nullaway.dataflow.cfg.node.TypeCastNode) rhs).getOperand();
+      } else if (rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.NullChkNode) {
+        rhs = ((org.checkerframework.nullaway.dataflow.cfg.node.NullChkNode) rhs).getOperand();
+      } else if (rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.WideningConversionNode) {
+        rhs = ((org.checkerframework.nullaway.dataflow.cfg.node.WideningConversionNode) rhs).getOperand();
+      } else if (rhs instanceof org.checkerframework.nullaway.dataflow.cfg.node.NarrowingConversionNode) {
+        rhs = ((org.checkerframework.nullaway.dataflow.cfg.node.NarrowingConversionNode) rhs).getOperand();
+      }
+    }
+
+    // Case 1: The RHS is a factory method (e.g., Optional.of or Optional.ofNullable)
+    if (rhs instanceof MethodInvocationNode methodNode) {
+      Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(methodNode.getTree());
+      Types types = state.getTypes();
+      if (symbol != null) {
+        if (optionalOfCall(symbol, types)) {
+          updateNonNullAPsForOptionalContent(state.context, updates, lhs, apContext);
+          return;
+        } else if (optionalOfNullableCall(symbol, types)) {
+          if (methodNode.getArguments().size() == 1) {
+            org.checkerframework.nullaway.dataflow.cfg.node.Node arg = methodNode.getArgument(0);
+            Nullness argNullness = inputs.valueOfSubNode(arg);
+            if (argNullness != Nullness.NONNULL) {
+              AccessPath argAp = AccessPath.getAccessPathForNode(arg, state, apContext);
+              if (argAp != null) {
+                argNullness = store.getNullnessOfAccessPath(argAp);
+              }
+            }
+            if (argNullness == Nullness.NONNULL) {
+              updateNonNullAPsForOptionalContent(state.context, updates, lhs, apContext);
+            }
+          }
+          return;
+        }
+      }
+    }
+
+    // Case 2: Copying existing tracking facts across regular variables (e.g., o2 = o1)
+    AccessPath rhsAp = AccessPath.fromBaseAndElement(
+        rhs, OptionalContentVariableElement.instance(state.context), apContext);
+    if (rhsAp != null) {
+      Nullness rhsNullness = store.getNullnessOfAccessPath(rhsAp);
+      if (rhsNullness == Nullness.NONNULL) {
+        updateNonNullAPsForOptionalContent(state.context, updates, lhs, apContext);
+      }
+    }
+  }
+
+  private void updateNonNullAPsForOptionalContent(
+      Context context,
+      AccessPathNullnessPropagation.Updates updates,
+      Node base,
+      AccessPath.AccessPathContext apContext) {
+    AccessPath ap =
+        AccessPath.fromBaseAndElement(
+            base, OptionalContentVariableElement.instance(context), apContext);
+    if (ap != null) {
+      updates.set(ap, Nullness.NONNULL);
+    }
   }
 
   private boolean isOptionalContentNullable(
@@ -259,32 +351,31 @@ public class OptionalEmptinessHandler implements Handler {
     return node;
   }
 
-  private void updateNonNullAPsForOptionalContent(
-      Context context,
-      AccessPathNullnessPropagation.Updates updates,
-      Node base,
-      AccessPath.AccessPathContext apContext) {
-    AccessPath ap =
-        AccessPath.fromBaseAndElement(
-            base, OptionalContentVariableElement.instance(context), apContext);
-    if (ap != null && base.getTree() != null) {
-      updates.set(ap, Nullness.NONNULL);
-    }
+  public static javax.lang.model.element.VariableElement getOptionalContentElement(com.sun.tools.javac.util.Context context) {
+    return OptionalContentVariableElement.instance(context);
   }
 
   private boolean optionalIsPresentCall(Symbol.MethodSymbol symbol, Types types) {
-    return isZeroArgOptionalMethod("isPresent", symbol, types);
+    return isOptionalMethod("isPresent", 0, symbol, types);
   }
 
   private boolean optionalIsEmptyCall(Symbol.MethodSymbol symbol, Types types) {
-    return isZeroArgOptionalMethod("isEmpty", symbol, types);
+    return isOptionalMethod("isEmpty", 0, symbol, types);
   }
 
-  private boolean isZeroArgOptionalMethod(
-      String methodName, Symbol.MethodSymbol symbol, Types types) {
+  private boolean optionalOfCall(Symbol.MethodSymbol symbol, Types types) {
+    return isOptionalMethod("of", 1, symbol, types);
+  }
+
+  private boolean optionalOfNullableCall(Symbol.MethodSymbol symbol, Types types) {
+    return isOptionalMethod("ofNullable", 1, symbol, types);
+  }
+
+  private boolean isOptionalMethod(
+      String methodName, int paramCount, Symbol.MethodSymbol symbol, Types types) {
     Preconditions.checkNotNull(optionalTypes);
     if (!(symbol.getSimpleName().toString().equals(methodName)
-        && symbol.getParameters().length() == 0)) {
+        && symbol.getParameters().length() == paramCount)) {
       return false;
     }
     for (Type optionalType : optionalTypes) {
@@ -296,7 +387,7 @@ public class OptionalEmptinessHandler implements Handler {
   }
 
   private boolean optionalIsGetCall(Symbol.MethodSymbol symbol, Types types) {
-    return isZeroArgOptionalMethod("get", symbol, types);
+    return isOptionalMethod("get", 0, symbol, types);
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/OptionalEmptinessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/OptionalEmptinessTests.java
@@ -724,4 +724,36 @@ public class OptionalEmptinessTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+  
+  @Test
+  public void testOptionalOfAndOfNullableInitialValues() {
+    makeTestHelperWithArgs(
+            java.util.List.of(
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckOptionalEmptiness=true"))
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import java.util.Optional;",
+            "import javax.annotation.Nullable;", 
+            "public class Test {",
+            "  public void logOptionalOf() {",
+            "    Optional<Object> o = Optional.of(new Object());",
+            "    // Should be a true negative (no error) because of Optional.of()",
+            "    o.get().hashCode();",
+            "  }",
+            "  public void logOptionalOfNullableWithNonNull() {",
+            "    Object nonNullObj = new Object();",
+            "    Optional<Object> o = Optional.ofNullable(nonNullObj);",
+            "    // Should be a true negative because the argument is explicitly non-null",
+            "    o.get().hashCode();",
+            "  }",
+            "  public void logOptionalOfNullableWithNullable(@Nullable Object nullableObj) {", 
+            "    Optional<Object> o = Optional.ofNullable(nullableObj);",
+            "    // BUG: Diagnostic contains: Invoking get() on possibly empty Optional o",
+            "    o.get().hashCode();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
### Description
This PR addresses the false positives in `Optional` emptiness tracking related to factory method initializations, addressing the primary concern raised in #889. 

### Motivation and Context
In #889, it was reported that `CheckOptionalEmptiness` ignores the initial value passed to an Optional factory (e.g., `Optional.of` and `Optional.ofNullable`), leading to false positives when developers safely call `.get()` on those variables. Previously, NullAway dropped emptiness tracking facts when an `Optional` was assigned to a variable or initialized inline. 

### Specific Changes
1. **New Handler Hook**: Introduced `onDataflowVisitAssignment` in the `Handler` interface (and `CompositeHandler` / `AccessPathNullnessPropagation`) to allow plugins to intercept assignment nodes.
2. **Robust Unwrapping**: Implemented the new hook in `OptionalEmptinessHandler` to peel back implicit compiler wrappers (`TypeCastNode`, `NullChkNode`, `WideningConversionNode`, `NarrowingConversionNode`) to safely reach the underlying `MethodInvocationNode` during assignments.
3. **Factory Method Support**: Added tracking for `Optional.of(...)` (always non-empty) and `Optional.ofNullable(...)` (non-empty if the argument is `@NonNull`).
4. **CFG Tree Check Fix**: Removed a restrictive `base.getTree() != null` check in `updateNonNullAPsForOptionalContent` that was silently dropping tracking facts for inline variable initializations.
5. **Test Suite Updates**: Added the explicit `@Nullable` annotation to the parameter in `logOptionalOfNullableWithNullable` to align the test expectations, and ensured `Optional.of` flows cleanly.

*Note: This addresses the factory initialization cases for #889. The trickier `.or()` fallback provider case mentioned in the issue may require additional modeling in a future PR, but this lays the necessary architectural groundwork.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved null-safety analysis: assignment sites are now analyzed with additional propagation hooks, improving detection and propagation of non-null facts through assignments and common RHS conversions.

* **Bug Fixes / Improvements**
  * More accurate tracking for Optional.of()/Optional.ofNullable(), reducing false positives for Optional.get().

* **Tests**
  * Added unit tests validating Optional.of and Optional.ofNullable initialization and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->