### PR TITLE
Report init warnings for JPA constructors with arguments

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1683,7 +1683,7 @@ public class NullAway extends BugChecker
     }
     ExpressionTree initializer = tree.getInitializer();
     if (initializer != null) {
-      if (!shouldSkipFieldInitializationCheck(state, symbol, null)) {
+      if (getFieldInitializationSkipResult(state, symbol, null) != Handler.FieldSkipResult.YES) {
         if (mayBeNullExpr(state, initializer)) {
           ErrorMessage errorMessage =
               new ErrorMessage(
@@ -2228,7 +2228,9 @@ public class NullAway extends BugChecker
     SetMultimap<MethodTree, Symbol> constructorInitInfo;
     if (entities.constructors().isEmpty()) {
       constructorInitInfo = null;
-      notInitializedInConstructors = entities.nonnullInstanceFields();
+      notInitializedInConstructors =
+          fieldsRequiringInitializationForConstructor(
+              entities.nonnullInstanceFields(), null, state);
     } else {
       constructorInitInfo = checkConstructorInitialization(entities, state);
       notInitializedInConstructors = ImmutableSet.copyOf(constructorInitInfo.values());
@@ -2373,15 +2375,39 @@ public class NullAway extends BugChecker
         // external framework initializes fields in this case
         continue;
       }
+      ImmutableSet<Symbol> fieldsToCheck =
+          fieldsRequiringInitializationForConstructor(nonnullInstanceFields, constructor, state);
       ImmutableSet<Element> guaranteedNonNull =
           guaranteedNonNullForConstructor(entities, state, trees, constructor);
-      for (Symbol fieldSymbol : nonnullInstanceFields) {
+      for (Symbol fieldSymbol : fieldsToCheck) {
         if (!guaranteedNonNull.contains(fieldSymbol)) {
           result.put(constructor, fieldSymbol);
         }
       }
     }
     return result;
+  }
+
+  /**
+   * Returns the fields whose initialization should be checked for the given constructor.
+   *
+   * <p>A {@code null} constructor represents the implicit zero-argument constructor for a class
+   * with no declared constructors. For zero-argument constructors, fields marked by a handler with
+   * {@link Handler.FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS} are treated as externally
+   * initialized and excluded from the result. For constructors with arguments, all fields remain
+   * subject to the normal initialization check.
+   */
+  private ImmutableSet<Symbol> fieldsRequiringInitializationForConstructor(
+      ImmutableSet<Symbol> fields, @Nullable MethodTree constructor, VisitorState state) {
+    if (constructor != null && !constructor.getParameters().isEmpty()) {
+      return fields;
+    }
+    return ImmutableSet.copyOf(
+        Sets.filter(
+            fields,
+            field ->
+                getFieldInitializationSkipResult(state, field, null)
+                    != Handler.FieldSkipResult.ONLY_FOR_ZERO_ARG_CONSTRUCTORS));
   }
 
   private boolean symbolHasExternalInitAnnotation(Symbol symbol) {
@@ -2571,7 +2597,8 @@ public class NullAway extends BugChecker
           // field declaration
           VariableTree varTree = (VariableTree) memberTree;
           Symbol fieldSymbol = ASTHelpers.getSymbol(varTree);
-          if (shouldSkipFieldInitializationCheck(state, fieldSymbol, classSymbol)) {
+          if (getFieldInitializationSkipResult(state, fieldSymbol, classSymbol)
+              == Handler.FieldSkipResult.YES) {
             continue;
           }
           if (varTree.getInitializer() != null) {
@@ -2611,17 +2638,21 @@ public class NullAway extends BugChecker
         ImmutableSet.copyOf(staticInitializerMethods));
   }
 
-  private boolean shouldSkipFieldInitializationCheck(
+  private Handler.FieldSkipResult getFieldInitializationSkipResult(
       VisitorState state, Symbol fieldSymbol, @Nullable ClassSymbol classSymbol) {
     if (classSymbol == null) {
       if (fieldSymbol.owner instanceof ClassSymbol ownerSymbol) {
         classSymbol = ownerSymbol;
       }
     }
-    return fieldSymbol.type.isPrimitive()
-        || skipFieldInitializationCheckingDueToAnnotation(fieldSymbol)
-        || (classSymbol != null
-            && handler.shouldSkipFieldInitializationCheck(classSymbol, fieldSymbol, state));
+    if (fieldSymbol.type.isPrimitive()
+        || skipFieldInitializationCheckingDueToAnnotation(fieldSymbol)) {
+      return Handler.FieldSkipResult.YES;
+    }
+    if (classSymbol != null) {
+      return handler.shouldSkipFieldInitializationCheck(classSymbol, fieldSymbol, state);
+    }
+    return Handler.FieldSkipResult.NO;
   }
 
   private boolean isConstructor(MethodTree methodTree) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2230,10 +2230,9 @@ public class NullAway extends BugChecker
     // framework-specific reporting suppressions
     ImmutableSet<Symbol> reportableNotInitializedInConstructors;
     SetMultimap<MethodTree, Symbol> constructorInitInfo;
-    SetMultimap<MethodTree, Symbol> reportableConstructorInitInfo;
+    SetMultimap<MethodTree, Symbol> reportableConstructorInitInfo = LinkedHashMultimap.create();
     if (entities.constructors().isEmpty()) {
       constructorInitInfo = null;
-      reportableConstructorInitInfo = null;
       notInitializedInConstructors = entities.nonnullInstanceFields();
       reportableNotInitializedInConstructors =
           reportableFieldsForConstructorInitialization(

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2223,17 +2223,28 @@ public class NullAway extends BugChecker
     FieldInitEntities entities = collectEntities(tree, state);
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(tree);
     class2Entities.put(classSymbol, entities);
-    // set of all non-null instance fields f such that *some* constructor does not initialize f
+    // set of all non-null instance fields f such that *some* constructor does not initialize f;
+    // used as an initialization fact by read-before-init checking
     ImmutableSet<Symbol> notInitializedInConstructors;
+    // fields for which we should report constructor initialization errors after applying
+    // framework-specific reporting suppressions
+    ImmutableSet<Symbol> reportableNotInitializedInConstructors;
     SetMultimap<MethodTree, Symbol> constructorInitInfo;
+    SetMultimap<MethodTree, Symbol> reportableConstructorInitInfo;
     if (entities.constructors().isEmpty()) {
       constructorInitInfo = null;
-      notInitializedInConstructors =
-          fieldsRequiringInitializationForConstructor(
+      reportableConstructorInitInfo = null;
+      notInitializedInConstructors = entities.nonnullInstanceFields();
+      reportableNotInitializedInConstructors =
+          reportableFieldsForConstructorInitialization(
               entities.nonnullInstanceFields(), null, state);
     } else {
       constructorInitInfo = checkConstructorInitialization(entities, state);
+      reportableConstructorInitInfo =
+          reportableConstructorInitializationInfo(constructorInitInfo, state);
       notInitializedInConstructors = ImmutableSet.copyOf(constructorInitInfo.values());
+      reportableNotInitializedInConstructors =
+          ImmutableSet.copyOf(reportableConstructorInitInfo.values());
     }
     // Filter out final fields, since javac will already check initialization
     notInitializedInConstructors =
@@ -2241,9 +2252,14 @@ public class NullAway extends BugChecker
             Sets.filter(
                 notInitializedInConstructors,
                 symbol -> !symbol.getModifiers().contains(Modifier.FINAL)));
+    reportableNotInitializedInConstructors =
+        ImmutableSet.copyOf(
+            Sets.filter(
+                reportableNotInitializedInConstructors,
+                symbol -> !symbol.getModifiers().contains(Modifier.FINAL)));
     class2ConstructorUninit.putAll(classSymbol, notInitializedInConstructors);
     Set<Symbol> notInitializedAtAll =
-        notAssignedInAnyInitializer(entities, notInitializedInConstructors, state);
+        notAssignedInAnyInitializer(entities, reportableNotInitializedInConstructors, state);
     SetMultimap<Element, Element> errorFieldsForInitializer = LinkedHashMultimap.create();
     // non-null if we have a single initializer method
     Symbol.MethodSymbol singleInitializerMethod = null;
@@ -2269,8 +2285,8 @@ public class NullAway extends BugChecker
         }
       } else {
         // report it on each constructor that does not initialize it
-        for (MethodTree methodTree : constructorInitInfo.keySet()) {
-          Set<Symbol> uninitFieldsForConstructor = constructorInitInfo.get(methodTree);
+        for (MethodTree methodTree : reportableConstructorInitInfo.keySet()) {
+          Set<Symbol> uninitFieldsForConstructor = reportableConstructorInitInfo.get(methodTree);
           if (uninitFieldsForConstructor.contains(uninitField)) {
             errorFieldsForInitializer.put(ASTHelpers.getSymbol(methodTree), uninitField);
           }
@@ -2375,11 +2391,9 @@ public class NullAway extends BugChecker
         // external framework initializes fields in this case
         continue;
       }
-      ImmutableSet<Symbol> fieldsToCheck =
-          fieldsRequiringInitializationForConstructor(nonnullInstanceFields, constructor, state);
       ImmutableSet<Element> guaranteedNonNull =
           guaranteedNonNullForConstructor(entities, state, trees, constructor);
-      for (Symbol fieldSymbol : fieldsToCheck) {
+      for (Symbol fieldSymbol : nonnullInstanceFields) {
         if (!guaranteedNonNull.contains(fieldSymbol)) {
           result.put(constructor, fieldSymbol);
         }
@@ -2389,15 +2403,16 @@ public class NullAway extends BugChecker
   }
 
   /**
-   * Returns the fields whose initialization should be checked for the given constructor.
+   * Applies framework-specific constructor initialization reporting suppressions to the given
+   * constructor initialization facts.
    *
    * <p>A {@code null} constructor represents the implicit zero-argument constructor for a class
    * with no declared constructors. For zero-argument constructors, fields marked by a handler with
-   * {@link Handler.FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS} are treated as externally
-   * initialized and excluded from the result. For constructors with arguments, all fields remain
-   * subject to the normal initialization check.
+   * {@link Handler.FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS} are excluded from reporting,
+   * while still being tracked elsewhere as not actually initialized by the constructor. For
+   * constructors with arguments, all fields remain subject to the normal initialization check.
    */
-  private ImmutableSet<Symbol> fieldsRequiringInitializationForConstructor(
+  private ImmutableSet<Symbol> reportableFieldsForConstructorInitialization(
       ImmutableSet<Symbol> fields, @Nullable MethodTree constructor, VisitorState state) {
     if (constructor != null && !constructor.getParameters().isEmpty()) {
       return fields;
@@ -2408,6 +2423,18 @@ public class NullAway extends BugChecker
             field ->
                 getFieldInitializationSkipResult(state, field, null)
                     != Handler.FieldSkipResult.ONLY_FOR_ZERO_ARG_CONSTRUCTORS));
+  }
+
+  private SetMultimap<MethodTree, Symbol> reportableConstructorInitializationInfo(
+      SetMultimap<MethodTree, Symbol> constructorInitInfo, VisitorState state) {
+    SetMultimap<MethodTree, Symbol> result = LinkedHashMultimap.create();
+    for (MethodTree constructor : constructorInitInfo.keySet()) {
+      result.putAll(
+          constructor,
+          reportableFieldsForConstructorInitialization(
+              ImmutableSet.copyOf(constructorInitInfo.get(constructor)), constructor, state));
+    }
+    return result;
   }
 
   private boolean symbolHasExternalInitAnnotation(Symbol symbol) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2223,8 +2223,7 @@ public class NullAway extends BugChecker
     FieldInitEntities entities = collectEntities(tree, state);
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(tree);
     class2Entities.put(classSymbol, entities);
-    // set of all non-null instance fields f such that *some* constructor does not initialize f;
-    // used as an initialization fact by read-before-init checking
+    // set of all non-null instance fields f such that *some* constructor does not initialize f
     ImmutableSet<Symbol> notInitializedInConstructors;
     // fields for which we should report constructor initialization errors after applying
     // framework-specific reporting suppressions

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -367,14 +367,18 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public boolean shouldSkipFieldInitializationCheck(
+  public FieldSkipResult shouldSkipFieldInitializationCheck(
       Symbol.ClassSymbol classSymbol, Symbol fieldSymbol, VisitorState state) {
+    FieldSkipResult result = FieldSkipResult.NO;
     for (Handler h : handlers) {
-      if (h.shouldSkipFieldInitializationCheck(classSymbol, fieldSymbol, state)) {
-        return true;
+      result =
+          FieldSkipResult.combine(
+              result, h.shouldSkipFieldInitializationCheck(classSymbol, fieldSymbol, state));
+      if (result == FieldSkipResult.YES) {
+        return result;
       }
     }
-    return false;
+    return result;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -520,7 +520,7 @@ public interface Handler {
         return first;
       }
       // one is YES and the other is ONLY_FOR_ZERO_ARG_CONSTRUCTORS; prefer YES
-      return first == YES ? first : second;
+      return YES;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -510,9 +510,15 @@ public interface Handler {
 
     /** combine two {@link FieldSkipResult}s, preferring to skip more field checks */
     public static FieldSkipResult combine(FieldSkipResult first, FieldSkipResult second) {
-      if (first == second) return first;
-      if (first == NO) return second;
-      if (second == NO) return first;
+      if (first == second) {
+        return first;
+      }
+      if (first == NO) {
+        return second;
+      }
+      if (second == NO) {
+        return first;
+      }
       // one is YES and the other is ONLY_FOR_ZERO_ARG_CONSTRUCTORS; prefer YES
       return first == YES ? first : second;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -495,6 +495,29 @@ public interface Handler {
     return methodType;
   }
 
+  enum FieldSkipResult {
+    /** do not skip the check */
+    NO,
+
+    /** always skip the check */
+    YES,
+
+    /**
+     * Only skip the check for constructors with no arguments. If a constructor with arguments does
+     * not initialize the field, report a warning.
+     */
+    ONLY_FOR_ZERO_ARG_CONSTRUCTORS;
+
+    /** combine two {@link FieldSkipResult}s, preferring to skip more field checks */
+    public static FieldSkipResult combine(FieldSkipResult first, FieldSkipResult second) {
+      if (first == second) return first;
+      if (first == NO) return second;
+      if (second == NO) return first;
+      // one is YES and the other is ONLY_FOR_ZERO_ARG_CONSTRUCTORS; prefer YES
+      return first == YES ? first : second;
+    }
+  }
+
   /**
    * Method to determine whether a field should be treated as initialized externally (e.g. by a
    * framework), using the field and its enclosing class.
@@ -502,12 +525,11 @@ public interface Handler {
    * @param classSymbol the symbol for the class declaring the field
    * @param fieldSymbol the symbol for the field
    * @param state visitor state
-   * @return {@code true} if initialization checking for the field should be skipped, {@code false}
-   *     otherwise
+   * @return a {@link FieldSkipResult} capturing when the check should be skipped
    */
-  default boolean shouldSkipFieldInitializationCheck(
+  default FieldSkipResult shouldSkipFieldInitializationCheck(
       Symbol.ClassSymbol classSymbol, Symbol fieldSymbol, VisitorState state) {
-    return false;
+    return FieldSkipResult.NO;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/JakartaPersistenceHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/JakartaPersistenceHandler.java
@@ -130,42 +130,48 @@ public class JakartaPersistenceHandler implements Handler {
 
   /**
    * Detects whether a field is handled by JPA persistence, in which case we can skip the field
-   * initialization check. Our logic is as follows:
+   * initialization check for zero-argument constructors. Our logic is as follows:
    *
    * <ol>
    *   <li>If the field is not in a JPA-managed type (based on the annotations on the enclosing
    *       class), or if the field is ineligible for persistence (e.g., due to being transient),
-   *       return false.
-   *   <li>Otherwise, if the field is annotated {@code @Access(FIELD)}, return true.
+   *       return {@link FieldSkipResult#NO}.
+   *   <li>Otherwise, if the field is annotated {@code @Access(FIELD)}, return {@link
+   *       FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS}.
    *   <li>Otherwise, determine the access type for the enclosing class, based on mapping
    *       annotations on fields / methods in the class and in superclasses. Then:
    *       <ol>
-   *         <li>If the access type is FIELD, return true.
-   *         <li>If the access type is PROPERTY, return true if the field is the backing field for a
-   *             persistent property (the field should have a getter _and_ setter, and the getter
-   *             should have a mapping annotation).
-   *         <li>If we cannot determine the access type, return false.
+   *         <li>If the access type is FIELD, return {@link
+   *             FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS}.
+   *         <li>If the access type is PROPERTY, return {@link
+   *             FieldSkipResult#ONLY_FOR_ZERO_ARG_CONSTRUCTORS} if the field is the backing field
+   *             for a persistent property (the field should have a getter _and_ setter, and the
+   *             getter should have a mapping annotation).
+   *         <li>If we cannot determine the access type, return {@link FieldSkipResult#NO}.
    *       </ol>
    * </ol>
    */
   @Override
-  public boolean shouldSkipFieldInitializationCheck(
+  public FieldSkipResult shouldSkipFieldInitializationCheck(
       Symbol.ClassSymbol classSymbol, Symbol fieldSymbol, VisitorState state) {
     // There must be an appropriate annotation on the enclosing class, and the field must be
     // eligible for persistence
     if (!hasAnyAnnotationMatching(classSymbol, JPA_MANAGED_TYPE_ANNOTS::contains)
         || !isJpaFieldEligibleForPersistence(fieldSymbol)) {
-      return false;
+      return FieldSkipResult.NO;
     }
     // if the field itself has an @Access(FIELD) annotation, it is managed
     if (hasJpaAccessAnnotation(fieldSymbol, "FIELD")) {
-      return true;
+      return FieldSkipResult.ONLY_FOR_ZERO_ARG_CONSTRUCTORS;
     }
     // otherwise, determine the access type for the enclosing class, and proceed appropriately
     return switch (getJpaAccess(classSymbol)) {
-      case FIELD -> true;
-      case PROPERTY -> isBackingFieldForPersistentProperty(classSymbol, fieldSymbol);
-      case UNKNOWN -> false;
+      case FIELD -> FieldSkipResult.ONLY_FOR_ZERO_ARG_CONSTRUCTORS;
+      case PROPERTY ->
+          isBackingFieldForPersistentProperty(classSymbol, fieldSymbol)
+              ? FieldSkipResult.ONLY_FOR_ZERO_ARG_CONSTRUCTORS
+              : FieldSkipResult.NO;
+      case UNKNOWN -> FieldSkipResult.NO;
     };
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
@@ -33,6 +33,8 @@ public class SpringHandler implements Handler {
       if (ASTHelpers.isSameType(
           (Type) annotationMirror.getAnnotationType(), VALUE_TYPE_SUPPLIER.get(state), state)) {
         String annotationValue = NullabilityUtil.getAnnotationValue(annotationMirror);
+        // We return FieldSkipResult.YES here since Spring framework initialization can also invoke
+        // constructors with arguments and then initialize other fields
         return annotationValue == null || !containsNullSpELExpression(annotationValue)
             ? FieldSkipResult.YES
             : FieldSkipResult.NO;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
@@ -33,8 +33,9 @@ public class SpringHandler implements Handler {
       if (ASTHelpers.isSameType(
           (Type) annotationMirror.getAnnotationType(), VALUE_TYPE_SUPPLIER.get(state), state)) {
         String annotationValue = NullabilityUtil.getAnnotationValue(annotationMirror);
-        // We return FieldSkipResult.YES here since Spring framework initialization can also invoke
-        // constructors with arguments and then initialize other fields
+        // We return FieldSkipResult.YES here when there is an appropriate @Value annotation, since
+        // Spring framework initialization can also invoke constructors that have arguments and then
+        // initialize other fields
         return annotationValue == null || !containsNullSpELExpression(annotationValue)
             ? FieldSkipResult.YES
             : FieldSkipResult.NO;

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
@@ -27,16 +27,18 @@ public class SpringHandler implements Handler {
       Pattern.compile("#\\{[^}]*\\bnull\\b[^}]*}");
 
   @Override
-  public boolean shouldSkipFieldInitializationCheck(
+  public FieldSkipResult shouldSkipFieldInitializationCheck(
       Symbol.ClassSymbol classSymbol, Symbol fieldSymbol, VisitorState state) {
     for (AnnotationMirror annotationMirror : fieldSymbol.getAnnotationMirrors()) {
       if (ASTHelpers.isSameType(
           (Type) annotationMirror.getAnnotationType(), VALUE_TYPE_SUPPLIER.get(state), state)) {
         String annotationValue = NullabilityUtil.getAnnotationValue(annotationMirror);
-        return annotationValue == null || !containsNullSpELExpression(annotationValue);
+        return annotationValue == null || !containsNullSpELExpression(annotationValue)
+            ? FieldSkipResult.YES
+            : FieldSkipResult.NO;
       }
     }
-    return false;
+    return FieldSkipResult.NO;
   }
 
   private static boolean containsNullSpELExpression(String annotationValue) {

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -450,6 +450,14 @@ public class FrameworkTests extends NullAwayTestsBase {
                 literalValue.toString();
               }
             }
+            class ValueFieldWithConstructor {
+              private final String name;
+              @Value("${app.description}")
+              String description;
+              ValueFieldWithConstructor(String name) {
+                this.name = name;
+              }
+            }
             """)
         .addSourceLines(
             "PositiveCases.java",

--- a/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
@@ -390,6 +390,60 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void jpaManagedFieldsSkippedOnlyForZeroArgConstructors() {
+    addJpaAnnotationStubs(defaultCompilationHelper)
+        .addSourceLines(
+            "TestEntity.java",
+            """
+            package com.uber;
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.Id;
+            @Entity
+            class TestEntity {
+              private String name;
+              private String extraInfo;
+
+              public TestEntity() {}
+
+              // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field extraInfo
+              public TestEntity(String name) {
+                this.name = name;
+              }
+
+              @Id
+              public String getName() {
+                return name;
+              }
+              public void setName(String name) {
+                this.name = name;
+              }
+              public String getExtraInfo() {
+                return extraInfo;
+              }
+              public void setExtraInfo(String extraInfo) {
+                this.extraInfo = extraInfo;
+              }
+            }
+            """)
+        .addSourceLines(
+            "ZeroArgOnlyEntity.java",
+            """
+            package com.uber;
+            import jakarta.persistence.Access;
+            import jakarta.persistence.AccessType;
+            import jakarta.persistence.Entity;
+            @Entity
+            @Access(AccessType.FIELD)
+            class ZeroArgOnlyEntity {
+              private String name;
+
+              public ZeroArgOnlyEntity() {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void lombokGetterSetter() {
     addJpaAnnotationStubs(defaultCompilationHelper)
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
@@ -444,6 +444,34 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void jpaZeroArgSkipDoesNotSuppressInitializerReadBeforeInit() {
+    addJpaAnnotationStubs(defaultCompilationHelper)
+        .addSourceLines(
+            "JpaInitializerRead.java",
+            """
+            package com.uber;
+            import com.uber.nullaway.annotations.Initializer;
+            import jakarta.persistence.Access;
+            import jakarta.persistence.AccessType;
+            import jakarta.persistence.Entity;
+            @Entity
+            @Access(AccessType.FIELD)
+            class JpaInitializerRead {
+              private String name;
+
+              public JpaInitializerRead() {}
+
+              @Initializer
+              public void init() {
+                // BUG: Diagnostic contains: read of @NonNull field name before initialization
+                name.toString();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void lombokGetterSetter() {
     addJpaAnnotationStubs(defaultCompilationHelper)
         .addSourceLines(


### PR DESCRIPTION
Fixes #1602 

We now report a warning for constructors with arguments in JPA-managed classes if they miss some field initialization.  We do this by generalizing the handler result to be a `FieldSkipResult` that can indicate a field init check should be skipped entirely or only for zero-arg constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Field-initialization checks now respect a per-field tri-state handler decision (always skip, skip only for zero-arg constructors, or do not skip) and apply constructor-aware filtering so zero-arg vs explicit constructors are handled correctly.
  * Framework integrations (Jakarta/JPA, Spring) updated to follow the tri-state skip behavior.

* **Tests**
  * Added and extended tests validating constructor-sensitive field-initialization behavior and that zero-arg skips do not suppress read-before-init checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->