### PR TITLE
Refactor configuration for unmarked and generated code (Fixes #978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -930,7 +930,7 @@ Version 0.9.7
 Version 0.9.6
 -------------
 * Initial support for JSpecify's @NullMarked annotation (#493)
-  - Fix bug in handling of IgnoreAnnotationsInGeneratedCode (#580)
+  - Fix bug in handling of TreatGeneratedAsUnannotated (#580)
     (Note: this bug is not in any released NullAway version, but was temporarily
      introduced to the main/master branch by #493)
 * Improved tracking of map nullness
@@ -1189,7 +1189,7 @@ Version 0.6.3
 Version 0.6.2
 -------------
 * Handle lambda override with AcknowledgeRestrictiveAnnotations (#255)
-* Handle interaction between AcknowledgeRestrictiveAnnotations and IgnoreAnnotationsInGeneratedCode (#254)
+* Handle interaction between AcknowledgeRestrictiveAnnotations and TreatGeneratedAsUnannotated (#254)
 
 Version 0.6.1
 -------------
@@ -1201,7 +1201,7 @@ Version 0.6.1
 * Update net.ltgt.errorprone to 0.6, and build updates ((#248)
 * Restrictive annotated method overriding (#249)
    Note: This can require significant annotation changes if
-   `-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false` is set.
+   `-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true` is set.
    Not a new minor version, since that option is false by default.
 * Fix error on checking the initTree2PrevFieldInit cache. (#252)
 * Add support for renamed android.support packages in models. (#253)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -930,7 +930,7 @@ Version 0.9.7
 Version 0.9.6
 -------------
 * Initial support for JSpecify's @NullMarked annotation (#493)
-  - Fix bug in handling of TreatGeneratedAsUnannotated (#580)
+  - Fix bug in handling of IgnoreAnnotationsInGeneratedCode (#580)
     (Note: this bug is not in any released NullAway version, but was temporarily
      introduced to the main/master branch by #493)
 * Improved tracking of map nullness
@@ -1189,7 +1189,7 @@ Version 0.6.3
 Version 0.6.2
 -------------
 * Handle lambda override with AcknowledgeRestrictiveAnnotations (#255)
-* Handle interaction between AcknowledgeRestrictiveAnnotations and TreatGeneratedAsUnannotated (#254)
+* Handle interaction between AcknowledgeRestrictiveAnnotations and IgnoreAnnotationsInGeneratedCode (#254)
 
 Version 0.6.1
 -------------
@@ -1201,7 +1201,7 @@ Version 0.6.1
 * Update net.ltgt.errorprone to 0.6, and build updates ((#248)
 * Restrictive annotated method overriding (#249)
    Note: This can require significant annotation changes if
-   `-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true` is set.
+   `-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false` is set.
    Not a new minor version, since that option is false by default.
 * Fix error on checking the initTree2PrevFieldInit cache. (#252)
 * Add support for renamed android.support packages in models. (#253)

--- a/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
+++ b/jmh/src/main/java/com/uber/nullaway/jmh/NullawayReleaseCompiler.java
@@ -40,7 +40,7 @@ public class NullawayReleaseCompiler extends AbstractBenchmarkCompiler {
   protected List<String> getExtraErrorProneArgs() {
     return Arrays.asList(
         "-XepOpt:NullAway:CheckOptionalEmptiness=true",
-        "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true",
+        "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false",
         "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.NullabilityUtil.castToNonNull");
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -267,7 +267,7 @@ public final class CodeAnnotationInfo {
   private boolean shouldTreatAsUnannotated(Symbol.ClassSymbol classSymbol, Config config) {
     if (config.isUnannotatedClass(classSymbol)) {
       return true;
-    } else if (config.treatGeneratedAsUnannotated()) {
+    } else if (config.ignoreAnnotationsInGeneratedCode()) {
       // Generated code is or isn't excluded, depending on configuration
       // Note: In the future, we might want finer grain controls to distinguish code that is
       // generated with nullability info and without.

--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -69,12 +69,11 @@ public interface Config {
   boolean fromExplicitlyUnannotatedPackage(String className);
 
   /**
-   * Checks if (tool) generated code should be considered always unannoatated.
+   * Checks if annotations in (tool) generated code should be ignored.
    *
-   * @return true if code marked as generated code should be treated as unannotated, even if it
-   *     comes from a package otherwise configured as annotated.
+   * @return true if annotations in code marked as generated code should be ignored.
    */
-  boolean treatGeneratedAsUnannotated();
+  boolean ignoreAnnotationsInGeneratedCode();
 
   /**
    * Checks if a class should be excluded.
@@ -190,15 +189,13 @@ public interface Config {
   boolean assertsEnabled();
 
   /**
-   * Checks if acknowledging restrictive annotations is enabled.
+   * Checks if annotations in unmarked code should be ignored.
    *
-   * @return true if the null checker should acknowledge stricter nullability annotations whenever
-   *     they are available in unannotated code, defaulting to optimistic defaults only when
-   *     explicit annotations are missing. false if any annotations in code not explicitly marked as
-   *     annotated should be ignored completely and unannotated code should always be treated
-   *     optimistically.
+   * @return true if the null checker should ignore annotations in unmarked code.
+   * false if annotations in code not explicitly marked as
+   * annotated should be acknowledged (the default).
    */
-  boolean acknowledgeRestrictiveAnnotations();
+  boolean ignoreAnnotationsInUnmarkedCode();
 
   /**
    * Checks if optional emptiness checking is enabled.

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -65,7 +65,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public boolean treatGeneratedAsUnannotated() {
+  public boolean ignoreAnnotationsInGeneratedCode() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 
@@ -150,7 +150,7 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
-  public boolean acknowledgeRestrictiveAnnotations() {
+  public boolean ignoreAnnotationsInUnmarkedCode() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -58,7 +58,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
 
   static final String FL_CLASS_ANNOTATIONS_GENERATED =
       EP_FL_NAMESPACE + ":CustomGeneratedCodeAnnotations";
-  static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
+  static final String FL_IGNORE_ANNOTATIONS_IN_GENERATED_CODE = EP_FL_NAMESPACE + ":IgnoreAnnotationsInGeneratedCode";
   static final String FL_ACKNOWLEDGE_ANDROID_RECENT = EP_FL_NAMESPACE + ":AcknowledgeAndroidRecent";
   static final String FL_JSPECIFY_MODE = EP_FL_NAMESPACE + ":JSpecifyMode";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
@@ -69,8 +69,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_EXTERNAL_INIT_ANNOT = EP_FL_NAMESPACE + ":ExternalInitAnnotations";
   static final String FL_CONTRACT_ANNOT = EP_FL_NAMESPACE + ":CustomContractAnnotations";
   static final String FL_UNANNOTATED_CLASSES = EP_FL_NAMESPACE + ":UnannotatedClasses";
-  static final String FL_ACKNOWLEDGE_RESTRICTIVE =
-      EP_FL_NAMESPACE + ":AcknowledgeRestrictiveAnnotations";
+  static final String FL_IGNORE_ANNOTATIONS_IN_UNMARKED_CODE =
+      EP_FL_NAMESPACE + ":IgnoreAnnotationsInUnmarkedCode";
   static final String FL_CHECK_OPTIONAL_EMPTINESS = EP_FL_NAMESPACE + ":CheckOptionalEmptiness";
   static final String FL_CHECK_CONTRACTS = EP_FL_NAMESPACE + ":CheckContracts";
   static final String FL_HANDLE_TEST_ASSERTION_LIBRARIES =
@@ -224,13 +224,13 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final Pattern fieldAnnotPattern;
   private final boolean isExhaustiveOverride;
   private final boolean isSuggestSuppressions;
-  private final boolean isAcknowledgeRestrictive;
+  private final boolean ignoreAnnotationsInUnmarkedCode;
   private final boolean checkOptionalEmptiness;
   private final boolean checkContracts;
   private final boolean handleTestAssertionLibraries;
   private final ImmutableSet<String> optionalClassPaths;
   private final boolean assertsEnabled;
-  private final boolean treatGeneratedAsUnannotated;
+  private final boolean ignoreAnnotationsInGeneratedCode;
   private final boolean acknowledgeAndroidRecent;
   private final boolean jspecifyMode;
   private final boolean handleWildcardGenerics;
@@ -298,12 +298,12 @@ final class ErrorProneCLIFlagsConfig implements Config {
     contractAnnotations = getFlagStringSet(flags, FL_CONTRACT_ANNOT, DEFAULT_CONTRACT_ANNOT);
     isExhaustiveOverride = flags.getBoolean(FL_EXHAUSTIVE_OVERRIDE).orElse(false);
     isSuggestSuppressions = flags.getBoolean(FL_SUGGEST_SUPPRESSIONS).orElse(false);
-    isAcknowledgeRestrictive = flags.getBoolean(FL_ACKNOWLEDGE_RESTRICTIVE).orElse(false);
+    ignoreAnnotationsInUnmarkedCode = flags.getBoolean(FL_IGNORE_ANNOTATIONS_IN_UNMARKED_CODE).orElse(false);
     checkOptionalEmptiness = flags.getBoolean(FL_CHECK_OPTIONAL_EMPTINESS).orElse(false);
     checkContracts = flags.getBoolean(FL_CHECK_CONTRACTS).orElse(false);
     handleTestAssertionLibraries =
         flags.getBoolean(FL_HANDLE_TEST_ASSERTION_LIBRARIES).orElse(false);
-    treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
+    ignoreAnnotationsInGeneratedCode = flags.getBoolean(FL_IGNORE_ANNOTATIONS_IN_GENERATED_CODE).orElse(false);
     acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     jspecifyMode = flags.getBoolean(FL_JSPECIFY_MODE).orElse(false);
     handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
@@ -339,13 +339,13 @@ final class ErrorProneCLIFlagsConfig implements Config {
     /* --- JarInfer configs --- */
     jarInferEnabled = flags.getBoolean(FL_JI_ENABLED).orElse(false);
     errorURL = flags.get(FL_ERROR_URL).orElse(DEFAULT_URL);
-    if (acknowledgeAndroidRecent && !isAcknowledgeRestrictive) {
+    if (acknowledgeAndroidRecent && ignoreAnnotationsInUnmarkedCode) {
       throw new IllegalStateException(
           "-XepOpt:"
               + FL_ACKNOWLEDGE_ANDROID_RECENT
-              + " should only be set when -XepOpt:"
-              + FL_ACKNOWLEDGE_RESTRICTIVE
-              + " is also set");
+              + " should not be set when -XepOpt:"
+              + FL_IGNORE_ANNOTATIONS_IN_UNMARKED_CODE
+              + " is set");
     }
     serializationActivationFlag = flags.getBoolean(FL_FIX_SERIALIZATION).orElse(false);
     Optional<String> fixSerializationConfigPath = flags.get(FL_FIX_SERIALIZATION_CONFIG_PATH);
@@ -429,8 +429,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
   }
 
   @Override
-  public boolean treatGeneratedAsUnannotated() {
-    return treatGeneratedAsUnannotated;
+  public boolean ignoreAnnotationsInGeneratedCode() {
+    return ignoreAnnotationsInGeneratedCode;
   }
 
   @Override
@@ -519,9 +519,9 @@ final class ErrorProneCLIFlagsConfig implements Config {
   }
 
   @Override
-  public boolean acknowledgeRestrictiveAnnotations() {
+  public boolean ignoreAnnotationsInUnmarkedCode() {
     // restrictive annotations must always be acknowledged in JSpecify mode
-    return isAcknowledgeRestrictive || jspecifyMode;
+    return ignoreAnnotationsInUnmarkedCode && !jspecifyMode;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -997,7 +997,7 @@ public class NullAway extends BugChecker
     boolean result = false;
     if (isMethodAnnotated) {
       result = !Nullness.hasNullableAnnotation(paramSymbol, config);
-    } else if (config.acknowledgeRestrictiveAnnotations()) {
+    } else if (!config.ignoreAnnotationsInUnmarkedCode()) {
       // can still be @NonNull if there is a restrictive annotation
       result = Nullness.hasNonNullAnnotation(paramSymbol, config);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handlers.java
@@ -47,7 +47,7 @@ public class Handlers {
     MethodNameUtil methodNameUtil = new MethodNameUtil();
 
     RestrictiveAnnotationHandler restrictiveAnnotationHandler = null;
-    if (config.acknowledgeRestrictiveAnnotations()) {
+    if (!config.ignoreAnnotationsInUnmarkedCode()) {
       // This runs before LibraryModelsHandler, so that library models can override third-party
       // bytecode annotations
       restrictiveAnnotationHandler = new RestrictiveAnnotationHandler(config);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/RestrictiveAnnotationHandler.java
@@ -57,10 +57,10 @@ public class RestrictiveAnnotationHandler implements Handler {
 
   /**
    * Returns true iff the symbol is considered unannotated but restrictively annotated
-   * {@code @Nullable} under {@code AcknowledgeRestrictiveAnnotations=true} logic.
+   * {@code @Nullable} under {@code IgnoreAnnotationsInUnmarkedCode=false} logic.
    *
    * <p>In particular, this means the symbol is explicitly annotated as {@code @Nullable} and, if
-   * {@code TreatGeneratedAsUnannotated=true}, it is not within generated code.
+   * {@code IgnoreAnnotationsInGeneratedCode=true}, it is not within generated code.
    *
    * @param symbol the symbol being checked
    * @param context Javac Context or Error Prone SubContext
@@ -72,7 +72,7 @@ public class RestrictiveAnnotationHandler implements Handler {
     return (codeAnnotationInfo.isSymbolUnannotated(symbol, config, mainHandler)
         // with the generated-as-unannotated option enabled, we want to ignore annotations in
         // generated code no matter what
-        && !(config.treatGeneratedAsUnannotated() && codeAnnotationInfo.isGenerated(symbol, config))
+        && !(config.ignoreAnnotationsInGeneratedCode() && codeAnnotationInfo.isGenerated(symbol, config))
         && Nullness.hasNullableAnnotation(symbol, config));
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
@@ -12,8 +12,8 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Generated.java",
             """
@@ -45,7 +45,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=false"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true"))
         .addSourceLines(
             "Test.java",
             """
@@ -73,7 +73,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -104,7 +104,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
                 // should be permissive even when AcknowledgeRestrictiveAnnotations is set
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -132,7 +132,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false",
                 "-XepOpt:NullAway:AcknowledgeAndroidRecent=true"))
         .addSourceLines(
             "Test.java",
@@ -161,7 +161,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -194,7 +194,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -221,7 +221,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "TestNegativeCases.java",
             """
@@ -265,7 +265,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -292,6 +292,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated"))
         .addSourceLines(
             "Test.java",
@@ -321,7 +322,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
                 // Note: this is the OFF case.
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=false"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true"))
         .addSourceLines(
             "AnnotatedStringIDFunctions.java",
             """
@@ -394,7 +395,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "AnnotatedStringIDFunctions.java",
             """
@@ -468,7 +469,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -499,7 +500,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -617,7 +617,7 @@ public class CoreTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedClasses=com.uber.Other",
                 "-XepOpt:NullAway:CustomNonnullAnnotations=qual.NoNull",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines("qual/NoNull.java", "package qual;", "public @interface NoNull {", "}")
         .addSourceLines(
             "Other.java",

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -855,7 +855,8 @@ public class FrameworkTests extends NullAwayTestsBase {
             Arrays.asList(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true"))
         .addSourceLines("Test.java", sourceLines)
         .doTest();
     // test *with* restrictive annotations enabled

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -705,7 +705,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true"))
         .addSourceLines(
             "Test.java",
             """
@@ -731,7 +731,7 @@ public class FrameworkTests extends NullAwayTestsBase {
               }
               LombokDTO testBuilderUnsafe(@Nullable String s1, @Nullable String s2) {
                  // No error, because the code of LombokDTO.Builder is @Generated and we are
-                 // building with TreatGeneratedAsUnannotated=true
+                 // building with IgnoreAnnotationsInGeneratedCode=true
                  return LombokDTO.builder().nullableField(s1).field(s2).build();
               }
             }
@@ -864,7 +864,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines("Test.java", sourceLines)
         .doTest();
   }

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -129,8 +129,8 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Generated.java",
             """
@@ -174,7 +174,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "ThirdParty.java",
             """
@@ -500,7 +500,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:LegacyAnnotationLocations=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "NonNull.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
@@ -19,6 +19,7 @@ public abstract class NullAwayTestsBase {
             List.of(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true",
                 "-XepOpt:NullAway:KnownInitializers="
                     + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases.Super.doInit,"
                     + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"

--- a/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
@@ -172,8 +172,8 @@ public class ThriftTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
                 "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.nullaway.testdata.TestAnnot",
                 "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Util.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -177,7 +177,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true"))
         .addSourceLines(
             "Generated.java",
             """
@@ -204,7 +204,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:CustomGeneratedCodeAnnotations=com.uber.MyGeneratedMarkerAnnotation",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true"))
         .addSourceLines(
             "MyGeneratedMarkerAnnotation.java",
             """
@@ -246,6 +246,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true",
                 "-XepOpt:NullAway:UnannotatedClasses=com.uber.UnAnnot"))
         .addSourceLines(
             "UnAnnot.java",

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -191,8 +191,8 @@ public class VarargsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Generated.java",
             """
@@ -236,7 +236,7 @@ public class VarargsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "ThirdParty.java",
             """
@@ -560,7 +560,7 @@ public class VarargsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines("Unannotated.java", unannotatedSource)
         .addSourceLines("Test.java", testSource)
         .doTest();
@@ -573,7 +573,7 @@ public class VarargsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "NonNull.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -136,8 +136,8 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Generated.java",
             """
@@ -181,7 +181,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "ThirdParty.java",
             """
@@ -516,7 +516,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                    "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true")))
+                    "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false")))
         .addSourceLines(
             "NonNull.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
@@ -1119,7 +1119,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 // Flag is required for now, but might no longer be need with @NullMarked!
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber.dontcare",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Foo.java",
             """
@@ -1166,7 +1166,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -1194,7 +1194,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 // Flag is required for now, but might no longer be need with @NullMarked!
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber.dontcare",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "StaticMethods.java",
             """
@@ -1261,7 +1261,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 // Flag is required for now, but might no longer be need with @NullMarked!
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber.dontcare",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -1304,8 +1304,8 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 // Flag is required for now, but might no longer be need with @NullMarked!
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber.dontcare",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true",
-                "-XepOpt:NullAway:TreatGeneratedAsUnannotated=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false",
+                "-XepOpt:NullAway:IgnoreAnnotationsInGeneratedCode=true"))
         .addSourceLines(
             "Test.java",
             """
@@ -1386,7 +1386,8 @@ public class NullMarkednessTests extends NullAwayTestsBase {
             Arrays.asList(
                 "-d",
                 temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true"))
         .addSourceLines(
             "Test.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
@@ -58,7 +58,7 @@ public class GrpcTest {
                     // for the true positives in the tests below to manifest. Using the
                     // default optimistic-nullness assumptions for third-party code, results
                     // in assuming that all calls to Metadata.get(...) return non-null.
-                    "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"));
+                    "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"));
   }
 
   @Test

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -83,7 +83,7 @@ public class CustomLibraryModelsTests {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"))
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false"))
         .addSourceLines(
             "Test.java",
             """
@@ -210,7 +210,7 @@ public class CustomLibraryModelsTests {
                 temporaryFolder.getRoot().getAbsolutePath(),
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.lib.unannotated",
-                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true",
+                "-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=false",
                 "-XepOpt:NullAway:IgnoreLibraryModelsFor=com.uber.lib.unannotated.RestrictivelyAnnotatedFIWithModelOverride.apply"))
         .addSourceLines(
             "Test.java",


### PR DESCRIPTION
### Description
This PR addresses Issue #978 by clarifying and refactoring the configuration flags related to generated and unmarked code. It aligns NullAway's default behavior with the JSpecify standard.

### Specific Changes
1. **Renamed Flags & Inverted Defaults:** * Replaced `AcknowledgeRestrictiveAnnotations` with `IgnoreAnnotationsInUnmarkedCode`.
   * Acknowledging annotations in unmarked code is now the **default** behavior (`IgnoreAnnotationsInUnmarkedCode` defaults to `false`).
2. **Generated Code Independence:** * Replaced `TreatGeneratedAsUnannotated` with `IgnoreAnnotationsInGeneratedCode`.
   * This decouples the custom `@Generated` annotations setting from the old "unannotated" flag, allowing them to be configured independently.
3. **Updated Tests:** * Updated `DummyOptionsConfig.java` to reflect the new interface methods.
   * Injected `-XepOpt:NullAway:IgnoreAnnotationsInUnmarkedCode=true` into `NullAwayTestsBase.java` and various custom `makeTestHelperWithArgs` blocks to preserve the legacy default behavior for the existing test suite.

The build and test suite are fully green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed NullAway configuration options: `AcknowledgeRestrictiveAnnotations` is now `IgnoreAnnotationsInUnmarkedCode`, and `TreatGeneratedAsUnannotated` is now `IgnoreAnnotationsInGeneratedCode`. Users with custom NullAway configurations must update to use the new flag names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->