### PR TITLE
Fix varargs element nullability check in JSpecify mode (Fixes #1002)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2083,9 +2083,16 @@ public class NullAway extends BugChecker
         } else {
           // we need to call paramHasNullableAnnotation here since the invoked method may be defined
           // in a class file
+          boolean hasNullableAnno = Nullness.paramHasNullableAnnotation(methodSymbol, i, config);
+          
+          // Fix for Issue #1002: In JSpecify mode, check element nullability for varargs
+          if (config.isJSpecifyMode() && methodSymbol.isVarArgs() && i == formalParams.size() - 1) {
+            hasNullableAnno = NullabilityUtil.nullableVarargsElementsForSourceOrBytecode(param, config);
+          }
+
           argumentNullness.setParameterNullness(
               i,
-              Nullness.paramHasNullableAnnotation(methodSymbol, i, config)
+              hasNullableAnno
                   ? Nullness.NULLABLE
                   : ((config.isJSpecifyMode()
                           && (tree instanceof MethodInvocationTree || tree instanceof NewClassTree))


### PR DESCRIPTION
### Description
This PR addresses Issue #1002 by fixing false positive warnings that occur when passing `@Nullable` arguments to varargs methods (like Caffeine's `requireState`) in JSpecify mode.

### Root Cause & Fix
When JSpecify mode is enabled, NullAway correctly parses a varargs parameter like `@Nullable Object... args` as an array with nullable *elements*, rather than a nullable array itself. 

However, during `handleInvocation`, NullAway was still using `Nullness.paramHasNullableAnnotation(...)` to check the varargs parameter. Because that method checks the top-level array type, it failed to see the `@Nullable` element annotation, resulting in NullAway strictly enforcing `@NonNull` arguments for the varargs positions.

I updated the logic inside `NullAway.java`'s `handleInvocation` method. When JSpecify mode is active and the parameter being evaluated is the final varargs parameter, it now explicitly delegates to `NullabilityUtil.nullableVarargsElementsForSourceOrBytecode(param, config)` to check the element's nullability. Legacy behavior is preserved when JSpecify mode is off.

The test suite is fully green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety checking accuracy for varargs parameters in JSpecify mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->