### PR TITLE
Fix stream nullability propagation through sorted() (Fixes #1538)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
@@ -95,6 +95,7 @@ public class StreamNullabilityPropagatorFactory {
             // nullability information from filter(...) should still be propagated to map(...),
             // ignoring the interleaving call to m().
             .withPassthroughMethodFromSignature("distinct()")
+            .withPassthroughMethodAllFromName("sorted")
             // List of methods of java.util.stream.Stream that both use the nullability information
             // internally (like map does), but also don't change the values flowing through the
             // stream

--- a/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
@@ -542,26 +542,28 @@ public class Java8Tests extends NullAwayTestsBase {
     defaultCompilationHelper
         .addSourceLines(
             "Test.java",
-            "package com.uber;",
-            "import javax.annotation.Nullable;",
-            "import java.util.List;",
-            "import java.util.stream.Collectors;",
-            "import java.util.Comparator;",
-            "public class Test {",
-            "  private String key = \"\";",
-            "  @Nullable",
-            "  private String value;",
-            "  public String getKey() { return key; }",
-            "  @Nullable",
-            "  public String getValue() { return value; }",
-            "  public String test(List<Test> testList) {",
-            "    return testList.stream()",
-            "        .filter(test -> test.getValue() != null)",
-            "        .sorted(Comparator.comparing(Test::getKey))",
-            "        .map(c -> c.getValue().toUpperCase())",
-            "        .collect(Collectors.joining(\",\"));",
-            "  }",
-            "}")
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import java.util.List;
+            import java.util.stream.Collectors;
+            import java.util.Comparator;
+            public class Test {
+              private String key = "";
+              @Nullable
+              private String value;
+              public String getKey() { return key; }
+              @Nullable
+              public String getValue() { return value; }
+              public String test(List<Test> testList) {
+                return testList.stream()
+                    .filter(test -> test.getValue() != null)
+                    .sorted(Comparator.comparing(Test::getKey))
+                    .map(c -> c.getValue().toUpperCase())
+                    .collect(Collectors.joining(","));
+              }
+            }
+            """)
         .doTest();
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
@@ -536,4 +536,32 @@ public class Java8Tests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void testIssue1538StreamSorted() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import java.util.List;",
+            "import java.util.stream.Collectors;",
+            "import java.util.Comparator;",
+            "public class Test {",
+            "  private String key = \"\";",
+            "  @Nullable",
+            "  private String value;",
+            "  public String getKey() { return key; }",
+            "  @Nullable",
+            "  public String getValue() { return value; }",
+            "  public String test(List<Test> testList) {",
+            "    return testList.stream()",
+            "        .filter(test -> test.getValue() != null)",
+            "        .sorted(Comparator.comparing(Test::getKey))",
+            "        .map(c -> c.getValue().toUpperCase())",
+            "        .collect(Collectors.joining(\",\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
### Description
This PR addresses Issue #1538, where NullAway drops nullability facts (such as those established by a `.filter()` operation) when a `.sorted()` operation is interleaved in a Java stream pipeline.

### Root Cause & Fix
The `StreamNullabilityPropagatorFactory` maintains a list of passthrough methods that do not alter the elements of the stream, allowing nullability facts to safely propagate to subsequent operations. The `sorted` method was missing from this list. 

I updated `getJavaStreamNullabilityPropagator` to include `.withPassthroughMethodAllFromName("sorted")`, ensuring that both `sorted()` and `sorted(Comparator)` act as passthrough methods.

I also added a regression test in `Java8Tests.java` that perfectly mirrors the failing stream pipeline reported in the issue to prevent this from regressing in the future.

The test suite is fully green.

Fixes #1538 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability propagation through Java stream chains by treating `sorted()` as a passthrough operation.
* **Tests**
  * Added a Java 8 stream test covering `filter` + `sorted` + `map` + `collect` with nullable inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->