### PR TITLE
Add reproducing test for Optional.or() false positive (Issue #1611)

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1756,4 +1756,23 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 "-XepOpt:NullAway:AnnotatedPackages=com.uber",
                 "-XepOpt:NullAway:WarnOnGenericInferenceFailure=true")));
   }
+
+  @Test
+  public void testIssue1611OptionalOr() {
+    makeHelper()
+        .addSourceLines(
+            "Main.java",
+            "package com.uber;",
+            "import org.jspecify.annotations.Nullable;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Optional;",
+            "@NullMarked",
+            "public class Main {",
+            "  public static Optional<String> getKey(@Nullable String key) {",
+            "    // BUG: Diagnostic contains: incompatible types",
+            "    return Optional.ofNullable(key).or(() -> Optional.ofNullable(System.getenv(\"DEFAULT_KEY\")));",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
### Description
This PR adds a reproducing test case for the `Optional.or()` false positive reported in Issue #1611. 

While looking into #1611, I traced the issue to NullAway locking the generic type parameter to `@Nullable String` when evaluating the receiver `Optional.ofNullable(key)`, which then propagates through the `.or()` method and clashes with the `Optional<String>` return type.

Since `msridhar` mentioned this is likely tied to the larger `jspecify_jdk` Epic (#950) and nested type variable substitution, I have isolated the bug into a clean test case in `GenericMethodTests.java` to help track the issue. The test currently expects the `incompatible types` diagnostic to pass.

### Testing
- `GenericMethodTests.testIssue1611OptionalOr` successfully catches the false positive diagnostic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify proper handling of `Optional` types with nullable parameters in null-checking validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->