### PR TITLE
Add more modeling for Optional

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -1078,10 +1078,6 @@ public class LibraryModelsHandler implements Handler {
                             ImmutableList.of(
                                 new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0)))))
                 .put(
-                    methodRef("java.util.Optional", "<T>ofNullable(T)"),
-                    ImmutableSetMultimap.of(
-                        0, new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
-                .put(
                     methodRef(
                         "java.util.Optional",
                         "<U>map(java.util.function.Function<? super T,? extends U>)"),
@@ -1092,21 +1088,12 @@ public class LibraryModelsHandler implements Handler {
                             ImmutableList.of(
                                 new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 1),
                                 new NestedAnnotationInfo.TypePathEntry(WILDCARD_BOUND, 0)))))
-                .put(
-                    methodRef("java.util.Optional", "orElse(T)"),
-                    ImmutableSetMultimap.of(
-                        -1,
-                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
-                        0,
-                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
                 // https://github.com/uber/NullAway/issues/1616
                 /*.put(
                 methodRef(
                     "java.util.Optional",
                     "orElseGet(java.util.function.Supplier<? extends T>)"),
                 ImmutableSetMultimap.of(
-                    -1,
-                    new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
                     0,
                     new NestedAnnotationInfo(
                         Annotation.NULLABLE,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -28,6 +28,7 @@ import static com.uber.nullaway.Nullness.NONNULL;
 import static com.uber.nullaway.Nullness.NULLABLE;
 import static com.uber.nullaway.librarymodel.NestedAnnotationInfo.TypePathEntry.Kind.ARRAY_ELEMENT;
 import static com.uber.nullaway.librarymodel.NestedAnnotationInfo.TypePathEntry.Kind.TYPE_ARGUMENT;
+import static com.uber.nullaway.librarymodel.NestedAnnotationInfo.TypePathEntry.Kind.WILDCARD_BOUND;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -750,6 +751,9 @@ public class LibraryModelsHandler implements Handler {
                     "android.view.GestureDetector.OnGestureListener",
                     "onScroll(android.view.MotionEvent,android.view.MotionEvent,float,float)"),
                 0)
+            .put(methodRef("java.util.Optional", "<T>ofNullable(T)"), 0)
+            .put(methodRef("java.util.Optional", "orElse(T)"), 0)
+            .put(methodRef("java.util.Optional", "equals(java.lang.Object)"), 0)
             .build();
 
     private static final ImmutableSetMultimap<MethodRef, Integer> NON_NULL_PARAMETERS =
@@ -980,6 +984,10 @@ public class LibraryModelsHandler implements Handler {
             .add(methodRef("android.view.View", "getHandler()"))
             .add(methodRef("android.webkit.WebView", "getUrl()"))
             .add(methodRef("android.widget.TextView", "getLayout()"))
+            .add(methodRef("java.util.Optional", "orElse(T)"))
+            .add(
+                methodRef(
+                    "java.util.Optional", "orElseGet(java.util.function.Supplier<? extends T>)"))
             .add(methodRef("java.lang.System", "console()"))
             .build();
 
@@ -1055,21 +1063,60 @@ public class LibraryModelsHandler implements Handler {
     private static final ImmutableMap<
             MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
         NESTED_ANNOTATIONS_FOR_METHODS =
-            ImmutableMap.of(
-                methodRef(
-                    "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
-                    "<U,W>newUpdater(java.lang.Class<U>,java.lang.Class<W>,java.lang.String)"),
-                // turns Class<W> into Class<@NonNull W>
-                ImmutableSetMultimap.of(
-                    1,
-                    new NestedAnnotationInfo(
-                        Annotation.NONNULL,
-                        ImmutableList.of(
-                            new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0)))));
+            new ImmutableMap.Builder<
+                    MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>()
+                .put(
+                    methodRef(
+                        "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
+                        "<U,W>newUpdater(java.lang.Class<U>,java.lang.Class<W>,java.lang.String)"),
+                    // turns Class<W> into Class<@NonNull W>
+                    ImmutableSetMultimap.of(
+                        1,
+                        new NestedAnnotationInfo(
+                            Annotation.NONNULL,
+                            ImmutableList.of(
+                                new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0)))))
+                .put(
+                    methodRef("java.util.Optional", "<T>ofNullable(T)"),
+                    ImmutableSetMultimap.of(
+                        0, new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
+                .put(
+                    methodRef(
+                        "java.util.Optional",
+                        "<U>map(java.util.function.Function<? super T,? extends U>)"),
+                    ImmutableSetMultimap.of(
+                        0,
+                        new NestedAnnotationInfo(
+                            Annotation.NULLABLE,
+                            ImmutableList.of(
+                                new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 1),
+                                new NestedAnnotationInfo.TypePathEntry(WILDCARD_BOUND, 0)))))
+                .put(
+                    methodRef("java.util.Optional", "orElse(T)"),
+                    ImmutableSetMultimap.of(
+                        -1,
+                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
+                        0,
+                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
+                .put(
+                    methodRef(
+                        "java.util.Optional",
+                        "orElseGet(java.util.function.Supplier<? extends T>)"),
+                    ImmutableSetMultimap.of(
+                        -1,
+                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
+                        0,
+                        new NestedAnnotationInfo(
+                            Annotation.NULLABLE,
+                            ImmutableList.of(
+                                new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0),
+                                new NestedAnnotationInfo.TypePathEntry(WILDCARD_BOUND, 0)))))
+                .build();
 
     private static final ImmutableSet<String> NULLMARKED_CLASSES =
         new ImmutableSet.Builder<String>()
             .add("java.util.function.Function")
+            .add("java.util.Optional")
             .add("java.util.concurrent.atomic.AtomicReference")
             .add("java.util.concurrent.atomic.AtomicReferenceFieldUpdater")
             .build();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -985,9 +985,9 @@ public class LibraryModelsHandler implements Handler {
             .add(methodRef("android.webkit.WebView", "getUrl()"))
             .add(methodRef("android.widget.TextView", "getLayout()"))
             .add(methodRef("java.util.Optional", "orElse(T)"))
-            .add(
-                methodRef(
-                    "java.util.Optional", "orElseGet(java.util.function.Supplier<? extends T>)"))
+            // .add(
+            //    methodRef(
+            //        "java.util.Optional", "orElseGet(java.util.function.Supplier<? extends T>)"))
             .add(methodRef("java.lang.System", "console()"))
             .build();
 
@@ -1098,19 +1098,19 @@ public class LibraryModelsHandler implements Handler {
                         new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
                         0,
                         new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
-                .put(
-                    methodRef(
-                        "java.util.Optional",
-                        "orElseGet(java.util.function.Supplier<? extends T>)"),
-                    ImmutableSetMultimap.of(
-                        -1,
-                        new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
-                        0,
-                        new NestedAnnotationInfo(
-                            Annotation.NULLABLE,
-                            ImmutableList.of(
-                                new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0),
-                                new NestedAnnotationInfo.TypePathEntry(WILDCARD_BOUND, 0)))))
+                /*.put(
+                methodRef(
+                    "java.util.Optional",
+                    "orElseGet(java.util.function.Supplier<? extends T>)"),
+                ImmutableSetMultimap.of(
+                    -1,
+                    new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
+                    0,
+                    new NestedAnnotationInfo(
+                        Annotation.NULLABLE,
+                        ImmutableList.of(
+                            new NestedAnnotationInfo.TypePathEntry(TYPE_ARGUMENT, 0),
+                            new NestedAnnotationInfo.TypePathEntry(WILDCARD_BOUND, 0)))))*/
                 .build();
 
     private static final ImmutableSet<String> NULLMARKED_CLASSES =

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -985,6 +985,7 @@ public class LibraryModelsHandler implements Handler {
             .add(methodRef("android.webkit.WebView", "getUrl()"))
             .add(methodRef("android.widget.TextView", "getLayout()"))
             .add(methodRef("java.util.Optional", "orElse(T)"))
+            // https://github.com/uber/NullAway/issues/1616
             // .add(
             //    methodRef(
             //        "java.util.Optional", "orElseGet(java.util.function.Supplier<? extends T>)"))
@@ -1098,6 +1099,7 @@ public class LibraryModelsHandler implements Handler {
                         new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
                         0,
                         new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
+                // https://github.com/uber/NullAway/issues/1616
                 /*.put(
                 methodRef(
                     "java.util.Optional",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -4,6 +4,7 @@ import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
@@ -26,6 +27,109 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
                 AtomicReference<@Nullable Integer> x = new AtomicReference<>(Integer.valueOf(3));
                 // BUG: Diagnostic contains: dereferenced expression 'x.get()' is @Nullable
                 x.get().hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void optionalOfNullableOr() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Optional;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              static Optional<String> getKey(@Nullable String key) {
+                return Optional.ofNullable(key).or(() -> Optional.ofNullable(System.getenv("DEFAULT_KEY")));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void optionalOfNullableFilter() {
+    makeHelper()
+        .addSourceLines(
+            "Repro.java",
+            """
+            import java.util.Optional;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            public record Repro(@Nullable String name) {
+              public Optional<String> getNameOpt() {
+                return Optional.ofNullable(name).filter(it -> true);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void optionalExplicitNullableAnnotations() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Optional;
+            import java.util.function.Function;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              Optional<String> ofNullableAcceptsNullable(@Nullable String value) {
+                return Optional.ofNullable(value);
+              }
+
+              Optional<String> mapCanReturnNullable(Optional<String> value) {
+                Function<String, @Nullable String> mapper = unused -> null;
+                return value.map(mapper);
+              }
+
+              void equalsAcceptsNullable(Optional<String> value) {
+                value.equals(null);
+              }
+
+              void ofRejectsNull() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                Optional.of(null);
+              }
+
+              void orElseReturnsNullable(Optional<String> value) {
+                // BUG: Diagnostic contains: dereferenced expression value.orElse(null) is @Nullable
+                value.orElse(null).hashCode();
+              }
+
+              void orElseGetReturnsNullable(Optional<String> value) {
+                // BUG: Diagnostic contains: dereferenced expression value.orElseGet(() -> null) is @Nullable
+                value.orElseGet(() -> null).hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Ignore(
+      "Lambda return checking does not yet use nested nullable type-use annotations from library models")
+  @Test
+  public void optionalMapAllowsNullableLambdaReturn() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Optional;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              Optional<String> mapCanReturnNullable(Optional<String> value) {
+                return value.map(unused -> null);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -91,7 +91,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore("TODO file issue")
+  @Ignore("https://github.com/uber/NullAway/issues/1616")
   @Test
   public void optionalOrElseGet() {
     makeHelper()

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -34,45 +34,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void optionalOfNullableOr() {
-    makeHelper()
-        .addSourceLines(
-            "Test.java",
-            """
-            import java.util.Optional;
-            import org.jspecify.annotations.*;
-
-            @NullMarked
-            class Test {
-              static Optional<String> getKey(@Nullable String key) {
-                return Optional.ofNullable(key).or(() -> Optional.ofNullable(System.getenv("DEFAULT_KEY")));
-              }
-            }
-            """)
-        .doTest();
-  }
-
-  @Test
-  public void optionalOfNullableFilter() {
-    makeHelper()
-        .addSourceLines(
-            "Repro.java",
-            """
-            import java.util.Optional;
-            import org.jspecify.annotations.*;
-
-            @NullMarked
-            public record Repro(@Nullable String name) {
-              public Optional<String> getNameOpt() {
-                return Optional.ofNullable(name).filter(it -> true);
-              }
-            }
-            """)
-        .doTest();
-  }
-
-  @Test
-  public void optionalExplicitNullableAnnotations() {
+  public void optionalMethods() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -110,6 +72,25 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void optionalMapWithLambdaArg() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Optional;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              Optional<String> mapCanReturnNullable(Optional<String> value) {
+                return value.map(unused -> null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Ignore("TODO file issue")
   @Test
   public void optionalOrElseGet() {
@@ -132,21 +113,38 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  @Ignore(
-      "Lambda return checking does not yet use nested nullable type-use annotations from library models")
   @Test
-  public void optionalMapAllowsNullableLambdaReturn() {
+  public void issue1611() {
     makeHelper()
         .addSourceLines(
             "Test.java",
+            """
+                    import java.util.Optional;
+                    import org.jspecify.annotations.*;
+
+                    @NullMarked
+                    class Test {
+                      static Optional<String> getKey(@Nullable String key) {
+                        return Optional.ofNullable(key).or(() -> Optional.ofNullable(System.getenv("DEFAULT_KEY")));
+                      }
+                    }
+                    """)
+        .doTest();
+  }
+
+  @Test
+  public void optionalOfNullableFilterIssue1597() {
+    makeHelper()
+        .addSourceLines(
+            "Repro.java",
             """
             import java.util.Optional;
             import org.jspecify.annotations.*;
 
             @NullMarked
-            class Test {
-              Optional<String> mapCanReturnNullable(Optional<String> value) {
-                return value.map(unused -> null);
+            public record Repro(@Nullable String name) {
+              public Optional<String> getNameOpt() {
+                return Optional.ofNullable(name).filter(it -> true);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -105,7 +105,24 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
                 // BUG: Diagnostic contains: dereferenced expression value.orElse(null) is @Nullable
                 value.orElse(null).hashCode();
               }
+            }
+            """)
+        .doTest();
+  }
 
+  @Ignore("TODO file issue")
+  @Test
+  public void optionalOrElseGet() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Optional;
+            import java.util.function.Function;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
               void orElseGetReturnsNullable(Optional<String> value) {
                 // BUG: Diagnostic contains: dereferenced expression value.orElseGet(() -> null) is @Nullable
                 value.orElseGet(() -> null).hashCode();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -64,7 +64,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
               }
 
               void orElseReturnsNullable(Optional<String> value) {
-                // BUG: Diagnostic contains: dereferenced expression value.orElse(null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'value.orElse(null)' is @Nullable
                 value.orElse(null).hashCode();
               }
             }
@@ -105,7 +105,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
             @NullMarked
             class Test {
               void orElseGetReturnsNullable(Optional<String> value) {
-                // BUG: Diagnostic contains: dereferenced expression value.orElseGet(() -> null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'value.orElseGet(() -> null)' is @Nullable
                 value.orElseGet(() -> null).hashCode();
               }
             }


### PR DESCRIPTION
Fixes #1611 

We manually write more models for `Optional`, so we can address before fully fixing #950.  Note that we do not model `orElseGet` as in JSpecify JDK right now due to false positives; see #1616.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety handling for `java.util.Optional`, including more accurate nullability propagation and diagnostics for `ofNullable`, `map`, `orElse`, `equals`, and `filter`.

* **Tests**
  * Expanded JUnit coverage for `Optional` with jspecify nullability, adding new positive and negative compilation assertions, with one scenario temporarily skipped pending a tracked issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->