### PR TITLE
Fix issue with passing poly expression to a function parameter with type from library model

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1160,12 +1160,12 @@ public class NullAway extends BugChecker
     }
     Symbol.MethodSymbol funcInterfaceMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
+    // we update the environment mapping before running any handlers, as some handlers
+    // (like Rx nullability) run dataflow analysis
+    updateEnvironmentMapping(state.getPath(), state);
     if (config.isJSpecifyMode()) {
       genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
     }
-    // we need to update environment mapping before running the handler, as some handlers
-    // (like Rx nullability) run dataflow analysis
-    updateEnvironmentMapping(state.getPath(), state);
     handler.onMatchLambdaExpression(
         tree, new MethodAnalysisContext(this, state, funcInterfaceMethod));
     if (codeAnnotationInfo.isSymbolUnannotated(funcInterfaceMethod, config, handler)) {

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -847,11 +847,16 @@ public class NullAway extends BugChecker
           // Check if the parameter type is a type variable and the corresponding generic type
           // argument is @Nullable
           if (memberReferenceTree != null || lambdaExpressionTree != null) {
+            // For a method reference or lambda, try to use a type inferred by GenericsChecks for
+            // the tree.  Fall back on the type inferred by javac.
             Tree polyExprTree =
                 castToNonNull(
                     memberReferenceTree != null ? memberReferenceTree : lambdaExpressionTree);
             Type functionalInterfaceType =
-                getFunctionalInterfaceTypeForPolyExpression(polyExprTree, state);
+                genericsChecks.getInferredPolyExpressionType(polyExprTree);
+            if (functionalInterfaceType == null) {
+              functionalInterfaceType = ASTHelpers.getType(polyExprTree);
+            }
             paramNullness =
                 genericsChecks.getGenericMethodParameterNullness(
                     i, overriddenMethod, functionalInterfaceType, state);
@@ -1124,11 +1129,7 @@ public class NullAway extends BugChecker
       if (inferredType != null) {
         lambdaType = inferredType;
       }
-      Nullness invocationTargetReturnNullness =
-          genericsChecks.getFunctionalInterfaceReturnNullnessFromEnclosingInvocation(
-              lambdaTree, methodSymbol, state);
-      if (Nullness.NULLABLE.equals(invocationTargetReturnNullness)
-          || genericsChecks
+      if (genericsChecks
               .getGenericMethodReturnTypeNullness(methodSymbol, lambdaType, state)
               .equals(Nullness.NULLABLE)
           || genericsChecks.passingLambdaOrMethodRefWithGenericReturnToUnmarkedCode(
@@ -1159,6 +1160,7 @@ public class NullAway extends BugChecker
     }
     Symbol.MethodSymbol funcInterfaceMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
+    genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
     // we need to update environment mapping before running the handler, as some handlers
     // (like Rx nullability) run dataflow analysis
     updateEnvironmentMapping(state.getPath(), state);
@@ -1197,6 +1199,7 @@ public class NullAway extends BugChecker
     if (!withinAnnotatedCode(state)) {
       return Description.NO_MATCH;
     }
+    genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
     // Technically the qualifier expression of a method reference gets passed to
     // Objects.requireNonNull, but it's fine to treat it as a dereference for error-checking
     // purposes.  The error message will be slightly inaccurate
@@ -1290,8 +1293,13 @@ public class NullAway extends BugChecker
     // using the type arguments from the type enclosing the overriding method
     if (config.isJSpecifyMode()) {
       if (memberReferenceTree != null) {
+        // For a method reference, we get generic type arguments from javac's inferred type for the
+        // tree, which properly preserves type-use annotations
         Type functionalInterfaceType =
-            getFunctionalInterfaceTypeForPolyExpression(memberReferenceTree, state);
+            genericsChecks.getInferredPolyExpressionType(memberReferenceTree);
+        if (functionalInterfaceType == null) {
+          functionalInterfaceType = ASTHelpers.getType(memberReferenceTree);
+        }
         return genericsChecks
                 .getGenericMethodReturnTypeNullness(
                     overriddenMethod, functionalInterfaceType, state)
@@ -1306,21 +1314,6 @@ public class NullAway extends BugChecker
       }
     }
     return true;
-  }
-
-  private @Nullable Type getFunctionalInterfaceTypeForPolyExpression(
-      Tree polyExpressionTree, VisitorState state) {
-    // For a method reference or lambda, prefer a type cached by GenericsChecks. Fall back to a
-    // target type restored from the enclosing invocation's formal parameter, then to javac.
-    Type functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(polyExpressionTree);
-    if (functionalInterfaceType == null) {
-      functionalInterfaceType =
-          genericsChecks.getGroundTargetTypeFromEnclosingInvocation(polyExpressionTree, state);
-    }
-    if (functionalInterfaceType == null) {
-      functionalInterfaceType = ASTHelpers.getType(polyExpressionTree);
-    }
-    return functionalInterfaceType;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1310,12 +1310,12 @@ public class NullAway extends BugChecker
 
   private @Nullable Type getFunctionalInterfaceTypeForPolyExpression(
       Tree polyExpressionTree, VisitorState state) {
-    // For a method reference or lambda, prefer a target type restored from the enclosing
-    // invocation's formal parameter. Fall back to a type cached by GenericsChecks, then to javac.
-    Type functionalInterfaceType =
-        genericsChecks.getGroundTargetTypeFromEnclosingInvocation(polyExpressionTree, state);
+    // For a method reference or lambda, prefer a type cached by GenericsChecks. Fall back to a
+    // target type restored from the enclosing invocation's formal parameter, then to javac.
+    Type functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(polyExpressionTree);
     if (functionalInterfaceType == null) {
-      functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(polyExpressionTree);
+      functionalInterfaceType =
+          genericsChecks.getGroundTargetTypeFromEnclosingInvocation(polyExpressionTree, state);
     }
     if (functionalInterfaceType == null) {
       functionalInterfaceType = ASTHelpers.getType(polyExpressionTree);

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -847,16 +847,11 @@ public class NullAway extends BugChecker
           // Check if the parameter type is a type variable and the corresponding generic type
           // argument is @Nullable
           if (memberReferenceTree != null || lambdaExpressionTree != null) {
-            // For a method reference or lambda, try to use a type inferred by GenericsChecks for
-            // the tree.  Fall back on the type inferred by javac.
             Tree polyExprTree =
                 castToNonNull(
                     memberReferenceTree != null ? memberReferenceTree : lambdaExpressionTree);
             Type functionalInterfaceType =
-                genericsChecks.getInferredPolyExpressionType(polyExprTree);
-            if (functionalInterfaceType == null) {
-              functionalInterfaceType = ASTHelpers.getType(polyExprTree);
-            }
+                getFunctionalInterfaceTypeForPolyExpression(polyExprTree, state);
             paramNullness =
                 genericsChecks.getGenericMethodParameterNullness(
                     i, overriddenMethod, functionalInterfaceType, state);
@@ -1129,7 +1124,11 @@ public class NullAway extends BugChecker
       if (inferredType != null) {
         lambdaType = inferredType;
       }
-      if (genericsChecks
+      Nullness invocationTargetReturnNullness =
+          genericsChecks.getFunctionalInterfaceReturnNullnessFromEnclosingInvocation(
+              lambdaTree, methodSymbol, state);
+      if (Nullness.NULLABLE.equals(invocationTargetReturnNullness)
+          || genericsChecks
               .getGenericMethodReturnTypeNullness(methodSymbol, lambdaType, state)
               .equals(Nullness.NULLABLE)
           || genericsChecks.passingLambdaOrMethodRefWithGenericReturnToUnmarkedCode(
@@ -1291,13 +1290,8 @@ public class NullAway extends BugChecker
     // using the type arguments from the type enclosing the overriding method
     if (config.isJSpecifyMode()) {
       if (memberReferenceTree != null) {
-        // For a method reference, we get generic type arguments from javac's inferred type for the
-        // tree, which properly preserves type-use annotations
         Type functionalInterfaceType =
-            genericsChecks.getInferredPolyExpressionType(memberReferenceTree);
-        if (functionalInterfaceType == null) {
-          functionalInterfaceType = ASTHelpers.getType(memberReferenceTree);
-        }
+            getFunctionalInterfaceTypeForPolyExpression(memberReferenceTree, state);
         return genericsChecks
                 .getGenericMethodReturnTypeNullness(
                     overriddenMethod, functionalInterfaceType, state)
@@ -1312,6 +1306,21 @@ public class NullAway extends BugChecker
       }
     }
     return true;
+  }
+
+  private @Nullable Type getFunctionalInterfaceTypeForPolyExpression(
+      Tree polyExpressionTree, VisitorState state) {
+    // For a method reference or lambda, prefer a target type restored from the enclosing
+    // invocation's formal parameter. Fall back to a type cached by GenericsChecks, then to javac.
+    Type functionalInterfaceType =
+        genericsChecks.getGroundTargetTypeFromEnclosingInvocation(polyExpressionTree, state);
+    if (functionalInterfaceType == null) {
+      functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(polyExpressionTree);
+    }
+    if (functionalInterfaceType == null) {
+      functionalInterfaceType = ASTHelpers.getType(polyExpressionTree);
+    }
+    return functionalInterfaceType;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1160,7 +1160,9 @@ public class NullAway extends BugChecker
     }
     Symbol.MethodSymbol funcInterfaceMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
-    genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
+    if (config.isJSpecifyMode()) {
+      genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
+    }
     // we need to update environment mapping before running the handler, as some handlers
     // (like Rx nullability) run dataflow analysis
     updateEnvironmentMapping(state.getPath(), state);
@@ -1199,7 +1201,9 @@ public class NullAway extends BugChecker
     if (!withinAnnotatedCode(state)) {
       return Description.NO_MATCH;
     }
-    genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
+    if (config.isJSpecifyMode()) {
+      genericsChecks.maybeStoreLibraryModeledPolyExpressionType(tree, state);
+    }
     // Technically the qualifier expression of a method reference gets passed to
     // Objects.requireNonNull, but it's fine to treat it as a dereference for error-checking
     // purposes.  The error message will be slightly inaccurate

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -130,120 +130,63 @@ public final class GenericsChecks {
     return inferredPolyExpressionTypes.get(tree);
   }
 
-  /**
-   * If a lambda is being passed as an invocation argument, returns the nullness of the return type
-   * of its functional interface method as a member of the invocation's formal parameter type.
-   *
-   * <p>This is needed before lambda body checking, which can happen before the enclosing invocation
-   * itself is checked and caches the lambda target type.
-   */
-  public @Nullable Nullness getFunctionalInterfaceReturnNullnessFromEnclosingInvocation(
-      LambdaExpressionTree lambdaTree,
-      Symbol.MethodSymbol functionalInterfaceMethod,
-      VisitorState state) {
-    Type groundTargetType = getGroundTargetTypeFromEnclosingInvocation(lambdaTree, state);
-    if (groundTargetType == null) {
-      return null;
-    }
-    Type functionalInterfaceMethodType =
-        TypeSubstitutionUtils.memberType(
-            state.getTypes(), groundTargetType, functionalInterfaceMethod, config);
-    verify(
-        functionalInterfaceMethodType instanceof ExecutableType,
-        "expected ExecutableType but instead got %s",
-        functionalInterfaceMethodType.getClass());
-    return getReturnTypeNullness(functionalInterfaceMethodType.getReturnType(), state);
-  }
-
-  /**
-   * If a lambda or method reference is being passed as an invocation argument, returns the grounded
-   * functional-interface target type from the corresponding formal parameter type.
-   */
-  public @Nullable Type getGroundTargetTypeFromEnclosingInvocation(
-      Tree polyExpressionTree, VisitorState state) {
-    Type formalParameterType =
-        getFormalParameterTypeFromEnclosingInvocation(polyExpressionTree, state);
-    if (formalParameterType == null || formalParameterType.isRaw()) {
-      return null;
-    }
-    return GenericsUtils.groundTargetType(formalParameterType, state, config, handler);
-  }
-
-  @SuppressWarnings("ReferenceEquality") // deliberate Tree identity comparison
-  private @Nullable Type getFormalParameterTypeFromEnclosingInvocation(
+  /** Stores the library-modeled target type for a direct invocation argument, if one exists. */
+  @SuppressWarnings({"ReferenceEquality", "TypeEquals"})
+  public void maybeStoreLibraryModeledPolyExpressionType(
       Tree polyExpressionTree, VisitorState state) {
     Preconditions.checkArgument(
         polyExpressionTree instanceof LambdaExpressionTree
             || polyExpressionTree instanceof MemberReferenceTree,
         "Expected lambda or method reference tree but got: %s",
         polyExpressionTree.getKind());
-    TreePath path = state.getPath();
-    while (path != null && ASTHelpers.stripParentheses(path.getLeaf()) != polyExpressionTree) {
-      path = path.getParentPath();
+    TreePath polyExpressionPath = state.getPath();
+    while (polyExpressionPath != null
+        && ASTHelpers.stripParentheses(polyExpressionPath.getLeaf()) != polyExpressionTree) {
+      polyExpressionPath = polyExpressionPath.getParentPath();
     }
-    if (path == null || path.getParentPath() == null) {
-      return null;
+    if (polyExpressionPath == null) {
+      return;
     }
-    TreePath invocationPath = path.getParentPath();
-    Tree parent = invocationPath.getLeaf();
-    Symbol invocationSymbol = ASTHelpers.getSymbol(parent);
-    if (!(invocationSymbol instanceof Symbol.MethodSymbol methodSymbol)) {
-      return null;
+    TreePath invocationPath = polyExpressionPath.getParentPath();
+    while (invocationPath != null && invocationPath.getLeaf() instanceof ParenthesizedTree) {
+      invocationPath = invocationPath.getParentPath();
     }
-    Type.MethodType methodType =
-        getInvocationMethodType(
-            methodSymbol, parent, state.withPath(invocationPath), invocationPath, false);
-    return getFormalParameterTypeForArgument(parent, methodType, polyExpressionTree);
-  }
-
-  @SuppressWarnings("ReferenceEquality") // deliberate Tree identity comparison
-  private Type.MethodType getInvocationMethodType(
-      Symbol.MethodSymbol methodSymbol,
-      Tree invocationTree,
-      VisitorState state,
-      @Nullable TreePath invocationPath,
-      boolean calledFromDataflow) {
-    Type invokedMethodType = methodSymbol.type;
-    Type enclosingType = null;
-    if (invocationTree instanceof NewClassTree newClassTree) {
-      if (hasInferredClassTypeArguments(newClassTree)) {
-        TreePath currentPath = invocationPath != null ? invocationPath : state.getPath();
-        if (currentPath != null
-            && ASTHelpers.stripParentheses(currentPath.getLeaf()) == invocationTree) {
-          TreePath parentPath = currentPath.getParentPath();
-          if (parentPath != null) {
-            enclosingType =
-                getDiamondTypeFromParentContext(
-                    newClassTree, state, parentPath, calledFromDataflow);
-          }
-        }
-      }
+    if (invocationPath == null
+        || !(invocationPath.getLeaf() instanceof MethodInvocationTree invocationTree)) {
+      return;
     }
-    if (enclosingType == null) {
-      enclosingType =
-          getEnclosingTypeForCallExpression(
-              methodSymbol, invocationTree, invocationPath, state, calledFromDataflow);
+    Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
+    if (methodSymbol == null) {
+      return;
     }
-    if (enclosingType != null) {
-      invokedMethodType =
-          TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, methodSymbol, config);
+    Type attributedMethodType = ASTHelpers.getType(invocationTree.getMethodSelect());
+    if (attributedMethodType == null) {
+      return;
     }
-
-    // substitute type arguments for generic methods with explicit type arguments
-    if (invocationTree instanceof MethodInvocationTree
-        && invokedMethodType instanceof Type.ForAll) {
-      invokedMethodType =
-          substituteTypeArgsInGenericMethodType(
-              invocationTree, (Type.ForAll) invokedMethodType, invocationPath, state, false);
+    Type.MethodType methodType = attributedMethodType.asMethodType();
+    Type.MethodType modeledMethodType =
+        handler.onOverrideMethodType(
+            methodSymbol, methodType, state.withPath(invocationPath), invocationTree);
+    if (modeledMethodType == methodType) {
+      return;
     }
-
-    return handler.onOverrideMethodType(
-        methodSymbol,
-        invokedMethodType.asMethodType(),
-        state,
-        invocationTree instanceof MethodInvocationTree methodInvocationTree
-            ? methodInvocationTree
-            : null);
+    Type formalParameter =
+        getFormalParameterTypeForArgument(invocationTree, modeledMethodType, polyExpressionTree);
+    if (formalParameter == null || formalParameter.isRaw()) {
+      return;
+    }
+    Type polyExpressionType = inferredPolyExpressionTypes.get(polyExpressionTree);
+    if (polyExpressionType == null) {
+      polyExpressionType = ASTHelpers.getType(polyExpressionTree);
+    }
+    if (polyExpressionType != null) {
+      Type groundTargetType =
+          GenericsUtils.groundTargetType(formalParameter, state, config, handler);
+      Type modeledPolyExpressionType =
+          TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
+              groundTargetType, polyExpressionType, config, Collections.emptyMap());
+      inferredPolyExpressionTypes.put(polyExpressionTree, modeledPolyExpressionType);
+    }
   }
 
   private final NullAway analysis;
@@ -1228,10 +1171,7 @@ public final class GenericsChecks {
           inferredTypeVarNullabilityForGenericCalls.put(invTree, successResult);
         }
         // Store inferred types for lambda or method reference arguments
-        Type.MethodType methodType =
-            handler.onOverrideMethodType(
-                methodSymbol, methodSymbol.type.asMethodType(), state, invocationTree);
-        new InvocationArguments(invocationTree, methodType)
+        new InvocationArguments(invocationTree, methodSymbol.type.asMethodType())
             .forEach(
                 (argument, argPos, formalParamType, unused) -> {
                   if (argument instanceof LambdaExpressionTree
@@ -1928,8 +1868,42 @@ public final class GenericsChecks {
     if (!config.isJSpecifyMode()) {
       return;
     }
+    Type invokedMethodType = methodSymbol.type;
+    Type enclosingType = null;
+    if (tree instanceof NewClassTree newClassTree) {
+      if (hasInferredClassTypeArguments(newClassTree)) {
+        TreePath currentPath = state.getPath();
+        if (currentPath != null && ASTHelpers.stripParentheses(currentPath.getLeaf()) == tree) {
+          TreePath parentPath = currentPath.getParentPath();
+          if (parentPath != null) {
+            enclosingType = getDiamondTypeFromParentContext(newClassTree, state, parentPath, false);
+          }
+        }
+      }
+    }
+    if (enclosingType == null) {
+      enclosingType = getEnclosingTypeForCallExpression(methodSymbol, tree, null, state, false);
+    }
+    if (enclosingType != null) {
+      invokedMethodType =
+          TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, methodSymbol, config);
+    }
+
+    // substitute type arguments for generic methods with explicit type arguments
+    if (tree instanceof MethodInvocationTree && invokedMethodType instanceof Type.ForAll) {
+      invokedMethodType =
+          substituteTypeArgsInGenericMethodType(
+              tree, (Type.ForAll) invokedMethodType, null, state, false);
+    }
+
     Type.MethodType finalMethodType =
-        getInvocationMethodType(methodSymbol, tree, state, state.getPath(), false);
+        handler.onOverrideMethodType(
+            methodSymbol,
+            invokedMethodType.asMethodType(),
+            state,
+            tree instanceof MethodInvocationTree methodInvocationTree
+                ? methodInvocationTree
+                : null);
     new InvocationArguments(tree, finalMethodType)
         .forEach(
             (currentActualParam, argPos, formalParameter, unused) -> {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -144,15 +144,11 @@ public final class GenericsChecks {
             || polyExpressionTree instanceof MemberReferenceTree,
         "Expected lambda or method reference tree but got: %s",
         polyExpressionTree.getKind());
-    TreePath polyExpressionPath = state.getPath();
-    while (polyExpressionPath != null
-        && ASTHelpers.stripParentheses(polyExpressionPath.getLeaf()) != polyExpressionTree) {
-      polyExpressionPath = polyExpressionPath.getParentPath();
-    }
-    if (polyExpressionPath == null) {
-      return;
-    }
-    TreePath invocationPath = polyExpressionPath.getParentPath();
+    Preconditions.checkArgument(
+        state.getPath().getLeaf() == polyExpressionTree,
+        "Expected current path leaf to be the poly expression");
+    TreePath invocationPath = state.getPath().getParentPath();
+    // Skip parentheses around the invocation argument.
     while (invocationPath != null && invocationPath.getLeaf() instanceof ParenthesizedTree) {
       invocationPath = invocationPath.getParentPath();
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -171,9 +171,9 @@ public final class GenericsChecks {
     if (modeledMethodType == methodType) {
       return;
     }
-    Type formalParameter =
+    Type formalParameterType =
         getFormalParameterTypeForArgument(invocationTree, modeledMethodType, polyExpressionTree);
-    if (formalParameter == null || formalParameter.isRaw()) {
+    if (formalParameterType == null || formalParameterType.isRaw()) {
       return;
     }
     Type polyExpressionType = inferredPolyExpressionTypes.get(polyExpressionTree);
@@ -182,7 +182,7 @@ public final class GenericsChecks {
     }
     if (polyExpressionType != null) {
       Type groundTargetType =
-          GenericsUtils.groundTargetType(formalParameter, state, config, handler);
+          GenericsUtils.groundTargetType(formalParameterType, state, config, handler);
       Type modeledPolyExpressionType =
           TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
               groundTargetType, polyExpressionType, config, Collections.emptyMap());

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -130,6 +130,122 @@ public final class GenericsChecks {
     return inferredPolyExpressionTypes.get(tree);
   }
 
+  /**
+   * If a lambda is being passed as an invocation argument, returns the nullness of the return type
+   * of its functional interface method as a member of the invocation's formal parameter type.
+   *
+   * <p>This is needed before lambda body checking, which can happen before the enclosing invocation
+   * itself is checked and caches the lambda target type.
+   */
+  public @Nullable Nullness getFunctionalInterfaceReturnNullnessFromEnclosingInvocation(
+      LambdaExpressionTree lambdaTree,
+      Symbol.MethodSymbol functionalInterfaceMethod,
+      VisitorState state) {
+    Type groundTargetType = getGroundTargetTypeFromEnclosingInvocation(lambdaTree, state);
+    if (groundTargetType == null) {
+      return null;
+    }
+    Type functionalInterfaceMethodType =
+        TypeSubstitutionUtils.memberType(
+            state.getTypes(), groundTargetType, functionalInterfaceMethod, config);
+    verify(
+        functionalInterfaceMethodType instanceof ExecutableType,
+        "expected ExecutableType but instead got %s",
+        functionalInterfaceMethodType.getClass());
+    return getReturnTypeNullness(functionalInterfaceMethodType.getReturnType(), state);
+  }
+
+  /**
+   * If a lambda or method reference is being passed as an invocation argument, returns the grounded
+   * functional-interface target type from the corresponding formal parameter type.
+   */
+  public @Nullable Type getGroundTargetTypeFromEnclosingInvocation(
+      Tree polyExpressionTree, VisitorState state) {
+    Type formalParameterType =
+        getFormalParameterTypeFromEnclosingInvocation(polyExpressionTree, state);
+    if (formalParameterType == null || formalParameterType.isRaw()) {
+      return null;
+    }
+    return GenericsUtils.groundTargetType(formalParameterType, state, config, handler);
+  }
+
+  @SuppressWarnings("ReferenceEquality") // deliberate Tree identity comparison
+  private @Nullable Type getFormalParameterTypeFromEnclosingInvocation(
+      Tree polyExpressionTree, VisitorState state) {
+    Preconditions.checkArgument(
+        polyExpressionTree instanceof LambdaExpressionTree
+            || polyExpressionTree instanceof MemberReferenceTree,
+        "Expected lambda or method reference tree but got: %s",
+        polyExpressionTree.getKind());
+    TreePath path = state.getPath();
+    while (path != null && ASTHelpers.stripParentheses(path.getLeaf()) != polyExpressionTree) {
+      path = path.getParentPath();
+    }
+    if (path == null || path.getParentPath() == null) {
+      return null;
+    }
+    TreePath invocationPath = path.getParentPath();
+    Tree parent = invocationPath.getLeaf();
+    Symbol invocationSymbol = ASTHelpers.getSymbol(parent);
+    if (!(invocationSymbol instanceof Symbol.MethodSymbol methodSymbol)) {
+      return null;
+    }
+    Type.MethodType methodType =
+        getInvocationMethodType(
+            methodSymbol, parent, state.withPath(invocationPath), invocationPath, false);
+    return getFormalParameterTypeForArgument(parent, methodType, polyExpressionTree);
+  }
+
+  @SuppressWarnings("ReferenceEquality") // deliberate Tree identity comparison
+  private Type.MethodType getInvocationMethodType(
+      Symbol.MethodSymbol methodSymbol,
+      Tree invocationTree,
+      VisitorState state,
+      @Nullable TreePath invocationPath,
+      boolean calledFromDataflow) {
+    Type invokedMethodType = methodSymbol.type;
+    Type enclosingType = null;
+    if (invocationTree instanceof NewClassTree newClassTree) {
+      if (hasInferredClassTypeArguments(newClassTree)) {
+        TreePath currentPath = invocationPath != null ? invocationPath : state.getPath();
+        if (currentPath != null
+            && ASTHelpers.stripParentheses(currentPath.getLeaf()) == invocationTree) {
+          TreePath parentPath = currentPath.getParentPath();
+          if (parentPath != null) {
+            enclosingType =
+                getDiamondTypeFromParentContext(
+                    newClassTree, state, parentPath, calledFromDataflow);
+          }
+        }
+      }
+    }
+    if (enclosingType == null) {
+      enclosingType =
+          getEnclosingTypeForCallExpression(
+              methodSymbol, invocationTree, invocationPath, state, calledFromDataflow);
+    }
+    if (enclosingType != null) {
+      invokedMethodType =
+          TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, methodSymbol, config);
+    }
+
+    // substitute type arguments for generic methods with explicit type arguments
+    if (invocationTree instanceof MethodInvocationTree
+        && invokedMethodType instanceof Type.ForAll) {
+      invokedMethodType =
+          substituteTypeArgsInGenericMethodType(
+              invocationTree, (Type.ForAll) invokedMethodType, invocationPath, state, false);
+    }
+
+    return handler.onOverrideMethodType(
+        methodSymbol,
+        invokedMethodType.asMethodType(),
+        state,
+        invocationTree instanceof MethodInvocationTree methodInvocationTree
+            ? methodInvocationTree
+            : null);
+  }
+
   private final NullAway analysis;
   private final Config config;
   private final Handler handler;
@@ -1809,42 +1925,8 @@ public final class GenericsChecks {
     if (!config.isJSpecifyMode()) {
       return;
     }
-    Type invokedMethodType = methodSymbol.type;
-    Type enclosingType = null;
-    if (tree instanceof NewClassTree newClassTree) {
-      if (hasInferredClassTypeArguments(newClassTree)) {
-        TreePath currentPath = state.getPath();
-        if (currentPath != null && ASTHelpers.stripParentheses(currentPath.getLeaf()) == tree) {
-          TreePath parentPath = currentPath.getParentPath();
-          if (parentPath != null) {
-            enclosingType = getDiamondTypeFromParentContext(newClassTree, state, parentPath, false);
-          }
-        }
-      }
-    }
-    if (enclosingType == null) {
-      enclosingType = getEnclosingTypeForCallExpression(methodSymbol, tree, null, state, false);
-    }
-    if (enclosingType != null) {
-      invokedMethodType =
-          TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, methodSymbol, config);
-    }
-
-    // substitute type arguments for generic methods with explicit type arguments
-    if (tree instanceof MethodInvocationTree && invokedMethodType instanceof Type.ForAll) {
-      invokedMethodType =
-          substituteTypeArgsInGenericMethodType(
-              tree, (Type.ForAll) invokedMethodType, null, state, false);
-    }
-
     Type.MethodType finalMethodType =
-        handler.onOverrideMethodType(
-            methodSymbol,
-            invokedMethodType.asMethodType(),
-            state,
-            tree instanceof MethodInvocationTree methodInvocationTree
-                ? methodInvocationTree
-                : null);
+        getInvocationMethodType(methodSymbol, tree, state, state.getPath(), false);
     new InvocationArguments(tree, finalMethodType)
         .forEach(
             (currentActualParam, argPos, formalParameter, unused) -> {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1228,7 +1228,10 @@ public final class GenericsChecks {
           inferredTypeVarNullabilityForGenericCalls.put(invTree, successResult);
         }
         // Store inferred types for lambda or method reference arguments
-        new InvocationArguments(invocationTree, methodSymbol.type.asMethodType())
+        Type.MethodType methodType =
+            handler.onOverrideMethodType(
+                methodSymbol, methodSymbol.type.asMethodType(), state, invocationTree);
+        new InvocationArguments(invocationTree, methodType)
             .forEach(
                 (argument, argPos, formalParamType, unused) -> {
                   if (argument instanceof LambdaExpressionTree

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -130,7 +130,12 @@ public final class GenericsChecks {
     return inferredPolyExpressionTypes.get(tree);
   }
 
-  /** Stores the library-modeled target type for a direct invocation argument, if one exists. */
+  /**
+   * Handles cases where a poly expression (lambda or method reference) is passed as a parameter,
+   * and the invoked function has a library model for the corresponding formal. In such cases, we
+   * ensure the appropriate formal parameter type from the library model is used when inferring the
+   * type of the poly expression, and cache the result.
+   */
   @SuppressWarnings({"ReferenceEquality", "TypeEquals"})
   public void maybeStoreLibraryModeledPolyExpressionType(
       Tree polyExpressionTree, VisitorState state) {
@@ -1912,7 +1917,10 @@ public final class GenericsChecks {
                 return;
               }
 
-              if (currentActualParam instanceof MemberReferenceTree memberReferenceTree) {
+              ExpressionTree actualParameterWithoutParentheses =
+                  ASTHelpers.stripParentheses(currentActualParam);
+              if (actualParameterWithoutParentheses
+                  instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
                     GenericsUtils.groundTargetType(formalParameter, state, config, handler);
                 // the type of the method reference tree provided by javac may not capture
@@ -1934,16 +1942,19 @@ public final class GenericsChecks {
                         }
                       }
                     });
-                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter, state);
+                maybeStorePolyExpressionTypeFromTarget(
+                    actualParameterWithoutParentheses, formalParameter, state);
                 return;
               }
 
               TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
               Type actualParameterType;
-              if (currentActualParam instanceof LambdaExpressionTree) {
-                maybeStorePolyExpressionTypeFromTarget(currentActualParam, formalParameter, state);
+              if (actualParameterWithoutParentheses instanceof LambdaExpressionTree) {
+                maybeStorePolyExpressionTypeFromTarget(
+                    actualParameterWithoutParentheses, formalParameter, state);
               }
-              Type inferredPolyType = inferredPolyExpressionTypes.get(currentActualParam);
+              Type inferredPolyType =
+                  inferredPolyExpressionTypes.get(actualParameterWithoutParentheses);
               if (inferredPolyType != null) {
                 actualParameterType = inferredPolyType;
               } else {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1122,6 +1122,34 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void lambdaReturnUsesNullableInvocationTargetType() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static void accept(Function<String, @Nullable String> mapper) {}
+
+              void expressionBody() {
+                accept(unused -> null);
+              }
+
+              void blockBody() {
+                accept(unused -> {
+                  return null;
+                });
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelperWithInferenceFailureWarning() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaBox.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaBox.java
@@ -1,0 +1,4 @@
+package com.uber.lib.unannotated;
+
+/* @NullMarked */
+public class LambdaBox<T> {}

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaConsumer.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaConsumer.java
@@ -1,0 +1,6 @@
+package com.uber.lib.unannotated;
+
+/* @NullMarked */
+public interface LambdaConsumer<T> {
+  void accept(T value);
+}

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaModel.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/LambdaModel.java
@@ -1,0 +1,17 @@
+package com.uber.lib.unannotated;
+
+import java.util.function.Function;
+
+/* @NullMarked */
+public class LambdaModel {
+
+  public static <U> LambdaBox<U> map(Function<String, ? extends /* @Nullable */ U> mapper) {
+    return new LambdaBox<>();
+  }
+
+  public static String apply(Function<String, /* @Nullable */ String> mapper) {
+    return mapper.apply("");
+  }
+
+  public static void consume(LambdaConsumer<? super /* @Nullable */ String> consumer) {}
+}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -270,6 +270,14 @@ public class TestLibraryModels implements LibraryModels {
         .put(
             methodRef(
                 "com.uber.lib.unannotated.LambdaModel",
+                "apply(java.util.function.Function<java.lang.String,java.lang.String>)"),
+            ImmutableSetMultimap.of(
+                0,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE, ImmutableList.of(new TypePathEntry(TYPE_ARGUMENT, 1)))))
+        .put(
+            methodRef(
+                "com.uber.lib.unannotated.LambdaModel",
                 "consume(com.uber.lib.unannotated.LambdaConsumer<? super java.lang.String>)"),
             ImmutableSetMultimap.of(
                 0,

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -172,6 +172,8 @@ public class TestLibraryModels implements LibraryModels {
   public ImmutableSet<String> nullMarkedClasses() {
     return ImmutableSet.of(
         "com.uber.lib.unannotated.ProviderNullMarkedViaModel",
+        "com.uber.lib.unannotated.LambdaBox",
+        "com.uber.lib.unannotated.LambdaModel",
         "com.uber.lib.unannotated.NestedAnnots",
         "com.uber.lib.unannotated.NullMarkedVarargsWithModel");
   }
@@ -253,6 +255,17 @@ public class TestLibraryModels implements LibraryModels {
                 1,
                 new NestedAnnotationInfo(
                     Annotation.NULLABLE, ImmutableList.of(new TypePathEntry(TYPE_ARGUMENT, 0)))))
+        .put(
+            methodRef(
+                "com.uber.lib.unannotated.LambdaModel",
+                "<U>map(java.util.function.Function<java.lang.String,? extends U>)"),
+            ImmutableSetMultimap.of(
+                0,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE,
+                    ImmutableList.of(
+                        new TypePathEntry(TYPE_ARGUMENT, 1),
+                        new TypePathEntry(WILDCARD_BOUND, 0)))))
         .put(
             methodRef(
                 "com.uber.lib.unannotated.NullMarkedVarargsWithModel",

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -173,6 +173,7 @@ public class TestLibraryModels implements LibraryModels {
     return ImmutableSet.of(
         "com.uber.lib.unannotated.ProviderNullMarkedViaModel",
         "com.uber.lib.unannotated.LambdaBox",
+        "com.uber.lib.unannotated.LambdaConsumer",
         "com.uber.lib.unannotated.LambdaModel",
         "com.uber.lib.unannotated.NestedAnnots",
         "com.uber.lib.unannotated.NullMarkedVarargsWithModel");
@@ -266,6 +267,17 @@ public class TestLibraryModels implements LibraryModels {
                     ImmutableList.of(
                         new TypePathEntry(TYPE_ARGUMENT, 1),
                         new TypePathEntry(WILDCARD_BOUND, 0)))))
+        .put(
+            methodRef(
+                "com.uber.lib.unannotated.LambdaModel",
+                "consume(com.uber.lib.unannotated.LambdaConsumer<? super java.lang.String>)"),
+            ImmutableSetMultimap.of(
+                0,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE,
+                    ImmutableList.of(
+                        new TypePathEntry(TYPE_ARGUMENT, 0),
+                        new TypePathEntry(WILDCARD_BOUND, 1)))))
         .put(
             methodRef(
                 "com.uber.lib.unannotated.NullMarkedVarargsWithModel",

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -632,6 +632,8 @@ public class CustomLibraryModelsTests {
               void test() {
                 LambdaModel.apply(unused -> null);
                 LambdaModel.apply(Test::returnsNullable);
+                LambdaModel.apply((unused -> null));
+                LambdaModel.apply((Test::returnsNullable));
               }
 
               static @Nullable String returnsNullable(String unused) {

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -593,6 +593,58 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void functionalInterfaceParameterUsesNestedLibraryModelLowerBound() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaConsumer.java",
+            """
+            package com.uber.lib.unannotated;
+
+            public interface LambdaConsumer<T> {
+              void accept(T value);
+            }
+            """)
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaModel.java",
+            """
+            package com.uber.lib.unannotated;
+
+            public class LambdaModel {
+              public static void consume(LambdaConsumer<? super String> consumer) {}
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.LambdaModel;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              void test() {
+                LambdaModel.consume(value -> {
+                  // BUG: Diagnostic contains: dereferenced expression value is @Nullable
+                  value.length();
+                });
+                LambdaModel.consume(Test::acceptsNullable);
+                // BUG: Diagnostic contains: parameter value of referenced method is @NonNull
+                LambdaModel.consume(Test::acceptsNonNull);
+              }
+
+              static void acceptsNullable(@Nullable String value) {}
+
+              static void acceptsNonNull(String value) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void suggestRemovingUnnecessaryCastToNonNullFromLibraryModel() {
     var testHelper =
         BugCheckerRefactoringTestHelper.newInstance(NullAway.class, getClass())

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -538,6 +538,10 @@ public class CustomLibraryModelsTests {
               LambdaBox<String> test() {
                 return LambdaModel.map(unused -> null);
               }
+
+              LambdaBox<String> testExplicitTypeArgument() {
+                return LambdaModel.<String>map(unused -> null);
+              }
             }
             """)
         .doTest();
@@ -582,6 +586,52 @@ public class CustomLibraryModelsTests {
             class Test {
               LambdaBox<String> test() {
                 return LambdaModel.map(Test::returnsNullable);
+              }
+
+              LambdaBox<String> testExplicitTypeArgument() {
+                return LambdaModel.<String>map(Test::returnsNullable);
+              }
+
+              static @Nullable String returnsNullable(String unused) {
+                return null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nonGenericModeledMethodUsesModeledFunctionReturn() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaModel.java",
+            """
+            package com.uber.lib.unannotated;
+
+            import java.util.function.Function;
+
+            public class LambdaModel {
+              public static String apply(Function<String, String> mapper) {
+                return mapper.apply("");
+              }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.LambdaModel;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              void test() {
+                LambdaModel.apply(unused -> null);
+                LambdaModel.apply(Test::returnsNullable);
               }
 
               static @Nullable String returnsNullable(String unused) {

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -499,6 +499,100 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void lambdaReturnUsesNestedLibraryModelAnnotation() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaBox.java",
+            """
+            package com.uber.lib.unannotated;
+
+            public class LambdaBox<T> {}
+            """)
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaModel.java",
+            """
+            package com.uber.lib.unannotated;
+
+            import java.util.function.Function;
+
+            public class LambdaModel {
+              public static <U> LambdaBox<U> map(Function<String, ? extends U> mapper) {
+                return new LambdaBox<>();
+              }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.LambdaBox;
+            import com.uber.lib.unannotated.LambdaModel;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              LambdaBox<String> test() {
+                return LambdaModel.map(unused -> null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void methodReferenceReturnUsesNestedLibraryModelAnnotation() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaBox.java",
+            """
+            package com.uber.lib.unannotated;
+
+            public class LambdaBox<T> {}
+            """)
+        .addSourceLines(
+            "com/uber/lib/unannotated/LambdaModel.java",
+            """
+            package com.uber.lib.unannotated;
+
+            import java.util.function.Function;
+
+            public class LambdaModel {
+              public static <U> LambdaBox<U> map(Function<String, ? extends U> mapper) {
+                return new LambdaBox<>();
+              }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.LambdaBox;
+            import com.uber.lib.unannotated.LambdaModel;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Test {
+              LambdaBox<String> test() {
+                return LambdaModel.map(Test::returnsNullable);
+              }
+
+              static @Nullable String returnsNullable(String unused) {
+                return null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void suggestRemovingUnnecessaryCastToNonNullFromLibraryModel() {
     var testHelper =
         BugCheckerRefactoringTestHelper.newInstance(NullAway.class, getClass())

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -507,26 +507,6 @@ public class CustomLibraryModelsTests {
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
-            "com/uber/lib/unannotated/LambdaBox.java",
-            """
-            package com.uber.lib.unannotated;
-
-            public class LambdaBox<T> {}
-            """)
-        .addSourceLines(
-            "com/uber/lib/unannotated/LambdaModel.java",
-            """
-            package com.uber.lib.unannotated;
-
-            import java.util.function.Function;
-
-            public class LambdaModel {
-              public static <U> LambdaBox<U> map(Function<String, ? extends U> mapper) {
-                return new LambdaBox<>();
-              }
-            }
-            """)
-        .addSourceLines(
             "Test.java",
             """
             import com.uber.lib.unannotated.LambdaBox;
@@ -555,26 +535,6 @@ public class CustomLibraryModelsTests {
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
-        .addSourceLines(
-            "com/uber/lib/unannotated/LambdaBox.java",
-            """
-            package com.uber.lib.unannotated;
-
-            public class LambdaBox<T> {}
-            """)
-        .addSourceLines(
-            "com/uber/lib/unannotated/LambdaModel.java",
-            """
-            package com.uber.lib.unannotated;
-
-            import java.util.function.Function;
-
-            public class LambdaModel {
-              public static <U> LambdaBox<U> map(Function<String, ? extends U> mapper) {
-                return new LambdaBox<>();
-              }
-            }
-            """)
         .addSourceLines(
             "Test.java",
             """
@@ -609,19 +569,6 @@ public class CustomLibraryModelsTests {
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
         .addSourceLines(
-            "com/uber/lib/unannotated/LambdaModel.java",
-            """
-            package com.uber.lib.unannotated;
-
-            import java.util.function.Function;
-
-            public class LambdaModel {
-              public static String apply(Function<String, String> mapper) {
-                return mapper.apply("");
-              }
-            }
-            """)
-        .addSourceLines(
             "Test.java",
             """
             import com.uber.lib.unannotated.LambdaModel;
@@ -652,24 +599,6 @@ public class CustomLibraryModelsTests {
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-XepOpt:NullAway:OnlyNullMarked=true")))
-        .addSourceLines(
-            "com/uber/lib/unannotated/LambdaConsumer.java",
-            """
-            package com.uber.lib.unannotated;
-
-            public interface LambdaConsumer<T> {
-              void accept(T value);
-            }
-            """)
-        .addSourceLines(
-            "com/uber/lib/unannotated/LambdaModel.java",
-            """
-            package com.uber.lib.unannotated;
-
-            public class LambdaModel {
-              public static void consume(LambdaConsumer<? super String> consumer) {}
-            }
-            """)
         .addSourceLines(
             "Test.java",
             """

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -609,7 +609,7 @@ public class CustomLibraryModelsTests {
             class Test {
               void test() {
                 LambdaModel.consume(value -> {
-                  // BUG: Diagnostic contains: dereferenced expression value is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
                   value.length();
                 });
                 LambdaModel.consume(Test::acceptsNullable);


### PR DESCRIPTION
Consider:
```java
public class LambdaModel {
 public static String apply(Function<String, /* @Nullable */ String> mapper) {
    return mapper.apply("");
  }
}
void test() {
  LambdaModel.apply(unused -> null);
}
```
Here, the `@Nullable` annotation within the comment comes from a library model.  Accounting for the library model, the code is legal.  Before, we did not properly account for the library model, so we assumed the type of the `apply` parameter was `Function<String, String>`, and reported a false positive error on the lambda body.  This PR properly uses the library models so we don't get errors for cases like the above.

We also do minor fixes for cases where lambdas or method references passed as parameters are enclosed in parentheses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced handling of modeled lambda and method-reference arguments in generic calls, improving propagation of nested nullable annotations.

* **Bug Fixes**
  * Fixed nullability inference for lambda expressions and method references passed to generic methods, including scenarios where the argument is parenthesized.

* **Tests**
  * Added new JSpecify and library-model tests covering lambda/method-reference return nullability, explicit type-argument forms, and functional-interface lower-bound mismatch diagnostics.

* **Documentation**
  * Added new modeled library API test classes to support the updated coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->