### PR TITLE
Fix crash with library model @Nullable being applied to wildcard

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -2,7 +2,6 @@ package com.uber.nullaway.librarymodel;
 
 import static com.uber.nullaway.generics.TypeMetadataBuilder.TYPE_METADATA_BUILDER;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Type;
@@ -89,8 +88,12 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
 
   @Override
   public Type visitWildcardType(Type.WildcardType t, Integer pathIndex) {
-    Preconditions.checkArgument(
-        pathIndex != typePath.size(), "cannot apply an annotation directly to a wildcard type");
+    if (pathIndex == typePath.size()) {
+      // Nullness annotations directly on wildcards are not legal under JSpecify.  This case can
+      // arise when member-type substitution replaces an annotated type variable with a wildcard;
+      // leave the wildcard unchanged and rely on the dedicated top-level parameter/return model.
+      return t;
+    }
     NestedAnnotationInfo.TypePathEntry entry = typePath.get(pathIndex);
     if (entry.kind() != NestedAnnotationInfo.TypePathEntry.Kind.WILDCARD_BOUND) {
       return t;

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/Box.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/Box.java
@@ -1,0 +1,9 @@
+package com.uber.lib.unannotated;
+
+/* @NullMarked */
+public class Box<T> {
+
+  public /* @Nullable */ T orElse(/* @Nullable */ T other) {
+    return other;
+  }
+}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -52,7 +52,7 @@ public class TestLibraryModels implements LibraryModels {
             "com.uber.lib.unannotated.NullMarkedVarargsWithModel",
             "bothNullable(java.lang.String...)"),
         0,
-        methodRef("com.uber.Box", "orElse(T)"),
+        methodRef("com.uber.lib.unannotated.Box", "orElse(T)"),
         0);
   }
 
@@ -100,7 +100,7 @@ public class TestLibraryModels implements LibraryModels {
         methodRef("com.uber.AnnotatedWithModels", "returnsNullFromModel()"),
         methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated()"),
         methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated2()"),
-        methodRef("com.uber.Box", "orElse(T)"));
+        methodRef("com.uber.lib.unannotated.Box", "orElse(T)"));
   }
 
   @Override
@@ -322,7 +322,7 @@ public class TestLibraryModels implements LibraryModels {
                 new NestedAnnotationInfo(
                     Annotation.NONNULL, ImmutableList.of(new TypePathEntry(ARRAY_ELEMENT, -1)))))
         .put(
-            methodRef("com.uber.Box", "orElse(T)"),
+            methodRef("com.uber.lib.unannotated.Box", "orElse(T)"),
             ImmutableSetMultimap.of(
                 -1,
                 new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -318,6 +318,10 @@ public class TestLibraryModels implements LibraryModels {
                 0,
                 new NestedAnnotationInfo(
                     Annotation.NONNULL, ImmutableList.of(new TypePathEntry(ARRAY_ELEMENT, -1)))))
+        .put(
+            methodRef("com.uber.Box", "accept(T)"),
+            ImmutableSetMultimap.of(
+                0, new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
         .build();
   }
 }

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -51,6 +51,8 @@ public class TestLibraryModels implements LibraryModels {
         methodRef(
             "com.uber.lib.unannotated.NullMarkedVarargsWithModel",
             "bothNullable(java.lang.String...)"),
+        0,
+        methodRef("com.uber.Box", "orElse(T)"),
         0);
   }
 
@@ -97,7 +99,8 @@ public class TestLibraryModels implements LibraryModels {
     return ImmutableSet.of(
         methodRef("com.uber.AnnotatedWithModels", "returnsNullFromModel()"),
         methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated()"),
-        methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated2()"));
+        methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated2()"),
+        methodRef("com.uber.Box", "orElse(T)"));
   }
 
   @Override
@@ -319,9 +322,12 @@ public class TestLibraryModels implements LibraryModels {
                 new NestedAnnotationInfo(
                     Annotation.NONNULL, ImmutableList.of(new TypePathEntry(ARRAY_ELEMENT, -1)))))
         .put(
-            methodRef("com.uber.Box", "accept(T)"),
+            methodRef("com.uber.Box", "orElse(T)"),
             ImmutableSetMultimap.of(
-                0, new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
+                -1,
+                new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of()),
+                0,
+                new NestedAnnotationInfo(Annotation.NULLABLE, ImmutableList.of())))
         .build();
   }
 }

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -359,6 +359,35 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void topLevelAnnotationOnWildcardSubstitutedMethodType() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.*;
+
+            @NullMarked
+            class Box<T> {
+              void accept(T value) {}
+            }
+
+            @NullMarked
+            class Test {
+              void use(Box<?> box) {
+                box.accept(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void deeplyNestedTypeAnnot() {
     makeLibraryModelsTestHelperWithArgs(
             JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -376,6 +376,9 @@ public class CustomLibraryModelsTests {
             @NullMarked
             class Test {
               void use(Object source, Box<?> box) {
+                // We have a library model on the orElse method making its parameter and return type @Nullable.
+                // This test ensures we do not crash when we invoke orElse on a Box<?>; before we tried to create
+                // the invalid type `@Nullable ?` which led to an assertion failure
                 Object sourceToUse =
                     source instanceof Box<?> matched ? matched.orElse(null) : source;
                 // BUG: Diagnostic contains: dereferenced expression 'box.orElse(null)' is @Nullable

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -374,13 +374,18 @@ public class CustomLibraryModelsTests {
 
             @NullMarked
             class Box<T> {
-              void accept(T value) {}
+              T orElse(T other) {
+                return other;
+              }
             }
 
             @NullMarked
             class Test {
-              void use(Box<?> box) {
-                box.accept(null);
+              void use(Object source, Box<?> box) {
+                Object sourceToUse =
+                    source instanceof Box<?> matched ? matched.orElse(null) : source;
+                // BUG: Diagnostic contains: dereferenced expression box.orElse(null) is @Nullable
+                box.orElse(null).toString();
               }
             }
             """)

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -370,14 +370,8 @@ public class CustomLibraryModelsTests {
             "Test.java",
             """
             package com.uber;
+            import com.uber.lib.unannotated.Box;
             import org.jspecify.annotations.*;
-
-            @NullMarked
-            class Box<T> {
-              T orElse(T other) {
-                return other;
-              }
-            }
 
             @NullMarked
             class Test {

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -378,7 +378,7 @@ public class CustomLibraryModelsTests {
               void use(Object source, Box<?> box) {
                 Object sourceToUse =
                     source instanceof Box<?> matched ? matched.orElse(null) : source;
-                // BUG: Diagnostic contains: dereferenced expression box.orElse(null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'box.orElse(null)' is @Nullable
                 box.orElse(null).toString();
               }
             }


### PR DESCRIPTION
Observed when running #1613 on Spring Framework.  If have a class `Box<T>` with a method method `foo(T)` with a library model making it `foo(@Nullable T)`, and a call site invoking `foo` on a `Box<?>`, we could crash trying to put an invalid `@Nullable` on the wildcard.  Instead, we can just not substitute in the `@Nullable` annotation; our existing wildcard checking logic should handle the `@Nullable` on the formal correctly for this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling a modeled generic container method with nullable input and output behavior.
  * Expanded library modeling to better recognize nullable returns and nested nullability in more call patterns.

* **Bug Fixes**
  * Improved handling of wildcard-based method calls so they no longer fail when annotation details are exhausted; the original wildcard is now preserved.

* **Tests**
  * Added coverage for wildcard-substituted method calls to verify the expected nullability warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->