### PR TITLE
Quote syntax element references in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ static void log(@Nullable Object x) {
 ```
 With this annotation, NullAway points out the possible null dereference:
 ```
-warning: [NullAway] dereferenced expression x is @Nullable
+warning: [NullAway] dereferenced expression 'x' is @Nullable
     System.out.println(x.toString());
                         ^
 ```

--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -330,7 +330,7 @@ public class JDKIntegrationTest {
               static void testPositive() {
                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
                 ParameterAnnotation.takesNonNullGenericArray(null);
-                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericArray()
+                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericArray()' is @Nullable
                 ReturnAnnotation.returnNullableGenericArray().hashCode();
               }
               static void testNegative() {
@@ -358,7 +358,7 @@ public class JDKIntegrationTest {
             import com.uber.nullaway.jdkannotations.ReturnAnnotation;
             class Test {
               static void testPositive() {
-                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericContainingNullable()
+                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericContainingNullable()' is @Nullable
                 ReturnAnnotation.returnNullableGenericContainingNullable().hashCode();
               }
               static void testNegative() {

--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -330,7 +330,7 @@ public class JDKIntegrationTest {
               static void testPositive() {
                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
                 ParameterAnnotation.takesNonNullGenericArray(null);
-                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericArray()
+                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericArray()
                 ReturnAnnotation.returnNullableGenericArray().hashCode();
               }
               static void testNegative() {
@@ -358,7 +358,7 @@ public class JDKIntegrationTest {
             import com.uber.nullaway.jdkannotations.ReturnAnnotation;
             class Test {
               static void testPositive() {
-                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.returnNullableGenericContainingNullable()
+                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.returnNullableGenericContainingNullable()
                 ReturnAnnotation.returnNullableGenericContainingNullable().hashCode();
               }
               static void testNegative() {
@@ -500,7 +500,7 @@ public class JDKIntegrationTest {
             import java.util.List;
             class Test<T> {
               void testCall() {
-                // BUG: Diagnostic contains: dereferenced expression ReturnAnnotation.getList(6, null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'ReturnAnnotation.getList(6, null)' is @Nullable
                 ReturnAnnotation.getList(6, null).isEmpty();
               }
             }
@@ -528,7 +528,7 @@ public class JDKIntegrationTest {
             import java.util.List;
             class Test {
               void testCall() {
-                // BUG: Diagnostic contains: dereferenced expression ParameterAnnotation.nullableTypeParam(1, null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'ParameterAnnotation.nullableTypeParam(1, null)' is @Nullable
                 ParameterAnnotation.nullableTypeParam(1, null).toString();
                 ParameterAnnotation.nullableTypeParam(1, "string").toString();
                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
@@ -537,7 +537,7 @@ public class JDKIntegrationTest {
                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
                 ParameterAnnotation.nonNullTypeParam(null);
                 Object x = ParameterAnnotation.twoNullableTypeParam(null, "string");
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 x.toString();
               }
             }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
@@ -39,7 +39,7 @@ public class InstanceOfBindingTests {
                   s.toString();
                   o.toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression 'o
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.toString();
               }
             }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/InstanceOfBindingTests.java
@@ -39,7 +39,7 @@ public class InstanceOfBindingTests {
                   s.toString();
                   o.toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression o
+                // BUG: Diagnostic contains: dereferenced expression 'o
                 o.toString();
               }
             }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/ModuleInfoTests.java
@@ -68,7 +68,7 @@ public class ModuleInfoTests {
             public class Test {
               public static void main(String[] args) {
                 String s = null;
-                // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                 s.hashCode();
               }
             }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
@@ -58,7 +58,7 @@ public class RecordTests {
               public void testRecordConstructors() {
                 Rec rec = new Rec(new Object(), null);
                 rec.first().toString();
-                // BUG: Diagnostic contains: dereferenced expression 'rec.second()
+                // BUG: Diagnostic contains: dereferenced expression 'rec.second()' is @Nullable
                 rec.second().toString();
               }
             }
@@ -85,7 +85,7 @@ public class RecordTests {
                 }
                 void derefs() {
                   first().toString();
-                  // BUG: Diagnostic contains: dereferenced expression 'second()
+                  // BUG: Diagnostic contains: dereferenced expression 'second()' is @Nullable
                   second().toString();
                 }
               }
@@ -113,7 +113,7 @@ public class RecordTests {
                 }
                 void derefs() {
                   first.toString();
-                  // BUG: Diagnostic contains: dereferenced expression 'second
+                  // BUG: Diagnostic contains: dereferenced expression 'second' is @Nullable
                   second.toString();
                 }
               }
@@ -134,7 +134,7 @@ public class RecordTests {
               record Rec(Object first, @Nullable Object second) {
                 Rec {
                   first.toString();
-                  // BUG: Diagnostic contains: dereferenced expression 'second
+                  // BUG: Diagnostic contains: dereferenced expression 'second' is @Nullable
                   second.toString();
                 }
               }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/RecordTests.java
@@ -58,7 +58,7 @@ public class RecordTests {
               public void testRecordConstructors() {
                 Rec rec = new Rec(new Object(), null);
                 rec.first().toString();
-                // BUG: Diagnostic contains: dereferenced expression rec.second()
+                // BUG: Diagnostic contains: dereferenced expression 'rec.second()
                 rec.second().toString();
               }
             }
@@ -85,7 +85,7 @@ public class RecordTests {
                 }
                 void derefs() {
                   first().toString();
-                  // BUG: Diagnostic contains: dereferenced expression second()
+                  // BUG: Diagnostic contains: dereferenced expression 'second()
                   second().toString();
                 }
               }
@@ -113,7 +113,7 @@ public class RecordTests {
                 }
                 void derefs() {
                   first.toString();
-                  // BUG: Diagnostic contains: dereferenced expression second
+                  // BUG: Diagnostic contains: dereferenced expression 'second
                   second.toString();
                 }
               }
@@ -134,7 +134,7 @@ public class RecordTests {
               record Rec(Object first, @Nullable Object second) {
                 Rec {
                   first.toString();
-                  // BUG: Diagnostic contains: dereferenced expression second
+                  // BUG: Diagnostic contains: dereferenced expression 'second
                   second.toString();
                 }
               }

--- a/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
+++ b/jdk-recent-unit-tests/src/test/java/com/uber/nullaway/jdk17/SwitchTests.java
@@ -57,7 +57,7 @@ public class SwitchTests {
             class SwitchExpr {
               public void testSwitchExpressionAssign(int i) {
                 Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.toString();
                 Object o2 = switch (i) { case 3, 4, 5 -> new Object(); default -> "hello"; };
                 // This dereference is safe
@@ -77,7 +77,7 @@ public class SwitchTests {
             package com.uber;
             class SwitchExpr {
               public void testDirectlyDerefedSwitchExpr(int i) {
-                // BUG: Diagnostic contains: dereferenced expression (switch
+                // BUG: Diagnostic contains: dereferenced expression '(switch
                 (switch (i) { case 3, 4, 5 -> new Object(); default -> null; }).toString();
                 // This deference is safe
                 (switch (i) { case 3, 4, 5 -> new Object(); default -> "hello"; }).toString();
@@ -121,14 +121,14 @@ public class SwitchTests {
                   case 3, 4, 5 -> { o = new Object(); }
                   default -> { o = null; }
                 }
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.toString();
                 Object o2 = null;
                 switch (i) {
                   case 3, 4, 5 -> { o2 = null; }
                   default -> { o2 = new Object(); }
                 }
-                // BUG: Diagnostic contains: dereferenced expression o2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o2' is @Nullable
                 o2.toString();
                 Object o3 = null;
                 switch (i) {
@@ -153,7 +153,7 @@ public class SwitchTests {
             class SwitchExpr {
               public void testSwitchExprUnbox() {
                 Integer i = null;
-                // BUG: Diagnostic contains: switch selector expression i is @Nullable
+                // BUG: Diagnostic contains: switch selector expression 'i' is @Nullable
                 Object o = switch (i) { case 3, 4, 5 -> new Object(); default -> null; };
                 int j1 = 0;
                 // BUG: Diagnostic contains: unboxing of a @Nullable value
@@ -207,7 +207,7 @@ public class SwitchTests {
                 };
               }
               static Object handleNullableEnumNoCaseNull(@Nullable NullableEnum nullableEnum) {
-                // BUG: Diagnostic contains: switch selector expression nullableEnum is @Nullable
+                // BUG: Diagnostic contains: switch selector expression 'nullableEnum' is @Nullable
                 return switch (nullableEnum) {
                   case A -> new Object();
                   case B -> new Object();
@@ -234,7 +234,7 @@ public class SwitchTests {
               static Object testPositive1(@Nullable NullableEnum nullableEnum) {
                 return switch (nullableEnum) {
                   case A -> new Object();
-                  // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'nullableEnum' is @Nullable
                   case null -> nullableEnum.hashCode();
                   default -> nullableEnum.toString();
                 };
@@ -242,7 +242,7 @@ public class SwitchTests {
               static Object testPositive2(@Nullable NullableEnum nullableEnum) {
                 return switch (nullableEnum) {
                   case A -> new Object();
-                  // BUG: Diagnostic contains: dereferenced expression nullableEnum is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'nullableEnum' is @Nullable
                   case null, default -> nullableEnum.toString();
                 };
               }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorBuilder.java
@@ -469,9 +469,9 @@ public class ErrorBuilder {
     Element uninitField;
     if (uninitFields.size() == 1) {
       uninitField = uninitFields.iterator().next();
-      message.append("field ");
+      message.append("field '");
       message.append(uninitField.toString());
-      message.append(" (line ");
+      message.append("' (line ");
       message.append(getLineNumForElement(uninitField, state));
       message.append(") is initialized");
     } else {
@@ -480,7 +480,11 @@ public class ErrorBuilder {
       while (it.hasNext()) {
         uninitField = it.next();
         message.append(
-            uninitField.toString() + " (line " + getLineNumForElement(uninitField, state) + ")");
+            "'"
+                + uninitField.toString()
+                + "' (line "
+                + getLineNumForElement(uninitField, state)
+                + ")");
         if (it.hasNext()) {
           message.append(", ");
         } else {
@@ -514,7 +518,7 @@ public class ErrorBuilder {
       state.reportMatch(
           createErrorDescription(
               new ErrorMessage(
-                  FIELD_NO_INIT, "@NonNull static field " + fieldName + " not initialized"),
+                  FIELD_NO_INIT, "@NonNull static field '" + fieldName + "' not initialized"),
               tree,
               builder,
               state,
@@ -522,7 +526,7 @@ public class ErrorBuilder {
     } else {
       state.reportMatch(
           createErrorDescription(
-              new ErrorMessage(FIELD_NO_INIT, "@NonNull field " + fieldName + " not initialized"),
+              new ErrorMessage(FIELD_NO_INIT, "@NonNull field '" + fieldName + "' not initialized"),
               tree,
               builder,
               state,

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -733,9 +733,9 @@ public class NullAway extends BugChecker
     }
     if (!hasNullCaseLabel && mayBeNullExpr(state, switchSelectorExpression)) {
       String message =
-          "switch selector expression "
+          "switch selector expression '"
               + state.getSourceForNode(switchSelectorExpression)
-              + " is @Nullable";
+              + "' is @Nullable";
       ErrorMessage errorMessage =
           new ErrorMessage(MessageTypes.SWITCH_EXPRESSION_NULLABLE, message);
 
@@ -1443,7 +1443,7 @@ public class NullAway extends BugChecker
       ErrorMessage errorMessage =
           new ErrorMessage(
               MessageTypes.NONNULL_FIELD_READ_BEFORE_INIT,
-              "read of @NonNull field " + symbol + " before initialization");
+              "read of @NonNull field '" + symbol + "' before initialization");
       return errorBuilder.createErrorDescription(errorMessage, buildDescription(tree), state, null);
     } else {
       return Description.NO_MATCH;
@@ -1956,7 +1956,7 @@ public class NullAway extends BugChecker
     ErrorMessage errorMessage =
         new ErrorMessage(
             MessageTypes.DEREFERENCE_NULLABLE,
-            "enhanced-for expression " + state.getSourceForNode(expr) + " is @Nullable");
+            "enhanced-for expression '" + state.getSourceForNode(expr) + "' is @Nullable");
     if (mayBeNullExpr(state, expr)) {
       return errorBuilder.createErrorDescription(errorMessage, buildDescription(expr), state, null);
     }
@@ -2002,9 +2002,9 @@ public class NullAway extends BugChecker
       ErrorMessage errorMessage =
           new ErrorMessage(
               MessageTypes.DEREFERENCE_NULLABLE,
-              "synchronized block expression \""
+              "synchronized block expression '"
                   + state.getSourceForNode(lockExpr)
-                  + "\" is @Nullable");
+                  + "' is @Nullable");
       return errorBuilder.createErrorDescription(
           errorMessage, buildDescription(lockExpr), state, null);
     }
@@ -2915,7 +2915,7 @@ public class NullAway extends BugChecker
     }
     if (mayBeNullExpr(state, baseExpression)) {
       String message =
-          "dereferenced expression " + state.getSourceForNode(baseExpression) + " is @Nullable";
+          "dereferenced expression '" + state.getSourceForNode(baseExpression) + "' is @Nullable";
       ErrorMessage errorMessage = new ErrorMessage(MessageTypes.DEREFERENCE_NULLABLE, message);
 
       return errorBuilder.createErrorDescriptionForNullAssignment(

--- a/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
@@ -62,7 +62,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
             public class Test {
               public void testEnhancedFor(NullableContainer<String, NullableContainer<Integer, Object>> c) {
                 if (c.get("KEY_STR") != null && c.get("KEY_STR").get(0) != null) {
-                  // BUG: Diagnostic contains: dereferenced expression 'c.get("KEY_STR").get(42)
+                  // BUG: Diagnostic contains: dereferenced expression 'c.get("KEY_STR").get(42)' is @Nullable
                   c.get("KEY_STR").get(42).toString();
                 }
               }

--- a/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AccessPathsTests.java
@@ -62,7 +62,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
             public class Test {
               public void testEnhancedFor(NullableContainer<String, NullableContainer<Integer, Object>> c) {
                 if (c.get("KEY_STR") != null && c.get("KEY_STR").get(0) != null) {
-                  // BUG: Diagnostic contains: dereferenced expression c.get("KEY_STR").get(42)
+                  // BUG: Diagnostic contains: dereferenced expression 'c.get("KEY_STR").get(42)
                   c.get("KEY_STR").get(42).toString();
                 }
               }
@@ -129,7 +129,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
               private Integer intKey = 42; // No guarantee it's a constant
               public void testEnhancedFor(NullableContainer<String, NullableContainer<Integer, Object>> c) {
                 if (c.get("KEY_STR") != null && c.get("KEY_STR").get(this.intKey) != null) {
-                  // BUG: Diagnostic contains: dereferenced expression c.get("KEY_STR").get
+                  // BUG: Diagnostic contains: dereferenced expression 'c.get("KEY_STR").get
                   c.get("KEY_STR").get(this.intKey).toString();
                 }
               }
@@ -222,7 +222,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
                 if (foo.o == null) {
                   (new Foo()).o = new Object();
                 }
-                // BUG: Diagnostic contains: dereferenced expression foo.o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo.o' is @Nullable
                 return foo.o.toString();
               }
             }
@@ -309,7 +309,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
                 this.mutableFoo = foo;
               }
               public Predicate<String> testReadFinalFromLambdaNoCheck() {
-                // BUG: Diagnostic contains: dereferenced expression foo is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo' is @Nullable
                 return (s -> foo.toString().equals(s));
               }
               public Predicate<String> testReadFinalFromLambdaAfterCheck() {
@@ -319,7 +319,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
               }
               public Predicate<String> testReadMutableFromLambdaAfterCheck() {
                 Preconditions.checkNotNull(mutableFoo);
-                // BUG: Diagnostic contains: dereferenced expression mutableFoo is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'mutableFoo' is @Nullable
                 return (s -> mutableFoo.toString().equals(s));
               }
               public Function<String, Predicate<String>> testReadFinalFromLambdaAfterCheckDeepContext() {
@@ -337,21 +337,21 @@ public class AccessPathsTests extends NullAwayTestsBase {
               public Predicate<String> testReadFinalFromLambdaAfterCheckDeepAPIncomplete() {
                 Preconditions.checkNotNull(foo);
                 Preconditions.checkNotNull(foo.bar);
-                // BUG: Diagnostic contains: dereferenced expression foo.bar.foo is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo.bar.foo' is @Nullable
                 return (s -> foo.bar.foo.toString().equals(s));
               }
               public Predicate<String> testReadMutableFromLambdaAfterCheckDeepAP1() {
                 Preconditions.checkNotNull(foo);
                 Preconditions.checkNotNull(foo.mutableBar);
                 Preconditions.checkNotNull(foo.mutableBar.foo);
-                // BUG: Diagnostic contains: dereferenced expression foo.mutableBar is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo.mutableBar' is @Nullable
                 return (s -> foo.mutableBar.foo.toString().equals(s));
               }
               public Predicate<String> testReadMutableFromLambdaAfterCheckDeepAP2() {
                 Preconditions.checkNotNull(foo);
                 Preconditions.checkNotNull(foo.bar);
                 Preconditions.checkNotNull(foo.bar.mutableFoo);
-                // BUG: Diagnostic contains: dereferenced expression foo.bar.mutableFoo is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo.bar.mutableFoo' is @Nullable
                 return (s -> foo.bar.mutableFoo.toString().equals(s));
               }
               public boolean testReadFinalFromLambdaAfterCheckLocalClass(String s) {
@@ -368,7 +368,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
                    public Inner() { }
                    // At the time of declaring this, foo is not known to be non-null!
                    public boolean doTest(String s)  {
-                     // BUG: Diagnostic contains: dereferenced expression foo is @Nullable
+                     // BUG: Diagnostic contains: dereferenced expression 'foo' is @Nullable
                      return foo.toString().equals(s);
                    }
                 }
@@ -382,7 +382,7 @@ public class AccessPathsTests extends NullAwayTestsBase {
                 class Inner {
                    public Inner() { }
                    public boolean doTest(String s) {
-                     // BUG: Diagnostic contains: dereferenced expression mutableFoo is @Nullable
+                     // BUG: Diagnostic contains: dereferenced expression 'mutableFoo' is @Nullable
                      return mutableFoo.toString().equals(s);
                    }
                    public boolean doTestSafe(String s) {
@@ -403,13 +403,13 @@ public class AccessPathsTests extends NullAwayTestsBase {
                    @Nullable private Foo foo;
                    public Inner() { this.foo = null; }
                    public boolean doTest(String s)  {
-                     // BUG: Diagnostic contains: dereferenced expression foo is @Nullable
+                     // BUG: Diagnostic contains: dereferenced expression 'foo' is @Nullable
                      return foo.toString().equals(s);
                    }
                    public boolean doTestSafe(String s)  {
                      // TODO: Technically safe, but it would need recognizing Test.this.[...] as the same AP as
                      //       that from the closure.
-                     // BUG: Diagnostic contains: dereferenced expression Test.this.foo is @Nullable
+                     // BUG: Diagnostic contains: dereferenced expression 'Test.this.foo' is @Nullable
                      return Test.this.foo.toString().equals(s);
                    }
                 }
@@ -447,11 +447,11 @@ public class AccessPathsTests extends NullAwayTestsBase {
                 }
                 public void testPositive() {
                   if (Foo.this.bar != null) {
-                    // BUG: Diagnostic contains: dereferenced expression this.bar is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'this.bar' is @Nullable
                     this.bar.toString();
                   }
                   if (this.bar != null) {
-                    // BUG: Diagnostic contains: dereferenced expression Foo.this.bar is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'Foo.this.bar' is @Nullable
                     Foo.this.bar.toString();
                   }
                 }
@@ -459,14 +459,14 @@ public class AccessPathsTests extends NullAwayTestsBase {
               public void testUnhandled1() {
                 if (bar != null) {
                   // This is safe but we don't currently handle it
-                  // BUG: Diagnostic contains: dereferenced expression Foo.this.bar is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'Foo.this.bar' is @Nullable
                   Foo.this.bar.toString();
                 }
               }
               public void testUnhandled2() {
                 if (Foo.this.bar != null) {
                   // This is safe but we don't currently handle it
-                  // BUG: Diagnostic contains: dereferenced expression bar is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'bar' is @Nullable
                   bar.toString();
                 }
               }
@@ -506,11 +506,11 @@ public class AccessPathsTests extends NullAwayTestsBase {
               public void putThenGetFooValueOf() {
                 map.put(valueOf(10), new Object());
                 // Unknown valueOf method so we report a warning
-                // BUG: Diagnostic contains: dereferenced expression map.get(valueOf(10)) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'map.get(valueOf(10))' is @Nullable
                 map.get(valueOf(10)).toString();
                 map.put(valueOf(10,20), new Object());
                 // Unknown valueOf method so we report a warning
-                // BUG: Diagnostic contains: dereferenced expression map.get(valueOf(10,20)) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'map.get(valueOf(10,20))' is @Nullable
                 map.get(valueOf(10,20)).toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
@@ -275,7 +275,7 @@ public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
             public class Test {
               void foo() {
                 RestrictivelyAnnotatedFI func = (x) -> {
-                  // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                   x.toString();
                   return new Object();
                 };

--- a/nullaway/src/test/java/com/uber/nullaway/ArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ArrayTests.java
@@ -44,7 +44,7 @@ public class ArrayTests extends NullAwayTestsBase {
               static void foo() {
                   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                   o1 = fizz;
-                  // BUG: Diagnostic contains: dereferenced expression fizz is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'fizz' is @Nullable
                   o1 = fizz.length;
               }
             }
@@ -66,7 +66,7 @@ public class ArrayTests extends NullAwayTestsBase {
               static void foo() {
                   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                   o1 = fizz;
-                  // BUG: Diagnostic contains: dereferenced expression fizz is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'fizz' is @Nullable
                   o1 = fizz.length;
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/BytecodeInteractionsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/BytecodeInteractionsTests.java
@@ -51,7 +51,7 @@ public class BytecodeInteractionsTests extends NullAwayTestsBase {
             import com.uber.lib.*;
             class Test {
               void foo(CFNullableStuff c) {
-                // BUG: Diagnostic contains: dereferenced expression c.f
+                // BUG: Diagnostic contains: dereferenced expression 'c.f
                 c.f.toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/BytecodeInteractionsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/BytecodeInteractionsTests.java
@@ -51,7 +51,7 @@ public class BytecodeInteractionsTests extends NullAwayTestsBase {
             import com.uber.lib.*;
             class Test {
               void foo(CFNullableStuff c) {
-                // BUG: Diagnostic contains: dereferenced expression 'c.f
+                // BUG: Diagnostic contains: dereferenced expression 'c.f' is @Nullable
                 c.f.toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -297,17 +297,17 @@ public class CoreTests extends NullAwayTestsBase {
              HIGH, MEDIUM, LOW }
             class TestPositive {
                void foo(@Nullable Integer s) {
-                // BUG: Diagnostic contains: switch selector expression s is @Nullable
+                // BUG: Diagnostic contains: switch selector expression 's' is @Nullable
                 switch(s) {
                   case 5: break;
                 }
                 String x = null;
-                // BUG: Diagnostic contains: switch selector expression x is @Nullable
+                // BUG: Diagnostic contains: switch selector expression 'x' is @Nullable
                 switch(x) {
                   default: break;
                 }
                 Level level = null;
-                // BUG: Diagnostic contains: switch selector expression level is @Nullable
+                // BUG: Diagnostic contains: switch selector expression 'level' is @Nullable
                 switch (level) {
                   default: break; }
                 }
@@ -406,7 +406,7 @@ public class CoreTests extends NullAwayTestsBase {
             package com.uber;
             import javax.annotation.Nullable;
             class Test {
-              // BUG: Diagnostic contains: @NonNull static field o not initialized
+              // BUG: Diagnostic contains: @NonNull static field 'o' not initialized
               static Object o;
               Object f, g;
               public Test() {
@@ -472,7 +472,7 @@ public class CoreTests extends NullAwayTestsBase {
             class Test {
               Object f;
               private native void foo();
-              // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f
+              // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f'
               Test() {
                 foo();
               }
@@ -498,7 +498,7 @@ public class CoreTests extends NullAwayTestsBase {
             import java.util.List;
             public class Test {
               public void testEnhancedFor(@Nullable List<String> l) {
-                // BUG: Diagnostic contains: enhanced-for expression l is @Nullable
+                // BUG: Diagnostic contains: enhanced-for expression 'l' is @Nullable
                 for (String x: l) {}
               }
             }
@@ -567,9 +567,9 @@ public class CoreTests extends NullAwayTestsBase {
             public class Test {
               public void derefTernary(boolean b) {
                 Object o1 = null, o2 = new Object();
-                // BUG: Diagnostic contains: dereferenced expression (b ? o1 : o2) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression '(b ? o1 : o2)' is @Nullable
                 (b ? o1 : o2).toString();
-                // BUG: Diagnostic contains: dereferenced expression (b ? o2 : o1) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression '(b ? o2 : o1)' is @Nullable
                 (b ? o2 : o1).toString();
                 // This case is safe
                 (b ? o2 : o2).toString();
@@ -600,7 +600,7 @@ public class CoreTests extends NullAwayTestsBase {
                  return null; // No error, should detect @Null
                }
                String bar(@Null Object item){
-                 // BUG: Diagnostic contains: dereferenced expression item is @Nullable
+                 // BUG: Diagnostic contains: dereferenced expression 'item' is @Nullable
                  return item.toString();
                }
             }
@@ -1245,7 +1245,7 @@ public class CoreTests extends NullAwayTestsBase {
             import org.jspecify.annotations.Nullable;
             public class TestCase {
               public static void testPositive(@Nullable Object lock) {
-                // BUG: Diagnostic contains: synchronized block expression "lock" is @Nullable
+                // BUG: Diagnostic contains: synchronized block expression 'lock' is @Nullable
                 synchronized (lock) {}
               }
               public static void testNegative(Object lock) {
@@ -1288,7 +1288,7 @@ public class CoreTests extends NullAwayTestsBase {
                     return outer.new Inner() {};
                 }
                 static Inner testPositive(@Nullable Outer outer) {
-                    // BUG: Diagnostic contains: dereferenced expression outer is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'outer' is @Nullable
                     return outer.new Inner() {};
                 }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullIfTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullIfTests.java
@@ -82,7 +82,7 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
                 if(hasNullableItem()) {
                   nullableItem.call();
                 }
-                // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
                 return 0;
               }
@@ -218,9 +218,9 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
               }
               public int runOk() {
                 if(hasNullableItem() || hasNullableItem2()) {
-                  // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                   nullableItem.call();
-                  // BUG: Diagnostic contains: dereferenced expression nullableItem2 is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'nullableItem2' is @Nullable
                   nullableItem2.call();
                   return 1;
                 }
@@ -321,7 +321,7 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
                   return 1;
                 }
                 nullableItem.call();
-                // BUG: Diagnostic contains: dereferenced expression nullableItem2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem2' is @Nullable
                 nullableItem2.call();
                 return 0;
               }
@@ -565,9 +565,9 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
                 return nullableItem == null || nullableItem2 == null;
               }
               public int runOk() {
-                // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
-                // BUG: Diagnostic contains: dereferenced expression nullableItem2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem2' is @Nullable
                 nullableItem2.call();
                 return 0;
               }
@@ -852,7 +852,7 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
               }
               public void runOk() {
                 hasNullableItem();
-                // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
               }
             }
@@ -1002,7 +1002,7 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
                 if(hasNullableItem()) {
                   nullableItem.call();
                 }
-                // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
                 return 0;
               }

--- a/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullTests.java
@@ -19,7 +19,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               public void run() {
                 nullableItem.call();
                 nullableItem = null;
-                // BUG: Diagnostic contains: dereferenced expression nullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
 
               }
@@ -62,7 +62,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               @RequiresNonNull("this.nullableItem")
               // BUG: Diagnostic contains: Cannot refer to static field nullableItem using this.
               public static void test() {
-              // BUG: Diagnostic contains:  dereferenced expression nullableItem is @Nullable
+              // BUG: Diagnostic contains:  dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
               }
               @EnsuresNonNull("this.nullableItem")
@@ -73,7 +73,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               @RequiresNonNull("nullableItem2")
               // BUG: Diagnostic contains: For @RequiresNonNull annotation, cannot find instance field nullableItem2 in class Foo
               public static void test4() {
-              // BUG: Diagnostic contains:  dereferenced expression nullableItem is @Nullable
+              // BUG: Diagnostic contains:  dereferenced expression 'nullableItem' is @Nullable
                 nullableItem.call();
               }
               @EnsuresNonNull("nullableItem2")
@@ -129,11 +129,11 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               @Nullable Item b;
               public void test0() { }
               public void test1() {
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.call();
               }
               public void test2() {
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.call();
               }
               @RequiresNonNull("a")
@@ -143,7 +143,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               @RequiresNonNull("b")
               // BUG: Diagnostic contains: precondition inheritance is violated, method in child class cannot have a stricter precondition than its closest overridden method, adding @requiresNonNull for fields [a] makes this method precondition stricter
               public void test4() {
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.call();
                 b.call();
               }
@@ -410,7 +410,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
               public void run() {
                 staticNullableItem.call();
                 staticNullableItem = null;
-                // BUG: Diagnostic contains: dereferenced expression staticNullableItem is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'staticNullableItem' is @Nullable
                 staticNullableItem.call();
               }
 

--- a/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
@@ -33,7 +33,7 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
             import org.jspecify.annotations.NullMarked;
             @NullMarked
             class Marked {
-              // BUG: Diagnostic contains: @NonNull field uninit not initialized
+              // BUG: Diagnostic contains: @NonNull field 'uninit' not initialized
               Object uninit;
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -82,7 +82,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 Map<Integer, String> testPositive1() {
                   List<Foo> foos = new ArrayList<>();
                   return foos.stream()
-                      // BUG: Diagnostic contains: dereferenced expression foo.bar is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 'foo.bar' is @Nullable
                       .collect(Collectors.toMap(foo -> foo.bar.length(), foo -> foo.baz));
                 }
                 Map<Integer, String> testPositive2() {
@@ -90,7 +90,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                   return foos.stream()
                       .filter(foo -> foo.baz != null)
                       .collect(Collectors.toMap(
-                        // BUG: Diagnostic contains: dereferenced expression foo.bar is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 'foo.bar' is @Nullable
                         new Function<Foo,Integer>() { public Integer apply(Foo foo) { return foo.bar.length(); } },
                         foo -> foo.baz));
                 }
@@ -124,7 +124,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 Map<Integer, List<Foo>> testPositive() {
                   List<Foo> foos = new ArrayList<>();
                   return foos.stream()
-                      // BUG: Diagnostic contains: dereferenced expression foo.bar is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 'foo.bar' is @Nullable
                       .collect(Collectors.groupingBy(foo -> foo.bar.length()));
                 }
             }
@@ -158,7 +158,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 Map<Integer, String> testPositive() {
                   List<Foo> foos = new ArrayList<>();
                   return foos.stream()
-                      // BUG: Diagnostic contains: dereferenced expression foo.bar is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 'foo.bar' is @Nullable
                       .collect(ImmutableMap.toImmutableMap(foo -> foo.bar.length(), foo -> foo.baz));
                 }
             }
@@ -267,7 +267,7 @@ public class FrameworkTests extends NullAwayTestsBase {
               @Nullable
               Object nullable = new Object();
               public void setNullable(@Nullable Object nullable) {this.nullable = nullable;}
-              // BUG: Diagnostic contains: dereferenced expression nullable is @Nullable
+              // BUG: Diagnostic contains: dereferenced expression 'nullable' is @Nullable
               public void run() {System.out.println(nullable.toString());}
             }
             """)
@@ -280,7 +280,7 @@ public class FrameworkTests extends NullAwayTestsBase {
               @CheckForNull
               Object checkForNull = new Object();
               public void setCheckForNull(@CheckForNull Object checkForNull) {this.checkForNull = checkForNull;}
-              // BUG: Diagnostic contains: dereferenced expression checkForNull is @Nullable
+              // BUG: Diagnostic contains: dereferenced expression 'checkForNull' is @Nullable
               public void run() {System.out.println(checkForNull.toString());}
             }
             """)
@@ -318,7 +318,7 @@ public class FrameworkTests extends NullAwayTestsBase {
                 return o.orElse(null);
               }
               public void bar(Optional<Object> o) {
-                // BUG: Diagnostic contains: dereferenced expression o.orElse(null) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o.orElse(null)' is @Nullable
                 System.out.println(o.orElse(null).toString());
               }
             }
@@ -466,10 +466,10 @@ public class FrameworkTests extends NullAwayTestsBase {
             import org.springframework.beans.factory.annotation.Value;
             class PositiveCases {
               @Value("#{null}")
-              // BUG: Diagnostic contains: @NonNull field spelNullValue not initialized
+              // BUG: Diagnostic contains: @NonNull field 'spelNullValue' not initialized
               String spelNullValue;
               @Value("${missing:#{null}}")
-              // BUG: Diagnostic contains: @NonNull field placeholderWithNullDefault not initialized
+              // BUG: Diagnostic contains: @NonNull field 'placeholderWithNullDefault' not initialized
               String placeholderWithNullDefault;
             }
             """)
@@ -823,7 +823,7 @@ public class FrameworkTests extends NullAwayTestsBase {
             package com.uber;
             class Test {
               void foo() {
-                 // BUG: Diagnostic contains: dereferenced expression System.console()
+                 // BUG: Diagnostic contains: dereferenced expression 'System.console()
                 System.console().toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -823,7 +823,7 @@ public class FrameworkTests extends NullAwayTestsBase {
             package com.uber;
             class Test {
               void foo() {
-                 // BUG: Diagnostic contains: dereferenced expression 'System.console()
+                 // BUG: Diagnostic contains: dereferenced expression 'System.console()' is @Nullable
                 System.console().toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/GuavaAssertionsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/GuavaAssertionsTests.java
@@ -301,7 +301,7 @@ public class GuavaAssertionsTests extends NullAwayTestsBase {
             class Test {
               private void foo(@Nullable Object a) {
                 Preconditions.checkArgument(this.hashCode() != 5);
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.toString();
               }
             }
@@ -325,7 +325,7 @@ public class GuavaAssertionsTests extends NullAwayTestsBase {
             class Test {
               private void foo(@Nullable Object a) {
                 Preconditions.checkArgument(this.hashCode() != 5 || a != null);
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.toString();
               }
             }
@@ -351,7 +351,7 @@ public class GuavaAssertionsTests extends NullAwayTestsBase {
                 try {
                   Preconditions.checkArgument(a != null);
                 } catch (IllegalArgumentException e) {}
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.toString();
               }
             }
@@ -377,7 +377,7 @@ public class GuavaAssertionsTests extends NullAwayTestsBase {
                 try {
                   Preconditions.checkState(a != null);
                 } catch (IllegalStateException e) {}
-                // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                 a.toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
@@ -117,7 +117,7 @@ public class InitializationTests extends NullAwayTestsBase {
             """
             package com.uber;
             class Test2 {
-              // BUG: Diagnostic contains: @NonNull field f not initialized
+              // BUG: Diagnostic contains: @NonNull field 'f' not initialized
               Object f;
             // must be on a constructor!
               @ExternalInitConstructor

--- a/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
@@ -192,7 +192,7 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
               static class FieldExplicitAccessEntity {
                 @Access(AccessType.FIELD) Long idExplicitAccess;
                 // @Access annotation does not apply to this other field
-                // BUG: Diagnostic contains: @NonNull field JpaEntities$FieldExplicitAccessEntity.name not initialized
+                // BUG: Diagnostic contains: @NonNull field 'JpaEntities$FieldExplicitAccessEntity.name' not initialized
                 String name;
               }
             }
@@ -224,18 +224,18 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
             @Entity
             class JpaNonPersistentFields {
               @Id Long id;
-              // BUG: Diagnostic contains: @NonNull field javaTransient not initialized
+              // BUG: Diagnostic contains: @NonNull field 'javaTransient' not initialized
               transient String javaTransient;
               @jakarta.persistence.Transient
-              // BUG: Diagnostic contains: @NonNull field jakartaTransient not initialized
+              // BUG: Diagnostic contains: @NonNull field 'jakartaTransient' not initialized
               String jakartaTransient;
               @javax.persistence.Transient
-              // BUG: Diagnostic contains: @NonNull field javaxTransient not initialized
+              // BUG: Diagnostic contains: @NonNull field 'javaxTransient' not initialized
               String javaxTransient;
               @org.springframework.data.annotation.Transient
-              // BUG: Diagnostic contains: @NonNull field springDataTransient not initialized
+              // BUG: Diagnostic contains: @NonNull field 'springDataTransient' not initialized
               String springDataTransient;
-              // BUG: Diagnostic contains: @NonNull static field staticField not initialized
+              // BUG: Diagnostic contains: @NonNull static field 'staticField' not initialized
               static String staticField;
             }
             """)
@@ -246,7 +246,7 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
             import jakarta.persistence.Entity;
             @Entity
             class UnknownJpaAccess {
-              // BUG: Diagnostic contains: @NonNull field name not initialized
+              // BUG: Diagnostic contains: @NonNull field 'name' not initialized
               String name;
             }
             """)
@@ -269,9 +269,9 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
             class PropertyAccessEntity {
               Long id;
               String name;
-              // BUG: Diagnostic contains: @NonNull field helper not initialized
+              // BUG: Diagnostic contains: @NonNull field 'helper' not initialized
               String helper;
-              // BUG: Diagnostic contains: @NonNull field derived not initialized
+              // BUG: Diagnostic contains: @NonNull field 'derived' not initialized
               String derived;
               @Id
               public Long getId() {
@@ -377,7 +377,7 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
             import jakarta.persistence.Id;
             @Entity
             class Test {
-              // BUG: Diagnostic contains: @NonNull field id not initialized
+              // BUG: Diagnostic contains: @NonNull field 'id' not initialized
               Long id;
               @Id
               public static Long getId() {
@@ -405,7 +405,7 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
 
               public TestEntity() {}
 
-              // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field extraInfo
+              // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'extraInfo'
               public TestEntity(String name) {
                 this.name = name;
               }
@@ -463,7 +463,7 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
 
               @Initializer
               public void init() {
-                // BUG: Diagnostic contains: read of @NonNull field name before initialization
+                // BUG: Diagnostic contains: read of @NonNull field 'name' before initialization
                 name.toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/Java8Tests.java
@@ -46,11 +46,11 @@ public class Java8Tests extends NullAwayTestsBase {
               }
 
               static void testNullableParam() {
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 NullableParamFunction n = (x) -> x.toString();
                 // BUG: Diagnostic contains: parameter x is @NonNull, but parameter in functional interface
                 NullableParamFunction n2 = (Object x) -> x.toString();
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 NonNullParamFunction n3 = (@Nullable Object x) -> x.toString();
                 // BUG: Diagnostic contains: parameter x is @NonNull, but parameter in functional interface
                 NullableParamFunction n4 = (@Nonnull Object x) -> x.toString();
@@ -499,7 +499,7 @@ public class Java8Tests extends NullAwayTestsBase {
             import java.util.stream.Collectors;
             class Test {
               public static boolean testPositive(@Nullable String text, java.util.Set<String> s) {
-                // BUG: Diagnostic contains: dereferenced expression text is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'text' is @Nullable
                 return s.stream().anyMatch(text::contains);
               }
               public static String[] testNegative(Object[] arr) {

--- a/nullaway/src/test/java/com/uber/nullaway/KeySetIteratorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/KeySetIteratorTests.java
@@ -37,7 +37,7 @@ public class KeySetIteratorTests extends NullAwayTestsBase {
                 for (Object k: m.keySet()) {
                   m.get(k).toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression m.get(k) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'm.get(k)' is @Nullable
                 m.get(k).toString();
               }
             }
@@ -72,7 +72,7 @@ public class KeySetIteratorTests extends NullAwayTestsBase {
                 }
                 for (Object k: mw.getMF2(j).keySet()) {
                   // Report error since we cannot represent mw.getMF2(j).get(k) with an access path
-                  // BUG: Diagnostic contains: dereferenced expression mw.getMF2(j).get(k) is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'mw.getMF2(j).get(k)' is @Nullable
                   mw.getMF2(j).get(k).toString();
                 }
               }

--- a/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/LegacyVarargsTests.java
@@ -58,7 +58,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             import javax.annotation.Nullable;
             public class Utilities {
              public static String takesNullableVarargs(Object o, @Nullable Object... others) {
-              // BUG: Diagnostic contains: [NullAway] dereferenced expression others is @Nullable
+              // BUG: Diagnostic contains: [NullAway] dereferenced expression 'others' is @Nullable
               String s = o.toString() + " " + others.toString();
               return s;
              }
@@ -93,7 +93,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             import org.checkerframework.checker.nullness.qual.Nullable;
             public class Utilities {
              public static String takesNullableVarargs(Object o, @Nullable Object... others) {
-              // BUG: Diagnostic contains: [NullAway] dereferenced expression others is @Nullable
+              // BUG: Diagnostic contains: [NullAway] dereferenced expression 'others' is @Nullable
               String s = o.toString() + " " + others.toString();
               for (Object other : others) {
                 // no error since we do not reason about array element nullability
@@ -244,7 +244,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -281,7 +281,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -326,7 +326,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -369,7 +369,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -412,7 +412,7 @@ public class LegacyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }

--- a/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
@@ -58,7 +58,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @MonotonicNonNull Object f1;
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 'f1
+                  // BUG: Diagnostic contains: dereferenced expression 'f1' is @Nullable
                   f1.toString();
                 };
               }
@@ -85,7 +85,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @MonotonicNonNull Object f1;
               void testPositiveParam(Test t) {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 't.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1' is @Nullable
                   t.f1.toString();
                 };
               }
@@ -98,7 +98,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               void testPositiveLocal() {
                 Test t = new Test();
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 't.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1' is @Nullable
                   t.f1.toString();
                 };
               }
@@ -127,7 +127,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               static final Test t = new Test();
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 't.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1' is @Nullable
                   t.f1.toString();
                 };
               }
@@ -156,7 +156,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @Nullable static Object f2;
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 'f1
+                  // BUG: Diagnostic contains: dereferenced expression 'f1' is @Nullable
                   f1.toString();
                 };
               }
@@ -169,7 +169,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               void testPositive2() {
                 f2 = new Object();
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression 'f2
+                  // BUG: Diagnostic contains: dereferenced expression 'f2' is @Nullable
                   f2.toString();
                 };
               }
@@ -192,7 +192,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 Runnable r = new Runnable() {
                   @Override
                   public void run() {
-                    // BUG: Diagnostic contains: dereferenced expression 'f1
+                    // BUG: Diagnostic contains: dereferenced expression 'f1' is @Nullable
                     f1.toString();
                   }
                 };
@@ -231,7 +231,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 f2.x = new Object();
                 Runnable r = () -> {
                   // report a bug since f2 may be overwritten
-                  // BUG: Diagnostic contains: dereferenced expression 'f2.x
+                  // BUG: Diagnostic contains: dereferenced expression 'f2.x' is @Nullable
                   f2.x.toString();
                 };
               }
@@ -240,7 +240,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 f3.x = new Object();
                 Runnable r = () -> {
                   // report a bug since f3 may be overwritten
-                  // BUG: Diagnostic contains: dereferenced expression 'f3.x
+                  // BUG: Diagnostic contains: dereferenced expression 'f3.x' is @Nullable
                   f3.x.toString();
                 };
               }

--- a/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
@@ -58,7 +58,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @MonotonicNonNull Object f1;
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression f1
+                  // BUG: Diagnostic contains: dereferenced expression 'f1
                   f1.toString();
                 };
               }
@@ -85,7 +85,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @MonotonicNonNull Object f1;
               void testPositiveParam(Test t) {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression t.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1
                   t.f1.toString();
                 };
               }
@@ -98,7 +98,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               void testPositiveLocal() {
                 Test t = new Test();
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression t.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1
                   t.f1.toString();
                 };
               }
@@ -127,7 +127,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               static final Test t = new Test();
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression t.f1
+                  // BUG: Diagnostic contains: dereferenced expression 't.f1
                   t.f1.toString();
                 };
               }
@@ -156,7 +156,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               @Nullable static Object f2;
               void testPositive() {
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression f1
+                  // BUG: Diagnostic contains: dereferenced expression 'f1
                   f1.toString();
                 };
               }
@@ -169,7 +169,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
               void testPositive2() {
                 f2 = new Object();
                 Runnable r = () -> {
-                  // BUG: Diagnostic contains: dereferenced expression f2
+                  // BUG: Diagnostic contains: dereferenced expression 'f2
                   f2.toString();
                 };
               }
@@ -192,7 +192,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 Runnable r = new Runnable() {
                   @Override
                   public void run() {
-                    // BUG: Diagnostic contains: dereferenced expression f1
+                    // BUG: Diagnostic contains: dereferenced expression 'f1
                     f1.toString();
                   }
                 };
@@ -231,7 +231,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 f2.x = new Object();
                 Runnable r = () -> {
                   // report a bug since f2 may be overwritten
-                  // BUG: Diagnostic contains: dereferenced expression f2.x
+                  // BUG: Diagnostic contains: dereferenced expression 'f2.x
                   f2.x.toString();
                 };
               }
@@ -240,7 +240,7 @@ public class MonotonicNonNullTests extends NullAwayTestsBase {
                 f3.x = new Object();
                 Runnable r = () -> {
                   // report a bug since f3 may be overwritten
-                  // BUG: Diagnostic contains: dereferenced expression f3.x
+                  // BUG: Diagnostic contains: dereferenced expression 'f3.x
                   f3.x.toString();
                 };
               }

--- a/nullaway/src/test/java/com/uber/nullaway/OptionalEmptinessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/OptionalEmptinessTests.java
@@ -76,7 +76,7 @@ public class OptionalEmptinessTests extends NullAwayTestsBase {
               @SuppressWarnings("NullAway.Optional")
               void SupWarn() {
                 Object a = null;
-                  // BUG: Diagnostic contains: dereferenced expression a is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'a' is @Nullable
                   a.toString();
                 }
             }
@@ -657,7 +657,7 @@ public class OptionalEmptinessTests extends NullAwayTestsBase {
               }
               void baz(@Nullable Object o) {
                 // unrelated errors not suppressed
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.toString();
               }
               public static class Inner {

--- a/nullaway/src/test/java/com/uber/nullaway/PureExceptLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/PureExceptLambdaTests.java
@@ -82,7 +82,7 @@ public class PureExceptLambdaTests extends NullAwayTestsBase {
                   throw new IllegalArgumentException();
                 }
                 // Without nullness preserving annotation, we should not propagate the non-null fact into the lambda
-                // BUG: Diagnostic contains: dereferenced expression this.f is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'this.f' is @Nullable
                 OrdinaryLibrary.withConsumer("x", v -> System.out.println(this.f.toString()));
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -568,7 +568,7 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplay(
                 "METHOD_NO_INIT",
-                "initializer method does not guarantee @NonNull fields h (line 5), f (line 5) are initialized along all control-flow paths",
+                "initializer method does not guarantee @NonNull fields 'h' (line 5), 'f' (line 5) are initialized along all control-flow paths",
                 "com.uber.Test",
                 "Test(boolean)",
                 184,
@@ -581,7 +581,7 @@ public class SerializationTest extends NullAwayTestsBase {
                 "null"),
             new ErrorDisplay(
                 "METHOD_NO_INIT",
-                "initializer method does not guarantee @NonNull fields g (line 5), i (line 5) are initialized along all control-flow paths",
+                "initializer method does not guarantee @NonNull fields 'g' (line 5), 'i' (line 5) are initialized along all control-flow paths",
                 "com.uber.Test",
                 "Test(boolean,boolean)",
                 425,
@@ -613,17 +613,17 @@ public class SerializationTest extends NullAwayTestsBase {
             """
             package com.uber;
             public class Test {
-               // BUG: Diagnostic contains: field f not initialized
+               // BUG: Diagnostic contains: field 'f' not initialized
                Object f;
             }
             """)
         .setExpectedOutputs(
             new ErrorDisplay(
                 "FIELD_NO_INIT",
-                "field f not initialized",
+                "field 'f' not initialized",
                 "com.uber.Test",
                 "f",
-                97,
+                99,
                 "com/uber/android/Test.java",
                 "FIELD",
                 "com.uber.Test",
@@ -654,7 +654,7 @@ public class SerializationTest extends NullAwayTestsBase {
             import javax.annotation.Nullable;
             public class Super {
                Object foo;
-               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field foo
+               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'foo'
                Super(boolean b) {
                }
                String test(@Nullable Object o) {
@@ -694,17 +694,17 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplay(
                 "METHOD_NO_INIT",
-                "initializer method does not guarantee @NonNull field foo",
+                "initializer method does not guarantee @NonNull field 'foo'",
                 "com.uber.Super",
                 "Super(boolean)",
-                180,
+                182,
                 "com/uber/Super.java"),
             new ErrorDisplay(
                 "ASSIGN_FIELD_NULLABLE",
                 "assigning @Nullable expression to @NonNull field",
                 "com.uber.Super",
                 "test(java.lang.Object)",
-                323,
+                325,
                 "com/uber/Super.java",
                 "FIELD",
                 "com.uber.Super",
@@ -714,17 +714,17 @@ public class SerializationTest extends NullAwayTestsBase {
                 "com/uber/Super.java"),
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression o is @Nullable",
+                "dereferenced expression 'o' is @Nullable",
                 "com.uber.Super",
                 "test(java.lang.Object)",
-                430,
+                432,
                 "com/uber/Super.java"),
             new ErrorDisplay(
                 "RETURN_NULLABLE",
                 "returning @Nullable expression from method",
                 "com.uber.Super",
                 "test(java.lang.Object)",
-                521,
+                523,
                 "com/uber/Super.java",
                 "METHOD",
                 "com.uber.Super",
@@ -856,7 +856,7 @@ public class SerializationTest extends NullAwayTestsBase {
                Object foo;
                Object bar;
                @Nullable Object nullableFoo;
-               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field foo
+               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'foo'
                Test() {
                    // We are not tracing initializations in constructors.
                    bar = new Object();
@@ -1362,7 +1362,7 @@ public class SerializationTest extends NullAwayTestsBase {
             public class Main {
                public void run(){
                  Foo foo = new Foo() {
-                   // BUG: Diagnostic contains: @NonNull field Main$1.bar not initialized
+                   // BUG: Diagnostic contains: @NonNull field 'Main$1.bar' not initialized
                    Object bar;
                  };
                }
@@ -1371,10 +1371,10 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplay(
                 "FIELD_NO_INIT",
-                "@NonNull field Main$1.bar not initialized",
+                "@NonNull field 'Main$1.bar' not initialized",
                 "com.uber.Main$1",
                 "bar",
-                206,
+                208,
                 "com/uber/Main.java",
                 "FIELD",
                 "com.uber.Main$1",
@@ -1406,7 +1406,7 @@ public class SerializationTest extends NullAwayTestsBase {
             public class Main {
                public void run(){
                  class Foo {
-                   // BUG: Diagnostic contains: @NonNull field Main$1Foo.bar not initialized
+                   // BUG: Diagnostic contains: @NonNull field 'Main$1Foo.bar' not initialized
                    Object bar;
                  };
                }
@@ -1415,10 +1415,10 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplay(
                 "FIELD_NO_INIT",
-                "@NonNull field Main$1Foo.bar not initialized",
+                "@NonNull field 'Main$1Foo.bar' not initialized",
                 "com.uber.Main$1Foo",
                 "bar",
-                199,
+                201,
                 "com/uber/Main.java",
                 "FIELD",
                 "com.uber.Main$1Foo",
@@ -1683,11 +1683,11 @@ public class SerializationTest extends NullAwayTestsBase {
                @Nullable B b2 = null;
                // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                Object baz1 = b1.foo;
-               // BUG: Diagnostic contains: dereferenced expression b2 is @Nullable
+               // BUG: Diagnostic contains: dereferenced expression 'b2' is @Nullable
                Object baz2 = b2.foo;
                // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                Object baz3 = b1.nonnullC.val;
-               // BUG: Diagnostic contains: dereferenced expression b1.nullableC is @Nullable
+               // BUG: Diagnostic contains: dereferenced expression 'b1.nullableC' is @Nullable
                @Nullable Object baz4 = b1.nullableC.val;
             }
             class B {
@@ -1718,7 +1718,7 @@ public class SerializationTest extends NullAwayTestsBase {
                 "assigning @Nullable expression to @NonNull field",
                 "com.uber.A",
                 "baz2",
-                295,
+                297,
                 "com/uber/A.java",
                 "FIELD",
                 "com.uber.A",
@@ -1731,7 +1731,7 @@ public class SerializationTest extends NullAwayTestsBase {
                 "assigning @Nullable expression to @NonNull field",
                 "com.uber.A",
                 "baz3",
-                401,
+                403,
                 "com/uber/A.java",
                 "FIELD",
                 "com.uber.A",
@@ -1741,17 +1741,17 @@ public class SerializationTest extends NullAwayTestsBase {
                 "com/uber/A.java"),
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression b2 is @Nullable",
+                "dereferenced expression 'b2' is @Nullable",
                 "com.uber.A",
                 "baz2",
-                309,
+                311,
                 "com/uber/A.java"),
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression b1.nullableC is @Nullable",
+                "dereferenced expression 'b1.nullableC' is @Nullable",
                 "com.uber.A",
                 "baz4",
-                541,
+                545,
                 "com/uber/A.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
@@ -1789,7 +1789,7 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression f is @Nullable",
+                "dereferenced expression 'f' is @Nullable",
                 "com.uber.A",
                 "A(java.lang.Object)",
                 194,
@@ -1835,7 +1835,7 @@ public class SerializationTest extends NullAwayTestsBase {
                   class Foo {
                       // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                       Object baz1 = other1.foo;
-                      // BUG: Diagnostic contains: dereferenced expression other2 is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 'other2' is @Nullable
                       Object baz2 = other2.foo;
                   }
                }
@@ -1863,7 +1863,7 @@ public class SerializationTest extends NullAwayTestsBase {
                 "assigning @Nullable expression to @NonNull field",
                 "com.uber.A$1Foo",
                 "baz2",
-                391,
+                393,
                 "com/uber/A.java",
                 "FIELD",
                 "com.uber.A$1Foo",
@@ -1873,10 +1873,10 @@ public class SerializationTest extends NullAwayTestsBase {
                 "com/uber/A.java"),
             new ErrorDisplay(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression other2 is @Nullable",
+                "dereferenced expression 'other2' is @Nullable",
                 "com.uber.A$1Foo",
                 "baz2",
-                405,
+                407,
                 "com/uber/A.java"))
         .setFactory(errorDisplayFactory)
         .setOutputFileNameAndHeader(ERROR_FILE_NAME, ERROR_FILE_HEADER)
@@ -1902,7 +1902,7 @@ public class SerializationTest extends NullAwayTestsBase {
             import javax.annotation.Nullable;
             public class Super {
                Object foo;
-               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field foo
+               // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'foo'
                Super(boolean b) {
                }
                String test(@Nullable Object o) {
@@ -1942,7 +1942,7 @@ public class SerializationTest extends NullAwayTestsBase {
         .setExpectedOutputs(
             new ErrorDisplayV1(
                 "METHOD_NO_INIT",
-                "initializer method does not guarantee @NonNull field foo",
+                "initializer method does not guarantee @NonNull field 'foo'",
                 "com.uber.Super",
                 "Super(boolean)"),
             new ErrorDisplayV1(
@@ -1958,7 +1958,7 @@ public class SerializationTest extends NullAwayTestsBase {
                 "com/uber/Super.java"),
             new ErrorDisplayV1(
                 "DEREFERENCE_NULLABLE",
-                "dereferenced expression o is @Nullable",
+                "dereferenced expression 'o' is @Nullable",
                 "com.uber.Super",
                 "test(java.lang.Object)"),
             new ErrorDisplayV1(

--- a/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SuppressionTests.java
@@ -29,7 +29,7 @@ public class SuppressionTests extends NullAwayTestsBase {
               }
               @SuppressWarnings("Baz")
               void baz(@Nullable Object o) {
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.getClass();
               }
             }
@@ -247,7 +247,7 @@ public class SuppressionTests extends NullAwayTestsBase {
                 f.next.next.hashCode();
                 f.next.next.next.hashCode();
                 // one too many
-                // BUG: Diagnostic contains: dereferenced expression f.next.next.next.next is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f.next.next.next.next' is @Nullable
                 f.next.next.next.next.hashCode();
               }
 
@@ -258,7 +258,7 @@ public class SuppressionTests extends NullAwayTestsBase {
                 f.getNext().getNext().hashCode();
                 f.getNext().getNext().getNext().hashCode();
                 // one too many
-                // BUG: Diagnostic contains: dereferenced expression f.getNext().getNext().getNext().getNext() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f.getNext().getNext().getNext().getNext()' is @Nullable
                 f.getNext().getNext().getNext().getNext().hashCode();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/SyncLambdasTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SyncLambdasTests.java
@@ -87,7 +87,7 @@ public class SyncLambdasTests extends NullAwayTestsBase {
                     this.resolved = new Object();
                     this.target.forEach((key, value) -> {
                         // error since this is a custom type, not inheriting from java.util.Map
-                        // BUG: Diagnostic contains: dereferenced expression this.resolved is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 'this.resolved' is @Nullable
                         System.out.println(this.resolved.toString());
                     });
                 }
@@ -117,7 +117,7 @@ public class SyncLambdasTests extends NullAwayTestsBase {
                     Iterable<Object> l2 = l;
                     l2.forEach(v -> System.out.println(v + this.f.toString()));
                     this.f = null;
-                    // BUG: Diagnostic contains: dereferenced expression this.f is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'this.f' is @Nullable
                     l2.forEach(v -> System.out.println(v + this.f.toString()));
                 }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
@@ -41,7 +41,7 @@ public class ThriftTests extends NullAwayTestsBase {
               }
               public void testPos(Generated g) {
                 if (!g.isSetId()) {
-                  // BUG: Diagnostic contains: dereferenced expression g.getId() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'g.getId()' is @Nullable
                   g.getId().hashCode();
                 } else {
                   g.id.toString();

--- a/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
@@ -134,7 +134,7 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
             class Test {
               Test.@Nullable Foo f1;
               // @Nullable does not apply to the inner type
-              // BUG: Diagnostic contains: @NonNull field f2 not initialized
+              // BUG: Diagnostic contains: @NonNull field 'f2' not initialized
               @Nullable Test.Foo f2;
               class Foo { }
               public void test() {
@@ -167,7 +167,7 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
             class Test {
                  Bar.@Nullable Foo f1;
                  // @Nullable does not apply to the inner type
-                 // BUG: Diagnostic contains: @NonNull field f2 not initialized
+                 // BUG: Diagnostic contains: @NonNull field 'f2' not initialized
                  @Nullable Bar.Foo f2;
                  public void test() {
                     // BUG: Diagnostic contains: dereferenced
@@ -189,7 +189,7 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
             import java.util.Set;
             import org.checkerframework.checker.nullness.qual.Nullable;
             class Test {
-              // BUG: Diagnostic contains: @NonNull field s not initialized
+              // BUG: Diagnostic contains: @NonNull field 's' not initialized
               Set<@Nullable Foo> s; // i.e. Set<Test.@Nullable Foo>
               class Foo { }
               public void test() {
@@ -394,7 +394,7 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
                 };
               }
               public static String test1() {
-                // BUG: Diagnostic contains: dereferenced expression getNullableSupplierOfNullable() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'getNullableSupplierOfNullable()' is @Nullable
                 return getNullableSupplierOfNullable().toString();
               }
               public static String test2() {

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -126,7 +126,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 }
               }
               static void bar() {
-                // BUG: Diagnostic contains: dereferenced expression Inner.foo()
+                // BUG: Diagnostic contains: dereferenced expression 'Inner.foo()
                 Inner.foo().toString();
               }
             }
@@ -267,7 +267,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 UnAnnot.retNull().toString();
                 // make sure other classes in the package still get analyzed
                 Object x = nullRetSameClass();
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 x.hashCode();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -126,7 +126,7 @@ public class UnannotatedTests extends NullAwayTestsBase {
                 }
               }
               static void bar() {
-                // BUG: Diagnostic contains: dereferenced expression 'Inner.foo()
+                // BUG: Diagnostic contains: dereferenced expression 'Inner.foo()' is @Nullable
                 Inner.foo().toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/VarargsTests.java
@@ -306,7 +306,7 @@ public class VarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -345,7 +345,7 @@ public class VarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -390,7 +390,7 @@ public class VarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -479,7 +479,7 @@ public class VarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -28,7 +28,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
               void test(Foo<String> foo) {
                 foo.doSomething(
                     t -> {
-                      // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                       return "length: " + t.length();
                     });
               }
@@ -53,7 +53,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
                 @Nullable Function<@Nullable T, T> field;
                 void assignField(Box<String> box) {
                   box.field = t -> {
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.length();
                     return t;
                   };
@@ -61,7 +61,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
                 void assignLocal() {
                   Function<@Nullable T, T> local =
                       t -> {
-                        // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                         t.length();
                         return t;
                       };
@@ -87,7 +87,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
               static class Box<T extends @Nullable CharSequence> {
                 Function<@Nullable T, T> make() {
                   return t -> {
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.length();
                     return t;
                   };

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -32,31 +32,31 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                     Object y = invokeWithReturn(() -> { return genericMethod(null);});
                     // legal, should infer x is a @NonNull String
                     x.hashCode();
-                    // BUG: Diagnostic contains: dereferenced expression y is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'y' is @Nullable
                     y.hashCode();
                     // Block-bodied with parenthesized return
                     Object x_block_paren = invokeWithReturn(() -> { return (genericMethod("value"));});
                     Object y_block_paren = invokeWithReturn(() -> { return (genericMethod(null));});
                     // legal, should infer x_block_paren is a @NonNull String
                     x_block_paren.hashCode();
-                    // BUG: Diagnostic contains: dereferenced expression y_block_paren is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'y_block_paren' is @Nullable
                     y_block_paren.hashCode();
                     // Expression-bodied
                     Object x_expr = invokeWithReturn(() -> genericMethod("value"));
                     Object y_expr = invokeWithReturn(() -> genericMethod(null));
                     // legal, should infer x_expr is a @NonNull String
                     x_expr.hashCode();
-                    // BUG: Diagnostic contains: dereferenced expression y_expr is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'y_expr' is @Nullable
                     y_expr.hashCode();
                     // Expression-bodied with parenthesized return
                     Object x_expr_paren = invokeWithReturn(() -> (genericMethod("value")));
                     Object y_expr_paren = invokeWithReturn(() -> (genericMethod(null)));
                     // legal, should infer x_expr_paren is a @NonNull String
                     x_expr_paren.hashCode();
-                    // BUG: Diagnostic contains: dereferenced expression y_expr_paren is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'y_expr_paren' is @Nullable
                     y_expr_paren.hashCode();
                     Object x2 = invokeWithReturn(() ->{ Object y2 = null; return y2;});
-                    // BUG: Diagnostic contains: dereferenced expression x2 is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'x2' is @Nullable
                     x2.hashCode();
                 }
             }
@@ -113,7 +113,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                     invoke(() -> null);
                     // legal, should infer R -> @Nullable Object
                     Object x = invokeWithReturn(() -> null);
-                    // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                     x.hashCode();
                 }
             }
@@ -136,7 +136,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
               }
               static void test() {
                 String t = run(s -> s == null ? null : s);
-                // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                 t.hashCode();
               }
             }
@@ -159,7 +159,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
               }
               static void test() {
                 String t = run(s -> { String result = null; return result; });
-                // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                 t.hashCode();
               }
             }
@@ -183,7 +183,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
               static void test() {
                 final String result = null;
                 String t = run(s -> result);
-                // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                 t.hashCode();
               }
             }
@@ -211,7 +211,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                 // Since f is not final, we won't propagate facts about it into the lambda
                 // So, we should infer T -> @Nullable String
                 String t = run(s -> x.f);
-                // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                 t.hashCode();
               }
             }
@@ -407,7 +407,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                 String s1 = create(Foo::create);
                 s1.hashCode(); // should be legal
                 String s2 = create(Foo::createNullable);
-                // BUG: Diagnostic contains: dereferenced expression s2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's2' is @Nullable
                 s2.hashCode();
                 // BUG: Diagnostic contains: parameter of functional interface method java.util.function.Function.apply(T) is @Nullable
                 String s3 = createWithNullable(Foo::create);
@@ -443,7 +443,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                 String s1 = create(Foo::get);
                 s1.hashCode(); // should be legal
                 String s2 = create(Foo::getNullable);
-                // BUG: Diagnostic contains: dereferenced expression s2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's2' is @Nullable
                 s2.hashCode();
               }
             }
@@ -476,7 +476,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
               }
               void test() {
                 String s = createBoth(Foo::get, Foo::getNullable);
-                // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                 s.hashCode();
               }
             }
@@ -587,12 +587,12 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                 String s1 = create(foo::make);
                 s1.hashCode(); // should be legal
                 String s2 = create(fooNullable::make);
-                // BUG: Diagnostic contains: dereferenced expression s2 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's2' is @Nullable
                 s2.hashCode();
                 // this is ok; we can infer V -> @Nullable String; foo::make returns a @NonNull String,
                 // which is compatible
                 String s3 = createMulti(foo::make, fooNullable::make);
-                // BUG: Diagnostic contains: dereferenced expression s3 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's3' is @Nullable
                 s3.hashCode();
               }
             }
@@ -1055,7 +1055,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
                 }
                 static void test(List<String> list) {
                     list.stream().map(Test::mapToNull).forEach(s -> {
-                        // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                         s.hashCode();
                     });
                 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -511,7 +511,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                     this.<String>foo(f);
                 }
                 void testPositive2(Function<@Nullable String, @Nullable String> f) {
-                    // BUG: Diagnostic contains: dereferenced expression this.<String>foo(f) is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'this.<String>foo(f)' is @Nullable
                     this.<String>foo(f).hashCode();
                 }
             }
@@ -810,14 +810,14 @@ public class GenericMethodTests extends NullAwayTestsBase {
               static void use() {
                 // should infer T -> @Nullable String
                 String result = firstOrDefault(Collections.singletonList(null), "hello");
-                // BUG: Diagnostic contains: dereferenced expression result is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'result' is @Nullable
                 result.hashCode();
                 // should infer T -> @NonNull String
                 String result2 = firstOrDefault(Collections.singletonList("bye"), "hello");
                 result2.hashCode();
                 // should infer T -> @Nullable String (testing that inference is called from dataflow)
                 String result3 = firstOrDefault(Collections.singletonList(null), "hello");
-                // BUG: Diagnostic contains: dereferenced expression result3 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'result3' is @Nullable
                 result3.hashCode();
               }
             }
@@ -847,7 +847,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 String x = null;
                 // should infer T -> @Nullable String
                 String result = firstOrDefault(Collections.singletonList(x), "hello");
-                // BUG: Diagnostic contains: dereferenced expression result is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'result' is @Nullable
                 result.hashCode();
               }
             }
@@ -871,7 +871,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 void testPositive() {
                     String s = null;
                     String t = id(s);
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.hashCode();
                 }
                 void testNegative() {
@@ -889,7 +889,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 void testField2() {
                     String s = null;
                     field2 = id(s);
-                    // BUG: Diagnostic contains: dereferenced expression field2 is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'field2' is @Nullable
                     field2.hashCode();
                     s = "hello";
                     field2 = id(s);
@@ -940,7 +940,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                     String s = "hello";
                     while (true) {
                         String t = id(s);
-                        // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                         t.hashCode();
                         s = null;
                     }
@@ -948,7 +948,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 void testLoop2() {
                     String t = "hello";
                     while (true) {
-                        // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                         t.hashCode();
                         String s = null;
                         t = id(s);
@@ -964,7 +964,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                         s = null;
                         i--;
                     }
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.hashCode();
                 }
             }
@@ -988,7 +988,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 @Nullable String field;
                 void testPositive() {
                     String t = id(field);
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.hashCode();
                 }
                 void testNegative() {
@@ -1001,7 +1001,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                     String s = "hello";
                     // dataflow can't prove the argument is non-null
                     String t = id(s == null ? null : s);
-                    // BUG: Diagnostic contains: dereferenced expression t is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 't' is @Nullable
                     t.hashCode();
                 }
             }
@@ -1154,7 +1154,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 // legal, should infer T -> @Nullable String
                 // we can pass String[] due to covariant subtyping
                 String s1 = f(arr, null);
-                // BUG: Diagnostic contains: dereferenced expression s1 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 's1' is @Nullable
                 s1.hashCode();
                 String s2 = f(arr, "hi");
                 // legal
@@ -1325,7 +1325,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 // to ensure that dataflow runs
                 Object x = new Object(); x.toString();
                 Object y = null;
-                // BUG: Diagnostic contains: dereferenced expression id(y) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'id(y)' is @Nullable
                 id(y).toString();
               }
               static Object testReturn() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -656,7 +656,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 return o.toString();
               }
               static void testPositive() {
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 A<@Nullable Object> p = x -> x.toString();
               }
               static void testNegative() {
@@ -788,7 +788,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 String function(T1 o);
               }
               static void testPositive() {
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 A<@Nullable Object> p = o -> o.toString();
               }
               static void testNegative() {
@@ -812,7 +812,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 String function(T1 o1,T2 o2);
               }
               static void testPositive() {
-                // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o1' is @Nullable
                 A<@Nullable Object,Object> p = (o1,o2) -> o1.toString();
               }
               static void testNegative() {
@@ -1698,12 +1698,12 @@ public class GenericsTests extends NullAwayTestsBase {
                 String s1 = (new Fn<String, @Nullable String>() {
                   public @Nullable String apply(String s) { return null; }
                 }).apply("hi");
-                // BUG: Diagnostic contains: dereferenced expression s1
+                // BUG: Diagnostic contains: dereferenced expression 's1
                 s1.hashCode();
                 String s2 = (new FnClass<String, @Nullable String>() {
                   public @Nullable String apply(String s) { return null; }
                 }).apply("hi");
-                // BUG: Diagnostic contains: dereferenced expression s2
+                // BUG: Diagnostic contains: dereferenced expression 's2
                 s2.hashCode();
                 (new Fn<String, String>() {
                   public String apply(String s) { return "hi"; }
@@ -1907,9 +1907,9 @@ public class GenericsTests extends NullAwayTestsBase {
                 // No error due to @Contract
                 (new TestFunc1()).apply("hello").hashCode();
                 Fn1<@Nullable String, @Nullable String> fn1 = new TestFunc1();
-                // BUG: Diagnostic contains: dereferenced expression fn1.apply("hello")
+                // BUG: Diagnostic contains: dereferenced expression 'fn1.apply("hello")
                 fn1.apply("hello").hashCode();
-                // BUG: Diagnostic contains: dereferenced expression (new TestFunc2())
+                // BUG: Diagnostic contains: dereferenced expression '(new TestFunc2())
                 (new TestFunc2()).apply("hello").hashCode();
                 Fn2<@Nullable String, @Nullable String> fn2 = new TestFunc2();
                 // No error due to @Contract

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1698,12 +1698,12 @@ public class GenericsTests extends NullAwayTestsBase {
                 String s1 = (new Fn<String, @Nullable String>() {
                   public @Nullable String apply(String s) { return null; }
                 }).apply("hi");
-                // BUG: Diagnostic contains: dereferenced expression 's1
+                // BUG: Diagnostic contains: dereferenced expression 's1' is @Nullable
                 s1.hashCode();
                 String s2 = (new FnClass<String, @Nullable String>() {
                   public @Nullable String apply(String s) { return null; }
                 }).apply("hi");
-                // BUG: Diagnostic contains: dereferenced expression 's2
+                // BUG: Diagnostic contains: dereferenced expression 's2' is @Nullable
                 s2.hashCode();
                 (new Fn<String, String>() {
                   public String apply(String s) { return "hi"; }
@@ -1907,7 +1907,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 // No error due to @Contract
                 (new TestFunc1()).apply("hello").hashCode();
                 Fn1<@Nullable String, @Nullable String> fn1 = new TestFunc1();
-                // BUG: Diagnostic contains: dereferenced expression 'fn1.apply("hello")
+                // BUG: Diagnostic contains: dereferenced expression 'fn1.apply("hello")' is @Nullable
                 fn1.apply("hello").hashCode();
                 // BUG: Diagnostic contains: dereferenced expression '(new TestFunc2())
                 (new TestFunc2()).apply("hello").hashCode();

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -41,11 +41,11 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
             class Test {
               static Integer @Nullable [] fizz = {1};
               static void foo() {
-                // BUG: Diagnostic contains: dereferenced expression fizz is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz' is @Nullable
                 int bar = fizz.length;
               }
               static void bar() {
-                // BUG: Diagnostic contains: dereferenced expression fizz is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz' is @Nullable
                 int bar = fizz[0];
               }
             }
@@ -84,7 +84,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               static @Nullable String [] fizz = {"1"};
               static Object foo = new Object();
               static void foo() {
-                  // BUG: Diagnostic contains: dereferenced expression fizz[0] is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'fizz[0]' is @Nullable
                   int bar = fizz[0].length();
                   // OK: valid dereference since only elements of the array can be null
                   foo = fizz.length;
@@ -136,7 +136,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                   // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                   o1 = fizz;
                   // This should not report an error while using JSpecify type-use annotation
-                  // BUG: Diagnostic contains: dereferenced expression fizz is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'fizz' is @Nullable
                   o1 = fizz.length;
               }
             }
@@ -158,7 +158,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               static void foo() {
                  if (fizz != null) {
                     String s = fizz[0];
-                    // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                     int l1 = s.length();
                     if (s != null){
                        // OK: handled by null check
@@ -478,7 +478,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               if (fizz[i]!=null) {
                fizz[i].toString();
             }
-                // BUG: Diagnostic contains: dereferenced expression fizz[i] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[i]' is @Nullable
                fizz[i].toString();
               }
             }
@@ -501,7 +501,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                 // OK: constant integer indexes are handled by dataflow
                fizz[0].toString();
             }
-                // BUG: Diagnostic contains: dereferenced expression fizz[0] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[0]' is @Nullable
                fizz[0].toString();
               }
             }
@@ -525,7 +525,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                 // OK: local variable indexes are handled by dataflow
                   fizz[index].toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression fizz[index] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[index]' is @Nullable
                 fizz[index].toString();
               }
             }
@@ -570,7 +570,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                   if (s != null) {
                     s.toString();
                   }
-                  // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                   s.toString();
                 }
               }
@@ -596,15 +596,15 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               static void foo() {
                 if (fizz[getIndex()] != null) {
                 // index methods aren't handled by dataflow
-                // BUG: Diagnostic contains: dereferenced expression fizz[getIndex()] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[getIndex()]' is @Nullable
                   fizz[getIndex()].toString();
                 }
                 if (fizz[i] != null) {
                 // wrapper class indexes aren't handled by dataflow
-                // BUG: Diagnostic contains: dereferenced expression fizz[i] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[i]' is @Nullable
                   fizz[i].toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression fizz[getIndex()] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[getIndex()]' is @Nullable
                 fizz[getIndex()].toString();
               }
             }
@@ -626,10 +626,10 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                 int i = 0;
                 if (fizz[i+1] != null) {
                 // index expressions aren't handled by dataflow
-                // BUG: Diagnostic contains: dereferenced expression fizz[i+1] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[i+1]' is @Nullable
                   fizz[i+1].toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression fizz[i+1] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'fizz[i+1]' is @Nullable
                 fizz[i+1].toString();
               }
             }
@@ -650,10 +650,10 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               static void foo() {
                 if (getArray()[0] != null) {
                 // array resulting from method invocation isn't handled by dataflow
-                // BUG: Diagnostic contains: dereferenced expression getArray()[0] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'getArray()[0]' is @Nullable
                   getArray()[0].toString();
                 }
-                // BUG: Diagnostic contains: dereferenced expression getArray()[0] is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'getArray()[0]' is @Nullable
                 getArray()[0].toString();
               }
             }
@@ -674,7 +674,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
               static void foo() {
                 int i = 0;
                 if (fizz[i] != null) {
-                  // BUG: Diagnostic contains: dereferenced expression fizz[i+1] is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'fizz[i+1]' is @Nullable
                   fizz[i+1].toString();
                 }
               }
@@ -707,17 +707,17 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                        // annotation is treated as declaration
                        String bar = foo2[0].toString();
                   }
-                  // BUG: Diagnostic contains: dereferenced expression foo2 is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo2' is @Nullable
                   String bar = foo2[0].toString();
               }
               static @Nullable String @Nullable [] foo3 = null;
               static void fizz() {
                   if (foo3 !=null){
                        // annotation is also applied to the elements
-                  // BUG: Diagnostic contains: dereferenced expression foo3[0] is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo3[0]' is @Nullable
                        String bar = foo3[0].toString();
                   }
-                  // BUG: Diagnostic contains: dereferenced expression foo3 is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo3' is @Nullable
                   String bar = foo3[0].toString();
               }
               @Nullable Object [][] foo4 = null;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -24,7 +24,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
               }
               void testPositive() {
                 AtomicReference<@Nullable Integer> x = new AtomicReference<>(Integer.valueOf(3));
-                // BUG: Diagnostic contains: dereferenced expression x.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x.get()' is @Nullable
                 x.get().hashCode();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -63,7 +63,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
              public static String takesNullableVarargs(Object o, @Nullable Object... others) {
               String s = o.toString() + " " + others.toString();
               for (Object other : others) {
-                // BUG: Diagnostic contains: dereferenced expression other is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'other' is @Nullable
                 s += other.toString();
               }
               return s;
@@ -102,7 +102,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
              public static String takesNullableVarargs(Object o, @Nullable Object... others) {
               String s = o.toString() + " " + others.toString();
               for (Object other : others) {
-                // BUG: Diagnostic contains: dereferenced expression other is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'other' is @Nullable
                 s += other.toString();
               }
               return s;
@@ -251,7 +251,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -290,9 +290,9 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
-                // BUG: Diagnostic contains: dereferenced expression other is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'other' is @Nullable
                 s += other.toString();
               }
               return s;
@@ -336,7 +336,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
                 s += (other == null) ? "(null) " : other.toString() + " ";
               }
@@ -383,7 +383,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
              public static String takesNullableVarargsArray(Object o, @Nullable Object... others) {
               String s = o.toString() + " ";
               for (Object other : others) {
-                // BUG: Diagnostic contains: dereferenced expression other is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'other' is @Nullable
                 s += other.toString();
               }
               return s;
@@ -426,9 +426,9 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
             public class Utilities {
              public static String takesNullableVarargsArray(Object o, @Nullable Object @Nullable... others) {
               String s = o.toString() + " ";
-              // BUG: Diagnostic contains: enhanced-for expression others is @Nullable
+              // BUG: Diagnostic contains: enhanced-for expression 'others' is @Nullable
               for (Object other : others) {
-                // BUG: Diagnostic contains: dereferenced expression other is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'other' is @Nullable
                 s += other.toString();
               }
               return s;
@@ -712,7 +712,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
               void test() {
                 NullableVarargsArrayConsumer consumer =
                     inputs -> {
-                      // BUG: Diagnostic contains: dereferenced expression inputs is @Nullable
+                      // BUG: Diagnostic contains: dereferenced expression 'inputs' is @Nullable
                       inputs.toString();
                     };
               }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullMarkednessTests.java
@@ -460,7 +460,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
               public static Object test() {
                 class Foo {
                   private Object o;
-                  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field o
+                  // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'o'
                   public Foo() { }
                   public String foo(String s) {
                     return s;
@@ -660,7 +660,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                 return null;
               }
               public static String unsafeStringOrDefault(@Nullable Object o1, String s) {
-                // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o1' is @Nullable
                 return o1.toString();
               }
             }
@@ -697,7 +697,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
             import org.jspecify.annotations.Nullable;
             public class MarkedImplicitly {
               public static String directlyUnsafeStringOrDefault(@Nullable Object o1, String s) {
-                // BUG: Diagnostic contains: dereferenced expression o1 is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o1' is @Nullable
                 return o1.toString();
               }
               public static String indirectlyUnsafeStringOrDefault(@Nullable Object o1, String s) {
@@ -900,7 +900,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
                     return o.toString();
                   }
                   public static String takeNullable(@Nullable Object o) {
-                    // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                     return o.toString();
                   }
                 }
@@ -1023,7 +1023,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
               }
               public static void caller() {
                 // Error due to explicit @Nullable annotation
-                // BUG: Diagnostic contains: dereferenced expression callee() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'callee()' is @Nullable
                 callee().toString();
               }
             }
@@ -1151,7 +1151,7 @@ public class NullMarkednessTests extends NullAwayTestsBase {
               @NullMarked
               public String derefUnmarkedField() {
                 // Error, since callee still has restrictive annotations!
-                // BUG: Diagnostic contains: dereferenced expression f is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f' is @Nullable
                 return f.toString();
               }
             }
@@ -1240,10 +1240,10 @@ public class NullMarkednessTests extends NullAwayTestsBase {
               public void test() {
                 Object o = getNewObject();
                 nonNullCallee(o).toString();
-                // BUG: Diagnostic contains: dereferenced expression nullableCallee(o) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'nullableCallee(o)' is @Nullable
                 nullableCallee(o).toString();
                 unmarkedCallee(o).toString();
-                // BUG: Diagnostic contains: dereferenced expression unmarkedNullableCallee(o) is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'unmarkedNullableCallee(o)' is @Nullable
                 unmarkedNullableCallee(o).toString();
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -27,12 +27,12 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
               }
               void test() {
                 var foo1 = make(null);
-                // BUG: Diagnostic contains: dereferenced expression foo1.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo1.get()' is @Nullable
                 foo1.get().hashCode();
                 var foo2 = make(new Object());
                 foo2.get().hashCode();
                 var foo3 = make(null);
-                // BUG: Diagnostic contains: dereferenced expression foo3.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'foo3.get()' is @Nullable
                 foo3.get().hashCode();
               }
             }
@@ -125,14 +125,14 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
               }
               void test() {
                 for (var foo1 = make(null); foo1 == null; ) {
-                  // BUG: Diagnostic contains: dereferenced expression foo1.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo1.get()' is @Nullable
                   foo1.get().hashCode();
                 }
                 for (var foo1 = make(new Object()); foo1 == null; ) {
                   foo1.get().hashCode();
                 }
                 for (var foo1 = make(null); foo1 == null; ) {
-                  // BUG: Diagnostic contains: dereferenced expression foo1.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo1.get()' is @Nullable
                   foo1.get().hashCode();
                 }
               }
@@ -161,7 +161,7 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
                 String s = "hello";
                 while (true) {
                   var foo = make(s);
-                  // BUG: Diagnostic contains: dereferenced expression foo.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'foo.get()' is @Nullable
                   foo.get().hashCode();
                   s = null;
                 }
@@ -196,7 +196,7 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
                   @Override
                   public void run() {
                     var foo = make(null);
-                    // BUG: Diagnostic contains: dereferenced expression foo.get() is @Nullable
+                    // BUG: Diagnostic contains: dereferenced expression 'foo.get()' is @Nullable
                     foo.get().hashCode();
                   }
                 };

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -387,7 +387,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 T get() { throw new RuntimeException(); }
               }
               static void testNullableExtendsBound(Foo<? extends @Nullable Object> f) {
-                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f.get()' is @Nullable
                 f.get().hashCode();
               }
               static void testNonNullExtendsBound(Foo<? extends Object> f) {
@@ -395,11 +395,11 @@ public class WildcardTests extends NullAwayTestsBase {
                 f.get().hashCode();
               }
               static void testNullableSuperBound(Foo<? super @Nullable String> f) {
-                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f.get()' is @Nullable
                 f.get().hashCode();
               }
               static void testNonNullSuperBound(Foo<? super String> f) {
-                // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'f.get()' is @Nullable
                 f.get().hashCode();
               }
             }""")
@@ -421,7 +421,7 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static class NullableBound<U extends @Nullable Object> {
                 void test(Foo<? extends U> f) {
-                  // BUG: Diagnostic contains: dereferenced expression f.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'f.get()' is @Nullable
                   f.get().hashCode();
                 }
               }
@@ -450,7 +450,7 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static void testNullableExtendsBound(Foo<? extends @Nullable Object> f) {
                 Object x = f.get();
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 x.hashCode();
               }
               static void testNonNullExtendsBound(Foo<? extends Object> f) {
@@ -460,12 +460,12 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static void testNullableSuperBound(Foo<? super @Nullable String> f) {
                 Object x = f.get();
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 x.hashCode();
               }
               static void testNonNullSuperBound(Foo<? super String> f) {
                 Object x = f.get();
-                // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                 x.hashCode();
               }
             }""")
@@ -701,7 +701,7 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static void testNestedWildcard() {
                 invokeNested(box -> {
-                  // BUG: Diagnostic contains: dereferenced expression box.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'box.get()' is @Nullable
                   box.get().hashCode();
                   return null;
                 });
@@ -714,14 +714,14 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static void testTopLevelWildcardBound() {
                 invokeTopLevelWildcard(box -> {
-                  // BUG: Diagnostic contains: dereferenced expression box.get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'box.get()' is @Nullable
                   box.get().hashCode();
                   return null;
                 });
               }
               static void testArrayWithNestedWildcard() {
                 invokeArray(boxes -> {
-                  // BUG: Diagnostic contains: dereferenced expression boxes[0].get() is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'boxes[0].get()' is @Nullable
                   boxes[0].get().hashCode();
                   return null;
                 });
@@ -827,7 +827,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 static void doNothing(@Nullable Object o) {}
                 static void testPositive(List<String> list) {
                     list.stream().map(Test::mapToNull).forEach(s -> {
-                        // BUG: Diagnostic contains: dereferenced expression s is @Nullable
+                        // BUG: Diagnostic contains: dereferenced expression 's' is @Nullable
                         s.hashCode();
                     });
                     // BUG: Diagnostic contains: parameter o of referenced method is @NonNull, but parameter in functional interface method Test.Consumer.accept(T) is @Nullable

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CapturingScopes.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CapturingScopes.java
@@ -38,13 +38,13 @@ public class CapturingScopes {
 
           @Override
           public void run() {
-            // BUG: Diagnostic contains: dereferenced expression 'outerVar
+            // BUG: Diagnostic contains: dereferenced expression 'outerVar' is @Nullable
             System.out.println(outerVar.toString());
           }
         });
       } else {
         return () -> {
-          // BUG: Diagnostic contains: dereferenced expression 'outerVar
+          // BUG: Diagnostic contains: dereferenced expression 'outerVar' is @Nullable
           outerVar.hashCode();
         };
       }
@@ -64,9 +64,9 @@ public class CapturingScopes {
         void foo() {
           // safe
           var1.toString();
-          // BUG: Diagnostic contains: dereferenced expression 'var2
+          // BUG: Diagnostic contains: dereferenced expression 'var2' is @Nullable
           var2.hashCode();
-          // BUG: Diagnostic contains: dereferenced expression 'var3
+          // BUG: Diagnostic contains: dereferenced expression 'var3' is @Nullable
           var3.hashCode();
         }
       }
@@ -82,9 +82,9 @@ public class CapturingScopes {
           Object var2 = o;
           class Local2 {
             void bar() {
-              // BUG: Diagnostic contains: dereferenced expression 'var1
+              // BUG: Diagnostic contains: dereferenced expression 'var1' is @Nullable
               var1.hashCode();
-              // BUG: Diagnostic contains: dereferenced expression 'var2
+              // BUG: Diagnostic contains: dereferenced expression 'var2' is @Nullable
               var2.hashCode();
             }
           }
@@ -99,7 +99,7 @@ public class CapturingScopes {
       Function<String, String> f =
           (x) -> {
             Object o = null;
-            // BUG: Diagnostic contains: dereferenced expression 'o
+            // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
             Function<String, String> g = (y) -> x.toString() + o.toString() + y.toString();
             return g.apply("hello");
           };

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CapturingScopes.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CapturingScopes.java
@@ -38,13 +38,13 @@ public class CapturingScopes {
 
           @Override
           public void run() {
-            // BUG: Diagnostic contains: dereferenced expression outerVar
+            // BUG: Diagnostic contains: dereferenced expression 'outerVar
             System.out.println(outerVar.toString());
           }
         });
       } else {
         return () -> {
-          // BUG: Diagnostic contains: dereferenced expression outerVar
+          // BUG: Diagnostic contains: dereferenced expression 'outerVar
           outerVar.hashCode();
         };
       }
@@ -64,9 +64,9 @@ public class CapturingScopes {
         void foo() {
           // safe
           var1.toString();
-          // BUG: Diagnostic contains: dereferenced expression var2
+          // BUG: Diagnostic contains: dereferenced expression 'var2
           var2.hashCode();
-          // BUG: Diagnostic contains: dereferenced expression var3
+          // BUG: Diagnostic contains: dereferenced expression 'var3
           var3.hashCode();
         }
       }
@@ -82,9 +82,9 @@ public class CapturingScopes {
           Object var2 = o;
           class Local2 {
             void bar() {
-              // BUG: Diagnostic contains: dereferenced expression var1
+              // BUG: Diagnostic contains: dereferenced expression 'var1
               var1.hashCode();
-              // BUG: Diagnostic contains: dereferenced expression var2
+              // BUG: Diagnostic contains: dereferenced expression 'var2
               var2.hashCode();
             }
           }
@@ -99,7 +99,7 @@ public class CapturingScopes {
       Function<String, String> f =
           (x) -> {
             Object o = null;
-            // BUG: Diagnostic contains: dereferenced expression o
+            // BUG: Diagnostic contains: dereferenced expression 'o
             Function<String, String> g = (y) -> x.toString() + o.toString() + y.toString();
             return g.apply("hello");
           };
@@ -113,7 +113,7 @@ public class CapturingScopes {
       HashMap<String, String> map =
           new HashMap<String, String>() {
             {
-              // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+              // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
               put("hi", o.toString());
             }
           };
@@ -141,7 +141,7 @@ public class CapturingScopes {
 
             class Inner {
               void foo() {
-                // BUG: Diagnostic contains: dereferenced expression o is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'o' is @Nullable
                 o.toString();
               }
             }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitPositiveCases.java
@@ -32,7 +32,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 33) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f' (line 33) is
     // initialized
     T1() {}
   }
@@ -41,15 +41,15 @@ public class CheckFieldInitPositiveCases {
 
     Object f, g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields f (line 42),
-    // g (line 42) are
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull fields 'f' (line 42),
+    // 'g' (line 42) are
     // initialized
     T2() {}
   }
 
   static class T3 {
 
-    // BUG: Diagnostic contains: @NonNull field CheckFieldInitPositiveCases$T3.f not initialized
+    // BUG: Diagnostic contains: @NonNull field 'CheckFieldInitPositiveCases$T3.f' not initialized
     Object f;
   }
 
@@ -71,7 +71,7 @@ public class CheckFieldInitPositiveCases {
 
     Object f;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 72) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f' (line 72) is
     // initialized
     T5(boolean b) {
       if (b) {
@@ -89,7 +89,7 @@ public class CheckFieldInitPositiveCases {
       this(false);
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 85) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f' (line 85) is
     // initialized
     T6(boolean b) {}
   }
@@ -99,7 +99,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
     Object g;
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 99) is
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f' (line 99) is
     // initialized
     T7(boolean b) {
       if (b) {
@@ -108,7 +108,7 @@ public class CheckFieldInitPositiveCases {
       g = new Object();
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g (line 100)
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'g' (line 100)
     // is
     // initialized
     T7() {
@@ -130,7 +130,7 @@ public class CheckFieldInitPositiveCases {
     Object f;
 
     @Initializer
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field f (line 130)
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'f' (line 130)
     // is
     // initialized
     public void init() {}
@@ -138,7 +138,7 @@ public class CheckFieldInitPositiveCases {
 
   static class T9 {
 
-    // BUG: Diagnostic contains: @NonNull static field CheckFieldInitPositiveCases$T9.f not
+    // BUG: Diagnostic contains: @NonNull static field 'CheckFieldInitPositiveCases$T9.f' not
     // initialized
     static Object f;
 
@@ -148,7 +148,7 @@ public class CheckFieldInitPositiveCases {
 
   static class T10 {
 
-    // BUG: Diagnostic contains: @NonNull static field CheckFieldInitPositiveCases$T10.f not
+    // BUG: Diagnostic contains: @NonNull static field 'CheckFieldInitPositiveCases$T10.f' not
     // initialized
     static Object f;
 
@@ -161,7 +161,7 @@ public class CheckFieldInitPositiveCases {
 
   static class T11 {
 
-    // BUG: Diagnostic contains: @NonNull static field CheckFieldInitPositiveCases$T11.f not
+    // BUG: Diagnostic contains: @NonNull static field 'CheckFieldInitPositiveCases$T11.f' not
     // initialized
     static Object f;
 
@@ -177,7 +177,7 @@ public class CheckFieldInitPositiveCases {
   public Object getT12() {
     return (new Object() {
       /*T12*/
-      // BUG: Diagnostic contains: f not initialized
+      // BUG: Diagnostic contains: .f' not initialized
       private Object f;
 
       public Object getF() {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayAnonymousClass.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayAnonymousClass.java
@@ -36,7 +36,7 @@ public class NullAwayAnonymousClass {
     Runnable r =
         new Runnable() {
 
-          // BUG: Diagnostic contains: @NonNull field NullAwayAnonymousClass$1.f not initialized
+          // BUG: Diagnostic contains: @NonNull field 'NullAwayAnonymousClass$1.f' not initialized
           private Object f;
 
           @Override

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayPositiveCases.java
@@ -237,12 +237,12 @@ public class NullAwayPositiveCases {
   }
 
   static void invokeOnNull2(@Nullable Object p) {
-    // BUG: Diagnostic contains: dereferenced expression p is @Nullable
+    // BUG: Diagnostic contains: dereferenced expression 'p' is @Nullable
     p.toString();
   }
 
   static void derefNullable(@Nullable Inner x) {
-    // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+    // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
     Object y = x.f2;
   }
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/NullAwayTryFinallyCases.java
@@ -259,7 +259,7 @@ public class NullAwayTryFinallyCases {
       // method... mmh
     }
 
-    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field g (line 228)
+    // BUG: Diagnostic contains: initializer method does not guarantee @NonNull field 'g' (line 228)
     // is
     // initialized
     Initializers(Object o1, Object o2, Object o3) {

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/ReadBeforeInitPositiveCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/ReadBeforeInitPositiveCases.java
@@ -32,10 +32,10 @@ public class ReadBeforeInitPositiveCases {
     Object g;
 
     T1() {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       System.out.println(f.toString());
       f = new Object();
-      // BUG: Diagnostic contains: read of @NonNull field g before
+      // BUG: Diagnostic contains: read of @NonNull field 'g' before
       System.out.println(g.toString());
       g = new Object();
     }
@@ -44,7 +44,7 @@ public class ReadBeforeInitPositiveCases {
       if (b) {
         f = new Object();
       }
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       System.out.println(f.toString());
       f = new Object();
       g = new Object();
@@ -57,14 +57,14 @@ public class ReadBeforeInitPositiveCases {
     Object f2;
 
     {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       System.out.println(f.toString());
     }
 
-    // BUG: Diagnostic contains: read of @NonNull field f2 before
+    // BUG: Diagnostic contains: read of @NonNull field 'f2' before
     Object g = f2;
 
-    // BUG: Diagnostic contains: read of @NonNull field f2 before
+    // BUG: Diagnostic contains: read of @NonNull field 'f2' before
     Object h = str(f2);
 
     T2() {
@@ -83,11 +83,11 @@ public class ReadBeforeInitPositiveCases {
     static Object f2;
 
     static {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       System.out.println(f.toString());
     }
 
-    // BUG: Diagnostic contains: read of @NonNull field f2 before
+    // BUG: Diagnostic contains: read of @NonNull field 'f2' before
     static Object g = f2;
 
     static {
@@ -102,7 +102,7 @@ public class ReadBeforeInitPositiveCases {
     Object g;
 
     InvokePrivate() {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       f.toString();
       initF();
       initG();
@@ -123,7 +123,7 @@ public class ReadBeforeInitPositiveCases {
     Object f;
 
     StoreInLocal() {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       Object x = this.f;
       x.toString();
       this.f = new Object();
@@ -136,7 +136,7 @@ public class ReadBeforeInitPositiveCases {
     Object baz;
 
     NestedWrite() {
-      // BUG: Diagnostic contains: read of @NonNull field foo before
+      // BUG: Diagnostic contains: read of @NonNull field 'foo' before
       this.foo.baz = new Object();
       this.foo = new NestedWrite();
       this.baz = new Object();
@@ -149,7 +149,7 @@ public class ReadBeforeInitPositiveCases {
 
     @Initializer
     public void init() {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       f.toString();
       f = new Object();
     }
@@ -175,7 +175,7 @@ public class ReadBeforeInitPositiveCases {
     @Initializer
     public void init() {
       g.toString();
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       f.toString();
     }
   }
@@ -188,7 +188,7 @@ public class ReadBeforeInitPositiveCases {
     @Initializer
     static void init() {
       g.toString();
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       f.toString();
     }
 
@@ -203,7 +203,7 @@ public class ReadBeforeInitPositiveCases {
 
     @Initializer
     void init() {
-      // BUG: Diagnostic contains: read of @NonNull field f before
+      // BUG: Diagnostic contains: read of @NonNull field 'f' before
       f = Util.id(f);
     }
   }

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnAttach.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnAttach.java
@@ -10,7 +10,7 @@ public class AndroidxFragmentWithoutOnAttach extends Fragment {
 
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnAttachInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnAttachInitialisedField' not initialized
   private Object mOnAttachInitialisedField;
 
   @Override

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnCreate.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnCreate.java
@@ -8,7 +8,7 @@ import android.view.ViewGroup;
 import androidx.fragment.app.Fragment;
 
 public class AndroidxFragmentWithoutOnCreate extends Fragment {
-  // BUG: Diagnostic contains: @NonNull field mOnCreateInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateInitialisedField' not initialized
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnCreateView.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/AndroidxFragmentWithoutOnCreateView.java
@@ -7,7 +7,7 @@ import androidx.fragment.app.Fragment;
 public class AndroidxFragmentWithoutOnCreateView extends Fragment {
 
   private Object mOnCreateInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnCreateViewInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateViewInitialisedField' not initialized
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnAttach.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnAttach.java
@@ -10,7 +10,7 @@ public class CoreFragmentWithoutOnAttach extends Fragment {
 
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnAttachInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnAttachInitialisedField' not initialized
   private Object mOnAttachInitialisedField;
 
   @Override

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnCreate.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnCreate.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 public class CoreFragmentWithoutOnCreate extends Fragment {
-  // BUG: Diagnostic contains: @NonNull field mOnCreateInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateInitialisedField' not initialized
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnCreateView.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/CoreFragmentWithoutOnCreateView.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 public class CoreFragmentWithoutOnCreateView extends Fragment {
 
   private Object mOnCreateInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnCreateViewInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateViewInitialisedField' not initialized
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;
 

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnAttach.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnAttach.java
@@ -10,7 +10,7 @@ public class SupportLibraryFragmentWithoutOnAttach extends Fragment {
 
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnAttachInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnAttachInitialisedField' not initialized
   private Object mOnAttachInitialisedField;
 
   @Override

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnCreate.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnCreate.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 public class SupportLibraryFragmentWithoutOnCreate extends Fragment {
-  // BUG: Diagnostic contains: @NonNull field mOnCreateInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateInitialisedField' not initialized
   private Object mOnCreateInitialisedField;
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnCreateView.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/android-error/SupportLibraryFragmentWithoutOnCreateView.java
@@ -7,7 +7,7 @@ import android.support.v4.app.Fragment;
 public class SupportLibraryFragmentWithoutOnCreateView extends Fragment {
 
   private Object mOnCreateInitialisedField;
-  // BUG: Diagnostic contains: @NonNull field mOnCreateViewInitialisedField not initialized
+  // BUG: Diagnostic contains: @NonNull field 'mOnCreateViewInitialisedField' not initialized
   private Object mOnCreateViewInitialisedField;
   private Object mOnAttachInitialisedField;
 

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -226,7 +226,7 @@ public class CustomLibraryModelsTests {
               void foo() {
                 RestrictivelyAnnotatedFIWithModelOverride func = (x) -> {
                  // Param is @NullableDecl in bytecode, and overriding library model is ignored, thus unsafe
-                 // BUG: Diagnostic contains: dereferenced expression x is @Nullable
+                 // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
                  return x.toString();
                 };
               }
@@ -267,7 +267,7 @@ public class CustomLibraryModelsTests {
                   }
                }
                String dereferenceTest() {
-                  // BUG: Diagnostic contains: dereferenced expression uwm.nullableFieldUnannotated1 is @Nullable
+                  // BUG: Diagnostic contains: dereferenced expression 'uwm.nullableFieldUnannotated1' is @Nullable
                   return uwm.nullableFieldUnannotated1.toString();
                }
                void assignmentTest() {
@@ -322,7 +322,7 @@ public class CustomLibraryModelsTests {
             public class Test {
               void test() {
                 ProviderNullMarkedViaModel<@Nullable Object> p = ProviderNullMarkedViaModel.of(null);
-                // BUG: Diagnostic contains: dereferenced expression p.get() is @Nullable
+                // BUG: Diagnostic contains: dereferenced expression 'p.get()' is @Nullable
                 p.get().toString();
                 // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
                 ProviderNullMarkedViaModel<Object> q = ProviderNullMarkedViaModel.of(null);


### PR DESCRIPTION
## Summary

Many NullAway error messages reference syntax elements (the dereferenced expression, an uninitialized field name, etc.) as plain text, which makes them hard to spot in otherwise verbose messages. Some messages already quote these references — e.g. `passing @Nullable parameter 'x' where @NonNull is required` — so this PR harmonizes the remaining messages to the same single-quote style.

Fixes #1619.

## Messages changed

- `dereferenced expression 'x' is @Nullable`
- `switch selector expression 'x' is @Nullable`
- `enhanced-for expression 'x' is @Nullable`
- `synchronized block expression 'x' is @Nullable` (previously double-quoted — now single, for consistency)
- `@NonNull field 'x' not initialized` / `@NonNull static field 'x' not initialized`
- `initializer method does not guarantee @NonNull field 'x' (line N) ...` (and the plural `fields 'x' (line N), 'y' (line N) ...` form)
- `read of @NonNull field 'x' before initialization`

## Scope

I intentionally left two messages that embed a fully-qualified `Class.method` symbol (the unbound-member-reference and override-parameter nullability errors) unquoted, since those reference a resolved symbol rather than user source text and aren't covered by the issue's examples. Happy to extend the change to those if you'd prefer full consistency.

## Tests

Updated the affected `// BUG: Diagnostic contains:` assertions and the `SerializationTest` expected outputs (a few serialized byte offsets shift because the in-source `// BUG:` comments grew by two characters). All tests pass locally:

- `:nullaway:test`
- `:test-library-models:test`
- `:jdk-recent-unit-tests:test`
- `:jdk-annotations:jdk-integration-test:test`

The README example output is updated to match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NullAway diagnostic text to consistently wrap referenced expressions and field names in single quotes (including dereferences, uninitialized-field reports, and related cases like switch selectors, enhanced-for, and synchronized blocks).
* **Tests**
  * Refreshed expected diagnostics and serialized outputs to match the updated wording across unit tests and test data.
* **Documentation**
  * Adjusted the NullAway warning example in the README to reflect the new quoted formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->