### PR TITLE
Test/increase test coverage

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/SpringHandler.java
@@ -20,11 +20,18 @@ public class SpringHandler implements Handler {
   /**
    * Matches a SpEL fragment like {@code #{...}} when it contains {@code null} as a standalone
    * token. This lets us distinguish Spring {@code @Value} expressions that may produce {@code null}
-   * from plain property placeholders or string literals containing the letters {@code null}. This
-   * is a heuristic match and may have false positives.
+   * from plain property placeholders or string literals containing the letters {@code null}.
    */
   private static final Pattern VALUE_NULL_SPEL_PATTERN =
       Pattern.compile("#\\{[^}]*\\bnull\\b[^}]*}");
+
+  /**
+   * Matches {@code null} used as an operand in equality comparisons ({@code == null}, {@code !=
+   * null}, {@code null ==}, {@code null !=}). These occurrences do not produce a {@code null} value
+   * and should be excluded from the SpEL null detection heuristic.
+   */
+  private static final Pattern NULL_COMPARISON_PATTERN =
+      Pattern.compile("[!=]=\\s*\\bnull\\b|\\bnull\\b\\s*[!=]=");
 
   @Override
   public FieldSkipResult shouldSkipFieldInitializationCheck(
@@ -45,6 +52,12 @@ public class SpringHandler implements Handler {
   }
 
   private static boolean containsNullSpELExpression(String annotationValue) {
-    return VALUE_NULL_SPEL_PATTERN.matcher(annotationValue).find();
+    if (!VALUE_NULL_SPEL_PATTERN.matcher(annotationValue).find()) {
+      return false;
+    }
+    // Strip null occurrences that are only used in equality comparisons (e.g., != null, == null)
+    // and re-check whether any standalone null token remains as a potential return value.
+    String withoutComparisons = NULL_COMPARISON_PATTERN.matcher(annotationValue).replaceAll("");
+    return VALUE_NULL_SPEL_PATTERN.matcher(withoutComparisons).find();
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/RequiresNonNullHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/RequiresNonNullHandler.java
@@ -106,7 +106,7 @@ public class RequiresNonNullHandler extends AbstractFieldContractHandler {
     StringBuilder errorMessage = new StringBuilder();
     errorMessage.append(
         "precondition inheritance is violated, method in child class cannot have a stricter precondition than its closest overridden method, adding @requiresNonNull for fields [");
-    Iterator<String> iterator = overriddenFieldNames.iterator();
+    Iterator<String> iterator = overridingFieldNames.iterator();
     while (iterator.hasNext()) {
       errorMessage.append(iterator.next());
       if (iterator.hasNext()) {

--- a/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullTests.java
@@ -141,7 +141,7 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
                 a.call();
               }
               @RequiresNonNull("b")
-              // BUG: Diagnostic contains: precondition inheritance is violated, method in child class cannot have a stricter precondition than its closest overridden method, adding @requiresNonNull for fields [a] makes this method precondition stricter
+              // BUG: Diagnostic contains: precondition inheritance is violated, method in child class cannot have a stricter precondition than its closest overridden method, adding @requiresNonNull for fields [b] makes this method precondition stricter
               public void test4() {
                 // BUG: Diagnostic contains: dereferenced expression a is @Nullable
                 a.call();
@@ -475,6 +475,46 @@ public class EnsuresNonNullTests extends NullAwayTestsBase {
                 negativeEnsureNonnull();
                 // BUG: Diagnostic contains: Expected static field field1 to be non-null at call site
                 combinedNegative();
+              }
+            }
+            """)
+        .addSourceLines(
+            "Item.java", "package com.uber;", "class Item {", "  public void call() { }", "}")
+        .doTest();
+  }
+
+  @Test
+  public void requiresNonNullOverridingErrorMessageListsExtraFields() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "SuperClass.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import com.uber.nullaway.annotations.RequiresNonNull;
+            class SuperClass {
+              @Nullable Item a;
+              @RequiresNonNull("a")
+              public void doWork() {
+                a.call();
+              }
+            }
+            """)
+        .addSourceLines(
+            "ChildClass.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import com.uber.nullaway.annotations.RequiresNonNull;
+            class ChildClass extends SuperClass {
+              @Nullable Item b;
+              @Nullable Item c;
+              @RequiresNonNull({"a", "b", "c"})
+              // BUG: Diagnostic contains: adding @requiresNonNull for fields [b, c] makes this method precondition stricter
+              public void doWork() {
+                a.call();
+                b.call();
+                c.call();
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1526,12 +1526,80 @@ public class FrameworkTests extends NullAwayTestsBase {
             package com.uber;
             import org.springframework.beans.factory.annotation.Value;
             class Test {
-              // SpEL conditional: 'null' is used as a comparison operand, not as a
-              // return value. However, the heuristic regex matches the word "null"
-              // anywhere inside #{...}, triggering a false positive.
+              // SpEL conditional: 'null' is used only as a comparison operand, not as a
+              // return value. The heuristic correctly strips comparison-only nulls.
               @Value("#{someBean != null ? someBean.value : 'default'}")
-              // BUG: Diagnostic contains: @NonNull field spelConditionalNullCheck not initialized
               String spelConditionalNullCheck;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void springValueSpelNullAsReturnValue() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Value.java",
+            """
+            package org.springframework.beans.factory.annotation;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Value {
+              String value();
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.springframework.beans.factory.annotation.Value;
+            class Test {
+              // Boundary: null appears in a comparison AND as a ternary return value (then-branch).
+              @Value("#{someBean != null ? null : 'default'}")
+              // BUG: Diagnostic contains: @NonNull field nullInThenBranch not initialized
+              String nullInThenBranch;
+              // Boundary: null appears in a comparison AND as a ternary return value (else-branch).
+              @Value("#{someBean != null ? someBean.value : null}")
+              // BUG: Diagnostic contains: @NonNull field nullInElseBranch not initialized
+              String nullInElseBranch;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void springValueSpelNullComparisonLeftSide() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Value.java",
+            """
+            package org.springframework.beans.factory.annotation;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Value {
+              String value();
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.springframework.beans.factory.annotation.Value;
+            class Test {
+              // Boundary: null on the LEFT side of != comparison (symmetric case).
+              @Value("#{null != someBean ? someBean.value : 'default'}")
+              String nullOnLeftNeq;
+              // Boundary: null on the LEFT side of == comparison (symmetric case).
+              @Value("#{null == someBean ? 'default' : someBean.value}")
+              String nullOnLeftEq;
             }
             """)
         .doTest();

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1502,4 +1502,38 @@ public class FrameworkTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void springValueSpelWithNullInConditional() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Value.java",
+            """
+            package org.springframework.beans.factory.annotation;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Value {
+              String value();
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.springframework.beans.factory.annotation.Value;
+            class Test {
+              // SpEL conditional: 'null' is used as a comparison operand, not as a
+              // return value. However, the heuristic regex matches the word "null"
+              // anywhere inside #{...}, triggering a false positive.
+              @Value("#{someBean != null ? someBean.value : 'default'}")
+              // BUG: Diagnostic contains: @NonNull field spelConditionalNullCheck not initialized
+              String spelConditionalNullCheck;
+            }
+            """)
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
@@ -503,4 +503,37 @@ public class JakartaPersistenceTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void jakartaPersistenceMixedAccessBothMappingsIsUnknown() {
+    addJpaAnnotationStubs(defaultCompilationHelper)
+        .addSourceLines(
+            "MixedAccessEntity.java",
+            """
+            package com.uber;
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.Column;
+            import jakarta.persistence.Id;
+            @Entity
+            class MixedAccessEntity {
+              // @Column on a field -> hasFieldMapping = true
+              @Column
+              // BUG: Diagnostic contains: @NonNull field name not initialized
+              String name;
+              // BUG: Diagnostic contains: @NonNull field id not initialized
+              Long id;
+              // @Id on a getter -> hasPropertyMapping = true
+              // Both field and property mappings present -> access type is UNKNOWN
+              // -> shouldSkipFieldInitializationCheck returns false for all fields
+              @Id
+              public Long getId() {
+                return id;
+              }
+              public void setId(Long id) {
+                this.id = id;
+              }
+            }
+            """)
+        .doTest();
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/SyncLambdasTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SyncLambdasTests.java
@@ -175,4 +175,40 @@ public class SyncLambdasTests extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void forEachOnMapWithAnonymousClass() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.Map;
+            import java.util.HashMap;
+            import java.util.function.BiConsumer;
+            import org.jspecify.annotations.Nullable;
+            public class Test {
+                private @Nullable Map<Object, Object> target;
+                private @Nullable Map<Object, Object> resolved;
+                public void initialize() {
+                    if (this.target == null) {
+                        throw new IllegalArgumentException();
+                    }
+                    this.resolved = new HashMap<>();
+                    // Unlike a lambda callback, an anonymous class callback does NOT propagate
+                    // nullness facts from the enclosing scope. 'Test.this.resolved' is known
+                    // non-null at this point, but inside the anonymous class method NullAway
+                    // cannot use that fact because the access path changes (this$0.resolved).
+                    this.target.forEach(new BiConsumer<Object, Object>() {
+                        @Override
+                        public void accept(Object key, Object value) {
+                            // BUG: Diagnostic contains: dereferenced expression Test.this.resolved is @Nullable
+                            Test.this.resolved.put(key, value);
+                        }
+                    });
+                }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
# Fix false positives in SpringHandler and RequiresNonNullHandler; add tests for coverage gaps

## What and why

This PR fixes two bugs found while increasing test coverage, and adds unit tests for previously
untested code paths in four handlers.

### Bug fixes

**1. `SpringHandler`: false positive for SpEL expressions with `null` in comparisons**

`containsNullSpELExpression` used a single regex that matched `null` anywhere inside a `#{...}`
expression. This caused a false positive for conditional expressions like:

```java
@Value("#{someBean != null ? someBean.value : 'default'}")
private String field;
```

NullAway incorrectly flagged `field` as potentially null, even though `null` here is only used in
a comparison, not as a possible return value. Fix: a second regex (`NULL_COMPARISON_PATTERN`) strips
null-in-comparison occurrences before re-checking whether `null` can actually be the value.

**2. `RequiresNonNullHandler`: error message in `validateOverridingRules` listed the wrong fields**

When a child method's `@RequiresNonNull` was stricter than its parent's (violating LSP), the error
message listed the **parent's** fields instead of the **extra** fields added by the child. Fix: use
the correct iterator (`overridingFieldNames` instead of `overriddenFieldNames`) when building the
message.

### New tests

- **`JakartaPersistenceTests.jakartaPersistenceMixedAccessBothMappingsIsUnknown`** — covers the
  case where a JPA entity has both field-level and getter-level mapping annotations simultaneously,
  which resolves to `UNKNOWN` access type and causes NullAway to report uninitialized-field errors.

- **`FrameworkTests.springValueSpelWithNullInConditional`**,
  **`springValueSpelNullAsReturnValue`**, **`springValueSpelNullComparisonLeftSide`** — regression
  tests for the `SpringHandler` fix, covering null-as-comparison-operand (both sides) and
  null-as-return-value in SpEL expressions.

- **`SyncLambdasTests.forEachOnMapWithAnonymousClass`** — documents that anonymous classes passed
  to `Map.forEach` do not benefit from nullness-fact propagation (unlike lambdas), because the AST
  parent node is `NewClassTree`, not `MethodInvocationTree`.

- **`EnsuresNonNullTests.requiresNonNullOverridingErrorMessageListsExtraFields`** — regression test
  for the `RequiresNonNullHandler` fix, verifying that the error message lists `[b, c]` (the extra
  fields added by the child) rather than `[a]` (the parent's fields) when multiple extra fields
  cause the violation.

### Unit tests

All four items above include unit tests. The two bug-fix items include regression tests that fail on
the unfixed code and pass after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-handling for Spring-style expression values so comparison-only uses of `null` are treated more accurately.
  * Clarified error messages for precondition inheritance issues, including the specific fields that make an override stricter.
  * Improved detection for mixed Jakarta Persistence access patterns and anonymous callback null checks.

* **Tests**
  * Added coverage for Spring expression cases, persistence access edge cases, and overriding precondition diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->