### PR TITLE
Update lombok section at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you have explicitly disabled this behavior then NullAway will not correctly r
 If you are using a Lombok version earlier than 1.18.34, you must enable the following configuration option in an applicable `lombok.config` file:
 
 ```
-lombok.addLombokGeneratedAnnotation = false
+lombok.addLombokGeneratedAnnotation = true
 ```
 
 ## Code Example

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you have explicitly disabled this behavior then NullAway will not correctly r
 
 If you are using a Lombok version earlier than 1.18.34, you must enable the following configuration option in an applicable `lombok.config` file:
 
-```
+```properties
 lombok.addLombokGeneratedAnnotation = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ Unlike other annotation processors above, Lombok modifies the in-memory AST of t
 
 We do not particularly recommend using NullAway with Lombok. However, NullAway encodes some knowledge of common Lombok annotations and we do try for best-effort compatibility. In particular, common usages like `@lombok.Builder` and `@Data` classes should be supported.
 
-In order for NullAway to successfully detect Lombok generated code within the in-memory Java AST, the following configuration option must be passed to Lombok as part of an applicable `lombok.config` file:
+Since Lombok v1.18.34, Lombok adds `@lombok.Generated` by default to the methods/classes it generates. NullAway relies on this annotation to detect generated code within the in-memory Java AST and will ignore (i.e. not check) the implementation of this generated code, treating it as unannotated.
+If you have explicitly disabled this behavior then NullAway will not correctly recognize Lombok-generated code, and compatibility may break.
+
+If you are using a Lombok version earlier than 1.18.34, you must enable the following configuration option in an applicable lombok.config file:
 
 ```
-lombok.addLombokGeneratedAnnotation = true
+lombok.addLombokGeneratedAnnotation = false
 ```
-
-This causes Lombok to add `@lombok.Generated` to the methods/classes it generates. NullAway will ignore (i.e. not check) the implementation of this generated code, treating it as unannotated. 
 
 ## Code Example
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We do not particularly recommend using NullAway with Lombok. However, NullAway e
 Since Lombok v1.18.34, Lombok adds `@lombok.Generated` by default to the methods/classes it generates. NullAway relies on this annotation to detect generated code within the in-memory Java AST and will ignore (i.e. not check) the implementation of this generated code, treating it as unannotated.
 If you have explicitly disabled this behavior then NullAway will not correctly recognize Lombok-generated code, and compatibility may break.
 
-If you are using a Lombok version earlier than 1.18.34, you must enable the following configuration option in an applicable lombok.config file:
+If you are using a Lombok version earlier than 1.18.34, you must enable the following configuration option in an applicable `lombok.config` file:
 
 ```
 lombok.addLombokGeneratedAnnotation = false


### PR DESCRIPTION
The README.md regarding Lombok is outdated. The `@lombok.Generated` annotation is set by default. From the [release notes](https://projectlombok.org/changelog) of Lombok:

> v1.18.34 (June 28th, 2024)
> IMPROBABLE BREAKING CHANGE: Lombok now adds @lombok.Generated by default to methods and types it generates. This may result in accidentally increasing your test coverage percentage. Issue [#3667](https://github.com/projectlombok/lombok/issues/3667).

I tested it myself, seems to work just fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated guidance on Lombok behavior starting in v1.18.34, including that `@lombok.Generated` is added by default to generated code.
  - Explained how this default influences generated-code detection during analysis/checks.
  - Added version-specific instructions for Lombok versions earlier than 1.18.34, including a `lombok.config` setting.
  - Warned that explicitly disabling the default `@lombok.Generated` behavior may break compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->