### PR TITLE
Support static @Initializer methods assigning receiver parameter fields

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2339,6 +2339,17 @@ public class NullAway extends BugChecker
           initMethodTree.getBody(),
           new TreePath(state.getPath(), initMethodTree));
     }
+    for (MethodTree initMethodTree : entities.staticInitializerMethods()) {
+      if (initMethodTree.getBody() == null || initMethodTree.getParameters().isEmpty()) {
+        continue;
+      }
+      Element firstParam = ASTHelpers.getSymbol(initMethodTree.getParameters().get(0));
+      AccessPathNullnessAnalysis nullnessAnalysis = getNullnessAnalysis(state);
+      Set<Element> nonnullAtExit =
+          nullnessAnalysis.getNonnullFieldsOfParameterAtExit(
+              new TreePath(state.getPath(), initMethodTree), state.context, firstParam);
+      initInSomeInitializerBuilder.addAll(nonnullAtExit);
+    }
     for (BlockTree block : entities.instanceInitializerBlocks()) {
       addInitializedFieldsForBlock(
           state,

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -2343,12 +2343,14 @@ public class NullAway extends BugChecker
       if (initMethodTree.getBody() == null || initMethodTree.getParameters().isEmpty()) {
         continue;
       }
-      Element firstParam = ASTHelpers.getSymbol(initMethodTree.getParameters().get(0));
       AccessPathNullnessAnalysis nullnessAnalysis = getNullnessAnalysis(state);
-      Set<Element> nonnullAtExit =
-          nullnessAnalysis.getNonnullFieldsOfParameterAtExit(
-              new TreePath(state.getPath(), initMethodTree), state.context, firstParam);
-      initInSomeInitializerBuilder.addAll(nonnullAtExit);
+      for (VariableTree param : initMethodTree.getParameters()) {
+        Element paramElement = ASTHelpers.getSymbol(param);
+        Set<Element> nonnullAtExit =
+            nullnessAnalysis.getNonnullFieldsOfParameterAtExit(
+                new TreePath(state.getPath(), initMethodTree), state.context, paramElement);
+        initInSomeInitializerBuilder.addAll(nonnullAtExit);
+      }
     }
     for (BlockTree block : entities.instanceInitializerBlocks()) {
       addInitializedFieldsForBlock(

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -179,6 +179,26 @@ public final class AccessPathNullnessAnalysis {
   }
 
   /**
+   * Get the fields of the given parameter that are guaranteed to be nonnull after a method or
+   * initializer block.
+   *
+   * @param path tree path of method, or initializer block
+   * @param context Javac context
+   * @param parameter parameter element
+   * @return fields guaranteed to be nonnull at exit of method (or initializer block)
+   */
+  public Set<Element> getNonnullFieldsOfParameterAtExit(
+      TreePath path, Context context, Element parameter) {
+    NullnessStore nullnessResult = dataFlow.finalResult(path, context, nullnessPropagation);
+    if (nullnessResult == null) {
+      // this case can occur if the method always throws an exception
+      // be conservative and say nothing is initialized
+      return Collections.emptySet();
+    }
+    return nullnessResult.getNonNullParameterFields(parameter);
+  }
+
+  /**
    * Get the instance fields that are guaranteed to be nonnull before the current expression.
    *
    * @param path tree path of some expression

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -290,6 +290,30 @@ public class NullnessStore implements Store<NullnessStore> {
   }
 
   /**
+   * Return all the fields of the given parameter in the store that are Non-Null.
+   *
+   * @param parameter The parameter element
+   * @return Set of fields (represented as {@code Element}s) of the given parameter that are
+   *     non-null
+   */
+  public Set<Element> getNonNullParameterFields(Element parameter) {
+    Set<AccessPath> nonnullAccessPaths = this.getAccessPathsWithValue(Nullness.NONNULL);
+    Set<Element> result = new LinkedHashSet<>();
+    for (AccessPath ap : nonnullAccessPaths) {
+      if (ap.getRoot() != null && ap.getRoot().equals(parameter)) {
+        ImmutableList<AccessPathElement> elements = ap.getElements();
+        if (elements.size() == 1) {
+          Element elem = elements.get(0).getJavaElement();
+          if (elem.getKind().equals(ElementKind.FIELD)) {
+            result.add(elem);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Return all the static fields in the store that are Non-Null.
    *
    * @return Set of static fields (represented as {@code Element}s) that are non-null

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -297,20 +297,7 @@ public class NullnessStore implements Store<NullnessStore> {
    *     non-null
    */
   public Set<Element> getNonNullParameterFields(Element parameter) {
-    Set<AccessPath> nonnullAccessPaths = this.getAccessPathsWithValue(Nullness.NONNULL);
-    Set<Element> result = new LinkedHashSet<>();
-    for (AccessPath ap : nonnullAccessPaths) {
-      if (ap.getRoot() != null && ap.getRoot().equals(parameter)) {
-        ImmutableList<AccessPathElement> elements = ap.getElements();
-        if (elements.size() == 1) {
-          Element elem = elements.get(0).getJavaElement();
-          if (elem.getKind().equals(ElementKind.FIELD)) {
-            result.add(elem);
-          }
-        }
-      }
-    }
-    return result;
+    return getFieldsWithRootMatching(Nullness.NONNULL, parameter::equals);
   }
 
   /**
@@ -338,11 +325,15 @@ public class NullnessStore implements Store<NullnessStore> {
    * @return Set of fields (represented as {@code Element}s) with the given {@code nullness}.
    */
   public Set<Element> getReceiverFields(Nullness nullness) {
+    return getFieldsWithRootMatching(nullness, root -> root == null);
+  }
+
+  private Set<Element> getFieldsWithRootMatching(
+      Nullness nullness, Predicate<Element> rootMatches) {
     Set<AccessPath> nonnullAccessPaths = this.getAccessPathsWithValue(nullness);
     Set<Element> result = new LinkedHashSet<>();
     for (AccessPath ap : nonnullAccessPaths) {
-      // A null root represents the receiver
-      if (ap.getRoot() == null) {
+      if (rootMatches.test(ap.getRoot())) {
         ImmutableList<AccessPathElement> elements = ap.getElements();
         if (elements.size() == 1) {
           Element elem = elements.get(0).getJavaElement();

--- a/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
+++ b/nullaway/src/test/resources/com/uber/nullaway/testdata/CheckFieldInitNegativeCases.java
@@ -346,4 +346,21 @@ public class CheckFieldInitNegativeCases {
       }
     });
   }
+
+  enum EnumWithStaticInitializer {
+    A,
+    B;
+
+    static {
+      init(A, "x");
+      init(B, "y");
+    }
+
+    @Initializer
+    static void init(EnumWithStaticInitializer e, String value) {
+      e.field = value;
+    }
+
+    String field;
+  }
 }


### PR DESCRIPTION
Thank you for contributing to NullAway!

Please note that once you click "Create Pull Request" you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/NullAway) via [CLA assistant](https://cla-assistant.io/).

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

## Description

Adds support for static methods annotated with `@Initializer` that initialize fields through a receiver parameter.

Currently, NullAway recognizes initialization performed through instance initializer methods, but static helper methods such as:

```java
@Initializer
static void init(MyEnum e, Object value) {
    e.field = value;
}
```

are not considered when checking field initialization.

This results in false positive `@NonNull field not initialized` warnings for cases such as enum constants that defer field assignment through shared static initialization logic.

This PR updates the initialization analysis to:
- collect fields initialized through parameter access paths
- support static `@Initializer` helper methods
- reuse the existing AccessPath-based nullness tracking
- preserve the existing instance initializer behavior

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

Fixes #1625 

  - [x] If applicable, unit tests.

Added regression coverage with `EnumWithStaticInitializer`, verifying that enum fields assigned through a static `@Initializer` helper are recognized as initialized.

## Testing

Ran successfully:

```bash
gradlew.bat spotlessApply
gradlew.bat :nullaway:test
```

Both completed with `BUILD SUCCESSFUL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Field initialization analysis now recognizes assignments made via static initializer methods, reducing false positives for fields that are initialized indirectly during class setup.
  * Initialization detection is more accurate when initializer logic derives non-null field values from method parameters.
* **Tests**
  * Expanded negative-case coverage with an enum scenario that uses a static initializer plus an initializer method to assign field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->