### PR TITLE
Improve wildcard mismatch diagnostics for identical-looking types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,7 @@ Our `CHANGELOG.md` file should be formatted as follows:
 Do not add top-level `@Nullable` annotations on local variables.  NullAway infers the nullability of local variables and
 ignores these explicit annotations.
 
+Whenever you add a non-trivial method, add Javadoc, even if it's a private method.
+
 You do _not_ need to run `./gradlew spotlessJavaCheck` to check formatting.  We have a pre-commit hook that
 automatically formats code before it is committed.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -450,10 +450,10 @@ public final class GenericsChecks {
   /**
    * Returns a description of the first wildcard bound difference between {@code lhsType} and {@code
    * rhsType}, or {@code null} if no such difference can be found. Recursively traverses {@code
-   * lhsType} and {@code rhsType} to find such a difreence.
+   * lhsType} and {@code rhsType} to find such a difference.
    *
-   * <p>This is used to improve diagnostics when two types pretty-print identically, but differ in
-   * the effective upper or lower bounds of a wildcard nested somewhere inside the type.
+   * <p>This is especially useful when two types pretty-print identically, but differ in the
+   * effective upper bound of a wildcard nested somewhere inside the type.
    */
   private @Nullable String firstDifferingWildcardBound(
       Type lhsType, Type rhsType, VisitorState state) {
@@ -495,16 +495,11 @@ public final class GenericsChecks {
   }
 
   /**
-   * Returns a diagnostic fragment describing how two wildcard bounds differ, or {@code null} if
-   * their relevant bounds pretty-print the same.
-   *
-   * <p>For {@code ? super} wildcards, lower bounds are compared first since they are the explicit
-   * user-written bounds. Otherwise, this compares the effective upper bounds used by NullAway's
-   * wildcard containment checks.
+   * Returns a diagnostic fragment describing how two wildcard effective upper bounds differ, or
+   * {@code null} if those bounds pretty-print the same.
    */
   private @Nullable String wildcardBoundMismatch(
       Type.WildcardType lhsWildcard, Type.WildcardType rhsWildcard, VisitorState state) {
-    // first, check upper bounds
     Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
     Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
     String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
@@ -514,19 +509,6 @@ public final class GenericsChecks {
           "target wildcard upper bound is %s; source wildcard upper bound is %s",
           prettyLhsUpperBound, prettyRhsUpperBound);
     }
-    // otherwise, lower bounds
-    if (lhsWildcard.kind == BoundKind.SUPER && rhsWildcard.kind == BoundKind.SUPER) {
-      Type lhsLowerBound = castToNonNull(lhsWildcard.getSuperBound());
-      Type rhsLowerBound = castToNonNull(rhsWildcard.getSuperBound());
-      String prettyLhsLowerBound = prettyTypeForError(lhsLowerBound, state);
-      String prettyRhsLowerBound = prettyTypeForError(rhsLowerBound, state);
-      if (!prettyLhsLowerBound.equals(prettyRhsLowerBound)) {
-        return String.format(
-            "target wildcard lower bound is %s; source wildcard lower bound is %s",
-            prettyLhsLowerBound, prettyRhsLowerBound);
-      }
-    }
-    // otherwise, give up
     return null;
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -449,13 +449,15 @@ public final class GenericsChecks {
 
   /**
    * Returns a description of the first wildcard bound difference between {@code lhsType} and {@code
-   * rhsType}, or {@code null} if no such difference can be found.
+   * rhsType}, or {@code null} if no such difference can be found. Recursively traverses {@code
+   * lhsType} and {@code rhsType} to find such a difreence.
    *
    * <p>This is used to improve diagnostics when two types pretty-print identically, but differ in
    * the effective upper or lower bounds of a wildcard nested somewhere inside the type.
    */
   private @Nullable String firstDifferingWildcardBound(
       Type lhsType, Type rhsType, VisitorState state) {
+    // base case: both wildcard types
     Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
     if (lhsWildcard != null && rhsWildcard != null) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -504,6 +504,17 @@ public final class GenericsChecks {
    */
   private @Nullable String wildcardBoundMismatch(
       Type.WildcardType lhsWildcard, Type.WildcardType rhsWildcard, VisitorState state) {
+    // first, check upper bounds
+    Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
+    Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
+    String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
+    String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
+    if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
+      return String.format(
+          "target wildcard upper bound is %s; source wildcard upper bound is %s",
+          prettyLhsUpperBound, prettyRhsUpperBound);
+    }
+    // otherwise, lower bounds
     if (lhsWildcard.kind == BoundKind.SUPER && rhsWildcard.kind == BoundKind.SUPER) {
       Type lhsLowerBound = castToNonNull(lhsWildcard.getSuperBound());
       Type rhsLowerBound = castToNonNull(rhsWildcard.getSuperBound());
@@ -515,16 +526,8 @@ public final class GenericsChecks {
             prettyLhsLowerBound, prettyRhsLowerBound);
       }
     }
-    Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
-    Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
-    String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
-    String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
-    if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
-      return String.format(
-          "target wildcard upper bound is %s; source wildcard upper bound is %s",
-          prettyLhsUpperBound, prettyRhsUpperBound);
-    }
-    return firstDifferingWildcardBound(lhsUpperBound, rhsUpperBound, state);
+    // otherwise, give up
+    return null;
   }
 
   private void reportInvalidReturnTypeError(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -420,10 +420,16 @@ public final class GenericsChecks {
   private String errorMessageForIncompatibleTypesAtPseudoAssignment(
       Type lhsType, Type rhsType, VisitorState state) {
     String prettyRhsType = prettyTypeForError(rhsType, state);
+    String prettyLhsType = prettyTypeForError(lhsType, state);
     String result =
         String.format(
-            "incompatible types: %s cannot be converted to %s",
-            prettyRhsType, prettyTypeForError(lhsType, state));
+            "incompatible types: %s cannot be converted to %s", prettyRhsType, prettyLhsType);
+    if (prettyRhsType.equals(prettyLhsType)) {
+      String wildcardBoundMismatch = firstDifferingWildcardBound(lhsType, rhsType, state);
+      if (wildcardBoundMismatch != null) {
+        result += " (" + wildcardBoundMismatch + ")";
+      }
+    }
     if (!ASTHelpers.isSameType(lhsType, rhsType, state)
         && lhsType.getKind() == TypeKind.DECLARED
         && rhsType.getKind() == TypeKind.DECLARED) {
@@ -439,6 +445,84 @@ public final class GenericsChecks {
       }
     }
     return result;
+  }
+
+  /**
+   * Returns a description of the first wildcard bound difference between {@code lhsType} and {@code
+   * rhsType}, or {@code null} if no such difference can be found.
+   *
+   * <p>This is used to improve diagnostics when two types pretty-print identically, but differ in
+   * the effective upper or lower bounds of a wildcard nested somewhere inside the type.
+   */
+  private @Nullable String firstDifferingWildcardBound(
+      Type lhsType, Type rhsType, VisitorState state) {
+    Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
+    Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
+    if (lhsWildcard != null && rhsWildcard != null) {
+      return wildcardBoundMismatch(lhsWildcard, rhsWildcard, state);
+    }
+    if (lhsType instanceof Type.ClassType lhsClassType && rhsType instanceof Type.ClassType) {
+      Type rhsTypeAsSuper =
+          TypeSubstitutionUtils.asSuper(
+              state.getTypes(), rhsType, (Symbol.ClassSymbol) lhsType.tsym, config);
+      if (!(rhsTypeAsSuper instanceof Type.ClassType rhsClassType)
+          || rhsTypeAsSuper.isRaw()
+          || lhsType.isRaw()) {
+        return null;
+      }
+      List<Type> lhsTypeArguments = lhsClassType.getTypeArguments();
+      List<Type> rhsTypeArguments = rhsClassType.getTypeArguments();
+      if (lhsTypeArguments.size() != rhsTypeArguments.size()) {
+        return null;
+      }
+      for (int i = 0; i < lhsTypeArguments.size(); i++) {
+        String mismatch =
+            firstDifferingWildcardBound(lhsTypeArguments.get(i), rhsTypeArguments.get(i), state);
+        if (mismatch != null) {
+          return mismatch;
+        }
+      }
+      return firstDifferingWildcardBound(
+          lhsClassType.getEnclosingType(), rhsClassType.getEnclosingType(), state);
+    }
+    if (lhsType instanceof Type.ArrayType lhsArrayType
+        && rhsType instanceof Type.ArrayType rhsArrayType) {
+      return firstDifferingWildcardBound(lhsArrayType.elemtype, rhsArrayType.elemtype, state);
+    }
+    return null;
+  }
+
+  /**
+   * Returns a diagnostic fragment describing how two wildcard bounds differ, or {@code null} if
+   * their relevant bounds pretty-print the same.
+   *
+   * <p>For {@code ? super} wildcards, lower bounds are compared first since they are the explicit
+   * user-written bounds. Otherwise, this compares the effective upper bounds used by NullAway's
+   * wildcard containment checks.
+   */
+  private @Nullable String wildcardBoundMismatch(
+      Type.WildcardType lhsWildcard, Type.WildcardType rhsWildcard, VisitorState state) {
+    if (lhsWildcard.kind == BoundKind.SUPER && rhsWildcard.kind == BoundKind.SUPER) {
+      Type lhsLowerBound = castToNonNull(lhsWildcard.getSuperBound());
+      Type rhsLowerBound = castToNonNull(rhsWildcard.getSuperBound());
+      String prettyLhsLowerBound = prettyTypeForError(lhsLowerBound, state);
+      String prettyRhsLowerBound = prettyTypeForError(rhsLowerBound, state);
+      if (!prettyLhsLowerBound.equals(prettyRhsLowerBound)) {
+        return String.format(
+            "target wildcard lower bound is %s; source wildcard lower bound is %s",
+            prettyLhsLowerBound, prettyRhsLowerBound);
+      }
+    }
+    Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
+    Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
+    String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
+    String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
+    if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
+      return String.format(
+          "target wildcard upper bound is %s; source wildcard upper bound is %s",
+          prettyLhsUpperBound, prettyRhsUpperBound);
+    }
+    return firstDifferingWildcardBound(lhsUpperBound, rhsUpperBound, state);
   }
 
   private void reportInvalidReturnTypeError(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -933,6 +933,30 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void weirdErrorMessageReducedFromSpring() {
+    makeHelperWithInferenceFailureWarning()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            @NullMarked
+            final class Test {
+              static final class Flux<T> {}
+              @NullUnmarked
+              static final class Flow<T> {}
+              static <T> Flux<T> asFlux(Flow<? extends T> flow) {
+                throw new RuntimeException();
+              }
+              static Flux<?> convert(Object source) {
+                return asFlux((Flow<?>) source);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -958,6 +958,31 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void identicalLookingWildcardNestedInArrayErrorMessage() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            @NullMarked
+            final class Test {
+              static final class Flux<T> {}
+              @NullUnmarked
+              static final class Flow<T> {}
+              static <T> Flux<T>[] asFluxArray(Flow<? extends T> flow) {
+                throw new RuntimeException();
+              }
+              static Flux<?>[] convert(Object source) {
+                // BUG: Diagnostic contains: incompatible types: Flux<?> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                return asFluxArray((Flow<?>) source);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -935,7 +935,7 @@ public class WildcardTests extends NullAwayTestsBase {
 
   @Test
   public void weirdErrorMessageReducedFromSpring() {
-    makeHelperWithInferenceFailureWarning()
+    makeHelper()
         .addSourceLines(
             "Test.java",
             """
@@ -950,6 +950,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?> convert(Object source) {
+                // BUG: Diagnostic contains: incompatible types: Flux<?> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return asFlux((Flow<?>) source);
               }
             }


### PR DESCRIPTION
Before, sometimes we would sometimes emit confusing errors involving wilcard types like:
```
incompatible types: Flux<?> cannot be converted to Flux<?>
```
In cases where the error is due to incompatible upper bounds (the case we have observed in practice), this PR extends the error messages to describe the relevant bounds.  We could definitely still do better here, but at least this helps a bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incompatible-type diagnostics for nested wildcard and generic array scenarios.
  * When LHS and RHS appear similar, the message now more clearly highlights mismatched target vs. source wildcard upper bounds.

* **Tests**
  * Added new JUnit cases covering reduced incompatible-type diagnostic text for nested wildcards and array forms.

* **Documentation**
  * Added a coding-style guideline requiring Javadoc for non-trivial methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->