### PR TITLE
Propagate nullness facts for CastToNonNullMethod

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/Config.java
+++ b/nullaway/src/main/java/com/uber/nullaway/Config.java
@@ -241,6 +241,14 @@ public interface Config {
   @Nullable String getCastToNonNullMethod();
 
   /**
+   * Checks whether the <code>castToNonNull()</code> method should be treated as failing on null.
+   *
+   * @return true if <code>castToNonNull()</code> methods are guaranteed to throw when passed null,
+   *     false otherwise
+   */
+  boolean castToNonNullMethodFailsOnNull();
+
+  /**
    * Gets the suppression name aliases.
    *
    * @return the name aliases that should be honored as part of a @SuppressWarnings annotation.

--- a/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/DummyOptionsConfig.java
@@ -180,6 +180,11 @@ public class DummyOptionsConfig implements Config {
   }
 
   @Override
+  public boolean castToNonNullMethodFailsOnNull() {
+    throw new IllegalStateException(ERROR_MESSAGE);
+  }
+
+  @Override
   public Set<String> getSuppressionNameAliases() {
     throw new IllegalStateException(ERROR_MESSAGE);
   }

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -66,6 +66,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_NULLABLE_ANNOT = EP_FL_NAMESPACE + ":CustomNullableAnnotations";
   static final String FL_NONNULL_ANNOT = EP_FL_NAMESPACE + ":CustomNonnullAnnotations";
   static final String FL_CTNN_METHOD = EP_FL_NAMESPACE + ":CastToNonNullMethod";
+  static final String FL_CTNN_METHOD_FAILS_ON_NULL =
+      EP_FL_NAMESPACE + ":CastToNonNullMethodFailsOnNull";
   static final String FL_EXTERNAL_INIT_ANNOT = EP_FL_NAMESPACE + ":ExternalInitAnnotations";
   static final String FL_CONTRACT_ANNOT = EP_FL_NAMESPACE + ":CustomContractAnnotations";
   static final String FL_UNANNOTATED_CLASSES = EP_FL_NAMESPACE + ":UnannotatedClasses";
@@ -243,6 +245,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final ImmutableSet<String> externalInitAnnotations;
   private final ImmutableSet<String> contractAnnotations;
   private final @Nullable String castToNonNullMethod;
+  private final boolean castToNonNullMethodFailsOnNull;
   private final String autofixSuppressionComment;
   private final ImmutableSet<String> suppressionNameAliases;
   private final ImmutableSet<String> skippedLibraryModels;
@@ -312,6 +315,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
         getPackagePattern(
             getFlagStringSet(flags, FL_EXCLUDED_FIELD_ANNOT, DEFAULT_EXCLUDED_FIELD_ANNOT));
     castToNonNullMethod = flags.get(FL_CTNN_METHOD).orElse(null);
+    castToNonNullMethodFailsOnNull = flags.getBoolean(FL_CTNN_METHOD_FAILS_ON_NULL).orElse(false);
     legacyAnnotationLocation = flags.getBoolean(FL_LEGACY_ANNOTATION_LOCATION).orElse(false);
     if (legacyAnnotationLocation && jspecifyMode) {
       throw new IllegalStateException(
@@ -552,6 +556,11 @@ final class ErrorProneCLIFlagsConfig implements Config {
   @Override
   public @Nullable String getCastToNonNullMethod() {
     return castToNonNullMethod;
+  }
+
+  @Override
+  public boolean castToNonNullMethodFailsOnNull() {
+    return castToNonNullMethodFailsOnNull;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -403,9 +403,12 @@ public class LibraryModelsHandler implements Handler {
         getOptLibraryModels(state.context).failIfNullParameters(callee);
     ImmutableSet<Integer> castToNonNullParameters =
         getOptLibraryModels(state.context).castToNonNullMethod(callee);
-    String qualifiedName = ASTHelpers.enclosingClass(callee) + "." + callee.getSimpleName();
+    String cliCastToNonNull = config.getCastToNonNullMethod();
     boolean isCliCastToNonNull =
-        qualifiedName.equals(config.getCastToNonNullMethod()) && callee.getParameters().size() == 1;
+        cliCastToNonNull != null
+            && callee.getParameters().size() == 1
+            && cliCastToNonNull.equals(
+                ASTHelpers.enclosingClass(callee) + "." + callee.getSimpleName());
 
     Set<Integer> allNonNullParams;
     if (castToNonNullParameters.isEmpty() && !isCliCastToNonNull) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -401,24 +401,28 @@ public class LibraryModelsHandler implements Handler {
       AccessPath.AccessPathContext apContext) {
     ImmutableSet<Integer> requiredNonNullParameters =
         getOptLibraryModels(state.context).failIfNullParameters(callee);
-    ImmutableSet<Integer> castToNonNullParameters =
-        getOptLibraryModels(state.context).castToNonNullMethod(callee);
-    String cliCastToNonNull = config.getCastToNonNullMethod();
-    boolean isCliCastToNonNull =
-        cliCastToNonNull != null
-            && callee.getParameters().size() == 1
-            && cliCastToNonNull.equals(
-                ASTHelpers.enclosingClass(callee) + "." + callee.getSimpleName());
-
     Set<Integer> allNonNullParams;
-    if (castToNonNullParameters.isEmpty() && !isCliCastToNonNull) {
-      allNonNullParams = requiredNonNullParameters;
-    } else {
-      allNonNullParams = new HashSet<>(requiredNonNullParameters);
-      allNonNullParams.addAll(castToNonNullParameters);
-      if (isCliCastToNonNull) {
-        allNonNullParams.add(0);
+    if (config.castToNonNullMethodFailsOnNull()) {
+      ImmutableSet<Integer> castToNonNullParameters =
+          getOptLibraryModels(state.context).castToNonNullMethod(callee);
+      String cliCastToNonNull = config.getCastToNonNullMethod();
+      boolean isCliCastToNonNull =
+          cliCastToNonNull != null
+              && callee.getParameters().size() == 1
+              && cliCastToNonNull.equals(
+                  ASTHelpers.enclosingClass(callee) + "." + callee.getSimpleName());
+
+      if (castToNonNullParameters.isEmpty() && !isCliCastToNonNull) {
+        allNonNullParams = requiredNonNullParameters;
+      } else {
+        allNonNullParams = new HashSet<>(requiredNonNullParameters);
+        allNonNullParams.addAll(castToNonNullParameters);
+        if (isCliCastToNonNull) {
+          allNonNullParams.add(0);
+        }
       }
+    } else {
+      allNonNullParams = requiredNonNullParameters;
     }
 
     for (AccessPath accessPath :

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -401,8 +401,25 @@ public class LibraryModelsHandler implements Handler {
       AccessPath.AccessPathContext apContext) {
     ImmutableSet<Integer> requiredNonNullParameters =
         getOptLibraryModels(state.context).failIfNullParameters(callee);
+    ImmutableSet<Integer> castToNonNullParameters =
+        getOptLibraryModels(state.context).castToNonNullMethod(callee);
+    String qualifiedName = ASTHelpers.enclosingClass(callee) + "." + callee.getSimpleName();
+    boolean isCliCastToNonNull =
+        qualifiedName.equals(config.getCastToNonNullMethod()) && callee.getParameters().size() == 1;
+
+    Set<Integer> allNonNullParams;
+    if (castToNonNullParameters.isEmpty() && !isCliCastToNonNull) {
+      allNonNullParams = requiredNonNullParameters;
+    } else {
+      allNonNullParams = new HashSet<>(requiredNonNullParameters);
+      allNonNullParams.addAll(castToNonNullParameters);
+      if (isCliCastToNonNull) {
+        allNonNullParams.add(0);
+      }
+    }
+
     for (AccessPath accessPath :
-        accessPathsAtIndexes(requiredNonNullParameters, arguments, state, apContext)) {
+        accessPathsAtIndexes(allNonNullParams, arguments, state, apContext)) {
       bothUpdates.set(accessPath, NONNULL);
     }
   }

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -397,6 +397,31 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testCastToNonNullPropagation() {
+    defaultCompilationHelper
+        .addSourceFile("testdata/Util.java")
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              static class Foo {
+                @Nullable String getToken() { return ""; }
+              }
+              void test(Foo value) {
+                if (castToNonNull(value.getToken()).contains("abc")) {
+                  value.getToken().length();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Test
   public void testReadStaticInConstructor() {
     defaultCompilationHelper

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -23,6 +23,7 @@
 package com.uber.nullaway;
 
 import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -399,7 +400,7 @@ public class CoreTests extends NullAwayTestsBase {
 
   @SuppressWarnings("deprecation")
   @Test
-  public void testCastToNonNullPropagation() {
+  public void testCastToNonNullPropagationDefault() {
     defaultCompilationHelper
         .addSourceFile("testdata/Util.java")
         .addSourceLines(
@@ -414,6 +415,98 @@ public class CoreTests extends NullAwayTestsBase {
               }
               void test(Foo value) {
                 if (castToNonNull(value.getToken()).contains("abc")) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value.getToken()' is @Nullable
+                  value.getToken().length();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testCastToNonNullPropagationExplicitFalse() {
+    makeTestHelperWithArgs(
+            List.of(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
+                "-XepOpt:NullAway:CastToNonNullMethodFailsOnNull=false"))
+        .addSourceFile("testdata/Util.java")
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              static class Foo {
+                @Nullable String getToken() { return ""; }
+              }
+              void test(Foo value) {
+                if (castToNonNull(value.getToken()).contains("abc")) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value.getToken()' is @Nullable
+                  value.getToken().length();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testCastToNonNullPropagationFailsOnNullEnabled() {
+    makeTestHelperWithArgs(
+            List.of(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
+                "-XepOpt:NullAway:CastToNonNullMethodFailsOnNull=true"))
+        .addSourceFile("testdata/Util.java")
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import static com.uber.nullaway.testdata.Util.castToNonNull;
+            class Test {
+              static class Foo {
+                @Nullable String getToken() { return ""; }
+              }
+              void test(Foo value) {
+                if (castToNonNull(value.getToken()).contains("abc")) {
+                  value.getToken().length();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void testObjectsRequireNonNullPropagationUnchanged() {
+    makeTestHelperWithArgs(
+            List.of(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CastToNonNullMethodFailsOnNull=false"))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.Objects;
+            import javax.annotation.Nullable;
+            class Test {
+              static class Foo {
+                @Nullable String getToken() { return ""; }
+              }
+              void test(Foo value) {
+                if (Objects.requireNonNull(value.getToken()).contains("abc")) {
                   value.getToken().length();
                 }
               }


### PR DESCRIPTION
Fixes #1628.

## Summary

`Objects.requireNonNull(...)` propagates non-null facts during dataflow analysis because it is guaranteed to throw when passed `null`. Arbitrary methods configured via `-XepOpt:NullAway:CastToNonNullMethod` do not necessarily have that guarantee, so propagating non-null facts by default would be unsound.

This PR introduces a new opt-in configuration option:

`-XepOpt:NullAway:CastToNonNullMethodFailsOnNull=true`

When enabled, configured `CastToNonNullMethod`s are treated as fail-fast during dataflow analysis and propagate non-null facts similarly to `Objects.requireNonNull(...)`. The default behavior remains unchanged, preserving backward compatibility and soundness.

## Changes

* Add the `CastToNonNullMethodFailsOnNull` configuration option.
* Enable downstream non-null propagation for configured `CastToNonNullMethod`s only when the option is enabled.
* Preserve the existing behavior for `failIfNullParameters` and the default `CastToNonNullMethod` behavior.
* Add regression tests covering:
  * default behavior,
  * explicit `false`,
  * explicit `true`,
  * unchanged `Objects.requireNonNull(...)` behavior.

## Validation

* Added regression tests covering the new configuration option.
* Ran `:nullaway:test`.
* Ran `spotlessCheck`.

## AI Usage

AI assistance was used during the development of this contribution to:

* understand the existing NullAway architecture and relevant code paths,
* discuss implementation approaches based on maintainer feedback,
* review and refine the implementation,
* help improve regression tests and this PR description.

I personally implemented, reviewed, and validated all code changes. I inspected the relevant source files, made the implementation decisions, ran the project's test suite locally, and verified the final behavior. I understand the implementation and can explain the reasoning behind each change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration/CLI option to control whether `castToNonNull(...)` is treated as throwing on null inputs.
* **Bug Fixes**
  * Improved nullability propagation for library-mode "cast-to-non-null" behavior, expanding the set of arguments treated as guaranteed and ensuring downstream dereference diagnostics match the configured semantics.
* **Tests**
  * Added coverage for default behavior, explicit `false`, and enabled `true` cases, plus verification that `Objects.requireNonNull(...)` behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->