### PR TITLE
Fix incorrect @NonNull requirement for nullable record components with compact constructors

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -356,14 +356,71 @@ public class NullabilityUtil {
   public static Stream<? extends AnnotationMirror> getAllAnnotationsForParameter(
       Symbol.MethodSymbol symbol, int paramInd, Config config) {
     Symbol.VarSymbol varSymbol = symbol.getParameters().get(paramInd);
-    return Stream.concat(
-        varSymbol.getAnnotationMirrors().stream(),
-        symbol.getRawTypeAttributes().stream()
-            .filter(
-                t ->
-                    t.position.type.equals(TargetType.METHOD_FORMAL_PARAMETER)
-                        && t.position.parameter_index == paramInd
-                        && NullabilityUtil.isDirectTypeUseAnnotation(t, symbol, config)));
+    Stream<? extends AnnotationMirror> result =
+        Stream.concat(
+            varSymbol.getAnnotationMirrors().stream(),
+            symbol.getRawTypeAttributes().stream()
+                .filter(
+                    t ->
+                        t.position.type.equals(TargetType.METHOD_FORMAL_PARAMETER)
+                            && t.position.parameter_index == paramInd
+                            && NullabilityUtil.isDirectTypeUseAnnotation(t, symbol, config)));
+
+    if (isCanonicalRecordConstructor(symbol)) {
+      Symbol.ClassSymbol classSymbol = (Symbol.ClassSymbol) symbol.owner;
+      List<?> recordComponents = classSymbol.getRecordComponents();
+      if (recordComponents != null && paramInd < recordComponents.size()) {
+        Symbol recordComponent = (Symbol) recordComponents.get(paramInd);
+        result =
+            Stream.concat(
+                result,
+                Stream.concat(
+                    recordComponent.getAnnotationMirrors().stream(),
+                    recordComponent.type.getAnnotationMirrors().stream()));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Checks if a symbol represents the canonical constructor of a record. We verify this by checking
+   * that it is a constructor of a record, has the same number of parameters as the record
+   * components, and the parameter types match the record component types exactly.
+   */
+  private static boolean isCanonicalRecordConstructor(Symbol.MethodSymbol symbol) {
+    if (!symbol.isConstructor() || !symbol.owner.getKind().equals(ElementKind.RECORD)) {
+      return false;
+    }
+    Symbol.ClassSymbol classSymbol = (Symbol.ClassSymbol) symbol.owner;
+    List<?> recordComponents = classSymbol.getRecordComponents();
+    if (recordComponents == null || symbol.getParameters().size() != recordComponents.size()) {
+      return false;
+    }
+    for (int i = 0; i < recordComponents.size(); i++) {
+      if (!isSameTypeIgnoredAnnotations(
+          symbol.getParameters().get(i).type, ((Symbol) recordComponents.get(i)).type)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Recursively compares two types for equality, ignoring any annotations present on them. */
+  @SuppressWarnings({"TypeEquals", "ReferenceEquality"})
+  private static boolean isSameTypeIgnoredAnnotations(Type t1, Type t2) {
+    if (t1 == t2) {
+      return true;
+    }
+    if (t1 == null || t2 == null) {
+      return false;
+    }
+    if (t1 instanceof Type.ArrayType arrayType1 && t2 instanceof Type.ArrayType arrayType2) {
+      return isSameTypeIgnoredAnnotations(arrayType1.elemtype, arrayType2.elemtype);
+    }
+    if (t1.tsym != null && t2.tsym != null) {
+      return t1.tsym.equals(t2.tsym);
+    }
+    return false;
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -817,6 +817,31 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void recordConstructorWithCompactConstructor() {
+    makeHelper()
+        .addSourceLines(
+            "TestRecord.java",
+            """
+            package com.uber;
+            import java.util.Objects;
+            import org.jspecify.annotations.Nullable;
+
+            public record TestRecord(Object type, String filename, byte @Nullable [] value) {
+
+              public static TestRecord file(final String filename) {
+                return new TestRecord(new Object(), filename, null);
+              }
+
+              public TestRecord {
+                Objects.requireNonNull(type, "type");
+                Objects.requireNonNull(filename, "filename");
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Fixes #1631

## Summary

Fix a false positive where NullAway incorrectly reports that a `@NonNull` value is required for a record component annotated with a type-use `@Nullable` annotation when the record defines a compact (custom) constructor.

## Root Cause

When analyzing canonical record constructors, NullAway only considered annotations attached directly to the constructor parameter. For canonical record constructors, the corresponding record component also carries relevant nullability annotations, but these were not being considered during analysis, causing the `@Nullable` annotation to be missed in this scenario.

## Fix

Update `NullabilityUtil.getAllAnnotationsForParameter` to detect canonical record constructors and retrieve annotations from the corresponding record component in addition to the constructor parameter. This ensures that declaration and type-use annotations on record components are available during nullability analysis.

## Tests

Added a regression test that reproduces the issue using a record with a compact constructor and a type-use `@Nullable` array component. The test fails without the fix and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for record constructors, including compact constructors.
  * Annotation handling now correctly accounts for annotations declared on record components and their types.

* **Tests**
  * Added coverage for nullable array components in records with compact constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->