### PR TITLE
Add policy on AI-generated PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,11 @@ Before pressing the "Create Pull Request" button, please provide the following:
 **Note on AI usage**
 
 We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
-all changes in the PR.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
-please indicate which AI tools were used in your PR description, and attest that you have read and understood all
-changes in the PR.
+all the changes.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
+please disclose in the PR description which AI tools were used and how they were used, and also attest
+that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
+[JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
+
+> I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.
+
+> I used ChatGPT to help me understand an error message and suggest debugging steps. I implemented the fix myself after verifying it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,10 @@ Before pressing the "Create Pull Request" button, please provide the following:
   - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
 
   - [ ] If applicable, unit tests.
+
+**Note on AI usage**
+
+We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
+all changes in the PR.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
+please indicate which AI tools were used in your PR description, and attest that you have read and understood all
+changes in the PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,8 @@ please disclose in the PR description which AI tools were used and how they were
 that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
 [JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
 
+<!-- first example -->
 > I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.
 
+<!-- second example -->
 > I used ChatGPT to help me understand an error message and suggest debugging steps. I implemented the fix myself after verifying it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ please disclose in the PR description which AI tools were used and how they were
 that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
 [JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
 
+<!-- first example -->
 > I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.
 
+<!-- second example -->
 > I used ChatGPT to help me understand an error message and suggest debugging steps. I implemented the fix myself after verifying it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,11 @@ AI usage
 --------
 
 We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
-all changes in the PR.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
-please indicate which AI tools were used in your PR description, and attest that you have read and understood all
-changes in the PR.
+all the changes.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
+please disclose in the PR description which AI tools were used and how they were used, and also attest
+that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
+[JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
+
+> I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.
+
+> I used ChatGPT to help me understand an error message and suggest debugging steps. I implemented the fix myself after verifying it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,11 @@ Guiding Principles
 * We allow anyone to participate in our projects. Tasks can be carried out by anyone that demonstrates the capability to complete them
 * Always be respectful of one another. Assume the best in others and act with empathy at all times
 * Collaborate closely with individuals maintaining the project or experienced users. Getting ideas out in the open and seeing a proposal before it's a pull request helps reduce redundancy and ensures we're all connected to the decision making process
+
+AI usage
+--------
+
+We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
+all changes in the PR.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
+please indicate which AI tools were used in your PR description, and attest that you have read and understood all
+changes in the PR.


### PR DESCRIPTION
This is a proposed policy on AI-generated PRs.  I don't think we should ban AI usage in contributed code, but I think we should try to ensure the contributors actually understand the changes they are contributing.  Hence, the proposed text:

> We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
all changes in the PR.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
please indicate which AI tools were used in your PR description, and attest that you have read and understood all
changes in the PR.

I call out first-time contributors since once someone has actually gotten a PR through the review process and established their understanding, I think we can take a lighter touch.  If new contributors repeatedly violate the guideline above, we should consider banning them from future contributions.

@yuxincs @lazaroclapp thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with an “AI usage” section covering review and disclosure expectations for AI-assisted contributions.
  * Added matching “AI usage” guidance to the contribution guide, including requirements for first-time AI users to list tools used, describe usage, and include an attestation with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->