### PR TITLE
Fix issue with reading annotations on record constructor parameters due to javac bug

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -356,14 +356,20 @@ public class NullabilityUtil {
   public static Stream<? extends AnnotationMirror> getAllAnnotationsForParameter(
       Symbol.MethodSymbol symbol, int paramInd, Config config) {
     Symbol.VarSymbol varSymbol = symbol.getParameters().get(paramInd);
-    return Stream.concat(
-        varSymbol.getAnnotationMirrors().stream(),
-        symbol.getRawTypeAttributes().stream()
-            .filter(
-                t ->
-                    t.position.type.equals(TargetType.METHOD_FORMAL_PARAMETER)
-                        && t.position.parameter_index == paramInd
-                        && NullabilityUtil.isDirectTypeUseAnnotation(t, symbol, config)));
+    // On modern javac versions, type-use annotations are attached directly to the parameter's
+    // type. Keep reading raw attributes as well for backward compatibility with older javac
+    // behavior and legacy annotation-location handling.
+    Stream<? extends AnnotationMirror> typeUseAnnotations =
+        Stream.concat(
+                varSymbol.type.getAnnotationMirrors().stream(),
+                symbol.getRawTypeAttributes().stream()
+                    .filter(
+                        t ->
+                            t.position.type.equals(TargetType.METHOD_FORMAL_PARAMETER)
+                                && t.position.parameter_index == paramInd
+                                && NullabilityUtil.isDirectTypeUseAnnotation(t, symbol, config)))
+            .distinct();
+    return Stream.concat(varSymbol.getAnnotationMirrors().stream(), typeUseAnnotations);
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
@@ -412,12 +412,19 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
         .addSourceLines(
             "Test.java",
             """
-            import java.util.Objects;
             import org.jspecify.annotations.*;
             @NullMarked
-            public record Test(byte @Nullable [] value) {
+            public record Test(String name, byte @Nullable [] value, Object marker) {
               public static Test file() {
-                return new Test(null);
+                return new Test("file", null, new Object());
+              }
+              public static Test nullName() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                return new Test(null, new byte[0], new Object());
+              }
+              public static Test nullMarker() {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                return new Test("file", new byte[0], null);
               }
               public Test {
               }

--- a/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
@@ -406,6 +406,26 @@ public class TypeUseAnnotationsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void recordConstructorParameter() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Objects;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public record Test(byte @Nullable [] value) {
+              public static Test file() {
+                return new Test(null);
+              }
+              public Test {
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeLegacyModeHelper() {
     return makeTestHelperWithArgs(
         Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -817,6 +817,28 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void recordConstructorParameter() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Objects;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public record Test(Object type, String filename, byte @Nullable [] value) {
+              public static Test file(final String filename) {
+                return new Test(new Object(), filename, null);
+              }
+              public Test {
+                Objects.requireNonNull(type, "type");
+                Objects.requireNonNull(filename, "filename");
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Due to a bug in `javac` in JDK 17-26 (fixed in https://github.com/openjdk/jdk/pull/29928), sometimes type use annotations appear on record constructor parameters with position `FIELD` (specifically, when a compact record constructor is used).  We work around that bug by also looking for type use annotations on the type of the symbol for the parameter.  Previously this would not work for parameters from bytecode, but it works now on the most recent versions of JDK 17 and 21 with the flag `-XDaddTypeAnnotationsToSymbol=true` passed to `javac`.  As it requires a significant hack to fix this otherwise, and it only impacts checking outside JSpecify mode, I'm not inclined to try to fix for when `-XDaddTypeAnnotationsToSymbol=true` is not passed.

Fixes #1631 