### PR TITLE
Fix handling of reference to method with `@Nullable` parameter from library model

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -816,10 +816,19 @@ public class NullAway extends BugChecker
                 && !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler))
             || lambdaExpressionTree != null;
     Type.MethodType jspecifyMemberReferenceMethodType = null;
+    // Keep handler-provided nullness for the referenced method separate from nullness for the
+    // functional interface method. Library models may change the referenced method's signature.
+    MethodParameterNullness referencedMethodParameterNullnessOverrides = null;
     if (memberReferenceTree != null) {
+      Symbol.MethodSymbol referencedMethod = castToNonNull(overridingMethod);
       jspecifyMemberReferenceMethodType =
-          genericsChecks.getMemberReferenceMethodType(
-              memberReferenceTree, castToNonNull(overridingMethod), state);
+          genericsChecks.getMemberReferenceMethodType(memberReferenceTree, referencedMethod, state);
+      referencedMethodParameterNullnessOverrides =
+          handler.onOverrideMethodInvocationParametersNullability(
+              state.context,
+              referencedMethod,
+              isOverridingMethodAnnotated,
+              MethodParameterNullness.create(referencedMethod));
     }
 
     MethodParameterNullness overriddenMethodArgumentNullness =
@@ -921,6 +930,15 @@ public class NullAway extends BugChecker
               isOverridingMethodAnnotated,
               memberReferenceTree,
               jspecifyMemberReferenceMethodType);
+      // A non-null entry is an explicit handler override, so it takes precedence over the result
+      // derived above from annotations and generic type substitution.
+      if (referencedMethodParameterNullnessOverrides != null) {
+        Nullness referencedParameterNullnessOverride =
+            referencedMethodParameterNullnessOverrides.getParameterNullness(methodParamInd);
+        if (referencedParameterNullnessOverride != null) {
+          paramIsNonNull = referencedParameterNullnessOverride.equals(Nullness.NONNULL);
+        }
+      }
       // in the case where we have a parameter of a lambda expression, we do
       // *not* force the parameter to be annotated with @Nullable; instead we "inherit"
       // nullability from the corresponding functional interface method.

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -929,16 +929,8 @@ public class NullAway extends BugChecker
               overridingMethod,
               isOverridingMethodAnnotated,
               memberReferenceTree,
-              jspecifyMemberReferenceMethodType);
-      // A non-null entry is an explicit handler override, so it takes precedence over the result
-      // derived above from annotations and generic type substitution.
-      if (referencedMethodParameterNullnessOverrides != null) {
-        Nullness referencedParameterNullnessOverride =
-            referencedMethodParameterNullnessOverrides.getParameterNullness(methodParamInd);
-        if (referencedParameterNullnessOverride != null) {
-          paramIsNonNull = referencedParameterNullnessOverride.equals(Nullness.NONNULL);
-        }
-      }
+              jspecifyMemberReferenceMethodType,
+              referencedMethodParameterNullnessOverrides);
       // in the case where we have a parameter of a lambda expression, we do
       // *not* force the parameter to be annotated with @Nullable; instead we "inherit"
       // nullability from the corresponding functional interface method.
@@ -999,6 +991,8 @@ public class NullAway extends BugChecker
    *     member reference; otherwise {@code null}
    * @param memberReferenceMethodType if the overriding method is a member reference, the method
    *     type of the member reference after handling generics; otherwise {@code null}
+   * @param referencedMethodParameterNullnessOverrides handler-provided parameter nullness for the
+   *     referenced method, or {@code null} if the overriding method is not a member reference
    * @return true if the parameter of the overriding method is effectively {@code @NonNull}, false
    *     otherwise
    */
@@ -1008,7 +1002,16 @@ public class NullAway extends BugChecker
       Symbol.@Nullable MethodSymbol overridingMethod,
       boolean isMethodAnnotated,
       @Nullable MemberReferenceTree memberReferenceTree,
-      Type.@Nullable MethodType memberReferenceMethodType) {
+      Type.@Nullable MethodType memberReferenceMethodType,
+      @Nullable MethodParameterNullness referencedMethodParameterNullnessOverrides) {
+    if (referencedMethodParameterNullnessOverrides != null) {
+      Nullness parameterNullnessOverride =
+          referencedMethodParameterNullnessOverrides.getParameterNullness(methodParamInd);
+      if (parameterNullnessOverride != null) {
+        // An explicit handler value takes precedence over annotations and generic substitution.
+        return parameterNullnessOverride.equals(Nullness.NONNULL);
+      }
+    }
     boolean result = false;
     if (isMethodAnnotated) {
       result = !Nullness.hasNullableAnnotation(paramSymbol, config);

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -52,6 +52,8 @@ public class TestLibraryModels implements LibraryModels {
             "com.uber.lib.unannotated.NullMarkedVarargsWithModel",
             "bothNullable(java.lang.String...)"),
         0,
+        methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "isNonNull(java.lang.Object)"),
+        0,
         methodRef("com.uber.lib.unannotated.Box", "orElse(T)"),
         0);
   }

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -240,6 +240,75 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void modeledNullableParameterUsedByFilterMethodReference() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber")))
+        .addSourceLines(
+            "List.java",
+            """
+            package com.uber;
+
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            public interface List<T extends @Nullable Object> {
+              Stream<T> stream();
+            }
+            """)
+        .addSourceLines(
+            "Stream.java",
+            """
+            package com.uber;
+
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            public interface Stream<T extends @Nullable Object> {
+              Stream<T> filter(Predicate<? super T> predicate);
+              boolean anyMatch(Predicate<? super T> predicate);
+            }
+            """)
+        .addSourceLines(
+            "Predicate.java",
+            """
+            package com.uber;
+
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            public interface Predicate<T extends @Nullable Object> {
+              boolean test(T value);
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+
+            import com.uber.lib.unannotated.UnannotatedWithModels;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static boolean hasNonNullString(List<@Nullable String> strings) {
+                return strings.stream()
+                    .filter(UnannotatedWithModels::isNonNull)
+                    .anyMatch(string -> true);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void libraryModelsAndOverridingFieldNullability() {
     makeLibraryModelsTestHelperWithArgs(
             Arrays.asList(

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -300,6 +300,8 @@ public class CustomLibraryModelsTests {
             class Test {
               static boolean hasNonNullString(List<@Nullable String> strings) {
                 return strings.stream()
+                    // we expect no warning here, since a library model indicates
+                    // the parameter of isNonNull is @Nullable
                     .filter(UnannotatedWithModels::isNonNull)
                     .anyMatch(string -> true);
               }


### PR DESCRIPTION
Consider the following case:
```java
class Test {
  static boolean hasNonNullString(List<@Nullable String> strings) {
    return strings.stream()
        .filter(UnannotatedWithModels::isNonNull)
        .anyMatch(string -> true);
  }
}
```
Say that the parameter of `UnannotatedWithModels::isNonNull` is not declared with a `@Nullable` annotation, but should be treated as `@Nullable` due to a library model.  In such a case, before we would still report a warning for the above code that `UnannotatedWithModels::isNonNull` cannot take a `@Nullable` parameter, since we weren't checking the library models in the right place.  This PR corrects this issue. This fix will be relevant to uses of `Objects::isNonNull` in stream pipelines when we enable JDK library models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullness analysis for method references used as functional-interface predicates by applying referenced-method parameter nullness overrides with the correct precedence.

* **Tests**
  * Updated test library models to add an additional explicitly modeled parameter nullness case.
  * Added a regression test to verify modeled nullable parameters flow correctly through `Stream.filter(...)` when using method references (validated via `anyMatch(...)`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->