### PR TITLE
Handle signature-polymorphic calls in InvocationArguments

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/InvocationArguments.java
+++ b/nullaway/src/main/java/com/uber/nullaway/InvocationArguments.java
@@ -60,8 +60,13 @@ public class InvocationArguments {
     com.sun.tools.javac.util.List<Type> parameterTypes = invokedMethodType.getParameterTypes();
     this.paramTypesArr = parameterTypes.toArray(new Type[parameterTypes.size()]);
 
-    // Precompute varargs state and related types
-    this.isVarArgs = methodSymbol.isVarArgs();
+    // Precompute varargs state and related types. For signature-polymorphic methods such as
+    // MethodHandle.invoke(), the symbol is varargs but javac adapts the invocation type to a
+    // fixed-arity signature whose final parameter is not necessarily an array.
+    this.isVarArgs =
+        methodSymbol.isVarArgs()
+            && paramTypesArr.length > 0
+            && paramTypesArr[paramTypesArr.length - 1] instanceof Type.ArrayType;
     if (this.isVarArgs) {
       this.varArgsIndex = paramTypesArr.length - 1;
       this.varArgsArrayType = (Type.ArrayType) paramTypesArr[varArgsIndex];

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -776,6 +776,23 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void methodHandleInvokeWithConditionalOperatorTest() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.lang.invoke.MethodHandle;
+            class Test {
+              public static void test(MethodHandle methodHandle, boolean value) throws Throwable {
+                methodHandle.invoke(value ? 1 : 0);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -776,6 +776,12 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * Tests that a conditional argument to the signature-polymorphic {@code MethodHandle.invoke} does
+   * not cause a {@link ClassCastException} when javac adapts its varargs parameter to a non-array
+   * call-site type. Regression test for <a
+   * href="https://github.com/uber/NullAway/issues/1643">issue #1643</a>.
+   */
   @Test
   public void methodHandleInvokeWithConditionalOperatorTest() {
     makeHelper()


### PR DESCRIPTION
Fixes #1643 

For calls to signature-polymorphic methods like `MethodHandle.invoke` we need a more careful check for whether the call is varargs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved varargs detection for method invocations, especially when signature-polymorphic calls are adapted to fixed-arity forms.
  * Refined varargs-specific analysis to avoid incorrect processing when the last formal parameter isn’t truly varargs.
* **Tests**
  * Added a regression test covering `MethodHandle.invoke` with conditional-expression arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->