### PR TITLE
Enable JSpecify JDK models for regression tests

### DIFF
--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -83,6 +83,9 @@ public class JDKIntegrationTest {
   public void libraryModelWithoutJarInferEnabledTest() {
     compilationHelper
         .setArgs(
+            // Run this test in JSpecify mode to ensure that loading of JDK models does not also
+            // load
+            // external astubx files from JarInfer
             JSpecifyJavacConfig.withJSpecifyModeArgs(
                 Arrays.asList(
                     "-d",

--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -83,10 +83,11 @@ public class JDKIntegrationTest {
   public void libraryModelWithoutJarInferEnabledTest() {
     compilationHelper
         .setArgs(
-            Arrays.asList(
-                "-d",
-                temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber")))
         .addSourceLines(
             "Test.java",
             """

--- a/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
+++ b/jdk-annotations/jdk-integration-test/src/test/java/com/uber/nullaway/jdkannotations/JDKIntegrationTest.java
@@ -84,8 +84,7 @@ public class JDKIntegrationTest {
     compilationHelper
         .setArgs(
             // Run this test in JSpecify mode to ensure that loading of JDK models does not also
-            // load
-            // external astubx files from JarInfer
+            // load external astubx files from JarInfer
             JSpecifyJavacConfig.withJSpecifyModeArgs(
                 Arrays.asList(
                     "-d",

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -20,9 +20,14 @@ public final class JSpecifyJavacConfig {
   public static final String ADD_TYPE_ANNOTATIONS_FLAG = "-XDaddTypeAnnotationsToSymbol=true";
   public static final String HANDLE_WILDCARD_GENERICS_FLAG =
       "-XepOpt:NullAway:HandleWildcardGenerics=true";
+  public static final String USE_JSPECIFY_JDK_MODELS = "-XepOpt:NullAway:JSpecifyJDKModels=true";
 
   private static final List<String> JSPECIFY_MODE_ARGS =
-      List.of(JSPECIFY_MODE_FLAG, ADD_TYPE_ANNOTATIONS_FLAG, HANDLE_WILDCARD_GENERICS_FLAG);
+      List.of(
+          JSPECIFY_MODE_FLAG,
+          ADD_TYPE_ANNOTATIONS_FLAG,
+          HANDLE_WILDCARD_GENERICS_FLAG,
+          USE_JSPECIFY_JDK_MODELS);
 
   private JSpecifyJavacConfig() {}
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -1657,7 +1657,7 @@ public class LibraryModelsHandler implements Handler {
 
     ExternalStubxLibraryModels(boolean isJarInferEnabled, boolean isJSpecifyJDKEnabled) {
       String libraryModelLogName = "LM";
-      StubxCacheUtil cacheUtil = new StubxCacheUtil(libraryModelLogName);
+      StubxCacheUtil cacheUtil = new StubxCacheUtil(libraryModelLogName, isJarInferEnabled);
       if (isJarInferEnabled) {
         // hardcoded loading of stubx files from android-jarinfer-models-sdkXX artifacts
         try (InputStream androidStubxIS =

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
@@ -80,21 +80,23 @@ public class StubxCacheUtil {
   private final Map<String, SetMultimap<Integer, NestedAnnotationInfo>> nestedAnnotationInfoCache;
 
   /**
-   * Initializes a new {@code StubxCacheUtil} instance.
-   *
-   * <p>This sets up the caches for argument annotations and upper bounds, sets the log caller, and
-   * loads the stubx files.
+   * Initializes a new {@code StubxCacheUtil} instance, optionally loading JarInfer stubx files
+   * discovered on the classpath.
    *
    * @param logCaller Identifier for logging purposes.
+   * @param loadJarInferModels whether to load stubx files provided by {@link JarInferStubxProvider}
+   *     implementations
    */
-  public StubxCacheUtil(String logCaller) {
+  StubxCacheUtil(String logCaller, boolean loadJarInferModels) {
     argAnnotCache = new LinkedHashMap<>();
     upperBoundCache = new HashMap<>();
     nullMarkedClassesCache = new HashSet<>();
     methodTypeParamNullableUpperBoundCache = HashMultimap.create();
     nestedAnnotationInfoCache = new HashMap<>();
     this.logCaller = logCaller;
-    loadStubxFiles();
+    if (loadJarInferModels) {
+      loadStubxFiles();
+    }
   }
 
   public Map<String, Integer> getUpperBoundCache() {

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -64,7 +64,8 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   @Test
   public void listContainingNullsWithoutModel() {
     makeTestHelperWithArgs(
-            // We specifically exclude the JSpecifyJDKModels flag here (so we can't use `withJSpecifyModeArgs`)
+            // We specifically exclude the JSpecifyJDKModels flag here (so we can't use
+            // `withJSpecifyModeArgs`)
             List.of(
                 "-XepOpt:NullAway:AnnotatedPackages=foo",
                 JSpecifyJavacConfig.JSPECIFY_MODE_FLAG,

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -64,7 +64,7 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   @Test
   public void listContainingNullsWithoutModel() {
     makeTestHelperWithArgs(
-            // We specifically exclude the JSpecifyJDKModels flag here
+            // We specifically exclude the JSpecifyJDKModels flag here (so we can't use `withJSpecifyModeArgs`)
             List.of(
                 "-XepOpt:NullAway:AnnotatedPackages=foo",
                 JSpecifyJavacConfig.JSPECIFY_MODE_FLAG,

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -36,9 +36,7 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   public void listContainingNullsWithModel() {
     makeTestHelperWithArgs(
             JSpecifyJavacConfig.withJSpecifyModeArgs(
-                List.of(
-                    "-XepOpt:NullAway:AnnotatedPackages=foo",
-                    "-XepOpt:NullAway:JSpecifyJDKModels=true")))
+                List.of("-XepOpt:NullAway:AnnotatedPackages=foo")))
         .addSourceLines(
             "Test.java",
             """
@@ -66,8 +64,11 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   @Test
   public void listContainingNullsWithoutModel() {
     makeTestHelperWithArgs(
-            JSpecifyJavacConfig.withJSpecifyModeArgs(
-                List.of("-XepOpt:NullAway:AnnotatedPackages=foo")))
+            List.of(
+                "-XepOpt:NullAway:AnnotatedPackages=foo",
+                JSpecifyJavacConfig.JSPECIFY_MODE_FLAG,
+                JSpecifyJavacConfig.ADD_TYPE_ANNOTATIONS_FLAG,
+                JSpecifyJavacConfig.HANDLE_WILDCARD_GENERICS_FLAG))
         .addSourceLines(
             "Test.java",
             """

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -64,6 +64,7 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   @Test
   public void listContainingNullsWithoutModel() {
     makeTestHelperWithArgs(
+            // We specifically exclude the JSpecifyJDKModels flag here
             List.of(
                 "-XepOpt:NullAway:AnnotatedPackages=foo",
                 JSpecifyJavacConfig.JSPECIFY_MODE_FLAG,

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2005,7 +2005,9 @@ public class GenericsTests extends NullAwayTestsBase {
             class Test {
               static void testNegative() {
                List<String> a = new ArrayList<String>();
-               Object[] o = a != null ? a.toArray() : null;
+               // TODO fix imprecise model of toArray()
+               // https://github.com/uber/NullAway/issues/1616
+               @Nullable Object[] o = a != null ? a.toArray() : null;
               }
             }
             """)
@@ -2582,6 +2584,8 @@ public class GenericsTests extends NullAwayTestsBase {
                 static class K<T extends @Nullable Object> {}
                 void foo(K<@Nullable Object> k) {
                     K<? extends @Nullable Object> k2 = k;
+                    // TODO should get no error here
+                    // BUG: Diagnostic contains: returning @Nullable
                     Supplier<? extends @Nullable Object> s = () -> null;
                 }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -38,7 +38,7 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
 
               static Optional<Double> sumDoublesMissingfilter(@Nullable Double... doubles) {
                 return Arrays.stream(doubles)
-                    // BUG: Diagnostic contains: incompatible types
+                    // BUG: Diagnostic contains: parameter a of referenced method is @NonNull
                     .reduce(Double::sum);
               }
 


### PR DESCRIPTION
This PR enables the JSpecify JDK models for all regression tests run in JSpecify mode.

The change exposed a bug where enabling the JDK models also enabled loading of external astubx files.  We fix that here and only load external astubx files if JarInfer is enabled.

There were a couple of issues exposed by this change by our current tests.  One is documented in #1616.  Another is fixed in #1647, a follow-up to this PR.  Another is just a change in the warning that gets printed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new compiler option to enable JSpecify JDK model support (`-XepOpt:NullAway:JSpecifyJDKModels=true`).
* **Bug Fixes**
  * Improved how JSpecify-related compiler arguments are composed and processed when JSpecify mode is enabled.
  * Updated stubx model caching to only load stubx files when JarInfer-based model loading is enabled.
* **Tests**
  * Adjusted JSpecify JDK models test configurations and updated expected nullability/diagnostic outcomes for generics, conditional expressions, and stream filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->