### PR TITLE
Fix bug with lambdas assigned to locals with a wildcard in their type

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -879,9 +879,7 @@ public final class GenericsChecks {
     if (rhsTree == null || rhsTree.getKind().equals(Tree.Kind.NULL_LITERAL)) {
       return;
     }
-    if (!assignedToLocal
-        && (rhsTree instanceof LambdaExpressionTree || rhsTree instanceof MemberReferenceTree)
-        && isAssignmentToField(tree)) {
+    if (rhsTree instanceof LambdaExpressionTree || rhsTree instanceof MemberReferenceTree) {
       maybeStorePolyExpressionTypeFromTarget(rhsTree, lhsType, state);
     }
     boolean varLocalDeclaration =
@@ -1009,10 +1007,6 @@ public final class GenericsChecks {
     } else {
       return getTreeType(rhsTree, state.withPath(pathToRhs), calledFromDataflow);
     }
-  }
-
-  private static boolean isAssignmentToField(Tree tree) {
-    return isAssignmentToKind(tree, ElementKind.FIELD);
   }
 
   private static boolean isAssignmentToKind(Tree tree, ElementKind kind) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -9,6 +9,28 @@ import org.junit.Test;
 public class GenericLambdaTests extends NullAwayTestsBase {
 
   @Test
+  public void lambdaAssignedToLocalRespectsExtendsWildcardBoundNullness() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.function.Supplier;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              void test() {
+                Supplier<? extends @Nullable Object> supplier = () -> null;
+                // BUG: Diagnostic contains: returning @Nullable
+                Supplier<? extends Object> nonNullSupplier = () -> null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void lambdaArgumentUsesAnnotatedTypeVar() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -2584,8 +2584,6 @@ public class GenericsTests extends NullAwayTestsBase {
                 static class K<T extends @Nullable Object> {}
                 void foo(K<@Nullable Object> k) {
                     K<? extends @Nullable Object> k2 = k;
-                    // TODO should get no error here
-                    // BUG: Diagnostic contains: returning @Nullable
                     Supplier<? extends @Nullable Object> s = () -> null;
                 }
             }


### PR DESCRIPTION
Previously, we only used the target type of an assignment when inferring the type of a lambda / method reference when a field was being assigned.  But this is incorrect; we should also use declared types of local variables.  (I think I was confused about local inference before; the top-level nullability of locals does get inferred, but here we need the type arguments, which are not inferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullness checking for generic lambdas and method references by expanding how inferred poly-expression target types are cached, including for local and resource variable initializers.
  * Enhanced generic assignability so `extends` wildcard nullness (including nullable bounds) is reflected more accurately in diagnostics.

* **Tests**
  * Added coverage for assigning a lambda to a local `Supplier<? extends `@Nullable` Object>` target and verifying expected nullness behavior.
  * Updated an existing generics compilation test to remove an assertion for a “returning `@Nullable`” diagnostic that no longer applies in that snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->