### PR TITLE
Add JSpecifyExperimental configuration flag

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -61,6 +61,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   static final String FL_GENERATED_UNANNOTATED = EP_FL_NAMESPACE + ":TreatGeneratedAsUnannotated";
   static final String FL_ACKNOWLEDGE_ANDROID_RECENT = EP_FL_NAMESPACE + ":AcknowledgeAndroidRecent";
   static final String FL_JSPECIFY_MODE = EP_FL_NAMESPACE + ":JSpecifyMode";
+  static final String FL_JSPECIFY_EXPERIMENTAL = EP_FL_NAMESPACE + ":JSpecifyExperimental";
   static final String FL_EXCLUDED_FIELD_ANNOT = EP_FL_NAMESPACE + ":ExcludedFieldAnnotations";
   static final String FL_INITIALIZER_ANNOT = EP_FL_NAMESPACE + ":CustomInitializerAnnotations";
   static final String FL_NULLABLE_ANNOT = EP_FL_NAMESPACE + ":CustomNullableAnnotations";
@@ -268,6 +269,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
   private final FixSerializationConfig fixSerializationConfig;
 
   ErrorProneCLIFlagsConfig(ErrorProneFlags flags) {
+    boolean jspecifyExperimental = flags.getBoolean(FL_JSPECIFY_EXPERIMENTAL).orElse(false);
     boolean annotatedPackagesPassed = flags.get(FL_ANNOTATED_PACKAGES).isPresent();
     boolean onlyNullMarked = flags.getBoolean(FL_ONLY_NULLMARKED).orElse(false);
     // exactly one of AnnotatedPackages or OnlyNullMarked should be passed in
@@ -306,7 +308,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
     treatGeneratedAsUnannotated = flags.getBoolean(FL_GENERATED_UNANNOTATED).orElse(false);
     acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     jspecifyMode = flags.getBoolean(FL_JSPECIFY_MODE).orElse(false);
-    handleWildcardGenerics = flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
+    handleWildcardGenerics =
+        jspecifyExperimental || flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(
@@ -329,7 +332,8 @@ final class ErrorProneCLIFlagsConfig implements Config {
 
     /* --- JarInfer configs --- */
     jarInferEnabled = flags.getBoolean(FL_JI_ENABLED).orElse(false);
-    jspecifyJDKModelsEnabled = flags.getBoolean(FL_JSPECIFY_JDK_ENABLED).orElse(false);
+    jspecifyJDKModelsEnabled =
+        jspecifyExperimental || flags.getBoolean(FL_JSPECIFY_JDK_ENABLED).orElse(false);
     if (jspecifyJDKModelsEnabled && !jspecifyMode) {
       throw new IllegalStateException(
           "-XepOpt:%s should only be set in JSpecify mode".formatted(FL_JSPECIFY_JDK_ENABLED));

--- a/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/ErrorProneCLIFlagsConfig.java
@@ -309,7 +309,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
     acknowledgeAndroidRecent = flags.getBoolean(FL_ACKNOWLEDGE_ANDROID_RECENT).orElse(false);
     jspecifyMode = flags.getBoolean(FL_JSPECIFY_MODE).orElse(false);
     handleWildcardGenerics =
-        jspecifyExperimental || flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(false);
+        flags.getBoolean(FL_HANDLE_WILDCARD_GENERICS).orElse(jspecifyExperimental);
     assertsEnabled = flags.getBoolean(FL_ASSERTS_ENABLED).orElse(false);
     fieldAnnotPattern =
         getPackagePattern(
@@ -333,7 +333,7 @@ final class ErrorProneCLIFlagsConfig implements Config {
     /* --- JarInfer configs --- */
     jarInferEnabled = flags.getBoolean(FL_JI_ENABLED).orElse(false);
     jspecifyJDKModelsEnabled =
-        jspecifyExperimental || flags.getBoolean(FL_JSPECIFY_JDK_ENABLED).orElse(false);
+        flags.getBoolean(FL_JSPECIFY_JDK_ENABLED).orElse(jspecifyExperimental);
     if (jspecifyJDKModelsEnabled && !jspecifyMode) {
       throw new IllegalStateException(
           "-XepOpt:%s should only be set in JSpecify mode".formatted(FL_JSPECIFY_JDK_ENABLED));

--- a/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.ErrorProneFlags;
 import java.util.List;
+import java.util.Map;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,5 +84,19 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
             .addSourceLines("Stub.java", "package com.uber; class Stub {}");
     AssertionError e = assertThrows(AssertionError.class, () -> compilationTestHelper.doTest());
     assertTrue(e.getMessage().contains("should only be set in JSpecify mode"));
+  }
+
+  @Test
+  public void jspecifyExperimentalEnablesExperimentalFeatures() {
+    ErrorProneCLIFlagsConfig config =
+        new ErrorProneCLIFlagsConfig(
+            ErrorProneFlags.fromMap(
+                Map.of(
+                    "NullAway:AnnotatedPackages", "foo",
+                    "NullAway:JSpecifyMode", "true",
+                    "NullAway:JSpecifyExperimental", "true")));
+
+    assertTrue(config.isJSpecifyJDKModels());
+    assertTrue(config.handleWildcardGenerics());
   }
 }


### PR DESCRIPTION
  Adds a new boolean CLI flag, `JSpecifyExperimental`.

  When enabled, it enables both experimental JSpecify features:

  - `JSpecifyJDKModels`
  - `HandleWildcardGenerics`

  The existing individual flags continue to work independently.  The plan is to encourage users to test with `JSpecifyExperimental` enabled to shake out more bugs before enabling these features by default in JSpecify mode.

  Added a regression test confirming that `JSpecifyExperimental` enables both underlying options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new experimental JSpecify flag; when enabled, it automatically turns on wildcard generic handling and enhanced JSpecify JDK model support.
* **Tests**
  * Added a new unit test to verify the experimental option enables both related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->