### PR TITLE
Fix Javadoc errors and allow future Javadoc errors to fail the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,17 @@ subprojects { project ->
         java.targetCompatibility = JavaVersion.VERSION_17
     }
 
+    // Javadoc runs in a separate process, so it does not inherit --add-exports options from JavaCompile.
+    // These exports are needed when documented APIs refer to javac internals.
+    tasks.withType(Javadoc).configureEach {
+        options.addMultilineStringsOption("-add-exports").setValue([
+            "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        ])
+    }
+
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -117,10 +117,6 @@ repositories {
     }
 }
 
-javadoc {
-    failOnError = false
-}
-
 apply plugin: 'com.vanniktech.maven.publish'
 
 // These --add-exports arguments are required when targeting JDK 11+ since Error Prone and NullAway access a bunch of


### PR DESCRIPTION
Codex found a simple fix for the errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Javadoc build compatibility for APIs referencing Java compiler internals.
  * Javadoc errors are now handled consistently by the standard build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->