### PR TITLE
Test on JDK 28 early access

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@v6
-      - name: 'Set up JDK 27 EA from jdk.java.net'
+      - name: 'Set up JDK 28 EA from jdk.java.net'
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
-          release: 27
+          release: 28
       - name: 'Set up JDKs'
         uses: actions/setup-java@v5
         with:

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 jacoco {
-    toolVersion = "0.8.15-SNAPSHOT"
+    toolVersion = "0.8.16-SNAPSHOT"
 }
 
 // Do not generate reports for individual projects
@@ -77,7 +77,7 @@ test {
 }
 
 // Tasks for testing on other JDK versions; see https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-[21, 26, 27].each { majorVersion ->
+[21, 26, 28].each { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/jar-infer/jar-infer-lib/build.gradle
+++ b/jar-infer/jar-infer-lib/build.gradle
@@ -50,8 +50,8 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
 }
 
-tasks.getByName('testJdk27').configure {
-    // Won't work until WALA supports JDK 27
+tasks.getByName('testJdk28').configure {
+    // Won't work until WALA supports JDK 28
     onlyIf { false }
 }
 apply plugin: 'com.vanniktech.maven.publish'


### PR DESCRIPTION
These are the latest early access builds available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and Testing**
  * Updated continuous integration to use JDK 28 Early Access instead of JDK 27.
  * Updated the test matrix to include JDK 28 and drop JDK 27.
  * Upgraded code coverage tooling to a newer snapshot version.
  * Prepared JDK 28 test configuration for compatibility validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->