### PR TITLE
Fix inference bug with generic instance methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -772,17 +772,9 @@ public final class GenericsChecks {
             // inference if needed, and then recompute the type as a member of the returned
             // enclosing type
             Symbol.MethodSymbol symbol = castToNonNull(ASTHelpers.getSymbol(invocationTree));
-            Type invokedMethodType = symbol.type;
-            Type enclosingType =
-                getEnclosingTypeForCallExpression(
-                    symbol, invocationTree, state.getPath(), state, calledFromDataflow);
-            if (enclosingType != null) {
-              invokedMethodType =
-                  TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, symbol, config);
-            }
             Type.MethodType methodType =
-                handler.onOverrideMethodType(
-                    symbol, invokedMethodType.asMethodType(), state, invocationTree);
+                getMethodTypeForInvocation(
+                    symbol, invocationTree, state.getPath(), state, calledFromDataflow);
             // restore explicit annotations from the return type
             Type returnType = methodType.getReturnType();
             result =
@@ -1119,7 +1111,6 @@ public final class GenericsChecks {
       boolean calledFromDataflow) {
     Verify.verify(isGenericCallNeedingInference(invocationTree));
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(invocationTree);
-    Type type = methodSymbol.type;
     Map<Element, ConstraintSolver.InferredNullability> typeVarNullability = null;
     MethodInferenceResult result = inferredTypeVarNullabilityForGenericCalls.get(invocationTree);
     if (result == null) { // have not yet attempted inference for this call
@@ -1135,7 +1126,9 @@ public final class GenericsChecks {
     if (result instanceof InferenceSuccess) {
       typeVarNullability = ((InferenceSuccess) result).typeVarNullability;
     }
-    Type methodReturnType = ((Type.ForAll) type).qtype.getReturnType();
+    Type methodReturnType =
+        getMethodTypeForInvocation(methodSymbol, invocationTree, path, state, calledFromDataflow)
+            .getReturnType();
     Type returnTypeAtCallSite = castToNonNull(ASTHelpers.getType(invocationTree));
     return TypeSubstitutionUtils.updateTypeWithInferredNullability(
         returnTypeAtCallSite, methodReturnType, typeVarNullability, state, config);
@@ -1199,7 +1192,10 @@ public final class GenericsChecks {
           inferredTypeVarNullabilityForGenericCalls.put(invTree, successResult);
         }
         // Store inferred types for lambda or method reference arguments
-        new InvocationArguments(invocationTree, methodSymbol.type.asMethodType())
+        Type.MethodType methodType =
+            getMethodTypeForInvocation(
+                methodSymbol, invocationTree, path, state, calledFromDataflow);
+        new InvocationArguments(invocationTree, methodType)
             .forEach(
                 (argument, argPos, formalParamType, unused) -> {
                   if (argument instanceof LambdaExpressionTree
@@ -1251,6 +1247,33 @@ public final class GenericsChecks {
   }
 
   /**
+   * Gets the type of a method at an invocation, substituting type arguments from the receiver and
+   * applying any handler-provided models.
+   *
+   * <p>Receiver substitution is necessary when an enclosing class type variable appears in the
+   * method signature. For example, for a method returning {@code T} on a receiver {@code
+   * Foo<@Nullable Object>}, the invocation return type is {@code @Nullable Object}, not the
+   * declaration-site type variable {@code T}.
+   */
+  private Type.MethodType getMethodTypeForInvocation(
+      Symbol.MethodSymbol methodSymbol,
+      MethodInvocationTree methodInvocationTree,
+      @Nullable TreePath path,
+      VisitorState state,
+      boolean calledFromDataflow) {
+    Type invokedMethodType = methodSymbol.type;
+    Type enclosingType =
+        getEnclosingTypeForCallExpression(
+            methodSymbol, methodInvocationTree, path, state, calledFromDataflow);
+    if (enclosingType != null) {
+      invokedMethodType =
+          TypeSubstitutionUtils.memberType(state.getTypes(), enclosingType, methodSymbol, config);
+    }
+    return handler.onOverrideMethodType(
+        methodSymbol, invokedMethodType.asMethodType(), state, methodInvocationTree);
+  }
+
+  /**
    * Generates inference constraints for a generic method call, including nested calls.
    *
    * @param state the visitor state
@@ -1281,8 +1304,8 @@ public final class GenericsChecks {
       boolean calledFromDataflow)
       throws UnsatisfiableConstraintsException {
     Type.MethodType methodType =
-        handler.onOverrideMethodType(
-            methodSymbol, methodSymbol.type.asMethodType(), state, methodInvocationTree);
+        getMethodTypeForInvocation(
+            methodSymbol, methodInvocationTree, path, state, calledFromDataflow);
     // first, handle the return type flow
     if (typeFromAssignmentContext != null) {
       solver.addSubtypeConstraint(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -114,6 +114,36 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void inferredGenericInstanceMethodReturnTypeUsesReceiverType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.Function;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              record Holder<T extends @Nullable Object>(T value) {}
+              record Box<V extends @Nullable Object>(V value) {
+                <E extends Exception> Holder<V> getOrThrow(
+                    Function<? super Exception, E> exceptionTransformer) throws E {
+                  return new Holder<>(value);
+                }
+              }
+              static <T extends @Nullable Object> Box<T> box(T value) {
+                return new Box<>(value);
+              }
+              static void test() {
+                var holder = box(null).getOrThrow(RuntimeException::new);
+                // BUG: Diagnostic contains: dereferenced expression 'holder.value()' is @Nullable
+                holder.value().hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void genericMethodAndVoidType() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -996,6 +996,8 @@ public class WildcardTests extends NullAwayTestsBase {
             final class Repro {
                 static List<?> readValues(List<String> inputs) {
                     return inputs.stream()
+                            // no error here: the lambda returns @Nullable Object, so we
+                            // should infer type variable R of Stream.map to be @Nullable Object
                             .map(input -> nullableBox().getOrThrow(RuntimeException::new))
                             .toList();
                 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -983,6 +983,35 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void weirdReducedFromJUnit() {
+    makeHelper()
+        .addSourceLines(
+            "Repro.java",
+            """
+            import java.util.List;
+            import java.util.function.Function;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            final class Repro {
+                static List<?> readValues(List<String> inputs) {
+                    return inputs.stream()
+                            .map(input -> nullableBox().getOrThrow(RuntimeException::new))
+                            .toList();
+                }
+                private static Box<@Nullable Object> nullableBox() {
+                    return new Box<>(null);
+                }
+                private record Box<V extends @Nullable Object>(V value) {
+                    <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) throws E {
+                        return value;
+                    }
+                }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -984,7 +984,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void weirdReducedFromJUnit() {
+  public void lambdaInferenceUsesGenericInstanceMethodReceiverType() {
     makeHelper()
         .addSourceLines(
             "Repro.java",


### PR DESCRIPTION
## Summary

Fix generic method inference to substitute type arguments from the invocation receiver before generating nullability constraints and reconstructing inferred types.

Previously, inference used the method’s declaration-site type. For a call such as a generic method returning `V` on a `Box<@Nullable Object>` receiver, NullAway treated the return as the unconstrained type variable `V` instead of `@Nullable Object`. The solver could consequently infer a non-null return and report a false-positive warning for a lambda returning that value.

## Implementation

Introduce a shared helper that:

- obtains the method’s enclosing receiver type;
- computes the method type as a member of that receiver;
- applies handler-provided method models.

Use this receiver-aware method type when:

- generating generic inference constraints;
- caching inferred lambda and method-reference types;
- reconstructing generic invocation return types;
- restoring method-invocation type annotations in `getTreeType`.

This also removes duplicated receiver-substitution logic.

## Tests

Added regression coverage for:

- a nullable generic instance-method return used within a `Stream.map` lambda returned as `List<?>`, which should produce no warning;
- a `var` initialized from a generic instance method on an inferred nullable receiver, ensuring the nested nullable type argument is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved generic method type inference for invocations using parameterized receiver types, preserving nullness correctly.
  * Fixed inferred generic instance-method return type behavior in wildcard and lambda/stream flows.

* **Tests**
  * Added regression coverage for receiver-based inferred generic instance method return types.
  * Added regression coverage ensuring lambda inference preserves generic instance method receiver typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->