### PR TITLE
Fixes related to captured types and inference

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -7,6 +7,7 @@ import com.google.errorprone.VisitorState;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
@@ -153,6 +154,11 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         directlyConstrainTypePair(subtype, supertype);
       }
       return visitType(subtype, supertype);
+    }
+
+    @Override
+    public @Nullable Void visitCapturedType(CapturedType subtype, Type supertype) {
+      return visitTypeVar(subtype, supertype);
     }
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -340,6 +340,11 @@ public class TypeSubstitutionUtils {
     }
 
     @Override
+    public Type visitCapturedType(Type.CapturedType t, Type other) {
+      return updateDirectNullabilityAnnotationsForType(t, other);
+    }
+
+    @Override
     public Type visitForAll(Type.ForAll t, Type other) {
       Type methodType = t.qtype;
       Type otherMethodType = ((Type.ForAll) other).qtype;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -180,6 +180,65 @@ public class GenericLambdaTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void varAndGenericInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.concurrent.CompletableFuture;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            final class Test {
+                static void reproduce() {
+                    var future = future();
+                    run(() -> future.join());
+                }
+                private static CompletableFuture<?> future() {
+                    return new CompletableFuture<>();
+                }
+                private static <T extends @Nullable Object> T run(Action<T> action) {
+                    return action.run();
+                }
+                private interface Action<T extends @Nullable Object> {
+                    T run();
+                }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void varAndGenericInferenceWithNonNullUpperBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.concurrent.CompletableFuture;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NonNull;
+            @NullMarked
+            final class Test {
+                static void reproduce() {
+                    var future = future();
+                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                    run(() -> future.join());
+                }
+                private static CompletableFuture<?> future() {
+                    return new CompletableFuture<>();
+                }
+                private static <T> T run(Action<T> action) {
+                    return action.run();
+                }
+                private interface Action<T> {
+                    T run();
+                }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Some initial fixes related to handling of captured types; see #1656 for more issues to handle later.

Here's the relevant example for this one:
```java
final class Test {
    static void reproduce() {
        var future = future();
        run(() -> future.join());
    }
    private static CompletableFuture<?> future() {
        return new CompletableFuture<>();
    }
    private static <T extends @Nullable Object> T run(Action<T> action) {
        return action.run();
    }
    private interface Action<T extends @Nullable Object> {
        T run();
    }
}
```
The `future` local variable gets a type `CompletableFuture<CAP#1>`, where `CAP#1` is a captured type variable whose upper bound is `@Nullable`.  Hence, the lambda `() -> future.join()` may return `@Nullable`, which is ok given the upper bound of `T` for `run`.  Before we would report a spurious warning for this case.  We also add a test that when `T`'s upper bound is `@NonNull` we still get an error.

The fix here is to handle captured types exactly like type variables when generating inference constraints and restoring nullness annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability constraint propagation for captured generic types.
  * Ensured direct nullability annotations are restored correctly when captured types are involved.
  * Fixed related generic inference behavior in lambda scenarios with nullable upper/lower bounds.
* **Tests**
  * Added new generic lambda tests covering `CompletableFuture.join()`, including verification of expected diagnostics for conflicting nullability constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->