### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ subprojects { project ->
     // Javadoc runs in a separate process, so it does not inherit --add-exports options from JavaCompile.
     // These exports are needed when documented APIs refer to javac internals.
     tasks.withType(Javadoc).configureEach {
+        // Many subprojects contain intentionally minimal test fixtures and samples. Keep doclint
+        // enabled for malformed documentation, but do not require API documentation for every
+        // public fixture member.
+        options.addBooleanOption("Xdoclint:all,-missing", true)
         options.addMultilineStringsOption("-add-exports").setValue([
             "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",

--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -192,8 +192,8 @@ public interface LibraryModels {
    * 8 streams or ReactiveX streams, so that NullAway is able to understand nullability invariants
    * across stream API calls. See {@link com.uber.nullaway.handlers.stream.StreamModelBuilder} for
    * details on how to construct these {@link com.uber.nullaway.handlers.stream.StreamTypeRecord}
-   * specs. A full example is available at {@link
-   * com.uber.nullaway.testlibrarymodels.TestLibraryModels}.
+   * specs. A full example is available in {@code TestLibraryModels} in the {@code
+   * test-library-models} subproject.
    *
    * @return A list of StreamTypeRecord specs (usually generated using StreamModelBuilder).
    */

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/NullnessStore.java
@@ -39,7 +39,7 @@ import org.checkerframework.nullaway.dataflow.expression.JavaExpression;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Highly based on {@link com.google.errorprone.dataflow.LocalStore}, but for {@link AccessPath}s.
+ * Highly based on {@code com.google.errorprone.dataflow.LocalStore}, but for {@link AccessPath}s.
  */
 public class NullnessStore implements Store<NullnessStore> {
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1558,11 +1558,11 @@ public final class GenericsChecks {
    *
    * <p>Usage:
    *
-   * <pre>
+   * <pre>{@code
    * Tree lambdaBody = myLambda.getBody();
    * TreePath lambdaBodyPath = new TreePath(lambdaPath, lambdaBody);
    * List<TreePath> returns = ReturnFinder.findReturnPaths(lambdaBodyPath);
-   * </pre>
+   * }</pre>
    */
   static class ReturnFinder extends TreePathScanner<@Nullable Void, @Nullable Void> {
 
@@ -2354,16 +2354,16 @@ public final class GenericsChecks {
    *
    * <p>Consider the following example:
    *
-   * <pre>
-   *     interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
-   *         R apply(P p);
+   * <pre>{@code
+   * interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
+   *     R apply(P p);
+   * }
+   * class C implements Fn<String, @Nullable String> {
+   *     public @Nullable String apply(String p) {
+   *         return null;
    *     }
-   *     class C implements Fn<String, @Nullable String> {
-   *         public @Nullable String apply(String p) {
-   *             return null;
-   *         }
-   *     }
-   * </pre>
+   * }
+   * }</pre>
    *
    * <p>Within the context of class {@code C}, the method {@code Fn.apply} has a return type of
    * {@code @Nullable String}, since {@code @Nullable String} is passed as the type parameter for
@@ -2448,20 +2448,20 @@ public final class GenericsChecks {
    *
    * <p>Consider the following example:
    *
-   * <pre>
-   *     interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
-   *         R apply(P p);
+   * <pre>{@code
+   * interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
+   *     R apply(P p);
+   * }
+   * class C implements Fn<String, @Nullable String> {
+   *     public @Nullable String apply(String p) {
+   *         return null;
    *     }
-   *     class C implements Fn<String, @Nullable String> {
-   *         public @Nullable String apply(String p) {
-   *             return null;
-   *         }
-   *     }
-   *     static void m() {
-   *         Fn<String, @Nullable String> f = new C();
-   *         f.apply("hello").hashCode(); // NPE
-   *     }
-   * </pre>
+   * }
+   * static void m() {
+   *     Fn<String, @Nullable String> f = new C();
+   *     f.apply("hello").hashCode(); // NPE
+   * }
+   * }</pre>
    *
    * <p>The declared type of {@code f} passes {@code Nullable String} as the type parameter for type
    * variable {@code R}. So, the call {@code f.apply("hello")} returns {@code @Nullable} and an
@@ -2742,20 +2742,20 @@ public final class GenericsChecks {
    *
    * <p>Consider the following example:
    *
-   * <pre>
-   *     interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
-   *         R apply(P p);
+   * <pre>{@code
+   * interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
+   *     R apply(P p);
+   * }
+   * class C implements Fn<@Nullable String, String> {
+   *     public String apply(@Nullable String p) {
+   *         return "";
    *     }
-   *     class C implements Fn<@Nullable String, String> {
-   *         public String apply(@Nullable String p) {
-   *             return "";
-   *         }
-   *     }
-   *     static void m() {
-   *         Fn<@Nullable String, String> f = new C();
-   *         f.apply(null);
-   *     }
-   * </pre>
+   * }
+   * static void m() {
+   *     Fn<@Nullable String, String> f = new C();
+   *     f.apply(null);
+   * }
+   * }</pre>
    *
    * <p>The declared type of {@code f} passes {@code Nullable String} as the type parameter for type
    * variable {@code P}. So, it is legal to pass {@code null} as a parameter to {@code f.apply}.
@@ -2864,16 +2864,16 @@ public final class GenericsChecks {
    *
    * <p>Consider the following example:
    *
-   * <pre>
-   *     interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
-   *         R apply(P p);
+   * <pre>{@code
+   * interface Fn<P extends @Nullable Object, R extends @Nullable Object> {
+   *     R apply(P p);
+   * }
+   * class C implements Fn<@Nullable String, String> {
+   *     public String apply(@Nullable String p) {
+   *         return "";
    *     }
-   *     class C implements Fn<@Nullable String, String> {
-   *         public String apply(@Nullable String p) {
-   *             return "";
-   *         }
-   *     }
-   * </pre>
+   * }
+   * }</pre>
    *
    * <p>Within the context of class {@code C}, the method {@code Fn.apply} has a parameter type of
    * {@code @Nullable String}, since {@code @Nullable String} is passed as the type parameter for

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
@@ -273,7 +273,7 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
   }
 
   /**
-   * On every method annotated with {@link EnsuresNonNullIf}, this method injects the {@code
+   * On every method annotated with {@code @EnsuresNonNullIf}, this method injects the {@code
    * Nonnull} value for the class fields given in the {@code @EnsuresNonNullIf} parameter to the
    * dataflow analysis.
    */


### PR DESCRIPTION
These have been popping up inside diffs due to a change in GitHub Actions.  Might as well fix them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Javadoc generation by allowing documentation checks while excluding missing-comment warnings.
  * Updated examples and references for clearer, more consistent Javadoc rendering.
  * Corrected documentation links and formatting across nullability, dataflow, generics, and contract-handling components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->