### PR TITLE
More consistent checks for captured types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -11,7 +11,6 @@ import com.uber.nullaway.Config;
 import com.uber.nullaway.handlers.Handler;
 import java.util.List;
 import javax.lang.model.type.NullType;
-import javax.lang.model.type.TypeKind;
 
 /**
  * Visitor that checks for identical nullability annotations at all nesting levels within two types.
@@ -37,7 +36,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     if (rhsType instanceof NullType || rhsType.isPrimitive()) {
       return true;
     }
-    if (rhsType.getKind().equals(TypeKind.WILDCARD)) {
+    if (GenericsUtils.asWildcard(rhsType) != null) {
       // TODO Handle wildcard types
       return true;
     }
@@ -120,16 +119,16 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * matching nested type arguments. Wildcard formals are delegated to {@link #wildcardContains}.
    */
   private boolean typeArgumentContainedBy(Type lhsTypeArgument, Type rhsTypeArgument) {
-    if (!config.handleWildcardGenerics()
-        && (lhsTypeArgument.getKind().equals(TypeKind.WILDCARD)
-            || rhsTypeArgument.getKind().equals(TypeKind.WILDCARD))) {
+    Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsTypeArgument);
+    Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
+    if (!config.handleWildcardGenerics() && (lhsWildcard != null || rhsWildcard != null)) {
       // Preserve the pre-flag behavior of skipping wildcard-aware checks entirely.
       return true;
     }
-    if (lhsTypeArgument instanceof Type.WildcardType lhsWildcard) {
+    if (lhsWildcard != null) {
       return wildcardContains(lhsWildcard, rhsTypeArgument);
     }
-    if (rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
+    if (rhsWildcard != null) {
       // This case should only arise when generic method invocation inference / capture conversion
       // lets a wildcard actual argument flow into a non-wildcard formal type argument, e.g.,
       // passing Foo<? extends T> to <U> void m(Foo<U>). We do not yet support wildcard inference.
@@ -186,7 +185,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private boolean superWildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
     // caller must ensure that lhsWildcard has a super bound
     Type lhsBound = castToNonNull(lhsWildcard.getSuperBound());
-    if (rhsTypeArgument instanceof Type.WildcardType rhsWildcard) {
+    Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
+    if (rhsWildcard != null) {
       if (rhsWildcard.kind != BoundKind.SUPER) {
         // This case cannot occur outside of inference: if the rhs is ? extends T, that is never
         // assignable to ? super S, since the rhs could be an arbitrary subtype of T (which may be a

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -119,7 +119,11 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * matching nested type arguments. Wildcard formals are delegated to {@link #wildcardContains}.
    */
   private boolean typeArgumentContainedBy(Type lhsTypeArgument, Type rhsTypeArgument) {
-    Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsTypeArgument);
+    // Do not use GenericsUtils.asWildcard() for the LHS. A captured LHS is a type variable, not a
+    // wildcard formal; unwrapping it can repeatedly expand recursive upper bounds (for example,
+    // F-bounded type parameters) as containment delegates back into subtype checking.
+    Type.WildcardType lhsWildcard =
+        lhsTypeArgument instanceof Type.WildcardType wildcardType ? wildcardType : null;
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
     if (!config.handleWildcardGenerics() && (lhsWildcard != null || rhsWildcard != null)) {
       // Preserve the pre-flag behavior of skipping wildcard-aware checks entirely.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -121,7 +121,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private boolean typeArgumentContainedBy(Type lhsTypeArgument, Type rhsTypeArgument) {
     // Do not use GenericsUtils.asWildcard() for the LHS. A captured LHS is a type variable, not a
     // wildcard formal; unwrapping it can repeatedly expand recursive upper bounds (for example,
-    // F-bounded type parameters) as containment delegates back into subtype checking.
+    // F-bounded type parameters) as containment delegates back into subtype checking.  See test
+    // com.uber.nullaway.jspecify.WildcardTests.capturedLhsWithFBoundedTypeParametersDoesNotRecurse
     Type.WildcardType lhsWildcard =
         lhsTypeArgument instanceof Type.WildcardType wildcardType ? wildcardType : null;
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -904,6 +904,56 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void capturedSuperWildcardReturnCheckedForContainment() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Box<T extends @Nullable Object> {}
+              static <T extends @Nullable Object> Box<T> identity(Box<T> box) {
+                return box;
+              }
+              void test(
+                  Box<? super String> nonNullBoundBox,
+                  Box<? super @Nullable String> nullableBoundBox) {
+                Box<? super String> ok = identity(nullableBoundBox);
+                // BUG: Diagnostic contains: incompatible types
+                Box<? super @Nullable String> bad = identity(nonNullBoundBox);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void capturedSuperWildcardReturnCheckedRecursively() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Box<T extends @Nullable Object> {}
+              interface Nested<T extends @Nullable Object> {}
+              static <T extends @Nullable Object> Box<T> identity(Box<T> box) {
+                return box;
+              }
+              void test(Box<? super Nested<String>> box) {
+                // BUG: Diagnostic contains: incompatible types
+                Box<? super Nested<@Nullable String>> bad = identity(box);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void nullableOnWildcard() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -954,6 +954,32 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void capturedLhsWithFBoundedTypeParametersDoesNotRecurse() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              interface Value<V extends Value<V>> {}
+              interface Store<S extends Store<S>> {}
+              interface Transfer<V extends Value<V>, S extends Store<S>> {}
+              static class Analysis<
+                  V extends Value<V>,
+                  S extends Store<S>,
+                  T extends Transfer<V, S>> {
+                Analysis(T transfer) {}
+              }
+              static Analysis<?, ?, ?> create(Transfer<?, ?> transfer) {
+                return new Analysis<>(transfer);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void nullableOnWildcard() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
This PR addresses this sub-issue of #1656:

> `CheckIdenticalNullabilityVisitor` inconsistently recognizes wildcards. `extendsBoundContains()`
> uses `GenericsUtils.asWildcard()`, which includes captured wildcards, but the surrounding logic and
> `superWildcardContains()` use `instanceof WildcardType` or `TypeKind.WILDCARD`.
> 
> Captured wildcards can therefore bypass containment and nullability checks, especially for
> `? super` cases.

The fix is to consistently call `GenericsUtils.asWildcard`, which handles both `WildcardType` and `CapturedType`, when checking if a type is a wildcard.

The new tests show subtyping issues that weren't identified before that are caught with these fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generic wildcard containment checks, including captured and nested `super` wildcards.
  * Correctly reports incompatible assignments involving recursive generic type inference.
  * Prevents incorrect recursive analysis for F-bounded type parameters.

* **Tests**
  * Added coverage for captured wildcard returns, nested containment, and F-bounded generics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->