### PR TITLE
Handle interaction of captured types and library models

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -355,10 +355,12 @@ public class TypeSubstitutionUtils {
     }
 
     /**
-     * Restores annotations on both a captured type and its backing wildcard.
+     * Restores annotations on both the captured type {@code t} and its backing wildcard.
      *
-     * <p>The source may still be an ordinary wildcard when javac has capture-converted the
-     * corresponding destination type.
+     * <p>The corresponding type {@code other} may be an ordinary wildcard because javac can
+     * capture-convert {@code t} without capture-converting {@code other}. In such cases, the
+     * annotation on the bound of {@code other} should be restored to the bound of the wildcard
+     * corresponding to {@code t}.
      */
     @Override
     public Type visitCapturedType(Type.CapturedType t, Type other) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -101,6 +101,21 @@ public class TypeSubstitutionUtils {
   }
 
   /**
+   * Returns a copy of {@code type} with {@code wildcard} as its backing wildcard.
+   *
+   * <p>The copy is necessary because javac capture types can be shared across attributed types.
+   */
+  public static Type.CapturedType replaceCapturedTypeWildcard(
+      Type.CapturedType type, Type.WildcardType wildcard) {
+    Type.CapturedType updated =
+        (Type.CapturedType)
+            TYPE_METADATA_BUILDER.cloneTypeWithMetadata(
+                type, TYPE_METADATA_BUILDER.create(type.getAnnotationMirrors()));
+    updated.wildcard = wildcard;
+    return updated;
+  }
+
+  /**
    * Updates a type {@code typeToUpdate} by applying inferred nullability for type variables. The
    * update proceeds in three steps:
    *
@@ -339,9 +354,25 @@ public class TypeSubstitutionUtils {
       return updateDirectNullabilityAnnotationsForType(t, other);
     }
 
+    /**
+     * Restores annotations on both a captured type and its backing wildcard.
+     *
+     * <p>The source may still be an ordinary wildcard when javac has capture-converted the
+     * corresponding destination type.
+     */
     @Override
     public Type visitCapturedType(Type.CapturedType t, Type other) {
-      return updateDirectNullabilityAnnotationsForType(t, other);
+      Type updated = updateDirectNullabilityAnnotationsForType(t, other);
+      Type.WildcardType otherWildcard = GenericsUtils.asWildcard(other);
+      if (otherWildcard == null) {
+        return updated;
+      }
+      Type.WildcardType updatedWildcard =
+          (Type.WildcardType) t.wildcard.accept(this, otherWildcard);
+      if (updatedWildcard == t.wildcard) {
+        return updated;
+      }
+      return replaceCapturedTypeWildcard((Type.CapturedType) updated, updatedWildcard);
     }
 
     @Override

--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -99,11 +99,11 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
     if (entry.kind() != NestedAnnotationInfo.TypePathEntry.Kind.WILDCARD_BOUND) {
       return t;
     }
-    int boundIndex = entry.index();
-    if (t.type == null) {
+    if (t.kind == BoundKind.UNBOUND) {
       // TODO we need to add logic to _introduce_ a bound if none exists (add follow-up issue)
       return t;
     }
+    int boundIndex = entry.index();
     if (boundIndex == 0 && t.kind == BoundKind.EXTENDS) {
       Type newBound = t.type.accept(this, pathIndex + 1);
       return newBound == t.type ? t : TYPE_METADATA_BUILDER.createWildcardType(t, newBound);
@@ -113,6 +113,33 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
       return newBound == t.type ? t : TYPE_METADATA_BUILDER.createWildcardType(t, newBound);
     }
     return t;
+  }
+
+  /**
+   * Updates a captured type while preserving the backing wildcard used by NullAway's wildcard-bound
+   * reasoning.
+   *
+   * <p>javac represents a captured wildcard as a type variable plus its original wildcard. A direct
+   * annotation on the capture is insufficient because effective-bound computations unwrap the
+   * backing wildcard, so updates must be reflected there as well.
+   */
+  @Override
+  public Type visitCapturedType(Type.CapturedType t, Integer pathIndex) {
+    Type.WildcardType updatedWildcard;
+    if (pathIndex < typePath.size()) {
+      updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, pathIndex);
+    } else {
+      if (t.wildcard.kind == BoundKind.UNBOUND) {
+        // Do not turn javac's placeholder bound for an unbounded wildcard into an explicit bound.
+        return t;
+      }
+      Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(t.wildcard.type, annotationType);
+      updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
+    }
+    if (updatedWildcard == t.wildcard) {
+      return t;
+    }
+    return TypeSubstitutionUtils.replaceCapturedTypeWildcard(t, updatedWildcard);
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -2,6 +2,7 @@ package com.uber.nullaway.librarymodel;
 
 import static com.uber.nullaway.generics.TypeMetadataBuilder.TYPE_METADATA_BUILDER;
 
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Type;
@@ -129,6 +130,7 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
     if (pathIndex < typePath.size()) {
       updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, pathIndex);
     } else {
+      Verify.verify(pathIndex == typePath.size(), "path index out of bounds");
       if (t.wildcard.kind == BoundKind.UNBOUND) {
         // Do not turn javac's placeholder bound for an unbounded wildcard into an explicit bound.
         return t;

--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -122,7 +122,7 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
    *
    * <p>javac represents a captured wildcard as a type variable plus its original wildcard. A direct
    * annotation on the capture is insufficient because effective-bound computations unwrap the
-   * backing wildcard, so updates must be reflected there as well.
+   * backing wildcard, so updates must be reflected there.
    */
   @Override
   public Type visitCapturedType(Type.CapturedType t, Integer pathIndex) {

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/NestedAnnots.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/NestedAnnots.java
@@ -3,6 +3,10 @@ package com.uber.lib.unannotated;
 /* @NullMarked */
 @SuppressWarnings("DoNotCallSuggester")
 public class NestedAnnots<T /* extends @Nullable Object */> {
+  public NestedAnnots<T> self() {
+    return this;
+  }
+
   public static <T /* extends @Nullable Object */> NestedAnnots<T> genericMethod(
       Class</* @NonNull */ T> clazz) {
     return new NestedAnnots<>();
@@ -21,6 +25,10 @@ public class NestedAnnots<T /* extends @Nullable Object */> {
   public static void wildcardUpper(NestedAnnots<? extends /* @NonNull */ String> t) {}
 
   public static void wildcardLower(NestedAnnots<? super /* @Nullable */ String> t) {}
+
+  public NestedAnnots<? extends /* @Nullable */ T> wildcardUpperTypeVariable() {
+    throw new RuntimeException();
+  }
 
   public static void multipleArgs(
       NestedAnnots<String> t1, NestedAnnots</* @Nullable */ Integer> t2) {}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -254,6 +254,15 @@ public class TestLibraryModels implements LibraryModels {
                         new TypePathEntry(TYPE_ARGUMENT, 0),
                         new TypePathEntry(WILDCARD_BOUND, 1)))))
         .put(
+            methodRef("com.uber.lib.unannotated.NestedAnnots", "wildcardUpperTypeVariable()"),
+            ImmutableSetMultimap.of(
+                -1,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE,
+                    ImmutableList.of(
+                        new TypePathEntry(TYPE_ARGUMENT, 0),
+                        new TypePathEntry(WILDCARD_BOUND, 0)))))
+        .put(
             methodRef(
                 "com.uber.lib.unannotated.NestedAnnots",
                 "multipleArgs(com.uber.lib.unannotated.NestedAnnots<java.lang.String>,com.uber.lib.unannotated.NestedAnnots<java.lang.Integer>)"),

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -570,6 +570,34 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void nestedWildcardWithCapturedTypeVariableBound() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.NestedAnnots;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              NestedAnnots<? extends String> test(
+                  NestedAnnots<? extends String> receiver) {
+                // should reject since return type of wildcardUpperTypeVariable
+                // is modeled to be NestedAnnots<? extends @Nullable T>, which
+                // here is incompatible with the return type NestedAnnots<? extends String>
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.self().wildcardUpperTypeVariable();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void multipleArgs() {
     makeLibraryModelsTestHelperWithArgs(
             JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
If we use a library model to add a `@Nullable` to the upper bound of a wildcard, we may need to update a `CapturedType` with that bound.  To do so, we update the wildcard type associated with the `CapturedType`.  See the test for an example warning we missed before.  (There are some related cases I know of that are still not working; addressing those in a follow-up.)

We also take the opportunity to replace some `null` checks with a more direct check for an unbound wildcard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nullability analysis for captured types and nested wildcard bounds.
  - Preserved nullability annotations more consistently when resolving generic type relationships.
  - Correctly handles unbounded wildcards without losing type information.
  - Detects unsafe assignments involving nullable upper-bounded wildcard types in JSpecify mode.
  - Improved handling of generic type substitutions during nested annotation processing.

- **Tests**
  - Added coverage for nested generic types and wildcard-based nullability violations.
  - Added validation for nullable upper bounds on captured type variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->