### PR TITLE
Follow-on fix for restoring annotation on captured type wildcards

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -360,17 +360,28 @@ public class TypeSubstitutionUtils {
      * <p>The corresponding type {@code other} may be an ordinary wildcard because javac can
      * capture-convert {@code t} without capture-converting {@code other}. In such cases, the
      * annotation on the bound of {@code other} should be restored to the bound of the wildcard
-     * corresponding to {@code t}.
+     * corresponding to {@code t}. Alternatively, nested capture conversion can make {@code t} a
+     * captured {@code extends} wildcard while the same position in {@code other} is a non-wildcard
+     * type. In that case, annotations from {@code other} must be restored to the backing wildcard's
+     * upper bound, since wildcard-aware checks use that bound rather than annotations directly on
+     * the captured type.
      */
     @Override
     public Type visitCapturedType(Type.CapturedType t, Type other) {
       Type updated = updateDirectNullabilityAnnotationsForType(t, other);
       Type.WildcardType otherWildcard = GenericsUtils.asWildcard(other);
-      if (otherWildcard == null) {
+      Type.WildcardType updatedWildcard;
+      if (otherWildcard != null) {
+        updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, otherWildcard);
+      } else if (t.wildcard.kind == BoundKind.EXTENDS) {
+        Type updatedBound = t.wildcard.type.accept(this, other);
+        if (updatedBound == t.wildcard.type) {
+          return updated;
+        }
+        updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
+      } else {
         return updated;
       }
-      Type.WildcardType updatedWildcard =
-          (Type.WildcardType) t.wildcard.accept(this, otherWildcard);
       if (updatedWildcard == t.wildcard) {
         return updated;
       }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -433,7 +433,7 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
-  public void wildcardCaptureRestoresConcreteAnnotatedBound() {
+  public void annotationRestoredFromUpperBoundToCapturedWildcard() {
     makeHelper()
         .addSourceLines(
             "Test.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -433,6 +433,45 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void wildcardCaptureRestoresConcreteAnnotatedBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Nested<T extends @Nullable Object> {
+                Nested<T> self() {
+                  return this;
+                }
+                Nested<? extends @Nullable T> wildcardUpperTypeVariable() {
+                  throw new RuntimeException();
+                }
+              }
+
+              Nested<? extends String> testDirect(Nested<? extends String> receiver) {
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.wildcardUpperTypeVariable();
+              }
+
+              Nested<? extends String> testWithSelf(Nested<? extends String> receiver) {
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.self().wildcardUpperTypeVariable();
+              }
+
+              Nested<? extends String> testWithVar(Nested<? extends String> receiver) {
+                var local = receiver;
+                // BUG: Diagnostic contains: incompatible types
+                return local.wildcardUpperTypeVariable();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void wildcardCaptureReturnWithTypeVariableUpperBound() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -466,6 +466,12 @@ public class WildcardTests extends NullAwayTestsBase {
                 // BUG: Diagnostic contains: incompatible types
                 return local.wildcardUpperTypeVariable();
               }
+
+              Nested<? extends @Nullable String> testWithVarSafe(Nested<? extends String> receiver) {
+                var local = receiver;
+                // safe
+                return local.wildcardUpperTypeVariable();
+              }
             }
             """)
         .doTest();

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -584,7 +584,17 @@ public class CustomLibraryModelsTests {
             import org.jspecify.annotations.*;
             @NullMarked
             public class Test {
-              NestedAnnots<? extends String> test(
+
+              NestedAnnots<? extends String> testDirect(
+                  NestedAnnots<? extends String> receiver) {
+                // should reject since return type of wildcardUpperTypeVariable
+                // is modeled to be NestedAnnots<? extends @Nullable T>, which
+                // here is incompatible with the return type NestedAnnots<? extends String>
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.wildcardUpperTypeVariable();
+              }
+
+              NestedAnnots<? extends String> testWithSelf(
                   NestedAnnots<? extends String> receiver) {
                 // should reject since return type of wildcardUpperTypeVariable
                 // is modeled to be NestedAnnots<? extends @Nullable T>, which
@@ -592,6 +602,18 @@ public class CustomLibraryModelsTests {
                 // BUG: Diagnostic contains: incompatible types
                 return receiver.self().wildcardUpperTypeVariable();
               }
+
+
+              NestedAnnots<? extends String> testWithVar(
+                  NestedAnnots<? extends String> receiver) {
+                var foo = receiver;
+                // should reject since return type of wildcardUpperTypeVariable
+                // is modeled to be NestedAnnots<? extends @Nullable T>, which
+                // here is incompatible with the return type NestedAnnots<? extends String>
+                // BUG: Diagnostic contains: incompatible types
+                return foo.wildcardUpperTypeVariable();
+              }
+
             }
             """)
         .doTest();


### PR DESCRIPTION
The fix in #1666 missed a case that has impacts outside of library models as well.  See the new test `WildcardTests.annotationRestoredFromUpperBoundToCapturedWildcard`.  The `testWithSelf` case was handled before, but not `testDirect` or `testWithVar`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability handling for captured wildcard types with annotated upper bounds.
  * Prevented incorrect compatibility results for nested wildcard types across direct calls, chained calls, and local variables.
  * Improved diagnostic accuracy when wildcard types conflict with nullable type-variable bounds.

* **Tests**
  * Added regression coverage for direct, chained, and local-variable wildcard-capture invocation patterns.
  * Expanded validation of incompatible nested wildcard and annotated type-variable combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->