### PR TITLE
Handle unbound wildcards and interactions with captured types better

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeMetadataBuilder.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeMetadataBuilder.java
@@ -24,6 +24,14 @@ public interface TypeMetadataBuilder {
 
   TypeMetadata create(com.sun.tools.javac.util.List<Attribute.TypeCompound> attrs);
 
+  /**
+   * Returns {@code typeToBeCloned} with {@code metaData}, without sharing mutable type-variable
+   * state with {@code typeToBeCloned}.
+   *
+   * <p>javac's metadata APIs normally return delegating wrappers for {@link Type.TypeVar} and
+   * {@link Type.CapturedType}. Implementations must first detach those types so later upper-bound
+   * mutation through the returned wrapper cannot affect compiler-owned types.
+   */
   Type cloneTypeWithMetadata(Type typeToBeCloned, TypeMetadata metaData);
 
   Type.ClassType createClassType(Type baseType, Type enclosingType, List<Type> typeArgs);
@@ -31,6 +39,88 @@ public interface TypeMetadataBuilder {
   Type.ArrayType createArrayType(Type.ArrayType baseType, Type elementType);
 
   Type.WildcardType createWildcardType(Type.WildcardType baseType, Type boundType);
+
+  /**
+   * Creates a mutable type variable that is detached from {@code baseType}, with {@code upperBound}
+   * as its upper bound.
+   *
+   * <p>Metadata must not be cloned directly from {@code baseType}. For type variables, javac's
+   * metadata APIs return a wrapper whose upper-bound getter and setter delegate to their receiver.
+   * The receiver must therefore be detached first, or mutating the apparent copy would mutate
+   * compiler-owned state.
+   */
+  Type.TypeVar createDetachedTypeVar(Type.TypeVar baseType, Type upperBound);
+
+  /**
+   * Creates a captured type detached from {@code baseType}, with {@code wildcard} as its backing
+   * wildcard and {@code upperBound} as its upper bound.
+   *
+   * <p>As with {@link #createDetachedTypeVar}, metadata may only be attached after constructing a
+   * detached receiver, because the resulting wrapper delegates upper-bound access and mutation to
+   * that receiver.
+   */
+  Type.CapturedType createDetachedCapturedType(
+      Type.CapturedType baseType, Type.WildcardType wildcard, Type upperBound);
+
+  /**
+   * Returns a safe receiver for javac's metadata-cloning APIs.
+   *
+   * <p>Only type variables and captures require detaching; metadata wrappers for other type
+   * implementations do not delegate mutable upper-bound state to their input.
+   */
+  private static Type detachMutableTypeForMetadata(
+      TypeMetadataBuilder builder, Type typeToBeCloned) {
+    if (typeToBeCloned instanceof Type.CapturedType capturedType) {
+      return builder.createDetachedCapturedType(
+          capturedType, capturedType.wildcard, capturedType.getUpperBound());
+    }
+    if (typeToBeCloned instanceof Type.TypeVar typeVariable) {
+      return builder.createDetachedTypeVar(typeVariable, typeVariable.getUpperBound());
+    }
+    return typeToBeCloned;
+  }
+
+  /**
+   * Creates a metadata-free type variable with independent mutable state and javac's expected base
+   * type identity.
+   */
+  private static Type.TypeVar createDetachedTypeVarWithoutMetadata(
+      Type.TypeVar originalType, Type upperBound) {
+    // This constructor is stable across the supported JDK versions, unlike the constructors that
+    // also accept metadata. javac compares type-variable objects by identity in its type relations,
+    // so baseType must return the original compiler-owned type variable when javac normalizes this
+    // detached view. getUpperBound and setUpperBound remain backed by this new object's own field.
+    return new Type.TypeVar(originalType.tsym, upperBound, originalType.lower) {
+      @Override
+      public Type baseType() {
+        return originalType.baseType();
+      }
+    };
+  }
+
+  /**
+   * Creates a metadata-free capture with independent mutable state and javac's expected base type
+   * identity.
+   */
+  private static Type.CapturedType createDetachedCapturedTypeWithoutMetadata(
+      Type.CapturedType originalType, Type.WildcardType wildcard, Type upperBound) {
+    // The symbol-taking constructor changed across supported JDK versions. This older constructor
+    // is stable; resetting tsym below preserves the symbol identity of the compiler-owned capture.
+    Type.CapturedType detachedType =
+        new Type.CapturedType(
+            originalType.tsym.name,
+            originalType.tsym.owner,
+            upperBound,
+            originalType.lower,
+            wildcard) {
+          @Override
+          public Type baseType() {
+            return originalType.baseType();
+          }
+        };
+    detachedType.tsym = originalType.tsym;
+    return detachedType;
+  }
 
   /**
    * Provides implementations for methods under TypeMetadataBuilder compatible with JDK 17 and
@@ -183,7 +273,8 @@ public interface TypeMetadataBuilder {
     @Override
     public Type cloneTypeWithMetadata(Type typeToBeCloned, TypeMetadata metadata) {
       try {
-        return (Type) cloneWithMetadataHandle.invoke(typeToBeCloned, metadata);
+        Type detachedType = detachMutableTypeForMetadata(this, typeToBeCloned);
+        return (Type) cloneWithMetadataHandle.invoke(detachedType, metadata);
       } catch (Throwable e) {
         throw new RuntimeException(e);
       }
@@ -224,6 +315,33 @@ public interface TypeMetadataBuilder {
         throw new RuntimeException(e);
       }
     }
+
+    @Override
+    public Type.TypeVar createDetachedTypeVar(Type.TypeVar baseType, Type upperBound) {
+      if (baseType instanceof Type.CapturedType capturedType) {
+        return createDetachedCapturedType(capturedType, capturedType.wildcard, upperBound);
+      }
+      try {
+        TypeMetadata metadata = (TypeMetadata) getMetadataHandleV17.invoke(baseType);
+        Type.TypeVar detachedType = createDetachedTypeVarWithoutMetadata(baseType, upperBound);
+        return (Type.TypeVar) cloneWithMetadataHandle.invoke(detachedType, metadata);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public Type.CapturedType createDetachedCapturedType(
+        Type.CapturedType baseType, Type.WildcardType wildcard, Type upperBound) {
+      try {
+        TypeMetadata metadata = (TypeMetadata) getMetadataHandleV17.invoke(baseType);
+        Type.CapturedType detachedType =
+            createDetachedCapturedTypeWithoutMetadata(baseType, wildcard, upperBound);
+        return (Type.CapturedType) cloneWithMetadataHandle.invoke(detachedType, metadata);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   /**
@@ -242,7 +360,8 @@ public interface TypeMetadataBuilder {
     /** In JDK 21+ cloneWithMetadata was removed; use dropMetadata/addMetadata. */
     @Override
     public Type cloneTypeWithMetadata(Type typeToBeCloned, TypeMetadata metadata) {
-      Type without = typeToBeCloned.dropMetadata(metadata.getClass());
+      Type detachedType = detachMutableTypeForMetadata(this, typeToBeCloned);
+      Type without = detachedType.dropMetadata(metadata.getClass());
       return without.addMetadata(metadata);
     }
 
@@ -263,6 +382,32 @@ public interface TypeMetadataBuilder {
     public Type.WildcardType createWildcardType(Type.WildcardType baseType, Type boundType) {
       com.sun.tools.javac.util.List<TypeMetadata> metadata = baseType.getMetadata();
       return new Type.WildcardType(boundType, baseType.kind, baseType.tsym, metadata);
+    }
+
+    @Override
+    public Type.TypeVar createDetachedTypeVar(Type.TypeVar baseType, Type upperBound) {
+      if (baseType instanceof Type.CapturedType capturedType) {
+        return createDetachedCapturedType(capturedType, capturedType.wildcard, upperBound);
+      }
+      return copyMetadata(createDetachedTypeVarWithoutMetadata(baseType, upperBound), baseType);
+    }
+
+    @Override
+    public Type.CapturedType createDetachedCapturedType(
+        Type.CapturedType baseType, Type.WildcardType wildcard, Type upperBound) {
+      return (Type.CapturedType)
+          copyMetadata(
+              createDetachedCapturedTypeWithoutMetadata(baseType, wildcard, upperBound), baseType);
+    }
+
+    /** Copies all metadata from {@code baseType} to the initially metadata-free {@code newType}. */
+    private static Type.TypeVar copyMetadata(Type.TypeVar newType, Type.TypeVar baseType) {
+      Type.TypeVar result = newType;
+      // addMetadata prepends, so iterate backwards to preserve javac's metadata ordering.
+      for (TypeMetadata metadata : baseType.getMetadata().reverse()) {
+        result = (Type.TypeVar) result.addMetadata(metadata);
+      }
+      return result;
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -17,7 +17,9 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.Nullness;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
@@ -107,12 +109,47 @@ public class TypeSubstitutionUtils {
    */
   public static Type.CapturedType replaceCapturedTypeWildcard(
       Type.CapturedType type, Type.WildcardType wildcard) {
-    Type.CapturedType updated =
-        (Type.CapturedType)
-            TYPE_METADATA_BUILDER.cloneTypeWithMetadata(
-                type, TYPE_METADATA_BUILDER.create(type.getAnnotationMirrors()));
-    updated.wildcard = wildcard;
-    return updated;
+    // Do not use cloneTypeWithMetadata here. javac implements metadata "clones" of captured types
+    // as wrappers whose upper-bound accessors delegate to the original capture. Returning such a
+    // wrapper would allow later javac operations to mutate compiler-owned state through our copy.
+    return TYPE_METADATA_BUILDER.createDetachedCapturedType(type, wildcard, type.getUpperBound());
+  }
+
+  /**
+   * Returns a copy of an unbounded wildcard with a new implicit upper bound.
+   *
+   * <p>Under JSpecify, an unbounded wildcard uses the upper bound of the formal type variable to
+   * which it is passed. javac stores that formal type variable in {@link Type.WildcardType#bound}.
+   * This method copies both the wildcard and that type variable before updating the latter's upper
+   * bound, so the wildcard remains unbounded and shared javac types are not mutated.
+   *
+   * @param wildcard the unbounded wildcard to copy
+   * @param upperBound the new implicit upper bound
+   * @return the copied wildcard
+   */
+  public static Type.WildcardType replaceUnboundedWildcardUpperBound(
+      Type.WildcardType wildcard, Type upperBound) {
+    Verify.verify(wildcard.kind == BoundKind.UNBOUND, "wildcard must be unbounded");
+    Type.TypeVar formalTypeVariable =
+        Verify.verifyNotNull(
+            wildcard.bound, "unbounded wildcard has no corresponding formal type variable");
+    return replaceUnboundedWildcardUpperBound(wildcard, formalTypeVariable, upperBound);
+  }
+
+  /**
+   * Returns a copy of an unbounded wildcard with its {@code bound} field set to a copy of {@code
+   * typeVariable} with {@code upperBound} as its upper bound.
+   */
+  private static Type.WildcardType replaceUnboundedWildcardUpperBound(
+      Type.WildcardType wildcard, Type.TypeVar typeVariable, Type upperBound) {
+    // A metadata clone of a javac TypeVar delegates setUpperBound() to the original TypeVar. Build
+    // a genuinely detached TypeVar with the desired bound instead of mutating an apparent clone.
+    Type.TypeVar updatedFormalTypeVariable =
+        TYPE_METADATA_BUILDER.createDetachedTypeVar(typeVariable, upperBound);
+    Type.WildcardType updatedWildcard =
+        TYPE_METADATA_BUILDER.createWildcardType(wildcard, wildcard.type);
+    updatedWildcard.bound = updatedFormalTypeVariable;
+    return updatedWildcard;
   }
 
   /**
@@ -275,6 +312,10 @@ public class TypeSubstitutionUtils {
 
     private final Config config;
 
+    /** Pairs of implicit wildcard bounds currently being traversed. */
+    private final IdentityHashMap<Type.TypeVar, Set<Type.TypeVar>> activeUnboundedWildcardBounds =
+        new IdentityHashMap<>();
+
     /**
      * Additional annotations to consider for type variables. If there is no explicit nullability
      * annotation on a type variable {@code X}, but {@code X} is present as a key in this map, the
@@ -338,6 +379,38 @@ public class TypeSubstitutionUtils {
       if (!(other instanceof Type.WildcardType wildcardType)) {
         return wt;
       }
+      // for unbound wildcards, we restore annotations onto the upper bound of the underlying type
+      // variable, stored in the `bound` field
+      if (wt.kind == BoundKind.UNBOUND
+          && wildcardType.kind == BoundKind.UNBOUND
+          && wt.bound != null
+          && wildcardType.bound != null) {
+        Type.TypeVar formalTypeVariable = wt.bound;
+        Type.TypeVar otherFormalTypeVariable = wildcardType.bound;
+        Set<Type.TypeVar> activeOtherBounds = activeUnboundedWildcardBounds.get(formalTypeVariable);
+        if (activeOtherBounds == null) {
+          activeOtherBounds = Collections.newSetFromMap(new IdentityHashMap<>());
+          activeUnboundedWildcardBounds.put(formalTypeVariable, activeOtherBounds);
+        } else if (activeOtherBounds.contains(otherFormalTypeVariable)) {
+          // F-bounded type variables make the implicit upper-bound graph cyclic. Re-entering the
+          // same pair cannot reveal any annotations that were not handled on the first visit.
+          return wt;
+        }
+        activeOtherBounds.add(otherFormalTypeVariable);
+        Type upperBound = formalTypeVariable.getUpperBound();
+        Type updatedUpperBound;
+        try {
+          updatedUpperBound = visit(upperBound, otherFormalTypeVariable.getUpperBound());
+        } finally {
+          activeOtherBounds.remove(otherFormalTypeVariable);
+          if (activeOtherBounds.isEmpty()) {
+            activeUnboundedWildcardBounds.remove(formalTypeVariable);
+          }
+        }
+        return updatedUpperBound == upperBound
+            ? wt
+            : replaceUnboundedWildcardUpperBound(wt, updatedUpperBound);
+      }
       Type t = wt.type;
       if (t != null) {
         t = visit(t, wildcardType.type);
@@ -363,8 +436,11 @@ public class TypeSubstitutionUtils {
      * corresponding to {@code t}. Alternatively, nested capture conversion can make {@code t} a
      * captured {@code extends} wildcard while the same position in {@code other} is a non-wildcard
      * type. In that case, annotations from {@code other} must be restored to the backing wildcard's
-     * upper bound, since wildcard-aware checks use that bound rather than annotations directly on
-     * the captured type.
+     * upper bound.
+     *
+     * <p>For an unbounded wildcard, the relevant upper bound is its implicit upper bound from the
+     * corresponding formal type variable. Wildcard-aware checks use these bounds rather than
+     * annotations directly on the captured type.
      */
     @Override
     public Type visitCapturedType(Type.CapturedType t, Type other) {
@@ -379,6 +455,15 @@ public class TypeSubstitutionUtils {
           return updated;
         }
         updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
+      } else if (t.wildcard.kind == BoundKind.UNBOUND) {
+        Type.TypeVar formalTypeVariable = t.wildcard.bound != null ? t.wildcard.bound : t;
+        Type upperBound = formalTypeVariable.getUpperBound();
+        Type updatedUpperBound = upperBound.accept(this, other);
+        if (updatedUpperBound == upperBound) {
+          return updated;
+        }
+        updatedWildcard =
+            replaceUnboundedWildcardUpperBound(t.wildcard, formalTypeVariable, updatedUpperBound);
       } else {
         return updated;
       }

--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -100,11 +100,21 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
     if (entry.kind() != NestedAnnotationInfo.TypePathEntry.Kind.WILDCARD_BOUND) {
       return t;
     }
-    if (t.kind == BoundKind.UNBOUND) {
-      // TODO we need to add logic to _introduce_ a bound if none exists (add follow-up issue)
-      return t;
-    }
     int boundIndex = entry.index();
+    if (t.kind == BoundKind.UNBOUND) {
+      if (boundIndex != 0) {
+        // An unbounded wildcard has an implicit upper bound, but no lower bound.
+        return t;
+      }
+      Type.TypeVar formalTypeVariable =
+          Verify.verifyNotNull(
+              t.bound, "unbounded wildcard has no corresponding formal type variable");
+      Type upperBound = formalTypeVariable.getUpperBound();
+      Type updatedUpperBound = upperBound.accept(this, pathIndex + 1);
+      return updatedUpperBound == upperBound
+          ? t
+          : TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(t, updatedUpperBound);
+    }
     if (boundIndex == 0 && t.kind == BoundKind.EXTENDS) {
       Type newBound = t.type.accept(this, pathIndex + 1);
       return newBound == t.type ? t : TYPE_METADATA_BUILDER.createWildcardType(t, newBound);
@@ -132,11 +142,17 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
     } else {
       Verify.verify(pathIndex == typePath.size(), "path index out of bounds");
       if (t.wildcard.kind == BoundKind.UNBOUND) {
-        // Do not turn javac's placeholder bound for an unbounded wildcard into an explicit bound.
-        return t;
+        Type.TypeVar formalTypeVariable =
+            Verify.verifyNotNull(
+                t.wildcard.bound, "unbounded wildcard has no corresponding formal type variable");
+        Type updatedUpperBound =
+            TypeSubstitutionUtils.typeWithAnnot(formalTypeVariable.getUpperBound(), annotationType);
+        updatedWildcard =
+            TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(t.wildcard, updatedUpperBound);
+      } else {
+        Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(t.wildcard.type, annotationType);
+        updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
       }
-      Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(t.wildcard.type, annotationType);
-      updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
     }
     if (updatedWildcard == t.wildcard) {
       return t;

--- a/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
@@ -1,0 +1,151 @@
+package com.uber.nullaway.generics;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.BoundKind;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TypeSubstitutionUtilsTests {
+
+  @Test
+  public void replaceUnboundedWildcardUpperBoundDoesNotMutateFormalTypeVariable() {
+    CompilationTestHelper.newInstance(TypeCopyIsolationChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test<T> {
+              Test<?> typeVarField;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void replaceCapturedTypeWildcardReturnsDetachedCapture() {
+    CompilationTestHelper.newInstance(TypeCopyIsolationChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test<T> {
+              Test<?> capturedTypeField;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void cloneTypeWithMetadataReturnsDetachedMutableTypes() {
+    CompilationTestHelper.newInstance(TypeCopyIsolationChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test<T> {
+              Test<?> typeVarMetadataField;
+              Test<?> capturedTypeMetadataField;
+            }
+            """)
+        .doTest();
+  }
+
+  /** Checker that exercises the mutable javac types used by the replacement helpers. */
+  @BugPattern(summary = "Checks that copied javac types are detached", severity = SUGGESTION)
+  public static final class TypeCopyIsolationChecker extends BugChecker
+      implements BugChecker.VariableTreeMatcher {
+
+    @Override
+    public Description matchVariable(VariableTree tree, VisitorState state) {
+      String fieldName = tree.getName().toString();
+      if (!fieldName.equals("typeVarField")
+          && !fieldName.equals("capturedTypeField")
+          && !fieldName.equals("typeVarMetadataField")
+          && !fieldName.equals("capturedTypeMetadataField")) {
+        return NO_MATCH;
+      }
+      Type.ClassType fieldType = (Type.ClassType) ASTHelpers.getType(tree);
+      Type.WildcardType sourceWildcard = (Type.WildcardType) fieldType.getTypeArguments().head;
+      Type.TypeVar formalTypeVariable = (Type.TypeVar) fieldType.tsym.type.getTypeArguments().head;
+      Type originalUpperBound = formalTypeVariable.getUpperBound();
+      Type updatedUpperBound =
+          TypeSubstitutionUtils.typeWithAnnot(
+              originalUpperBound, GenericsChecks.getSyntheticNullableAnnotType(state));
+      Type.WildcardType unboundedWildcard =
+          new Type.WildcardType(
+              sourceWildcard.type, BoundKind.UNBOUND, sourceWildcard.tsym, formalTypeVariable);
+
+      if (fieldName.equals("typeVarField")) {
+        Type.WildcardType updatedWildcard =
+            TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(
+                unboundedWildcard, updatedUpperBound);
+        assertThat(formalTypeVariable.getUpperBound()).isSameInstanceAs(originalUpperBound);
+        assertThat(updatedWildcard).isNotSameInstanceAs(unboundedWildcard);
+        assertThat(updatedWildcard.bound).isNotSameInstanceAs(formalTypeVariable);
+        assertThat(updatedWildcard.bound.tsym).isSameInstanceAs(formalTypeVariable.tsym);
+        assertThat(updatedWildcard.bound.lower).isSameInstanceAs(formalTypeVariable.lower);
+        assertThat(updatedWildcard.bound.getUpperBound()).isSameInstanceAs(updatedUpperBound);
+      } else if (fieldName.equals("typeVarMetadataField")) {
+        Type.TypeVar updatedTypeVariable =
+            (Type.TypeVar)
+                TypeSubstitutionUtils.typeWithAnnot(
+                    formalTypeVariable, GenericsChecks.getSyntheticNullableAnnotType(state));
+        updatedTypeVariable.setUpperBound(updatedUpperBound);
+        assertThat(formalTypeVariable.getUpperBound()).isSameInstanceAs(originalUpperBound);
+        assertThat(updatedTypeVariable.getUpperBound()).isSameInstanceAs(updatedUpperBound);
+        assertThat(updatedTypeVariable.baseType()).isSameInstanceAs(formalTypeVariable.baseType());
+        assertThat(formalTypeVariable.getAnnotationMirrors()).isEmpty();
+        assertThat(updatedTypeVariable.getAnnotationMirrors()).isNotEmpty();
+      } else {
+        Symbol owner = ASTHelpers.getSymbol(tree);
+        Type.CapturedType capturedType =
+            new Type.CapturedType(
+                formalTypeVariable.tsym.name,
+                owner,
+                originalUpperBound,
+                state.getSymtab().botType,
+                unboundedWildcard);
+        if (fieldName.equals("capturedTypeField")) {
+          Type.WildcardType replacementWildcard =
+              new Type.WildcardType(updatedUpperBound, BoundKind.EXTENDS, sourceWildcard.tsym);
+          Type.CapturedType updatedCapture =
+              TypeSubstitutionUtils.replaceCapturedTypeWildcard(capturedType, replacementWildcard);
+          assertThat(updatedCapture).isNotSameInstanceAs(capturedType);
+          assertThat(updatedCapture.tsym).isSameInstanceAs(capturedType.tsym);
+          assertThat(updatedCapture.lower).isSameInstanceAs(capturedType.lower);
+          assertThat(capturedType.wildcard).isSameInstanceAs(unboundedWildcard);
+          assertThat(updatedCapture.wildcard).isSameInstanceAs(replacementWildcard);
+
+          // A javac metadata clone delegates this setter to the original capture. Mutating the
+          // replacement therefore proves that it is a genuinely detached object, not such a clone.
+          updatedCapture.setUpperBound(updatedUpperBound);
+          assertThat(capturedType.getUpperBound()).isSameInstanceAs(originalUpperBound);
+          assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(updatedUpperBound);
+        } else {
+          Type.CapturedType updatedCapture =
+              (Type.CapturedType)
+                  TypeSubstitutionUtils.typeWithAnnot(
+                      capturedType, GenericsChecks.getSyntheticNullableAnnotType(state));
+          updatedCapture.setUpperBound(updatedUpperBound);
+          assertThat(capturedType.getUpperBound()).isSameInstanceAs(originalUpperBound);
+          assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(updatedUpperBound);
+          assertThat(updatedCapture.baseType()).isSameInstanceAs(capturedType.baseType());
+          assertThat(capturedType.getAnnotationMirrors()).isEmpty();
+          assertThat(updatedCapture.getAnnotationMirrors()).isNotEmpty();
+        }
+      }
+      return NO_MATCH;
+    }
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
@@ -97,7 +97,7 @@ public class TypeSubstitutionUtilsTests {
         case CAPTURED_TYPE_METADATA_FIELD ->
             checkCapturedTypeMetadataCopy(testTypeContext, tree, state);
         default -> {
-          return NO_MATCH;
+          throw new RuntimeException("Unknown field name: " + fieldName);
         }
       }
       return NO_MATCH;

--- a/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/generics/TypeSubstitutionUtilsTests.java
@@ -18,6 +18,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/**
+ * Tests operations that copy mutable javac type variables and captured types.
+ *
+ * <p>These behaviors require types created by an active javac compilation, so each test compiles a
+ * small source file with {@link TypeCopyIsolationChecker}. Special field names in that source
+ * select the operation that the checker exercises; the assertions themselves run inside the checker
+ * while the corresponding javac types are available.
+ */
 @RunWith(JUnit4.class)
 public class TypeSubstitutionUtilsTests {
 
@@ -61,91 +69,153 @@ public class TypeSubstitutionUtilsTests {
         .doTest();
   }
 
-  /** Checker that exercises the mutable javac types used by the replacement helpers. */
+  /**
+   * Checker that exercises the mutable javac types used by the replacement helpers.
+   *
+   * <p>The fields named {@code typeVarField} and {@code capturedTypeField} exercise the two public
+   * replacement helpers. The fields named {@code typeVarMetadataField} and {@code
+   * capturedTypeMetadataField} exercise the metadata-copying path used by {@link
+   * TypeSubstitutionUtils#typeWithAnnot}. Other variable declarations are ignored.
+   */
   @BugPattern(summary = "Checks that copied javac types are detached", severity = SUGGESTION)
   public static final class TypeCopyIsolationChecker extends BugChecker
       implements BugChecker.VariableTreeMatcher {
 
+    private static final String TYPE_VAR_FIELD = "typeVarField";
+    private static final String CAPTURED_TYPE_FIELD = "capturedTypeField";
+    private static final String TYPE_VAR_METADATA_FIELD = "typeVarMetadataField";
+    private static final String CAPTURED_TYPE_METADATA_FIELD = "capturedTypeMetadataField";
+
     @Override
     public Description matchVariable(VariableTree tree, VisitorState state) {
       String fieldName = tree.getName().toString();
-      if (!fieldName.equals("typeVarField")
-          && !fieldName.equals("capturedTypeField")
-          && !fieldName.equals("typeVarMetadataField")
-          && !fieldName.equals("capturedTypeMetadataField")) {
-        return NO_MATCH;
-      }
-      Type.ClassType fieldType = (Type.ClassType) ASTHelpers.getType(tree);
-      Type.WildcardType sourceWildcard = (Type.WildcardType) fieldType.getTypeArguments().head;
-      Type.TypeVar formalTypeVariable = (Type.TypeVar) fieldType.tsym.type.getTypeArguments().head;
-      Type originalUpperBound = formalTypeVariable.getUpperBound();
-      Type updatedUpperBound =
-          TypeSubstitutionUtils.typeWithAnnot(
-              originalUpperBound, GenericsChecks.getSyntheticNullableAnnotType(state));
-      Type.WildcardType unboundedWildcard =
-          new Type.WildcardType(
-              sourceWildcard.type, BoundKind.UNBOUND, sourceWildcard.tsym, formalTypeVariable);
-
-      if (fieldName.equals("typeVarField")) {
-        Type.WildcardType updatedWildcard =
-            TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(
-                unboundedWildcard, updatedUpperBound);
-        assertThat(formalTypeVariable.getUpperBound()).isSameInstanceAs(originalUpperBound);
-        assertThat(updatedWildcard).isNotSameInstanceAs(unboundedWildcard);
-        assertThat(updatedWildcard.bound).isNotSameInstanceAs(formalTypeVariable);
-        assertThat(updatedWildcard.bound.tsym).isSameInstanceAs(formalTypeVariable.tsym);
-        assertThat(updatedWildcard.bound.lower).isSameInstanceAs(formalTypeVariable.lower);
-        assertThat(updatedWildcard.bound.getUpperBound()).isSameInstanceAs(updatedUpperBound);
-      } else if (fieldName.equals("typeVarMetadataField")) {
-        Type.TypeVar updatedTypeVariable =
-            (Type.TypeVar)
-                TypeSubstitutionUtils.typeWithAnnot(
-                    formalTypeVariable, GenericsChecks.getSyntheticNullableAnnotType(state));
-        updatedTypeVariable.setUpperBound(updatedUpperBound);
-        assertThat(formalTypeVariable.getUpperBound()).isSameInstanceAs(originalUpperBound);
-        assertThat(updatedTypeVariable.getUpperBound()).isSameInstanceAs(updatedUpperBound);
-        assertThat(updatedTypeVariable.baseType()).isSameInstanceAs(formalTypeVariable.baseType());
-        assertThat(formalTypeVariable.getAnnotationMirrors()).isEmpty();
-        assertThat(updatedTypeVariable.getAnnotationMirrors()).isNotEmpty();
-      } else {
-        Symbol owner = ASTHelpers.getSymbol(tree);
-        Type.CapturedType capturedType =
-            new Type.CapturedType(
-                formalTypeVariable.tsym.name,
-                owner,
-                originalUpperBound,
-                state.getSymtab().botType,
-                unboundedWildcard);
-        if (fieldName.equals("capturedTypeField")) {
-          Type.WildcardType replacementWildcard =
-              new Type.WildcardType(updatedUpperBound, BoundKind.EXTENDS, sourceWildcard.tsym);
-          Type.CapturedType updatedCapture =
-              TypeSubstitutionUtils.replaceCapturedTypeWildcard(capturedType, replacementWildcard);
-          assertThat(updatedCapture).isNotSameInstanceAs(capturedType);
-          assertThat(updatedCapture.tsym).isSameInstanceAs(capturedType.tsym);
-          assertThat(updatedCapture.lower).isSameInstanceAs(capturedType.lower);
-          assertThat(capturedType.wildcard).isSameInstanceAs(unboundedWildcard);
-          assertThat(updatedCapture.wildcard).isSameInstanceAs(replacementWildcard);
-
-          // A javac metadata clone delegates this setter to the original capture. Mutating the
-          // replacement therefore proves that it is a genuinely detached object, not such a clone.
-          updatedCapture.setUpperBound(updatedUpperBound);
-          assertThat(capturedType.getUpperBound()).isSameInstanceAs(originalUpperBound);
-          assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(updatedUpperBound);
-        } else {
-          Type.CapturedType updatedCapture =
-              (Type.CapturedType)
-                  TypeSubstitutionUtils.typeWithAnnot(
-                      capturedType, GenericsChecks.getSyntheticNullableAnnotType(state));
-          updatedCapture.setUpperBound(updatedUpperBound);
-          assertThat(capturedType.getUpperBound()).isSameInstanceAs(originalUpperBound);
-          assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(updatedUpperBound);
-          assertThat(updatedCapture.baseType()).isSameInstanceAs(capturedType.baseType());
-          assertThat(capturedType.getAnnotationMirrors()).isEmpty();
-          assertThat(updatedCapture.getAnnotationMirrors()).isNotEmpty();
+      TestTypeContext testTypeContext = createTestTypeContext(tree, state);
+      switch (fieldName) {
+        case TYPE_VAR_FIELD -> checkUnboundedWildcardReplacement(testTypeContext);
+        case CAPTURED_TYPE_FIELD -> checkCapturedWildcardReplacement(testTypeContext, tree, state);
+        case TYPE_VAR_METADATA_FIELD -> checkTypeVariableMetadataCopy(testTypeContext);
+        case CAPTURED_TYPE_METADATA_FIELD ->
+            checkCapturedTypeMetadataCopy(testTypeContext, tree, state);
+        default -> {
+          return NO_MATCH;
         }
       }
       return NO_MATCH;
     }
+
+    /**
+     * Extracts the compiler types shared by all four scenarios from a synthetic {@code Test<?>}
+     * field.
+     */
+    private static TestTypeContext createTestTypeContext(VariableTree tree, VisitorState state) {
+      Type.ClassType fieldType = (Type.ClassType) ASTHelpers.getType(tree);
+      Type.WildcardType sourceWildcard = (Type.WildcardType) fieldType.getTypeArguments().head;
+      Type.TypeVar formalTypeVariable = (Type.TypeVar) fieldType.tsym.type.getTypeArguments().head;
+      Type originalUpperBound = formalTypeVariable.getUpperBound();
+      Type nullableAnnotationType = GenericsChecks.getSyntheticNullableAnnotType(state);
+      Type updatedUpperBound =
+          TypeSubstitutionUtils.typeWithAnnot(originalUpperBound, nullableAnnotationType);
+      Type.WildcardType unboundedWildcard =
+          new Type.WildcardType(
+              sourceWildcard.type, BoundKind.UNBOUND, sourceWildcard.tsym, formalTypeVariable);
+      return new TestTypeContext(
+          sourceWildcard,
+          formalTypeVariable,
+          originalUpperBound,
+          updatedUpperBound,
+          nullableAnnotationType,
+          unboundedWildcard);
+    }
+
+    /**
+     * Checks that replacing an implicit unbounded-wildcard bound copies its formal type variable.
+     */
+    private static void checkUnboundedWildcardReplacement(TestTypeContext context) {
+      Type.WildcardType updatedWildcard =
+          TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(
+              context.unboundedWildcard(), context.updatedUpperBound());
+      assertThat(context.formalTypeVariable().getUpperBound())
+          .isSameInstanceAs(context.originalUpperBound());
+      assertThat(updatedWildcard).isNotSameInstanceAs(context.unboundedWildcard());
+      assertThat(updatedWildcard.bound).isNotSameInstanceAs(context.formalTypeVariable());
+      assertThat(updatedWildcard.bound.tsym).isSameInstanceAs(context.formalTypeVariable().tsym);
+      assertThat(updatedWildcard.bound.lower).isSameInstanceAs(context.formalTypeVariable().lower);
+      assertThat(updatedWildcard.bound.getUpperBound())
+          .isSameInstanceAs(context.updatedUpperBound());
+    }
+
+    /** Checks that adding metadata to a type variable does not share its mutable upper bound. */
+    private static void checkTypeVariableMetadataCopy(TestTypeContext context) {
+      Type.TypeVar updatedTypeVariable =
+          (Type.TypeVar)
+              TypeSubstitutionUtils.typeWithAnnot(
+                  context.formalTypeVariable(), context.nullableAnnotationType());
+      updatedTypeVariable.setUpperBound(context.updatedUpperBound());
+      assertThat(context.formalTypeVariable().getUpperBound())
+          .isSameInstanceAs(context.originalUpperBound());
+      assertThat(updatedTypeVariable.getUpperBound()).isSameInstanceAs(context.updatedUpperBound());
+      assertThat(updatedTypeVariable.baseType())
+          .isSameInstanceAs(context.formalTypeVariable().baseType());
+      assertThat(context.formalTypeVariable().getAnnotationMirrors()).isEmpty();
+      assertThat(updatedTypeVariable.getAnnotationMirrors()).isNotEmpty();
+    }
+
+    /** Checks that replacing a capture's backing wildcard returns a fully detached capture. */
+    private static void checkCapturedWildcardReplacement(
+        TestTypeContext context, VariableTree tree, VisitorState state) {
+      Type.CapturedType capturedType = createCapturedType(context, tree, state);
+      Type.WildcardType replacementWildcard =
+          new Type.WildcardType(
+              context.updatedUpperBound(), BoundKind.EXTENDS, context.sourceWildcard().tsym);
+      Type.CapturedType updatedCapture =
+          TypeSubstitutionUtils.replaceCapturedTypeWildcard(capturedType, replacementWildcard);
+      assertThat(updatedCapture).isNotSameInstanceAs(capturedType);
+      assertThat(updatedCapture.tsym).isSameInstanceAs(capturedType.tsym);
+      assertThat(updatedCapture.lower).isSameInstanceAs(capturedType.lower);
+      assertThat(capturedType.wildcard).isSameInstanceAs(context.unboundedWildcard());
+      assertThat(updatedCapture.wildcard).isSameInstanceAs(replacementWildcard);
+
+      // A javac metadata clone delegates this setter to the original capture. Mutating the
+      // replacement therefore proves that it is a genuinely detached object, not such a clone.
+      updatedCapture.setUpperBound(context.updatedUpperBound());
+      assertThat(capturedType.getUpperBound()).isSameInstanceAs(context.originalUpperBound());
+      assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(context.updatedUpperBound());
+    }
+
+    /** Checks that adding metadata to a capture does not share its mutable upper bound. */
+    private static void checkCapturedTypeMetadataCopy(
+        TestTypeContext context, VariableTree tree, VisitorState state) {
+      Type.CapturedType capturedType = createCapturedType(context, tree, state);
+      Type.CapturedType updatedCapture =
+          (Type.CapturedType)
+              TypeSubstitutionUtils.typeWithAnnot(capturedType, context.nullableAnnotationType());
+      updatedCapture.setUpperBound(context.updatedUpperBound());
+      assertThat(capturedType.getUpperBound()).isSameInstanceAs(context.originalUpperBound());
+      assertThat(updatedCapture.getUpperBound()).isSameInstanceAs(context.updatedUpperBound());
+      assertThat(updatedCapture.baseType()).isSameInstanceAs(capturedType.baseType());
+      assertThat(capturedType.getAnnotationMirrors()).isEmpty();
+      assertThat(updatedCapture.getAnnotationMirrors()).isNotEmpty();
+    }
+
+    /** Creates the synthetic captured type used by both capture-copy scenarios. */
+    private static Type.CapturedType createCapturedType(
+        TestTypeContext context, VariableTree tree, VisitorState state) {
+      Symbol owner = ASTHelpers.getSymbol(tree);
+      return new Type.CapturedType(
+          context.formalTypeVariable().tsym.name,
+          owner,
+          context.originalUpperBound(),
+          state.getSymtab().botType,
+          context.unboundedWildcard());
+    }
+
+    /** Compiler types derived from one synthetic field and shared by a single test scenario. */
+    private record TestTypeContext(
+        Type.WildcardType sourceWildcard,
+        Type.TypeVar formalTypeVariable,
+        Type originalUpperBound,
+        Type updatedUpperBound,
+        Type nullableAnnotationType,
+        Type.WildcardType unboundedWildcard) {}
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1123,6 +1123,41 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void annotationRestorationForFBoundedWildcardPreservesInferredNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Value<V extends Value<V>> {}
+              interface Store<S extends Store<S>> {}
+              interface Transfer<V extends Value<V>, S extends Store<S>> {}
+              static class Analysis<
+                  V extends Value<V>,
+                  S extends Store<S>,
+                  T extends Transfer<V, S>,
+                  R extends @Nullable Object> {
+                R value() {
+                  throw new UnsupportedOperationException();
+                }
+              }
+              static <R extends @Nullable Object> Analysis<?, ?, ?, R> make(R value) {
+                throw new UnsupportedOperationException();
+              }
+              void test() {
+                make(new Object()).value().hashCode();
+                // BUG: Diagnostic contains: dereferenced expression 'make(null).value()' is @Nullable
+                make(null).value().hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /** ensures we avoid a crash related to wildcards when wildcard handling is disabled */
   @Test
   public void methodRefParameterSuperWildcardWithHandlingDisabled() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -478,6 +478,49 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void annotationRestoredFromUpperBoundToCapturedUnboundedWildcard() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Nested<T extends @Nullable Object> {
+                Nested<T> self() {
+                  return this;
+                }
+                Nested<? extends @Nullable T> wildcardUpperTypeVariable() {
+                  throw new RuntimeException();
+                }
+              }
+
+              Nested<? extends Object> testDirect(Nested<?> receiver) {
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.wildcardUpperTypeVariable();
+              }
+
+              Nested<? extends Object> testWithSelf(Nested<?> receiver) {
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.self().wildcardUpperTypeVariable();
+              }
+
+              Nested<? extends Object> testWithVar(Nested<?> receiver) {
+                var local = receiver;
+                // BUG: Diagnostic contains: incompatible types
+                return local.wildcardUpperTypeVariable();
+              }
+
+              Nested<? extends @Nullable Object> testCompatible(Nested<?> receiver) {
+                return receiver.wildcardUpperTypeVariable();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void wildcardCaptureReturnWithTypeVariableUpperBound() {
     makeHelper()
         .addSourceLines(
@@ -1044,6 +1087,36 @@ public class WildcardTests extends NullAwayTestsBase {
               }
               static Analysis<?, ?, ?> create(Transfer<?, ?> transfer) {
                 return new Analysis<>(transfer);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotationRestorationForUnboundedWildcardWithFBoundedFormalDoesNotRecurse() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              interface Value<V extends Value<V>> {}
+              interface Store<S extends Store<S>> {}
+              interface Transfer<V extends Value<V>, S extends Store<S>> {}
+              static class Analysis<
+                  V extends Value<V>,
+                  S extends Store<S>,
+                  T extends Transfer<V, S>> {}
+              static class Cache<K, V> {
+                V getUnchecked(K key) {
+                  throw new UnsupportedOperationException();
+                }
+              }
+              final Cache<Object, Analysis<?, ?, ?>> cache = new Cache<>();
+              void test(Object key) {
+                Analysis<?, ?, ?> analysis = cache.getUnchecked(key);
               }
             }
             """)

--- a/test-java-lib/src/main/java/com/uber/lib/unannotated/UnboundWildcards.java
+++ b/test-java-lib/src/main/java/com/uber/lib/unannotated/UnboundWildcards.java
@@ -1,0 +1,18 @@
+package com.uber.lib.unannotated;
+
+/* @NullMarked */
+@SuppressWarnings("DoNotCallSuggester")
+public class UnboundWildcards<T /* extends @Nullable Object */> {
+
+  public UnboundWildcards<T> self() {
+    return this;
+  }
+
+  public static UnboundWildcards<? extends /* @Nullable */ Object> literalWildcard() {
+    throw new RuntimeException();
+  }
+
+  public UnboundWildcards</* @Nullable */ T> typeVariable() {
+    throw new RuntimeException();
+  }
+}

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -170,6 +170,8 @@ public class TestLibraryModels implements LibraryModels {
         "com.uber.lib.unannotated.ProviderNullMarkedViaModel",
         0,
         "com.uber.lib.unannotated.NestedAnnots",
+        0,
+        "com.uber.lib.unannotated.UnboundWildcards",
         0);
   }
 
@@ -181,7 +183,8 @@ public class TestLibraryModels implements LibraryModels {
         "com.uber.lib.unannotated.LambdaConsumer",
         "com.uber.lib.unannotated.LambdaModel",
         "com.uber.lib.unannotated.NestedAnnots",
-        "com.uber.lib.unannotated.NullMarkedVarargsWithModel");
+        "com.uber.lib.unannotated.NullMarkedVarargsWithModel",
+        "com.uber.lib.unannotated.UnboundWildcards");
   }
 
   @Override
@@ -262,6 +265,21 @@ public class TestLibraryModels implements LibraryModels {
                     ImmutableList.of(
                         new TypePathEntry(TYPE_ARGUMENT, 0),
                         new TypePathEntry(WILDCARD_BOUND, 0)))))
+        .put(
+            methodRef("com.uber.lib.unannotated.UnboundWildcards", "literalWildcard()"),
+            ImmutableSetMultimap.of(
+                -1,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE,
+                    ImmutableList.of(
+                        new TypePathEntry(TYPE_ARGUMENT, 0),
+                        new TypePathEntry(WILDCARD_BOUND, 0)))))
+        .put(
+            methodRef("com.uber.lib.unannotated.UnboundWildcards", "typeVariable()"),
+            ImmutableSetMultimap.of(
+                -1,
+                new NestedAnnotationInfo(
+                    Annotation.NULLABLE, ImmutableList.of(new TypePathEntry(TYPE_ARGUMENT, 0)))))
         .put(
             methodRef(
                 "com.uber.lib.unannotated.NestedAnnots",

--- a/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
+++ b/test-library-models/src/test/java/com/uber/nullaway/CustomLibraryModelsTests.java
@@ -620,6 +620,46 @@ public class CustomLibraryModelsTests {
   }
 
   @Test
+  public void nestedAnnotationsOnUnboundedWildcardBounds() {
+    makeLibraryModelsTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.uber.lib.unannotated.UnboundWildcards;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+
+              UnboundWildcards<? extends Object> testLiteral() {
+                // BUG: Diagnostic contains: incompatible types
+                return UnboundWildcards.literalWildcard();
+              }
+
+              UnboundWildcards<? extends @Nullable Object> testLiteralCompatible() {
+                return UnboundWildcards.literalWildcard();
+              }
+
+              UnboundWildcards<? extends Object> testCaptured(
+                  UnboundWildcards<?> receiver) {
+                // BUG: Diagnostic contains: incompatible types
+                return receiver.self().typeVariable();
+              }
+
+              UnboundWildcards<? extends @Nullable Object> testCapturedCompatible(
+                  UnboundWildcards<?> receiver) {
+                return receiver.self().typeVariable();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void multipleArgs() {
     makeLibraryModelsTestHelperWithArgs(
             JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
We correctly restore annotations from library models onto unbounded wildcard types, and the corresponding captured type variables.  Add tests involving library models and also regular annotated source code, including a test with recursive bounds on the variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for unbounded and captured wildcards.
  * Correctly restores annotations on wildcard upper bounds, including nested and F-bounded generic types.
  * Prevented incorrect acceptance of incompatible non-null assignments while preserving valid nullable assignments.
  * Improved handling of wildcard bounds represented through library models.

* **Tests**
  * Added regression coverage for captured wildcards, library-model annotations, and nullable wildcard bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->