### PR TITLE
Test case and fix for issue 1672

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -134,7 +134,8 @@ public final class GenericsChecks {
    * Handles cases where a poly expression (lambda or method reference) is passed as a parameter,
    * and the invoked function has a library model for the corresponding formal. In such cases, we
    * ensure the appropriate formal parameter type from the library model is used when inferring the
-   * type of the poly expression, and cache the result.
+   * type of the poly expression, and cache the result. If inference has already cached a
+   * context-derived type, we preserve it since inference itself applies library models.
    */
   @SuppressWarnings({"ReferenceEquality", "TypeEquals"})
   public void maybeStoreLibraryModeledPolyExpressionType(
@@ -147,6 +148,9 @@ public final class GenericsChecks {
     Preconditions.checkArgument(
         state.getPath().getLeaf() == polyExpressionTree,
         "Expected current path leaf to be the poly expression");
+    if (inferredPolyExpressionTypes.containsKey(polyExpressionTree)) {
+      return;
+    }
     TreePath invocationPath = state.getPath().getParentPath();
     // Skip parentheses around the invocation argument.
     while (invocationPath != null && invocationPath.getLeaf() instanceof ParenthesizedTree) {
@@ -176,10 +180,7 @@ public final class GenericsChecks {
     if (formalParameterType == null || formalParameterType.isRaw()) {
       return;
     }
-    Type polyExpressionType = inferredPolyExpressionTypes.get(polyExpressionTree);
-    if (polyExpressionType == null) {
-      polyExpressionType = ASTHelpers.getType(polyExpressionTree);
-    }
+    Type polyExpressionType = ASTHelpers.getType(polyExpressionTree);
     if (polyExpressionType != null) {
       Type groundTargetType =
           GenericsUtils.groundTargetType(formalParameterType, state, config, handler);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -239,6 +239,30 @@ public class GenericLambdaTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void optionalOfNullableRefinesNullableFunctionResult() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import java.util.Optional;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              public static <T> Optional<String> convert(
+                  final T value, final Function<T, @Nullable List<String>> extractor) {
+                return Optional.ofNullable(extractor.apply(value))
+                    .map(list -> Integer.toString(list.size()));
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Fixes #1672 

We were checking too late if we already had a cached type computed for a poly expression.  Now, if such a type exists, bail out immediately from `maybeStoreLibraryModeledPolyExpressionType`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for generic lambdas and method references.
  * Correctly preserves inferred types when analyzing chained optional and collection operations.
  * Fixed nullable function results being refined before subsequent mapping operations.

* **Tests**
  * Added regression coverage for nullable results passed through `Optional.ofNullable` and mapped collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->