### PR TITLE
Improve error messages involving capture variables

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
@@ -6,6 +6,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import org.jspecify.annotations.Nullable;
@@ -94,7 +95,21 @@ final class GenericTypePrettyPrintingVisitor
 
   @Override
   public String visitCapturedType(Type.CapturedType t, @Nullable Void s) {
-    return t.wildcard.accept(this, null);
+    StringBuilder sb = new StringBuilder();
+    appendNullableAnnotationIfPresent(t, sb);
+    sb.append("capture of ");
+    sb.append(t.wildcard.accept(this, null));
+    Type.TypeVar formalTypeVariable = t.wildcard.bound;
+    if (formalTypeVariable != null
+        && formalTypeVariable.tsym.owner instanceof Symbol.ClassSymbol owner
+        && !owner.getSimpleName().isEmpty()) {
+      sb.append(" (for ")
+          .append(formalTypeVariable.tsym.getSimpleName())
+          .append(" in ")
+          .append(owner.getSimpleName())
+          .append(')');
+    }
+    return sb.toString();
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericTypePrettyPrintingVisitor.java
@@ -6,7 +6,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
-import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import org.jspecify.annotations.Nullable;
@@ -99,16 +98,6 @@ final class GenericTypePrettyPrintingVisitor
     appendNullableAnnotationIfPresent(t, sb);
     sb.append("capture of ");
     sb.append(t.wildcard.accept(this, null));
-    Type.TypeVar formalTypeVariable = t.wildcard.bound;
-    if (formalTypeVariable != null
-        && formalTypeVariable.tsym.owner instanceof Symbol.ClassSymbol owner
-        && !owner.getSimpleName().isEmpty()) {
-      sb.append(" (for ")
-          .append(formalTypeVariable.tsym.getSimpleName())
-          .append(" in ")
-          .append(owner.getSimpleName())
-          .append(')');
-    }
     return sb.toString();
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -425,11 +425,11 @@ public final class GenericsChecks {
     String result =
         String.format(
             "incompatible types: %s cannot be converted to %s", prettyRhsType, prettyLhsType);
-    if (prettyRhsType.equals(prettyLhsType)) {
-      String wildcardBoundMismatch = firstDifferingWildcardBound(lhsType, rhsType, state);
-      if (wildcardBoundMismatch != null) {
-        result += " (" + wildcardBoundMismatch + ")";
-      }
+    boolean requireCapturedWildcard = !prettyRhsType.equals(prettyLhsType);
+    String wildcardBoundMismatch =
+        firstDifferingWildcardBound(lhsType, rhsType, state, requireCapturedWildcard);
+    if (wildcardBoundMismatch != null) {
+      result += " (" + wildcardBoundMismatch + ")";
     }
     if (!ASTHelpers.isSameType(lhsType, rhsType, state)
         && lhsType.getKind() == TypeKind.DECLARED
@@ -455,13 +455,20 @@ public final class GenericsChecks {
    *
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
+   *
+   * @param requireCapturedWildcard if true, only returns a mismatch involving a captured wildcard
    */
   private @Nullable String firstDifferingWildcardBound(
-      Type lhsType, Type rhsType, VisitorState state) {
+      Type lhsType, Type rhsType, VisitorState state, boolean requireCapturedWildcard) {
     // base case: both wildcard types
     Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
     if (lhsWildcard != null && rhsWildcard != null) {
+      if (requireCapturedWildcard
+          && !(lhsType instanceof Type.CapturedType)
+          && !(rhsType instanceof Type.CapturedType)) {
+        return null;
+      }
       return wildcardBoundMismatch(lhsWildcard, rhsWildcard, state);
     }
     if (lhsType instanceof Type.ClassType lhsClassType && rhsType instanceof Type.ClassType) {
@@ -480,17 +487,22 @@ public final class GenericsChecks {
       }
       for (int i = 0; i < lhsTypeArguments.size(); i++) {
         String mismatch =
-            firstDifferingWildcardBound(lhsTypeArguments.get(i), rhsTypeArguments.get(i), state);
+            firstDifferingWildcardBound(
+                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, requireCapturedWildcard);
         if (mismatch != null) {
           return mismatch;
         }
       }
       return firstDifferingWildcardBound(
-          lhsClassType.getEnclosingType(), rhsClassType.getEnclosingType(), state);
+          lhsClassType.getEnclosingType(),
+          rhsClassType.getEnclosingType(),
+          state,
+          requireCapturedWildcard);
     }
     if (lhsType instanceof Type.ArrayType lhsArrayType
         && rhsType instanceof Type.ArrayType rhsArrayType) {
-      return firstDifferingWildcardBound(lhsArrayType.elemtype, rhsArrayType.elemtype, state);
+      return firstDifferingWildcardBound(
+          lhsArrayType.elemtype, rhsArrayType.elemtype, state, requireCapturedWildcard);
     }
     return null;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -456,6 +456,9 @@ public final class GenericsChecks {
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
    *
+   * @param lhsType the lhs (target) type
+   * @param rhsType the rhs (source) type
+   * @param state the visitor state
    * @param allowNonCaptureMismatch whether a mismatch may be returned when neither causal wildcard
    *     is captured. Such details are useful when the full types print identically, but redundant
    *     when the full types already expose the difference.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -450,6 +450,9 @@ public final class GenericsChecks {
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
    *
+   * @param lhsType the lhs (target) type
+   * @param rhsType the rhs (source) type
+   * @param state the visitor state
    * @param allowNonCaptureMismatch whether a mismatch may be returned when neither causal wildcard
    *     is captured. Such details are useful when the full types print identically, but redundant
    *     when the full types already expose the difference.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -419,11 +419,11 @@ public final class GenericsChecks {
     String result =
         String.format(
             "incompatible types: %s cannot be converted to %s", prettyRhsType, prettyLhsType);
-    if (prettyRhsType.equals(prettyLhsType)) {
-      String wildcardBoundMismatch = firstDifferingWildcardBound(lhsType, rhsType, state);
-      if (wildcardBoundMismatch != null) {
-        result += " (" + wildcardBoundMismatch + ")";
-      }
+    boolean requireCapturedWildcard = !prettyRhsType.equals(prettyLhsType);
+    String wildcardBoundMismatch =
+        firstDifferingWildcardBound(lhsType, rhsType, state, requireCapturedWildcard);
+    if (wildcardBoundMismatch != null) {
+      result += " (" + wildcardBoundMismatch + ")";
     }
     if (!ASTHelpers.isSameType(lhsType, rhsType, state)
         && lhsType.getKind() == TypeKind.DECLARED
@@ -449,13 +449,20 @@ public final class GenericsChecks {
    *
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
+   *
+   * @param requireCapturedWildcard if true, only returns a mismatch involving a captured wildcard
    */
   private @Nullable String firstDifferingWildcardBound(
-      Type lhsType, Type rhsType, VisitorState state) {
+      Type lhsType, Type rhsType, VisitorState state, boolean requireCapturedWildcard) {
     // base case: both wildcard types
     Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
     if (lhsWildcard != null && rhsWildcard != null) {
+      if (requireCapturedWildcard
+          && !(lhsType instanceof Type.CapturedType)
+          && !(rhsType instanceof Type.CapturedType)) {
+        return null;
+      }
       return wildcardBoundMismatch(lhsWildcard, rhsWildcard, state);
     }
     if (lhsType instanceof Type.ClassType lhsClassType && rhsType instanceof Type.ClassType) {
@@ -474,17 +481,22 @@ public final class GenericsChecks {
       }
       for (int i = 0; i < lhsTypeArguments.size(); i++) {
         String mismatch =
-            firstDifferingWildcardBound(lhsTypeArguments.get(i), rhsTypeArguments.get(i), state);
+            firstDifferingWildcardBound(
+                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, requireCapturedWildcard);
         if (mismatch != null) {
           return mismatch;
         }
       }
       return firstDifferingWildcardBound(
-          lhsClassType.getEnclosingType(), rhsClassType.getEnclosingType(), state);
+          lhsClassType.getEnclosingType(),
+          rhsClassType.getEnclosingType(),
+          state,
+          requireCapturedWildcard);
     }
     if (lhsType instanceof Type.ArrayType lhsArrayType
         && rhsType instanceof Type.ArrayType rhsArrayType) {
-      return firstDifferingWildcardBound(lhsArrayType.elemtype, rhsArrayType.elemtype, state);
+      return firstDifferingWildcardBound(
+          lhsArrayType.elemtype, rhsArrayType.elemtype, state, requireCapturedWildcard);
     }
     return null;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -469,7 +469,7 @@ public final class GenericsChecks {
           && !(rhsType instanceof Type.CapturedType)) {
         return null;
       }
-      return wildcardBoundMismatch(lhsWildcard, rhsWildcard, state);
+      return wildcardBoundMismatch(lhsType, rhsType, lhsWildcard, rhsWildcard, state);
     }
     if (lhsType instanceof Type.ClassType lhsClassType && rhsType instanceof Type.ClassType) {
       Type rhsTypeAsSuper =
@@ -512,17 +512,47 @@ public final class GenericsChecks {
    * {@code null} if those bounds pretty-print the same.
    */
   private @Nullable String wildcardBoundMismatch(
-      Type.WildcardType lhsWildcard, Type.WildcardType rhsWildcard, VisitorState state) {
+      Type lhsType,
+      Type rhsType,
+      Type.WildcardType lhsWildcard,
+      Type.WildcardType rhsWildcard,
+      VisitorState state) {
     Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
     Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
     String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
     String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
     if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
-      return String.format(
-          "target wildcard upper bound is %s; source wildcard upper bound is %s",
-          prettyLhsUpperBound, prettyRhsUpperBound);
+      String result =
+          String.format(
+              "target wildcard upper bound is %s; source wildcard upper bound is %s",
+              prettyLhsUpperBound, prettyRhsUpperBound);
+      String lhsCaptureDescription = captureDescription(lhsType, "target");
+      if (lhsCaptureDescription != null) {
+        result += "; " + lhsCaptureDescription;
+      }
+      String rhsCaptureDescription = captureDescription(rhsType, "source");
+      if (rhsCaptureDescription != null) {
+        result += "; " + rhsCaptureDescription;
+      }
+      return result;
     }
     return null;
+  }
+
+  /** Returns a short description of the type parameter underlying a captured type, if available. */
+  private static @Nullable String captureDescription(Type type, String assignmentRole) {
+    if (!(type instanceof Type.CapturedType capturedType)) {
+      return null;
+    }
+    Type.TypeVar formalTypeVariable = capturedType.wildcard.bound;
+    if (formalTypeVariable == null
+        || !(formalTypeVariable.tsym.owner instanceof Symbol.ClassSymbol owner)
+        || owner.getSimpleName().isEmpty()) {
+      return null;
+    }
+    return String.format(
+        "%s wildcard is the type argument for type variable %s of %s",
+        assignmentRole, formalTypeVariable.tsym.getSimpleName(), owner.getSimpleName());
   }
 
   private void reportInvalidReturnTypeError(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -463,7 +463,7 @@ public final class GenericsChecks {
           && !(rhsType instanceof Type.CapturedType)) {
         return null;
       }
-      return wildcardBoundMismatch(lhsWildcard, rhsWildcard, state);
+      return wildcardBoundMismatch(lhsType, rhsType, lhsWildcard, rhsWildcard, state);
     }
     if (lhsType instanceof Type.ClassType lhsClassType && rhsType instanceof Type.ClassType) {
       Type rhsTypeAsSuper =
@@ -506,17 +506,47 @@ public final class GenericsChecks {
    * {@code null} if those bounds pretty-print the same.
    */
   private @Nullable String wildcardBoundMismatch(
-      Type.WildcardType lhsWildcard, Type.WildcardType rhsWildcard, VisitorState state) {
+      Type lhsType,
+      Type rhsType,
+      Type.WildcardType lhsWildcard,
+      Type.WildcardType rhsWildcard,
+      VisitorState state) {
     Type lhsUpperBound = GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler);
     Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
     String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
     String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
     if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
-      return String.format(
-          "target wildcard upper bound is %s; source wildcard upper bound is %s",
-          prettyLhsUpperBound, prettyRhsUpperBound);
+      String result =
+          String.format(
+              "target wildcard upper bound is %s; source wildcard upper bound is %s",
+              prettyLhsUpperBound, prettyRhsUpperBound);
+      String lhsCaptureDescription = captureDescription(lhsType, "target");
+      if (lhsCaptureDescription != null) {
+        result += "; " + lhsCaptureDescription;
+      }
+      String rhsCaptureDescription = captureDescription(rhsType, "source");
+      if (rhsCaptureDescription != null) {
+        result += "; " + rhsCaptureDescription;
+      }
+      return result;
     }
     return null;
+  }
+
+  /** Returns a short description of the type parameter underlying a captured type, if available. */
+  private static @Nullable String captureDescription(Type type, String assignmentRole) {
+    if (!(type instanceof Type.CapturedType capturedType)) {
+      return null;
+    }
+    Type.TypeVar formalTypeVariable = capturedType.wildcard.bound;
+    if (formalTypeVariable == null
+        || !(formalTypeVariable.tsym.owner instanceof Symbol.ClassSymbol owner)
+        || owner.getSimpleName().isEmpty()) {
+      return null;
+    }
+    return String.format(
+        "%s wildcard is the type argument for type variable %s of %s",
+        assignmentRole, formalTypeVariable.tsym.getSimpleName(), owner.getSimpleName());
   }
 
   private void reportInvalidReturnTypeError(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -419,11 +419,11 @@ public final class GenericsChecks {
     String result =
         String.format(
             "incompatible types: %s cannot be converted to %s", prettyRhsType, prettyLhsType);
-    boolean requireCapturedWildcard = !prettyRhsType.equals(prettyLhsType);
-    String wildcardBoundMismatch =
-        firstDifferingWildcardBound(lhsType, rhsType, state, requireCapturedWildcard);
+    boolean allowNonCaptureMismatch = prettyRhsType.equals(prettyLhsType);
+    WildcardBoundMismatch wildcardBoundMismatch =
+        firstWildcardBoundMismatch(lhsType, rhsType, state, allowNonCaptureMismatch);
     if (wildcardBoundMismatch != null) {
-      result += " (" + wildcardBoundMismatch + ")";
+      result += " (" + describeWildcardBoundMismatch(wildcardBoundMismatch) + ")";
     }
     if (!ASTHelpers.isSameType(lhsType, rhsType, state)
         && lhsType.getKind() == TypeKind.DECLARED
@@ -443,22 +443,24 @@ public final class GenericsChecks {
   }
 
   /**
-   * Returns a description of the first wildcard bound difference between {@code lhsType} and {@code
-   * rhsType}, or {@code null} if no such difference can be found. Recursively traverses {@code
-   * lhsType} and {@code rhsType} to find such a difference.
+   * Returns the first wildcard bound difference between {@code lhsType} and {@code rhsType}, or
+   * {@code null} if no such difference can be found. Recursively traverses {@code lhsType} and
+   * {@code rhsType} to find such a difference.
    *
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
    *
-   * @param requireCapturedWildcard if true, only returns a mismatch involving a captured wildcard
+   * @param allowNonCaptureMismatch whether a mismatch may be returned when neither causal wildcard
+   *     is captured. Such details are useful when the full types print identically, but redundant
+   *     when the full types already expose the difference.
    */
-  private @Nullable String firstDifferingWildcardBound(
-      Type lhsType, Type rhsType, VisitorState state, boolean requireCapturedWildcard) {
+  private @Nullable WildcardBoundMismatch firstWildcardBoundMismatch(
+      Type lhsType, Type rhsType, VisitorState state, boolean allowNonCaptureMismatch) {
     // base case: both wildcard types
     Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
     if (lhsWildcard != null && rhsWildcard != null) {
-      if (requireCapturedWildcard
+      if (!allowNonCaptureMismatch
           && !(lhsType instanceof Type.CapturedType)
           && !(rhsType instanceof Type.CapturedType)) {
         return null;
@@ -480,32 +482,32 @@ public final class GenericsChecks {
         return null;
       }
       for (int i = 0; i < lhsTypeArguments.size(); i++) {
-        String mismatch =
-            firstDifferingWildcardBound(
-                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, requireCapturedWildcard);
+        WildcardBoundMismatch mismatch =
+            firstWildcardBoundMismatch(
+                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, allowNonCaptureMismatch);
         if (mismatch != null) {
           return mismatch;
         }
       }
-      return firstDifferingWildcardBound(
+      return firstWildcardBoundMismatch(
           lhsClassType.getEnclosingType(),
           rhsClassType.getEnclosingType(),
           state,
-          requireCapturedWildcard);
+          allowNonCaptureMismatch);
     }
     if (lhsType instanceof Type.ArrayType lhsArrayType
         && rhsType instanceof Type.ArrayType rhsArrayType) {
-      return firstDifferingWildcardBound(
-          lhsArrayType.elemtype, rhsArrayType.elemtype, state, requireCapturedWildcard);
+      return firstWildcardBoundMismatch(
+          lhsArrayType.elemtype, rhsArrayType.elemtype, state, allowNonCaptureMismatch);
     }
     return null;
   }
 
   /**
-   * Returns a diagnostic fragment describing how two wildcard effective upper bounds differ, or
-   * {@code null} if those bounds pretty-print the same.
+   * Creates a structured mismatch for two wildcards with visibly different effective upper bounds,
+   * or returns {@code null} if those bounds pretty-print the same.
    */
-  private @Nullable String wildcardBoundMismatch(
+  private @Nullable WildcardBoundMismatch wildcardBoundMismatch(
       Type lhsType,
       Type rhsType,
       Type.WildcardType lhsWildcard,
@@ -516,25 +518,35 @@ public final class GenericsChecks {
     String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
     String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
     if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
-      String result =
-          String.format(
-              "target wildcard upper bound is %s; source wildcard upper bound is %s",
-              prettyLhsUpperBound, prettyRhsUpperBound);
-      String lhsCaptureDescription = captureDescription(lhsType, "target");
-      if (lhsCaptureDescription != null) {
-        result += "; " + lhsCaptureDescription;
-      }
-      String rhsCaptureDescription = captureDescription(rhsType, "source");
-      if (rhsCaptureDescription != null) {
-        result += "; " + rhsCaptureDescription;
-      }
-      return result;
+      return new WildcardBoundMismatch(lhsType, rhsType, prettyLhsUpperBound, prettyRhsUpperBound);
     }
     return null;
   }
 
+  /**
+   * Describes a wildcard-bound mismatch, including provenance for every captured wildcard that
+   * directly participates in that mismatch.
+   */
+  private static String describeWildcardBoundMismatch(WildcardBoundMismatch mismatch) {
+    String result =
+        String.format(
+            "target wildcard upper bound is %s; source wildcard upper bound is %s",
+            mismatch.prettyTargetUpperBound(), mismatch.prettySourceUpperBound());
+    String targetCaptureDescription =
+        captureProvenanceDescription(mismatch.targetWildcardType(), "target");
+    if (targetCaptureDescription != null) {
+      result += "; " + targetCaptureDescription;
+    }
+    String sourceCaptureDescription =
+        captureProvenanceDescription(mismatch.sourceWildcardType(), "source");
+    if (sourceCaptureDescription != null) {
+      result += "; " + sourceCaptureDescription;
+    }
+    return result;
+  }
+
   /** Returns a short description of the type parameter underlying a captured type, if available. */
-  private static @Nullable String captureDescription(Type type, String assignmentRole) {
+  private static @Nullable String captureProvenanceDescription(Type type, String assignmentRole) {
     if (!(type instanceof Type.CapturedType capturedType)) {
       return null;
     }
@@ -548,6 +560,19 @@ public final class GenericsChecks {
         "%s wildcard is the type argument for type variable %s of %s",
         assignmentRole, formalTypeVariable.tsym.getSimpleName(), owner.getSimpleName());
   }
+
+  /**
+   * A difference between the effective upper bounds of two corresponding wildcards.
+   *
+   * <p>The wildcard types are retained so the diagnostic can report provenance for the captured
+   * wildcard or wildcards that directly caused the mismatch, without reporting unrelated captures
+   * elsewhere in the enclosing types.
+   */
+  private record WildcardBoundMismatch(
+      Type targetWildcardType,
+      Type sourceWildcardType,
+      String prettyTargetUpperBound,
+      String prettySourceUpperBound) {}
 
   private void reportInvalidReturnTypeError(
       Tree tree, Type methodType, Type returnType, VisitorState state) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -425,11 +425,11 @@ public final class GenericsChecks {
     String result =
         String.format(
             "incompatible types: %s cannot be converted to %s", prettyRhsType, prettyLhsType);
-    boolean requireCapturedWildcard = !prettyRhsType.equals(prettyLhsType);
-    String wildcardBoundMismatch =
-        firstDifferingWildcardBound(lhsType, rhsType, state, requireCapturedWildcard);
+    boolean allowNonCaptureMismatch = prettyRhsType.equals(prettyLhsType);
+    WildcardBoundMismatch wildcardBoundMismatch =
+        firstWildcardBoundMismatch(lhsType, rhsType, state, allowNonCaptureMismatch);
     if (wildcardBoundMismatch != null) {
-      result += " (" + wildcardBoundMismatch + ")";
+      result += " (" + describeWildcardBoundMismatch(wildcardBoundMismatch) + ")";
     }
     if (!ASTHelpers.isSameType(lhsType, rhsType, state)
         && lhsType.getKind() == TypeKind.DECLARED
@@ -449,22 +449,24 @@ public final class GenericsChecks {
   }
 
   /**
-   * Returns a description of the first wildcard bound difference between {@code lhsType} and {@code
-   * rhsType}, or {@code null} if no such difference can be found. Recursively traverses {@code
-   * lhsType} and {@code rhsType} to find such a difference.
+   * Returns the first wildcard bound difference between {@code lhsType} and {@code rhsType}, or
+   * {@code null} if no such difference can be found. Recursively traverses {@code lhsType} and
+   * {@code rhsType} to find such a difference.
    *
    * <p>This is especially useful when two types pretty-print identically, but differ in the
    * effective upper bound of a wildcard nested somewhere inside the type.
    *
-   * @param requireCapturedWildcard if true, only returns a mismatch involving a captured wildcard
+   * @param allowNonCaptureMismatch whether a mismatch may be returned when neither causal wildcard
+   *     is captured. Such details are useful when the full types print identically, but redundant
+   *     when the full types already expose the difference.
    */
-  private @Nullable String firstDifferingWildcardBound(
-      Type lhsType, Type rhsType, VisitorState state, boolean requireCapturedWildcard) {
+  private @Nullable WildcardBoundMismatch firstWildcardBoundMismatch(
+      Type lhsType, Type rhsType, VisitorState state, boolean allowNonCaptureMismatch) {
     // base case: both wildcard types
     Type.WildcardType lhsWildcard = GenericsUtils.asWildcard(lhsType);
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsType);
     if (lhsWildcard != null && rhsWildcard != null) {
-      if (requireCapturedWildcard
+      if (!allowNonCaptureMismatch
           && !(lhsType instanceof Type.CapturedType)
           && !(rhsType instanceof Type.CapturedType)) {
         return null;
@@ -486,32 +488,32 @@ public final class GenericsChecks {
         return null;
       }
       for (int i = 0; i < lhsTypeArguments.size(); i++) {
-        String mismatch =
-            firstDifferingWildcardBound(
-                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, requireCapturedWildcard);
+        WildcardBoundMismatch mismatch =
+            firstWildcardBoundMismatch(
+                lhsTypeArguments.get(i), rhsTypeArguments.get(i), state, allowNonCaptureMismatch);
         if (mismatch != null) {
           return mismatch;
         }
       }
-      return firstDifferingWildcardBound(
+      return firstWildcardBoundMismatch(
           lhsClassType.getEnclosingType(),
           rhsClassType.getEnclosingType(),
           state,
-          requireCapturedWildcard);
+          allowNonCaptureMismatch);
     }
     if (lhsType instanceof Type.ArrayType lhsArrayType
         && rhsType instanceof Type.ArrayType rhsArrayType) {
-      return firstDifferingWildcardBound(
-          lhsArrayType.elemtype, rhsArrayType.elemtype, state, requireCapturedWildcard);
+      return firstWildcardBoundMismatch(
+          lhsArrayType.elemtype, rhsArrayType.elemtype, state, allowNonCaptureMismatch);
     }
     return null;
   }
 
   /**
-   * Returns a diagnostic fragment describing how two wildcard effective upper bounds differ, or
-   * {@code null} if those bounds pretty-print the same.
+   * Creates a structured mismatch for two wildcards with visibly different effective upper bounds,
+   * or returns {@code null} if those bounds pretty-print the same.
    */
-  private @Nullable String wildcardBoundMismatch(
+  private @Nullable WildcardBoundMismatch wildcardBoundMismatch(
       Type lhsType,
       Type rhsType,
       Type.WildcardType lhsWildcard,
@@ -522,25 +524,35 @@ public final class GenericsChecks {
     String prettyLhsUpperBound = prettyTypeForError(lhsUpperBound, state);
     String prettyRhsUpperBound = prettyTypeForError(rhsUpperBound, state);
     if (!prettyLhsUpperBound.equals(prettyRhsUpperBound)) {
-      String result =
-          String.format(
-              "target wildcard upper bound is %s; source wildcard upper bound is %s",
-              prettyLhsUpperBound, prettyRhsUpperBound);
-      String lhsCaptureDescription = captureDescription(lhsType, "target");
-      if (lhsCaptureDescription != null) {
-        result += "; " + lhsCaptureDescription;
-      }
-      String rhsCaptureDescription = captureDescription(rhsType, "source");
-      if (rhsCaptureDescription != null) {
-        result += "; " + rhsCaptureDescription;
-      }
-      return result;
+      return new WildcardBoundMismatch(lhsType, rhsType, prettyLhsUpperBound, prettyRhsUpperBound);
     }
     return null;
   }
 
+  /**
+   * Describes a wildcard-bound mismatch, including provenance for every captured wildcard that
+   * directly participates in that mismatch.
+   */
+  private static String describeWildcardBoundMismatch(WildcardBoundMismatch mismatch) {
+    String result =
+        String.format(
+            "target wildcard upper bound is %s; source wildcard upper bound is %s",
+            mismatch.prettyTargetUpperBound(), mismatch.prettySourceUpperBound());
+    String targetCaptureDescription =
+        captureProvenanceDescription(mismatch.targetWildcardType(), "target");
+    if (targetCaptureDescription != null) {
+      result += "; " + targetCaptureDescription;
+    }
+    String sourceCaptureDescription =
+        captureProvenanceDescription(mismatch.sourceWildcardType(), "source");
+    if (sourceCaptureDescription != null) {
+      result += "; " + sourceCaptureDescription;
+    }
+    return result;
+  }
+
   /** Returns a short description of the type parameter underlying a captured type, if available. */
-  private static @Nullable String captureDescription(Type type, String assignmentRole) {
+  private static @Nullable String captureProvenanceDescription(Type type, String assignmentRole) {
     if (!(type instanceof Type.CapturedType capturedType)) {
       return null;
     }
@@ -554,6 +566,19 @@ public final class GenericsChecks {
         "%s wildcard is the type argument for type variable %s of %s",
         assignmentRole, formalTypeVariable.tsym.getSimpleName(), owner.getSimpleName());
   }
+
+  /**
+   * A difference between the effective upper bounds of two corresponding wildcards.
+   *
+   * <p>The wildcard types are retained so the diagnostic can report provenance for the captured
+   * wildcard or wildcards that directly caused the mismatch, without reporting unrelated captures
+   * elsewhere in the enclosing types.
+   */
+  private record WildcardBoundMismatch(
+      Type targetWildcardType,
+      Type sourceWildcardType,
+      String prettyTargetUpperBound,
+      String prettySourceUpperBound) {}
 
   private void reportInvalidReturnTypeError(
       Tree tree, Type methodType, Type returnType, VisitorState state) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1433,7 +1433,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
             class Test {
               static Foo<?> getReturnType() {
                 var returnType = Api.convert(Api.wildcard());
-                // BUG: Diagnostic contains: incompatible types: Foo<@Nullable capture of ? (for T in Box)> cannot be converted to Foo<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Foo<@Nullable capture of ?> cannot be converted to Foo<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Box)
                 return returnType;
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1392,8 +1392,9 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** This was reduced from some real code in JUnit */
   @Test
-  public void capturedTypeWithDirectNullableAnnotationInErrorMessage() {
+  public void capturedTypeAtNullUnmarkedBoundary() {
     makeHelper()
         .addSourceLines(
             "Test.java",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1392,6 +1392,55 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void capturedTypeWithDirectNullableAnnotationInErrorMessage() {
+    makeHelper()
+        .addSourceLines(
+            "lib/Box.java",
+            """
+            package lib;
+            public class Box<T> {}
+            """)
+        .addSourceLines(
+            "lib/Api.java",
+            """
+            package lib;
+            import com.uber.Foo;
+            public class Api {
+              public static Box<?> wildcard() {
+                return null;
+              }
+              public static <T> Foo<T> convert(Box<T> box) {
+                return null;
+              }
+            }
+            """)
+        .addSourceLines(
+            "com/uber/Foo.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            public class Foo<T> {}
+            """)
+        .addSourceLines(
+            "com/uber/Test.java",
+            """
+            package com.uber;
+            import lib.Api;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              static Foo<?> getReturnType() {
+                var returnType = Api.convert(Api.wildcard());
+                // BUG: Diagnostic contains: incompatible types: Foo<?> cannot be converted to Foo<?>
+                return returnType;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /** Self-contained test for https://github.com/uber/NullAway/issues/1157. */
   @Test
   public void atomicReferenceFieldUpdaterSelfContained() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1433,7 +1433,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
             class Test {
               static Foo<?> getReturnType() {
                 var returnType = Api.convert(Api.wildcard());
-                // BUG: Diagnostic contains: incompatible types: Foo<?> cannot be converted to Foo<?>
+                // BUG: Diagnostic contains: incompatible types: Foo<@Nullable capture of ? (for T in Box)> cannot be converted to Foo<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return returnType;
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1441,6 +1441,34 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void capturedTypeGetsDirectNullableAnnotationFromTypeVariableUse() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Foo<T extends @Nullable Object> {}
+              static class Holder<T extends @Nullable Object> {
+                Foo<@Nullable T> value;
+
+                Holder(Foo<@Nullable T> value) {
+                  this.value = value;
+                }
+              }
+
+              static Foo<? extends Object> test(Holder<?> holder) {
+                // BUG: Diagnostic contains: incompatible types: Foo<@Nullable capture of ?> cannot be converted to Foo<? extends Object> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Holder)
+                return holder.value;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /** Self-contained test for https://github.com/uber/NullAway/issues/1157. */
   @Test
   public void atomicReferenceFieldUpdaterSelfContained() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1396,41 +1396,28 @@ public class GenericMethodTests extends NullAwayTestsBase {
   public void capturedTypeWithDirectNullableAnnotationInErrorMessage() {
     makeHelper()
         .addSourceLines(
-            "lib/Box.java",
+            "Test.java",
             """
-            package lib;
-            public class Box<T> {}
-            """)
-        .addSourceLines(
-            "lib/Api.java",
-            """
-            package lib;
-            import com.uber.Foo;
-            public class Api {
-              public static Box<?> wildcard() {
-                return null;
-              }
-              public static <T> Foo<T> convert(Box<T> box) {
-                return null;
-              }
-            }
-            """)
-        .addSourceLines(
-            "com/uber/Foo.java",
-            """
-            package com.uber;
             import org.jspecify.annotations.NullMarked;
-            @NullMarked
-            public class Foo<T> {}
-            """)
-        .addSourceLines(
-            "com/uber/Test.java",
-            """
-            package com.uber;
-            import lib.Api;
-            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
             @NullMarked
             class Test {
+              static class Foo<T> {}
+
+              @NullUnmarked
+              static class Box<T> {}
+
+              @NullUnmarked
+              static class Api {
+                static Box<?> wildcard() {
+                  return null;
+                }
+
+                static <T> Foo<T> convert(Box<T> box) {
+                  return null;
+                }
+              }
+
               static Foo<?> getReturnType() {
                 var returnType = Api.convert(Api.wildcard());
                 // BUG: Diagnostic contains: incompatible types: Foo<@Nullable capture of ?> cannot be converted to Foo<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Box)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1256,7 +1256,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?> convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<?> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return asFlux((Flow<?>) source);
               }
             }
@@ -1281,7 +1281,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?>[] convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<?> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return asFluxArray((Flow<?>) source);
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1221,7 +1221,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?> convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ?> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Flow)
                 return asFlux((Flow<?>) source);
               }
             }
@@ -1246,7 +1246,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?>[] convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ?> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Flow)
                 return asFluxArray((Flow<?>) source);
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1256,7 +1256,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?> convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ?> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Flow)
                 return asFlux((Flow<?>) source);
               }
             }
@@ -1281,7 +1281,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?>[] convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ?> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object; source wildcard is the type argument for type variable T of Flow)
                 return asFluxArray((Flow<?>) source);
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1221,7 +1221,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?> convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<?> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> cannot be converted to Flux<?> (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return asFlux((Flow<?>) source);
               }
             }
@@ -1246,7 +1246,7 @@ public class WildcardTests extends NullAwayTestsBase {
                 throw new RuntimeException();
               }
               static Flux<?>[] convert(Object source) {
-                // BUG: Diagnostic contains: incompatible types: Flux<?> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
+                // BUG: Diagnostic contains: incompatible types: Flux<capture of ? (for T in Flow)> [] cannot be converted to Flux<?> [] (target wildcard upper bound is Object; source wildcard upper bound is @Nullable Object)
                 return asFluxArray((Flow<?>) source);
               }
             }


### PR DESCRIPTION
Previously, capture variables were just printed like a wildcard (`?`), which led to confusing errors on real-world benchmarks.  Now we print more information about a capture variable, including some information on the source wildcard where it came from.  The error messages are far from perfect, but better than what we had before.

This PR does not change any checking logic, only what information we include in errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nullability diagnostics for generic wildcard mismatches.
  - Added clearer details when nullable captured types conflict with non-null wildcard types.
  - Reduced redundant mismatch messages while preserving relevant type-variable context, including nested and array types.

- **Tests**
  - Added regression coverage for wildcard capture nullability across `@NullUnmarked` generic APIs.
  - Updated expected diagnostics to reflect enhanced captured-type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->