### PR TITLE
Update to Checker Dataflow 4.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 asm = "9.3"
-check-framework = "4.0.0"
+checker-framework = "4.2.2"
 support = "27.1.1"
 wala = "1.7.1"
 commons-cli = "1.4"
@@ -75,7 +75,7 @@ error-prone-core = { module = "com.google.errorprone:error_prone_core", version.
 error-prone-test-helpers = { module = "com.google.errorprone:error_prone_test_helpers", version.ref = "errorProne" }
 
 # Dataflow & Utils
-checker-dataflow = { module = "org.checkerframework:dataflow-nullaway", version.ref = "check-framework" }
+checker-dataflow = { module = "org.checkerframework:dataflow-nullaway", version.ref = "checker-framework" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guava-latest = { module = "com.google.guava:guava", version.ref = "guava-latest" }
@@ -98,7 +98,7 @@ junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 apiguardian = { module = "org.apiguardian:apiguardian-api", version.ref = "apiguardian" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
-checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "check-framework" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-framework" }
 checker-compat-qual = { module = "org.checkerframework:checker-compat-qual", version.ref = "checker-compat-qual" }
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/RunOnceForwardAnalysisImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/RunOnceForwardAnalysisImpl.java
@@ -5,8 +5,6 @@ import org.checkerframework.nullaway.dataflow.analysis.ForwardAnalysisImpl;
 import org.checkerframework.nullaway.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.nullaway.dataflow.analysis.Store;
 import org.checkerframework.nullaway.dataflow.cfg.ControlFlowGraph;
-import org.checkerframework.nullaway.dataflow.cfg.node.Node;
-import org.jspecify.annotations.Nullable;
 
 /**
  * A ForwardAnalysis implementation that overrides {@link #performAnalysis(ControlFlowGraph)} to
@@ -33,29 +31,5 @@ class RunOnceForwardAnalysisImpl<
       super.performAnalysis(cfg);
       analysisPerformed = true;
     }
-  }
-
-  /**
-   * Override as a workaround for <a
-   * href="https://github.com/typetools/checker-framework/issues/7726">Checker Framework issue
-   * 7726</a>. This version returns the current value for {@code n} even if we have a running
-   * analysis and {@code n} is not a (transitive) operand of the current node of the analysis.
-   * Otherwise, its implementation is identical to that of {@code
-   * org.checkerframework.nullaway.dataflow.analysis.AbstractAnalysis#getValue(Node).}
-   *
-   * <p>We should remove this method if / when CF issue 7726 is fixed in a suitable manner.
-   */
-  @Override
-  @SuppressWarnings("ReferenceEquality") // intentional reference comparison
-  public @Nullable V getValue(Node n) {
-    if (isRunning) {
-      if (currentNode == null
-          || currentNode == n
-          || (currentTree != null && currentTree == n.getTree())) {
-        return null;
-      }
-      assert !n.isLValue() : "Did not expect an lvalue, but got " + n;
-    }
-    return nodeValues.get(n);
   }
 }


### PR DESCRIPTION
Since typetools/checker-framework#7726 was fixed, we can remove our override of `getValue` in `RunOnceForwardAnalysisImpl`.

Also fix a typo in `libs.version.toml`.