### PR TITLE
Honor @Contract when a @Nullable method is used as a method reference

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -31,15 +31,20 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
+import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.dataflow.AccessPath;
 import com.uber.nullaway.dataflow.AccessPathNullnessPropagation;
 import com.uber.nullaway.dataflow.cfg.NullAwayCFGBuilder;
+import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.handlers.Handler;
+import com.uber.nullaway.handlers.MethodAnalysisContext;
 import java.util.Optional;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.nullaway.dataflow.cfg.node.AbstractNodeVisitor;
@@ -116,6 +121,105 @@ public class ContractHandler implements Handler {
       }
     }
     return false;
+  }
+
+  /**
+   * If the referenced method has a {@code @Contract} clause guaranteeing a non-null return value
+   * for the arguments that the functional interface method is going to pass, then the method
+   * reference is a valid implementation of that interface, even though the referenced method is
+   * declared {@code @Nullable}. We record that fact as computed nullness, so that the check in
+   * {@code NullAway#checkOverriding} does not report a spurious {@code WRONG_OVERRIDE_RETURN}
+   * error.
+   *
+   * <p>E.g., a method with the contract {@code "null -> null; !null -> !null"} can be referenced
+   * where a {@code Function<String, String>} is expected in {@code @NullMarked} code, since that
+   * interface never passes null.
+   */
+  @Override
+  public void onMatchMethodReference(
+      MemberReferenceTree tree, MethodAnalysisContext methodAnalysisContext) {
+    Symbol.MethodSymbol referencedMethod = methodAnalysisContext.methodSymbol();
+    String[] clauses = ContractUtils.getContractClauses(referencedMethod, config);
+    if (clauses.length == 0) {
+      return;
+    }
+    NullAway analysis = methodAnalysisContext.analysis();
+    VisitorState state = methodAnalysisContext.state();
+    Symbol.MethodSymbol funcInterfaceMethod =
+        NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
+    int numParams = referencedMethod.getParameters().size();
+    // We only reason about references whose parameters line up one-to-one with the parameters of
+    // the functional interface method. In particular, this bails out on unbound references, where
+    // the first parameter of the interface method becomes the receiver, and on varargs.
+    if (referencedMethod.isVarArgs()
+        || funcInterfaceMethod.isVarArgs()
+        || funcInterfaceMethod.getParameters().size() != numParams) {
+      return;
+    }
+    for (String clause : clauses) {
+      String[] parts = clause.split("->");
+      if (parts.length != 2 || !parts[1].trim().equals("!null")) {
+        continue;
+      }
+      String[] antecedent = parts[0].trim().isEmpty() ? new String[0] : parts[0].split(",");
+      if (antecedent.length != numParams) {
+        continue;
+      }
+      boolean guaranteedNonNull = true;
+      for (int i = 0; i < antecedent.length; i++) {
+        String valueConstraint = antecedent[i].trim();
+        if (valueConstraint.equals("_")) {
+          // the clause holds no matter what is passed at this position
+          continue;
+        }
+        if (!valueConstraint.equals("!null")
+            || !funcInterfaceParamIsNonNull(tree, funcInterfaceMethod, i, analysis, state)) {
+          guaranteedNonNull = false;
+          break;
+        }
+      }
+      if (guaranteedNonNull) {
+        analysis.setComputedNullness(tree, Nullness.NONNULL);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Checks whether the functional interface method is guaranteed to pass a non-null value at the
+   * given parameter position. The logic mirrors how {@code NullAway#checkParamOverriding} computes
+   * the nullness of the parameters of the overridden method for a method reference.
+   *
+   * @param tree the method reference
+   * @param funcInterfaceMethod the method of the functional interface being implemented
+   * @param paramIndex index of the parameter
+   * @param analysis a reference to the running NullAway analysis
+   * @param state the visitor state
+   * @return true if the parameter at {@code paramIndex} is known to be non-null
+   */
+  private boolean funcInterfaceParamIsNonNull(
+      MemberReferenceTree tree,
+      Symbol.MethodSymbol funcInterfaceMethod,
+      int paramIndex,
+      NullAway analysis,
+      VisitorState state) {
+    if (Nullness.paramHasNullableAnnotation(funcInterfaceMethod, paramIndex, config)) {
+      return false;
+    }
+    if (config.isJSpecifyMode()) {
+      // The parameter type may be a type variable instantiated with a @Nullable type argument at
+      // this use site, e.g. Function<@Nullable String, String>; ask GenericsChecks about it.
+      GenericsChecks genericsChecks = analysis.getGenericsChecks();
+      Type functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(tree);
+      if (functionalInterfaceType == null) {
+        functionalInterfaceType = ASTHelpers.getType(tree);
+      }
+      return genericsChecks
+          .getGenericMethodParameterNullness(
+              paramIndex, funcInterfaceMethod, functionalInterfaceType, state)
+          .equals(Nullness.NONNULL);
+    }
+    return true;
   }
 
   @Override

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -255,6 +255,124 @@ public class ContractsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /** Tests for the false positive reported in https://github.com/uber/NullAway/issues/1502 */
+  @Test
+  public void contractImpliesNonNullForMethodReference() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "NullnessChecker.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import org.jetbrains.annotations.Contract;
+            public class NullnessChecker {
+              @Contract("null -> null; !null -> !null")
+              static @Nullable String strictContract(@Nullable String s) { return s; }
+              @Contract("_ -> !null")
+              static @Nullable String unconditionalContract(@Nullable String s) { return "x"; }
+              @Contract("!null, _ -> !null")
+              static @Nullable String twoArgContract(@Nullable String s, @Nullable String t) { return s; }
+              @Contract("null -> null")
+              static @Nullable String uselessContract(@Nullable String s) { return s; }
+              static @Nullable String noContract(@Nullable String s) { return s; }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            class Test {
+              interface StringFn { String apply(String s); }
+              interface StringFn2 { String apply(String s, String t); }
+              interface NullableParamFn { String apply(@Nullable String s); }
+              String[] map(String[] in, StringFn f) { return in; }
+              String[] map2(String[] in, StringFn2 f) { return in; }
+              String[] mapNullableParam(String[] in, NullableParamFn f) { return in; }
+              String[] testStrictContract(String[] w) {
+                return map(w, NullnessChecker::strictContract);
+              }
+              String[] testUnconditionalContract(String[] w) {
+                return map(w, NullnessChecker::unconditionalContract);
+              }
+              String[] testTwoArgContract(String[] w) {
+                return map2(w, NullnessChecker::twoArgContract);
+              }
+              String[] testUselessContract(String[] w) {
+                // the contract says nothing about non-null arguments
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return map(w, NullnessChecker::uselessContract);
+              }
+              String[] testNoContract(String[] w) {
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return map(w, NullnessChecker::noContract);
+              }
+              String[] testNullableParamOfInterface(String[] w) {
+                // the interface may pass null, so the contract does not apply
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return mapNullableParam(w, NullnessChecker::strictContract);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /** Like {@link #contractImpliesNonNullForMethodReference()}, but in JSpecify mode */
+  @Test
+  public void contractImpliesNonNullForMethodReferenceJSpecify() {
+    makeTestHelperWithArgs(
+            withJSpecifyModeArgs(
+                Arrays.asList(
+                    "-d",
+                    temporaryFolder.getRoot().getAbsolutePath(),
+                    "-XepOpt:NullAway:AnnotatedPackages=com.uber")))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.function.Function;
+            import org.jetbrains.annotations.Contract;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Fn<P extends @Nullable Object, R extends @Nullable Object> { R apply(P p); }
+              @Contract("null -> null; !null -> !null")
+              static @Nullable String strictContract(@Nullable String s) { return s; }
+              @Contract("null -> null")
+              static @Nullable String uselessContract(@Nullable String s) { return s; }
+              String[] map(String[] in, Function<String, String> f) { return in; }
+              String[] mapNullableJdk(String[] in, Function<@Nullable String, String> f) { return in; }
+              String[] mapOwn(String[] in, Fn<String, String> f) { return in; }
+              String[] mapOwnNullable(String[] in, Fn<@Nullable String, String> f) { return in; }
+              String[] testStrictContract(String[] w) {
+                return map(w, Test::strictContract);
+              }
+              String[] testOwnInterface(String[] w) {
+                return mapOwn(w, Test::strictContract);
+              }
+              String[] testUselessContract(String[] w) {
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return map(w, Test::uselessContract);
+              }
+              String[] testNullableTypeArgumentJdk(String[] w) {
+                // the interface may pass null, so the contract does not apply
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return mapNullableJdk(w, Test::strictContract);
+              }
+              String[] testNullableTypeArgumentOwn(String[] w) {
+                // BUG: Diagnostic contains: referenced method returns @Nullable
+                return mapOwnNullable(w, Test::strictContract);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Test
   public void impliesNonNullContractAnnotation() {
     makeTestHelperWithArgs(


### PR DESCRIPTION
Fixes #1502.

## The problem

A method annotated `@Contract("null -> null; !null -> !null")` returns non-null whenever it is given a non-null argument. When such a method is passed as a method reference to a functional interface whose parameter is `@NonNull`, the reference is a valid implementation of that interface — but NullAway reports:

```
referenced method returns @Nullable, but functional interface method
java.util.function.Function.apply(T) returns @NonNull
```

The `@Contract` handler is not consulted on this path at all: `NullAway#checkOverriding` only asks for the *declared* return nullness of the referenced method.

## The fix

`NullAway#matchMemberReference` already calls `handler.onMatchMethodReference(...)` immediately before `checkOverriding`, and `checkOverriding` skips the error when the member reference has been given a computed nullness of `NONNULL`:

```java
&& (memberReferenceTree == null
    || getComputedNullness(memberReferenceTree).equals(Nullness.NULLABLE))
```

`StreamNullabilityPropagator#onMatchMethodReference` already uses exactly this mechanism to mark a reference non-null. This PR implements `onMatchMethodReference` in `ContractHandler` the same way: if some contract clause has the consequent `!null` and every antecedent is either `_` or `!null` at a position where the functional interface method is guaranteed to pass a non-null value, the reference is marked `NONNULL`.

The per-parameter nullness of the functional interface method is computed the same way `NullAway#checkParamOverriding` computes it: `Nullness.paramHasNullableAnnotation`, plus `GenericsChecks#getGenericMethodParameterNullness` against the inferred functional interface type in JSpecify mode, so that a `@Nullable` **type argument** is respected.

Conservative by construction:

* only clauses whose antecedent count matches the referenced method's parameter count are used;
* varargs on either side, and references whose parameter count differs from the interface's (i.e. unbound references, where the first interface parameter becomes the receiver), are skipped;
* any antecedent that is not `_` or `!null` (e.g. `null`, `true`, `false`) disqualifies the clause.

## Tests

`ContractsTests#contractImpliesNonNullForMethodReference` and its JSpecify counterpart. Both fail on `master` and pass with the fix. Between them they cover five newly-accepted cases and five that must keep reporting:

| case | before | after |
|---|---|---|
| `@Contract("null -> null; !null -> !null")` → `String apply(String)` | error | accepted |
| `@Contract("_ -> !null")` | error | accepted |
| `@Contract("!null, _ -> !null")` → two-parameter interface | error | accepted |
| JSpecify: `Function<String, String>` (the reported case) | error | accepted |
| JSpecify: own `Fn<P extends @Nullable Object, ...>` with `Fn<String, String>` | error | accepted |
| `@Contract("null -> null")` only | error | **error** |
| no `@Contract` at all | error | **error** |
| interface parameter declared `@Nullable` | error | **error** |
| JSpecify: `Function<@Nullable String, String>` | error | **error** |
| JSpecify: own `Fn<@Nullable String, String>` | error | **error** |

The full `:nullaway:test` suite passes, and Google Java Format leaves the change unmodified.

---

Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

**Note on AI usage**

I am a first-time contributor here, so per `CONTRIBUTING.md`: I used Claude to help explore the `checkOverriding` / `onMatchMethodReference` code path and to draft the handler implementation and the tests. I reviewed every line of the change myself, ran the two new tests against unpatched `master` first to confirm they fail without the fix, then ran them and the full `:nullaway:test` suite with the fix applied. I have read and understood all of the changes in this PR.