### PR TITLE
More TreePath hardening

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -174,8 +174,12 @@ public class AccessPathNullnessPropagation
 
   private final NullnessStoreInitializer nullnessStoreInitializer;
 
-  static class FailingTreePath extends TreePath {
-    public FailingTreePath(CompilationUnitTree tree) {
+  /**
+   * A stub {@link TreePath} implementation where every method fails immediately. Used to ensure the
+   * {@link TreePath} stored in {@link #state} is never used.
+   */
+  private static class FailingTreePath extends TreePath {
+    FailingTreePath(CompilationUnitTree tree) {
       super(tree);
     }
 
@@ -212,6 +216,7 @@ public class AccessPathNullnessPropagation
       NullnessStoreInitializer nullnessStoreInitializer) {
     this.defaultAssumption = defaultAssumption;
     this.methodReturnsNonNull = analysis::isMethodUnannotated;
+    // Overwrite the TreePath with a FailingTreePath to ensure it never gets used
     this.state = state.withPath(new FailingTreePath(state.getPath().getCompilationUnit()));
     this.apContext = apContext;
     this.config = analysis.getConfig();

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -32,6 +32,7 @@ import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
@@ -49,6 +50,7 @@ import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handler.NullnessHint;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -172,6 +174,36 @@ public class AccessPathNullnessPropagation
 
   private final NullnessStoreInitializer nullnessStoreInitializer;
 
+  static class FailingTreePath extends TreePath {
+    public FailingTreePath(CompilationUnitTree tree) {
+      super(tree);
+    }
+
+    @Override
+    public CompilationUnitTree getCompilationUnit() {
+      throw new RuntimeException(
+          "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
+    }
+
+    @Override
+    public Tree getLeaf() {
+      throw new RuntimeException(
+          "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
+    }
+
+    @Override
+    public TreePath getParentPath() {
+      throw new RuntimeException(
+          "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
+    }
+
+    @Override
+    public Iterator<Tree> iterator() {
+      throw new RuntimeException(
+          "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
+    }
+  }
+
   public AccessPathNullnessPropagation(
       Nullness defaultAssumption,
       VisitorState state,
@@ -180,7 +212,7 @@ public class AccessPathNullnessPropagation
       NullnessStoreInitializer nullnessStoreInitializer) {
     this.defaultAssumption = defaultAssumption;
     this.methodReturnsNonNull = analysis::isMethodUnannotated;
-    this.state = state;
+    this.state = state.withPath(new FailingTreePath(state.getPath().getCompilationUnit()));
     this.apContext = apContext;
     this.config = analysis.getConfig();
     this.handler = analysis.getHandler();
@@ -872,8 +904,7 @@ public class AccessPathNullnessPropagation
   @Override
   public TransferResult<Nullness, NullnessStore> visitReturn(
       ReturnNode returnNode, TransferInput<Nullness, NullnessStore> input) {
-    handler.onDataflowVisitReturn(
-        returnNode.getTree(), state, input.getThenStore(), input.getElseStore());
+    handler.onDataflowVisitReturn(returnNode.getTree(), input.getThenStore(), input.getElseStore());
     return noStoreChanges(NULLABLE, input);
   }
 
@@ -1051,7 +1082,14 @@ public class AccessPathNullnessPropagation
         node, callee, node.getArguments(), values(input), thenUpdates, bothUpdates);
     NullnessHint nullnessHint =
         handler.onDataflowVisitMethodInvocation(
-            node, callee, state, apContext, values(input), thenUpdates, elseUpdates, bothUpdates);
+            node,
+            callee,
+            state.withPath(node.getTreePath()),
+            apContext,
+            values(input),
+            thenUpdates,
+            elseUpdates,
+            bothUpdates);
     Nullness nullness = returnValueNullness(node, input, nullnessHint);
     if (booleanReturnType(callee)) {
       ResultingStore thenStore = updateStore(input.getThenStore(), thenUpdates, bothUpdates);

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -46,6 +46,7 @@ import com.uber.nullaway.Config;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
+import com.uber.nullaway.annotations.JacocoIgnoreGenerated;
 import com.uber.nullaway.generics.GenericsChecks;
 import com.uber.nullaway.handlers.Handler;
 import com.uber.nullaway.handlers.Handler.NullnessHint;
@@ -183,24 +184,28 @@ public class AccessPathNullnessPropagation
       super(tree);
     }
 
+    @JacocoIgnoreGenerated
     @Override
     public CompilationUnitTree getCompilationUnit() {
       throw new RuntimeException(
           "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
     }
 
+    @JacocoIgnoreGenerated
     @Override
     public Tree getLeaf() {
       throw new RuntimeException(
           "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
     }
 
+    @JacocoIgnoreGenerated
     @Override
     public TreePath getParentPath() {
       throw new RuntimeException(
           "Do not rely on this TreePath!  It came from the global VisitorState object in AccessPathNullnessPropagation.");
     }
 
+    @JacocoIgnoreGenerated
     @Override
     public Iterator<Tree> iterator() {
       throw new RuntimeException(

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -223,9 +223,9 @@ class CompositeHandler implements Handler {
 
   @Override
   public void onDataflowVisitReturn(
-      ReturnTree tree, VisitorState state, NullnessStore thenStore, NullnessStore elseStore) {
+      ReturnTree tree, NullnessStore thenStore, NullnessStore elseStore) {
     for (Handler h : handlers) {
-      h.onDataflowVisitReturn(tree, state, thenStore, elseStore);
+      h.onDataflowVisitReturn(tree, thenStore, elseStore);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -309,14 +309,13 @@ public interface Handler {
    * Called when the Dataflow analysis visits a return statement.
    *
    * @param tree The AST node for the return statement being matched.
-   * @param state The current visitor state
    * @param thenStore The NullnessStore for the true case of the expression inside the return
    *     statement.
    * @param elseStore The NullnessStore for the false case of the expression inside the return
    *     statement.
    */
   default void onDataflowVisitReturn(
-      ReturnTree tree, VisitorState state, NullnessStore thenStore, NullnessStore elseStore) {
+      ReturnTree tree, NullnessStore thenStore, NullnessStore elseStore) {
     // NoOp
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -683,7 +683,7 @@ class StreamNullabilityPropagator implements Handler {
 
   @Override
   public void onDataflowVisitReturn(
-      ReturnTree tree, VisitorState state, NullnessStore thenStore, NullnessStore elseStore) {
+      ReturnTree tree, NullnessStore thenStore, NullnessStore elseStore) {
     Tree filterTree = returnToEnclosingMethodOrLambda.get(tree);
     if (filterTree != null) {
       assert (filterTree instanceof MethodTree || filterTree instanceof LambdaExpressionTree);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
@@ -44,7 +44,7 @@ import com.uber.nullaway.dataflow.NullnessStore;
 import com.uber.nullaway.handlers.AbstractFieldContractHandler;
 import com.uber.nullaway.handlers.MethodAnalysisContext;
 import com.uber.nullaway.handlers.contract.ContractUtils;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -62,10 +62,9 @@ import org.jspecify.annotations.Nullable;
  */
 public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
 
-  // List of return trees in the method under analysis
-  // This list is built in a way that return trees inside lambdas
-  // or anonymous classes aren't included.
-  private final Set<ReturnTree> returnTreesInMethodUnderAnalysis = new HashSet<>();
+  // Map of return trees in the method under analysis to their paths. This map is built in a way
+  // that return trees inside lambdas or anonymous classes aren't included.
+  private final Map<ReturnTree, TreePath> returnTreePathsInMethodUnderAnalysis = new HashMap<>();
 
   // The MethodTree and MethodAnalysisContext of the EnsureNonNullIf method
   // under current semantic validation
@@ -91,7 +90,7 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
     // clean up state variables, as we are visiting a new annotated method
     methodTreeUnderAnalysis = tree;
     methodAnalysisContextUnderAnalysis = methodAnalysisContext;
-    returnTreesInMethodUnderAnalysis.clear();
+    returnTreePathsInMethodUnderAnalysis.clear();
 
     VisitorState state = methodAnalysisContext.state();
     NullAway analysis = methodAnalysisContext.analysis();
@@ -101,7 +100,7 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
     buildUpReturnToEnclosingMethodMap(state);
 
     // if no returns, then, this method doesn't return boolean, and it's wrong
-    if (returnTreesInMethodUnderAnalysis.isEmpty()) {
+    if (returnTreePathsInMethodUnderAnalysis.isEmpty()) {
       raiseError(
           tree, state, "Method is annotated with @EnsuresNonNullIf but does not return boolean");
       return false;
@@ -116,13 +115,13 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
     // Clean up state
     methodTreeUnderAnalysis = null;
     methodAnalysisContextUnderAnalysis = null;
-    returnTreesInMethodUnderAnalysis.clear();
+    returnTreePathsInMethodUnderAnalysis.clear();
 
     return true;
   }
 
   private void buildUpReturnToEnclosingMethodMap(VisitorState methodState) {
-    returnTreesInMethodUnderAnalysis.clear();
+    returnTreePathsInMethodUnderAnalysis.clear();
     new TreePathScanner<@Nullable Void, @Nullable Void>() {
       @Override
       public @Nullable Void visitReturn(ReturnTree node, @Nullable Void unused) {
@@ -134,7 +133,7 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
 
         // We only add returns that are directly in the method under analysis
         if (enclosingMethod.getLeaf().equals(methodTreeUnderAnalysis)) {
-          returnTreesInMethodUnderAnalysis.add(node);
+          returnTreePathsInMethodUnderAnalysis.put(node, getCurrentPath());
         }
         return super.visitReturn(node, null);
       }
@@ -158,16 +157,19 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
 
   @Override
   public void onDataflowVisitReturn(
-      ReturnTree returnTree, VisitorState state, NullnessStore thenStore, NullnessStore elseStore) {
+      ReturnTree returnTree, NullnessStore thenStore, NullnessStore elseStore) {
     // We only explore return statements that is inside
     // the method under validation
-    if (!returnTreesInMethodUnderAnalysis.contains(returnTree)) {
+    TreePath returnTreePath = returnTreePathsInMethodUnderAnalysis.get(returnTree);
+    if (returnTreePath == null) {
       return;
     }
 
     // Get the declared configuration of the EnsureNonNullIf method under analysis
-    Symbol.MethodSymbol methodSymbolUnderAnalysis =
-        NullabilityUtil.castToNonNull(methodAnalysisContextUnderAnalysis).methodSymbol();
+    MethodAnalysisContext methodAnalysisContext =
+        NullabilityUtil.castToNonNull(methodAnalysisContextUnderAnalysis);
+    Symbol.MethodSymbol methodSymbolUnderAnalysis = methodAnalysisContext.methodSymbol();
+    VisitorState state = methodAnalysisContext.state().withPath(returnTreePath);
 
     Set<String> fieldNames = getAnnotationValueArray(methodSymbolUnderAnalysis, annotName, false);
     if (fieldNames == null) {

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/fieldcontract/EnsuresNonNullIfHandler.java
@@ -120,6 +120,11 @@ public class EnsuresNonNullIfHandler extends AbstractFieldContractHandler {
     return true;
   }
 
+  /**
+   * Performs a scan of a method to find its {@link ReturnTree}s, excluding returns within nested
+   * lambdas or anonymous classes. Updates {@link #returnTreePathsInMethodUnderAnalysis} to map each
+   * such {@link ReturnTree} to its {@link TreePath}.
+   */
   private void buildUpReturnToEnclosingMethodMap(VisitorState methodState) {
     returnTreePathsInMethodUnderAnalysis.clear();
     new TreePathScanner<@Nullable Void, @Nullable Void>() {

--- a/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullIfTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/EnsuresNonNullIfTests.java
@@ -1012,4 +1012,33 @@ public class EnsuresNonNullIfTests extends NullAwayTestsBase {
             "Item.java", "package com.uber;", "class Item {", "  public void call() { }", "}")
         .doTest();
   }
+
+  @Test
+  public void invalidContractCanBeSuppressed() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import com.uber.nullaway.annotations.EnsuresNonNullIf;
+            class Foo {
+              @Nullable Item nullableItem;
+              @SuppressWarnings("NullAway")
+              @EnsuresNonNullIf("nullableItem")
+              boolean hasNullableItem() {
+                return true;
+              }
+            }
+            """)
+        .addSourceLines(
+            "Item.java",
+            """
+            package com.uber;
+            class Item {
+              public void call() { }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
For step 3 of https://github.com/uber/NullAway/issues/1680#issuecomment-5219151033

We modify the global `VisitorState` stored in `AccessPathNullnessPropagation` such that any use of its `TreePath` causes an immediate failure at runtime, via the new class `FailingTreePath`.  This exposed an issue in the `EnsuresNonNullIfHandler` where this tree path was being used to check suppressions on return trees.  Now, we store correct paths for those return trees and use those instead.  This allows us to remove the `VisitorState` parameter from `onDataflowVisitReturn` entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-aware nullness analysis for return statements and method invocations.
  * Prevented invalid path access during dataflow processing.
  * Improved validation of `@EnsuresNonNullIf` contracts across control-flow paths and source locations.

* **Behavior**
  * Invalid `@EnsuresNonNullIf` diagnostics can now be suppressed with `@SuppressWarnings("NullAway")`.

* **Tests**
  * Added coverage for suppressing diagnostics from invalid conditional nullness contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->