### PR TITLE
Update JarInfer to skip synthetic methods

### DIFF
--- a/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
+++ b/jar-infer/jar-infer-lib/src/main/java/com/uber/nullaway/jarinfer/DefinitelyDerefedParamsDriver.java
@@ -355,6 +355,7 @@ public class DefinitelyDerefedParamsDriver {
 
   private boolean shouldCheckMethod(IMethod mtd) {
     return !mtd.isPrivate()
+        && !mtd.isSynthetic()
         && !mtd.isAbstract()
         && !mtd.isNative()
         && !isAllPrimitiveTypes(mtd)

--- a/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
+++ b/jar-infer/jar-infer-lib/src/test/java/com/uber/nullaway/jarinfer/JarInferTest.java
@@ -579,6 +579,31 @@ public class JarInferTest {
   }
 
   @Test
+  public void syntheticMethodsAreSkipped() throws Exception {
+    compilationTestHelper =
+        CompilationTestHelper.newInstance(DummyChecker.class, getClass())
+            .setArgs(
+                Arrays.asList("-d", temporaryFolder.getRoot().getAbsolutePath(), "--release", "8"));
+    testTemplate(
+        "syntheticMethodsAreSkipped",
+        "syntheticmethods",
+        "Test",
+        ImmutableMap.of(
+            "syntheticmethods.Test:int dereference(syntheticmethods.Test)", Sets.newHashSet(0)),
+        "public class Test {",
+        "  private String value;",
+        "  public static int dereference(Test test) {",
+        "    return test.value.length();",
+        "  }",
+        "  public static class Nested {",
+        "    public static String getValue(Test test) {",
+        "      return test.value;",
+        "    }",
+        "  }",
+        "}");
+  }
+
+  @Test
   public void toyJARAnnotatingClasses() throws Exception {
     testAnnotationInJarTemplate(
         "toyJARAnnotatingClasses",


### PR DESCRIPTION
As synthetic methods are guaranteed to not be part of a public API, we should skip them in JarInfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis accuracy by excluding compiler-generated synthetic methods.
  * Prevented synthetic methods from producing unnecessary dereference findings.
* **Tests**
  * Added coverage confirming explicit dereference analysis remains reported while generated methods are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->