### PR TITLE
Fix bug with storing library model type variable upper bounds

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -37,7 +37,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
@@ -1669,8 +1668,8 @@ public class LibraryModelsHandler implements Handler {
 
     private final Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache;
     private final Set<String> nullMarkedClassesCache;
-    private final Map<String, Integer> upperBoundsCache;
-    private final Multimap<String, Integer> methodTypeParamNullableUpperBoundCache;
+    private final SetMultimap<String, Integer> upperBoundsCache;
+    private final SetMultimap<String, Integer> methodTypeParamNullableUpperBoundCache;
     private final Map<String, SetMultimap<Integer, NestedAnnotationInfo>> nestedAnnotationInfo;
 
     ExternalStubxLibraryModels(boolean isJarInferEnabled, boolean isJSpecifyJDKEnabled) {
@@ -1746,7 +1745,7 @@ public class LibraryModelsHandler implements Handler {
     public ImmutableSetMultimap<String, Integer> typeVariablesWithNullableUpperBounds() {
       ImmutableSetMultimap.Builder<String, Integer> mapBuilder =
           new ImmutableSetMultimap.Builder<>();
-      for (Map.Entry<String, Integer> entry : upperBoundsCache.entrySet()) {
+      for (Map.Entry<String, Integer> entry : upperBoundsCache.entries()) {
         mapBuilder.put(entry.getKey(), entry.getValue());
       }
       return mapBuilder.build();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
@@ -24,7 +24,6 @@ package com.uber.nullaway.handlers;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.uber.nullaway.jarinfer.JarInferStubxProvider;
 import com.uber.nullaway.libmodel.NestedAnnotationInfo;
@@ -71,7 +70,7 @@ public class StubxCacheUtil {
 
   private final Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache;
 
-  private final Map<String, Integer> upperBoundCache;
+  private final SetMultimap<String, Integer> upperBoundCache;
 
   private final Set<String> nullMarkedClassesCache;
 
@@ -89,7 +88,7 @@ public class StubxCacheUtil {
    */
   StubxCacheUtil(String logCaller, boolean loadJarInferModels) {
     argAnnotCache = new LinkedHashMap<>();
-    upperBoundCache = new HashMap<>();
+    upperBoundCache = HashMultimap.create();
     nullMarkedClassesCache = new HashSet<>();
     methodTypeParamNullableUpperBoundCache = HashMultimap.create();
     nestedAnnotationInfoCache = new HashMap<>();
@@ -99,7 +98,7 @@ public class StubxCacheUtil {
     }
   }
 
-  public Map<String, Integer> getUpperBoundCache() {
+  public SetMultimap<String, Integer> getUpperBoundCache() {
     return upperBoundCache;
   }
 
@@ -107,7 +106,7 @@ public class StubxCacheUtil {
     return nullMarkedClassesCache;
   }
 
-  public Multimap<String, Integer> getMethodTypeParamNullableUpperBoundCache() {
+  public SetMultimap<String, Integer> getMethodTypeParamNullableUpperBoundCache() {
     return methodTypeParamNullableUpperBoundCache;
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -94,4 +94,25 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
             """)
         .doTest();
   }
+
+  @Test
+  public void biConsumerNullableUpperBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            import java.util.function.*;
+            @NullMarked
+            class Test {
+              @Nullable BiConsumer<@Nullable Object, @Nullable Object> b = null;
+            }
+            """)
+        .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        JSpecifyJavacConfig.withJSpecifyModeArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=true")));
+  }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -105,6 +105,7 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
             import java.util.function.*;
             @NullMarked
             class Test {
+              // test that we can make both type arguments @Nullable
               @Nullable BiConsumer<@Nullable Object, @Nullable Object> b = null;
             }
             """)


### PR DESCRIPTION
We can have multiple type variables with modeled upper bounds.  Before we used a `Map` incorrectly, causing issues for types like `BiConsumer`.  Now use a `MultiMap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiple nullable upper bounds in external library models.
  * Fixed nullable upper-bound processing for JSpecify-mode analysis, including `BiConsumer` declarations.
  * Improved analysis accuracy for code using generic type parameters with multiple nullable constraints.

* **Tests**
  * Added regression coverage for nullable upper bounds under JSpecify nullness checking.
  * Added validation for JSpecify library models configured with strict null-marked analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->