### PR TITLE
Update script to use snapshot builds in integration tests

### DIFF
--- a/.github/workflows/use-snapshot.gradle.kts
+++ b/.github/workflows/use-snapshot.gradle.kts
@@ -1,24 +1,20 @@
 // An init script to override a build configuration to use a snapshot version of NullAway
-allprojects {
+gradle.lifecycle.beforeProject {
   repositories {
     mavenCentral()
     mavenLocal()
     gradlePluginPortal()
   }
-}
 
-gradle.projectsLoaded {
-  rootProject.allprojects {
-    configurations.all {
-      resolutionStrategy {
-        eachDependency {
-          if (requested.group == "com.uber.nullaway") {
-            useVersion("+")
-          }
+  configurations.configureEach {
+    resolutionStrategy {
+      eachDependency {
+        if (requested.group == "com.uber.nullaway") {
+          useVersion("+")
         }
-        cacheChangingModulesFor(0, "seconds")
-        cacheDynamicVersionsFor(0, "seconds")
       }
+      cacheChangingModulesFor(0, "seconds")
+      cacheDynamicVersionsFor(0, "seconds")
     }
   }
 }


### PR DESCRIPTION
Now the script works in the presence of [isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html), which were recently enabled by JUnit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal build configuration for more consistent dependency resolution.
  * Renamed an internal generic-call inference result type without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->