### PR TITLE
Add test for issue 1693

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -58,6 +58,39 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1693() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import java.util.Objects;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static List<FilterFieldInput> convert(
+                  List<@Nullable FilterField> filterFields) {
+                return filterFields.stream()
+                    .filter(Objects::nonNull)
+                    .map(filterField -> new FilterFieldInput(filterField.getName()))
+                    .toList();
+              }
+
+              static class FilterField {
+                String getName() {
+                  return "name";
+                }
+              }
+
+              record FilterFieldInput(String name) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void filterWithStringUtilsHasLength() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
The test already passes on our current main branch.

Fixes #1693 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that filtering nullable list elements with a non-null predicate allows safe dereferencing and collection of non-null results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->