### PR TITLE
Fix crash in @Contract dataflow init for zero-argument methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -90,14 +90,8 @@ public class ContractCheckHandler implements Handler {
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(tree);
     Preconditions.checkNotNull(callee);
     // Check to see if this method has an @Contract annotation
-    String contractString = ContractUtils.getContractString(callee, config);
-    if (contractString != null) {
-      // Found a contract, lets parse it.
-      String[] clauses = contractString.split(";");
-      if (clauses.length != 1) {
-        return;
-      }
-
+    String[] clauses = ContractUtils.getContractClauses(callee, config);
+    if (clauses.length == 1) {
       String clause = clauses[0];
       NullAway analysis = methodAnalysisContext.analysis();
       VisitorState state = methodAnalysisContext.state();
@@ -188,7 +182,7 @@ public class ContractCheckHandler implements Handler {
 
           if (contractViolated) {
             String errorMessage =
-                getErrorMessageForViolatedContract(antecedent, callee, contractString, tree);
+                getErrorMessageForViolatedContract(antecedent, callee, clause, tree);
 
             state.reportMatch(
                 analysis
@@ -208,7 +202,7 @@ public class ContractCheckHandler implements Handler {
   }
 
   private static String getErrorMessageForViolatedContract(
-      String[] antecedent, Symbol.MethodSymbol callee, String contractString, MethodTree tree) {
+      String[] antecedent, Symbol.MethodSymbol callee, String clause, MethodTree tree) {
     String errorMessage;
 
     // used for error message
@@ -229,7 +223,7 @@ public class ContractCheckHandler implements Handler {
           "Method "
               + callee.name
               + " has @Contract("
-              + contractString
+              + clause
               + "), but this appears to be violated, as a @Nullable value may be returned when parameter "
               + tree.getParameters().get(nonNullAntecedentPosition).getName()
               + " is non-null.";
@@ -238,7 +232,7 @@ public class ContractCheckHandler implements Handler {
           "Method "
               + callee.name
               + " has @Contract("
-              + contractString
+              + clause
               + "), but this appears to be violated, as a @Nullable value may be returned "
               + "when the contract preconditions are true.";
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractNullnessStoreInitializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractNullnessStoreInitializer.java
@@ -43,15 +43,13 @@ public class ContractNullnessStoreInitializer extends NullnessStoreInitializer {
     MethodTree methodTree = ((UnderlyingAST.CFGMethod) underlyingAST).getMethod();
     ClassTree classTree = ((UnderlyingAST.CFGMethod) underlyingAST).getClassTree();
     Symbol.MethodSymbol callee = ASTHelpers.getSymbol(methodTree);
-    String contractString = ContractUtils.getContractString(callee, config);
+    String[] clauses = ContractUtils.getContractClauses(callee, config);
 
-    if (contractString == null) {
-      throw new IllegalStateException("expected non-null contractString");
+    if (clauses.length == 0) {
+      throw new IllegalStateException("expected a contract clause for method " + callee);
     }
 
-    String[] clauses = contractString.split(";");
-    String[] parts = clauses[0].split("->");
-    String[] antecedent = parts[0].split(",");
+    String[] antecedent = ContractUtils.parseAntecedent(clauses[0]);
 
     NullnessStore envStore = getEnvNullnessStoreForClass(classTree, context);
     NullnessStore.Builder result = envStore.toBuilder();

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -87,9 +87,7 @@ public class ContractUtils {
       Symbol callee,
       int numOfArguments) {
 
-    String[] parts = clause.split("->");
-
-    String[] antecedent = parts[0].trim().isEmpty() ? new String[0] : parts[0].split(",");
+    String[] antecedent = parseAntecedent(clause);
 
     if (antecedent.length != numOfArguments && shouldReportInvalidContract(tree)) {
       String message =
@@ -114,6 +112,21 @@ public class ContractUtils {
                   null));
     }
     return antecedent;
+  }
+
+  /**
+   * Parses the antecedent portion of a contract clause into its component value constraints,
+   * without validating the count against a particular method's parameters (contrast with {@link
+   * #getAntecedent}, which performs that validation and reports an error on a given {@code Tree} if
+   * it fails).
+   *
+   * @param clause the contract clause
+   * @return the value constraints in the clause's antecedent, or an empty array if the antecedent
+   *     is empty (e.g. for a contract on a method with no arguments)
+   */
+  static String[] parseAntecedent(String clause) {
+    String[] parts = clause.split("->");
+    return parts[0].trim().isEmpty() ? new String[0] : parts[0].split(",");
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -76,6 +76,39 @@ public class ContractsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void checkContractZeroArgumentMethod() {
+    // Regression test for a crash (IndexOutOfBoundsException) when a zero-argument method has a
+    // @Contract with an empty antecedent, e.g. "-> !null".  See
+    // https://github.com/uber/NullAway/issues/424
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckContracts=true"))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            import org.jetbrains.annotations.Contract;
+            public class Test {
+              @Contract("-> !null")
+              Object okay() {
+                return new Object();
+              }
+              @Contract("-> !null")
+              @Nullable
+              Object violates() {
+                // BUG: Diagnostic contains: Method violates has @Contract(-> !null), but this appears to be violated, as a @Nullable value may be returned when the contract preconditions are true.
+                return null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void noContractCheckErrorsWithoutFlag() {
     makeTestHelperWithArgs(
             Arrays.asList(


### PR DESCRIPTION
## Summary

- `ContractNullnessStoreInitializer` re-implemented `@Contract`-clause parsing by hand instead of using the shared helpers in `ContractUtils`, and its version of the antecedent split was missing the guard for an empty antecedent.
- For a zero-argument method with an empty-antecedent contract (e.g. `@Contract("-> !null")`), the manual parsing produced a one-element array containing an empty string instead of an empty array, and the resulting out-of-bounds `parameters.get(0)` call crashed NullAway with an `IndexOutOfBoundsException`.
- Extracts the guarded antecedent-parsing logic into `ContractUtils.parseAntecedent` (already used internally by `getAntecedent`), and routes both `ContractNullnessStoreInitializer` and `ContractCheckHandler` through `ContractUtils.getContractClauses`/`parseAntecedent` — the same shared helpers `ContractHandler` already used — fixing the crash by construction rather than adding a special case.

Part of #424.

## Testing

- Reproduced the crash first with a scratch test before writing any fix.
- Added `checkContractZeroArgumentMethod` in `ContractsTests.java`, covering both a zero-arg method that satisfies its contract and one that violates it (confirming the fix doesn't just swallow the crash).
- Negative control: temporarily reverted the fix and confirmed the new test fails with the same crash.
- `./gradlew :nullaway:test` (full module suite: 916 tests, 0 failures)
- `./gradlew :nullaway:spotlessJavaCheck`

## AI usage disclosure

> I used Claude Code for this PR. It scoped the fix, reproduced the crash, and drafted the fix. I asked follow-up questions to understand the cause of the crash, the `ContractUtils.getContractString`/`getContractClauses` methods, and why the fix prevents the crash. I have read and understood all the changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract annotations with empty antecedents, including zero-argument methods.
  * Contract violations are now reported using the relevant parsed clause.
  * Prevented crashes when checking contracts for nullable results.

* **Tests**
  * Added regression coverage for valid and invalid results from zero-argument contract methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->