### PR TITLE
Add library model for ObjectUtils.firstNonNull

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -114,6 +114,34 @@ public interface LibraryModels {
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters();
 
   /**
+   * Get library methods whose return value is {@code null} only when <em>every</em> argument passed
+   * at the call site is {@code null}, and non-{@code null} otherwise.
+   *
+   * <p>Unlike {@link #nullImpliesNullParameters()}, which ties the nullness of the return value to
+   * specific argument positions, this model applies to all arguments of the call. That makes it
+   * suitable for varargs methods, whose arity differs from one call site to the next and so cannot
+   * be described by fixed parameter indices. The motivating example is {@code
+   * org.apache.commons.lang3.ObjectUtils.firstNonNull}.
+   *
+   * <p>"Every argument is {@code null}" here means that no argument is known to be non-{@code
+   * null}; an argument of unknown nullness counts as possibly {@code null}. A call passing no
+   * arguments at all therefore has a {@code null} return.
+   *
+   * <p>Note that such methods are often used in the manner of SQL's {@code COALESCE}, relying on an
+   * invariant that this analysis cannot see. In a call like {@code firstNonNull(primary, fallback)}
+   * where a constructor guarantees that exactly one of the two is non-{@code null}, that guarantee
+   * is a relational fact holding <em>between</em> two access paths. NullAway tracks nullness for
+   * each access path independently, so it has no way to represent such a fact, and it reports the
+   * result as possibly {@code null}. Code relying on an invariant of this kind needs {@code
+   * Objects.requireNonNull} or a suppression where the result is dereferenced.
+   *
+   * @return set of library methods returning {@code null} only if all their arguments are null
+   */
+  default ImmutableSet<MethodRef> allParamsNullImpliesNullReturn() {
+    return ImmutableSet.of();
+  }
+
+  /**
    * Get the set of library methods that may return null.
    *
    * @return set of library methods that may return null

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
+import org.checkerframework.nullaway.dataflow.cfg.node.ArrayCreationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.nullaway.dataflow.cfg.node.Node;
@@ -245,6 +246,10 @@ public class LibraryModelsHandler implements Handler {
     if (!optLibraryModels.nullImpliesNullParameters(methodSymbol).isEmpty()) {
       return true;
     }
+    if (optLibraryModels.hasAllParamsNullImpliesNullReturn(
+        methodSymbol, state.getTypes(), isMethodUnannotated)) {
+      return true;
+    }
     return false;
   }
 
@@ -309,6 +314,34 @@ public class LibraryModelsHandler implements Handler {
         }
       }
       return anyNull ? NullnessHint.HINT_NULLABLE : NullnessHint.FORCE_NONNULL;
+    }
+    if (optLibraryModels.hasAllParamsNullImpliesNullReturn(
+        callee, state.getTypes(), !isMethodAnnotated)) {
+      // The return is null only if every value passed is null, so a single value known to be
+      // non-null makes the return non-null.  Note that for a varargs call the CFG has already
+      // desugared the individual values into an array creation, so we must look inside that node
+      // rather than at the argument itself, which is a freshly-created (hence non-null) array.  If
+      // instead an existing array is passed in the varargs position, we cannot see the values it
+      // holds, and we conservatively treat the return as nullable.
+      int varArgsIndex = callee.isVarArgs() ? callee.getParameters().size() - 1 : -1;
+      List<Node> arguments = node.getArguments();
+      for (int i = 0; i < arguments.size(); i++) {
+        Node argument = arguments.get(i);
+        if (i == varArgsIndex) {
+          if (argument instanceof ArrayCreationNode arrayCreationNode) {
+            for (Node element : arrayCreationNode.getInitializers()) {
+              if (inputs.valueOfSubNode(element).equals(NONNULL)) {
+                return NullnessHint.FORCE_NONNULL;
+              }
+            }
+          }
+          continue;
+        }
+        if (inputs.valueOfSubNode(argument).equals(NONNULL)) {
+          return NullnessHint.FORCE_NONNULL;
+        }
+      }
+      return NullnessHint.HINT_NULLABLE;
     }
     Types types = state.getTypes();
     if (optLibraryModels.hasNonNullReturn(callee, types, !isMethodAnnotated)) {
@@ -1059,6 +1092,11 @@ public class LibraryModelsHandler implements Handler {
             .put(methodRef("java.util.Objects", "toString(java.lang.Object,java.lang.String)"), 1)
             .build();
 
+    private static final ImmutableSet<MethodRef> ALL_PARAMS_NULL_IMPLIES_NULL_RETURN =
+        new ImmutableSet.Builder<MethodRef>()
+            .add(methodRef("org.apache.commons.lang3.ObjectUtils", "<T>firstNonNull(T...)"))
+            .build();
+
     private static final ImmutableSet<MethodRef> ALWAYS_NULLABLE_RETURNS =
         new ImmutableSet.Builder<MethodRef>()
             .add(methodRef("com.sun.source.tree.CompilationUnitTree", "getPackageName()"))
@@ -1260,6 +1298,11 @@ public class LibraryModelsHandler implements Handler {
     }
 
     @Override
+    public ImmutableSet<MethodRef> allParamsNullImpliesNullReturn() {
+      return ALL_PARAMS_NULL_IMPLIES_NULL_RETURN;
+    }
+
+    @Override
     public ImmutableSet<MethodRef> nullableReturns() {
       return nullableReturnsForConfig;
     }
@@ -1320,6 +1363,8 @@ public class LibraryModelsHandler implements Handler {
 
     private final ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters;
 
+    private final ImmutableSet<MethodRef> allParamsNullImpliesNullReturn;
+
     private final ImmutableSet<MethodRef> nullableReturns;
 
     private final ImmutableSet<MethodRef> nonNullReturns;
@@ -1361,6 +1406,8 @@ public class LibraryModelsHandler implements Handler {
           new ImmutableSetMultimap.Builder<>();
       ImmutableSetMultimap.Builder<MethodRef, Integer> nullImpliesNullParametersBuilder =
           new ImmutableSetMultimap.Builder<>();
+      ImmutableSet.Builder<MethodRef> allParamsNullImpliesNullReturnBuilder =
+          new ImmutableSet.Builder<>();
       ImmutableSet.Builder<MethodRef> nullableReturnsBuilder = new ImmutableSet.Builder<>();
       ImmutableSet.Builder<MethodRef> nonNullReturnsBuilder = new ImmutableSet.Builder<>();
       ImmutableSetMultimap.Builder<MethodRef, Integer> castToNonNullMethodsBuilder =
@@ -1418,6 +1465,12 @@ public class LibraryModelsHandler implements Handler {
           }
           nullImpliesNullParametersBuilder.put(entry);
         }
+        for (MethodRef name : libraryModels.allParamsNullImpliesNullReturn()) {
+          if (shouldSkipModel(name)) {
+            continue;
+          }
+          allParamsNullImpliesNullReturnBuilder.add(name);
+        }
         for (MethodRef name : libraryModels.nullableReturns()) {
           if (shouldSkipModel(name)) {
             continue;
@@ -1467,6 +1520,7 @@ public class LibraryModelsHandler implements Handler {
       nullImpliesFalseParameters = nullImpliesFalseParametersBuilder.build();
       ensuresNonNullIfTrueMethodCalls = ensuresNonNullIfTrueMethodCallsBuilder.build();
       nullImpliesNullParameters = nullImpliesNullParametersBuilder.build();
+      allParamsNullImpliesNullReturn = allParamsNullImpliesNullReturnBuilder.build();
       nullableReturns = nullableReturnsBuilder.build();
       nonNullReturns = nonNullReturnsBuilder.build();
       castToNonNullMethods = castToNonNullMethodsBuilder.build();
@@ -1522,6 +1576,11 @@ public class LibraryModelsHandler implements Handler {
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters() {
       return nullImpliesNullParameters;
+    }
+
+    @Override
+    public ImmutableSet<MethodRef> allParamsNullImpliesNullReturn() {
+      return allParamsNullImpliesNullReturn;
     }
 
     @Override
@@ -1607,6 +1666,7 @@ public class LibraryModelsHandler implements Handler {
     private final NameIndexedMap<ImmutableSet<Integer>> nullImpliesFalseParams;
     private final NameIndexedMap<ImmutableSet<MethodRef>> ensuresNonNullIfTrueMethodCalls;
     private final NameIndexedMap<ImmutableSet<Integer>> nullImpliesNullParams;
+    private final NameIndexedMap<Boolean> allParamsNullImpliesNullRet;
     private final NameIndexedMap<Boolean> nullableRet;
     private final NameIndexedMap<Boolean> nonNullRet;
     private final NameIndexedMap<ImmutableSet<Integer>> castToNonNullMethods;
@@ -1625,6 +1685,8 @@ public class LibraryModelsHandler implements Handler {
       ensuresNonNullIfTrueMethodCalls =
           makeOptimizedSetLookup(names, models.ensuresNonNullIfTrueMethodCalls());
       nullImpliesNullParams = makeOptimizedSetLookup(names, models.nullImpliesNullParameters());
+      allParamsNullImpliesNullRet =
+          makeOptimizedBoolLookup(names, models.allParamsNullImpliesNullReturn());
       nullableRet = makeOptimizedBoolLookup(names, models.nullableReturns());
       nonNullRet = makeOptimizedBoolLookup(names, models.nonNullReturns());
       castToNonNullMethods = makeOptimizedSetLookup(names, models.castToNonNullMethods());
@@ -1668,6 +1730,12 @@ public class LibraryModelsHandler implements Handler {
 
     ImmutableSet<Integer> nullImpliesNullParameters(Symbol.MethodSymbol symbol) {
       return lookupImmutableSet(symbol, nullImpliesNullParams);
+    }
+
+    boolean hasAllParamsNullImpliesNullReturn(
+        Symbol.MethodSymbol symbol, Types types, boolean checkSuper) {
+      return lookupHandlingOverrides(symbol, types, allParamsNullImpliesNullRet, checkSuper)
+          != null;
     }
 
     ImmutableSet<Integer> castToNonNullMethod(Symbol.MethodSymbol symbol) {

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1276,6 +1276,91 @@ public class FrameworkTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void apacheObjectUtilsFirstNonNull() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            """
+            package com.uber;
+            import org.apache.commons.lang3.ObjectUtils;
+            import org.jetbrains.annotations.Nullable;
+            public class Foo {
+              public void allValuesMayBeNull(@Nullable String a, @Nullable String b) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(a, b)' is @Nullable
+                ObjectUtils.firstNonNull(a, b).length();
+              }
+              public void lastValueNonNull(@Nullable String a) {
+                ObjectUtils.firstNonNull(a, "default").length();
+              }
+              public void firstValueNonNull(@Nullable String a) {
+                ObjectUtils.firstNonNull("default", a).length();
+              }
+              public void nonNullOnlyViaDataflow(@Nullable String a, @Nullable String b) {
+                if (a != null) {
+                  ObjectUtils.firstNonNull(a, b).length();
+                }
+              }
+              public void noValues() {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull()' is @Nullable
+                ObjectUtils.firstNonNull().toString();
+              }
+              public void resultCheckedBeforeUse(@Nullable String a, @Nullable String b) {
+                String result = ObjectUtils.firstNonNull(a, b);
+                if (result != null) {
+                  result.length();
+                }
+              }
+              @Nullable
+              public String resultNotDereferenced(@Nullable String a, @Nullable String b) {
+                return ObjectUtils.firstNonNull(a, b);
+              }
+              public void unboxingNullableResult(@Nullable Integer a, @Nullable Integer b) {
+                // BUG: Diagnostic contains: unboxing of a @Nullable expression 'ObjectUtils.firstNonNull(a, b)'
+                int n = ObjectUtils.firstNonNull(a, b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void apacheObjectUtilsFirstNonNullVarargsForms() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Foo.java",
+            """
+            package com.uber;
+            import org.apache.commons.lang3.ObjectUtils;
+            import org.jetbrains.annotations.Nullable;
+            public class Foo {
+              // An existing array is passed in the varargs position, so the values it holds are not
+              // visible and the result must be treated as nullable.
+              public void arrayPassedInVarargsPosition(String[] values) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(values)' is @Nullable
+                ObjectUtils.firstNonNull(values).length();
+              }
+              // An array created at the call site does have visible values.
+              public void explicitArrayCreationAllNullable(@Nullable String a, @Nullable String b) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(new String[] {a, b})' is @Nullable
+                ObjectUtils.firstNonNull(new String[] {a, b}).length();
+              }
+              public void explicitArrayCreationSomeNonNull(@Nullable String a) {
+                ObjectUtils.firstNonNull(new String[] {"default", a}).length();
+              }
+              // The values themselves are of array type, so T is String[].
+              public void valuesOfArrayTypeAllNullable(String @Nullable [] p, String @Nullable [] q) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(p, q)' is @Nullable
+                int n = ObjectUtils.firstNonNull(p, q).length;
+              }
+              public void valuesOfArrayTypeSomeNonNull(String @Nullable [] p) {
+                int n = ObjectUtils.firstNonNull(p, new String[0]).length;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void apacheValidateArrayNoNullElementsWithMessage() {
     defaultCompilationHelper
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -158,6 +158,32 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void objectUtilsFirstNonNull() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.apache.commons.lang3.ObjectUtils;
+            import org.jspecify.annotations.*;
+            @NullMarked
+            class Test {
+              void testNegative(@Nullable String a) {
+                ObjectUtils.firstNonNull(a, "default").length();
+              }
+              void testPositive(@Nullable String a, @Nullable String b) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(a, b)' is @Nullable
+                ObjectUtils.firstNonNull(a, b).length();
+              }
+              void arrayPassedInVarargsPosition(String[] values) {
+                // BUG: Diagnostic contains: dereferenced expression 'ObjectUtils.firstNonNull(values)' is @Nullable
+                ObjectUtils.firstNonNull(values).length();
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
## Summary

`org.apache.commons.lang3.ObjectUtils.firstNonNull` returns the first non-`null` value passed to it, or
`null` when every value is `null`. Today NullAway has no model for it, so — since `ObjectUtils` is
unannotated — the return is optimistically treated as non-`null` and code like this is silently accepted:

```java
ObjectUtils.firstNonNull(a, b).length();  // NPE when both are null
ObjectUtils.firstNonNull().toString();    // guaranteed NPE
```

As #612 notes, the semantics are "`@Contract("!null -> !null")` for each element of its varargs." That
can't be written as a `@Contract` today: `ContractUtils.getAntecedent` requires the antecedent to have
exactly one entry per call-site argument, and a varargs method has a different arity at each call site.

## Approach

This adds a library model kind, `allParamsNullImpliesNullReturn`, for methods whose return is `null` only
when *all* of their arguments are `null`. It is the dual of the existing `nullImpliesNullParameters` —
that one is "any listed argument null ⇒ nullable return", this one is "every argument null ⇒ nullable
return" — and it keys on `MethodRef` alone rather than on fixed parameter indices, which is what makes it
applicable to varargs. It is a `default` method on `LibraryModels` so existing implementors are unaffected.

The one subtlety worth flagging for review is in `onDataflowVisitMethodInvocation`. By the time the
dataflow hook runs, the CFG has already desugared a varargs call: `node.getArguments()` returns a single
`ArrayCreationNode`, and `AccessPathNullnessPropagation.visitArrayCreation` correctly reports it as
non-`null`, because a freshly created array is never null. Reading the arguments directly therefore
concludes "some argument is non-null" at every call site. The implementation instead inspects that node's
initializers. This also means `firstNonNull(new String[] {"x", a})` is handled correctly, which is
covered by a test rather than assumed.

When an *existing* array is passed in the varargs position, its contents are not visible at this level, so
those positions are skipped and the return is conservatively treated as nullable.

The model is consumed in two places: the dataflow hook above, and `onOverrideMayBeNullExpr`, the
non-dataflow path answering whether an expression can be null at all. Without the second, the first is
overruled.

## Known tradeoff

`firstNonNull` is often used the way SQL's `COALESCE` is, relying on an invariant the analysis cannot see —
for example two fields where a constructor guarantees exactly one is non-`null`. That guarantee is a
relational fact *between* two access paths, and NullAway tracks nullness for each access path
independently, so such calls will now be reported. `Objects.requireNonNull` at the point of use resolves
it (verified), as does a suppression. I've documented this on the new interface method so it's discoverable
next to the model definition.

This is the same shape of tradeoff as modeling `Map.remove` as `@Nullable` in #1623, which shipped with a
release note about newly-reported warnings — but it is a real behavior change and I'd rather have it
called out explicitly than found in review. Happy to drop or gate the model if you'd rather not take it.

`ObjectUtils.defaultIfNull(T, T)` has identical semantics and would be a one-line addition to the same set,
but it is an even purer instance of the `COALESCE` idiom, so I left it out deliberately rather than
doubling the affected surface in one PR.

## Testing

Two tests in `FrameworkTests.java`, alongside the existing commons-lang3 `Validate` tests.

`apacheObjectUtilsFirstNonNull` covers the semantics: all values nullable (reported), last value non-null
(silent), first value non-null (silent — so the check isn't accidentally position-dependent), non-null known
only from dataflow via an enclosing null check (silent), no arguments at all (reported), result null-checked
before use (silent), result never dereferenced (silent), and a boxed result unboxed to `int` (reported as an
unboxing error).

`apacheObjectUtilsFirstNonNullVarargsForms` covers the call shapes: an existing array passed in the varargs
position (reported, contents not visible), an array created at the call site with all-nullable elements
(reported) and with a non-null element (silent), and values that are themselves of array type so that `T` is
`String[]`, both all-nullable (reported) and with one non-null (silent).

`objectUtilsFirstNonNull` in `JSpecifyLibraryModelsTests.java` pins the same behavior down in JSpecify
mode, since library modeling of varargs differs there (#1481, #1485). Behavior is identical in both modes.

- Negative control: deleting the single `methodRef` entry makes both tests fail, so every assertion is
  load-bearing and the signature string is confirmed correct. That matters here because model lookup is
  string equality against `MethodSymbol.toString()` with no validation — a typo silently matches nothing.
- `./gradlew :nullaway:test` — 920 tests, 0 failures.
- `./gradlew :test-library-models:test` — passing; run because the `LibraryModels` interface changed.

No CHANGELOG entry, as that file has no unreleased section; happy to add one wherever you'd prefer.

Fixes #612

## AI usage disclosure

> I recognize this is a low-priority issue. I chose it deliberately as an educational exercise, to learn
> more about the codebase — so please weigh it accordingly, and don't feel obliged to take it if the
> tradeoff above isn't one you want.
>
> I used Claude Code for this PR. I picked the issue and directed the approach throughout. It walked me
> through the library-model pipeline — the `LibraryModels` interface, `DefaultLibraryModels`,
> `CombinedLibraryModels`, `OptimizedLibraryModels`, and the two consumer sites — and wrote the
> registration boilerplate once I understood what each layer did. I made the design calls: framing the
> model's semantics in terms of arguments that are *possibly* null rather than known-null, accepting the
> `COALESCE`-style false positive as preferable to silently missing real NPEs, and asking for that
> limitation to be documented on the interface method. Its first implementation compiled and was silently
> wrong, reading the desugared array rather than the values; it found the cause by instrumenting the
> handler. I then pushed back on whether the test cases were exhaustive, particularly for varargs whose
> values are themselves arrays. That review took the tests from five assertions to thirteen and caught a
> behavior — the handling of an array created at the call site — that was about to be described in this PR
> without any test covering it. I also asked whether #1485 had any bearing here, which is what prompted the
> JSpecify-mode test. I have read and understood all the changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved nullness analysis for methods that return a nullable value only when all arguments are null.
  * Added support for zero-argument and varargs calls, including explicit varargs arrays.
  * Added handling for Apache Commons Lang `ObjectUtils.firstNonNull`.

* **Bug Fixes**
  * Nullability warnings now more accurately identify unsafe dereferences and unboxing when no non-null fallback is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->