### PR TITLE
Basic nullability inference for diamond constructor type arguments

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2978,6 +2978,7 @@ public final class GenericsChecks {
             targetTypeAndAssignmentKind.assignedToLocal());
       }
     }
+    // an unhandled case; for now, give up and return no assignment context
     return new CallAndContext(call, null, false);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2886,6 +2886,9 @@ public final class GenericsChecks {
     if (call instanceof MethodInvocationTree
         && parent instanceof MethodInvocationTree parentInvocation
         && isCallNeedingInference(parentInvocation)) {
+      // this is the case of a nested generic call, e.g., id(id(x)) where id is generic
+      // we want to find the outermost call that requires inference, since that is the one whose
+      // assignment context is relevant
       return getCallAndContextForInference(
           parentPath, state.withPath(parentPath), calledFromDataflow);
     }
@@ -2927,6 +2930,7 @@ public final class GenericsChecks {
       // could be a parameter to another method call, or part of a conditional expression, etc.
       // in any case, just return the type of the parent expression
       if (exprParent instanceof MethodInvocationTree parentInvocation) {
+        // the call is either a regular parameter to the parent call, or the receiver expression
         Type formalParamType =
             getFormalParameterTypeForArgument(
                 parentInvocation,

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -762,13 +762,11 @@ public final class GenericsChecks {
         TreePath currentPath = state.getPath();
         CallAndContext directContext =
             getDirectCallContextForInference(currentPath, state, calledFromDataflow);
-        Type constructorAssignmentContext =
-            sanitizeAssignmentContextForDiamondConstructor(directContext.typeFromAssignmentContext);
         return inferCallType(
             state,
             newClassTree,
             currentPath,
-            constructorAssignmentContext,
+            directContext.typeFromAssignmentContext,
             directContext.assignedToLocal,
             calledFromDataflow);
       }
@@ -1338,16 +1336,6 @@ public final class GenericsChecks {
         callTree instanceof MethodInvocationTree || callTree instanceof NewClassTree,
         "Expected a MethodInvocationTree or a NewClassTree");
     return (Symbol.MethodSymbol) castToNonNull(ASTHelpers.getSymbol(callTree));
-  }
-
-  /**
-   * A bare method type variable does not provide useful structure for inferring nullability of a
-   * diamond constructor's class type arguments. In such cases we let constructor inference rely on
-   * constructor arguments and any more structured surrounding context instead.
-   */
-  private @Nullable Type sanitizeAssignmentContextForDiamondConstructor(
-      @Nullable Type contextType) {
-    return contextType instanceof Type.TypeVar ? null : contextType;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -753,19 +753,29 @@ public final class GenericsChecks {
       return typeOrNullIfRaw(result);
     }
     if (tree instanceof NewClassTree newClassTree) {
-      if (TreeInfo.isDiamond((JCTree) newClassTree)) {
-        if (newClassTree.getClassBody() != null) {
-          // Keep existing behavior for diamond anonymous classes, which are not yet fully
-          // supported.  Tracked in https://github.com/uber/NullAway/issues/1475
-          return null;
-        }
-        // For constructor calls using diamond operator, infer from assignment context.
-        // TODO handle diamond constructor calls passed to generic methods
-        // https://github.com/uber/NullAway/issues/1470
-        Type fromAssignmentContext =
-            getDiamondTypeFromContext(newClassTree, state, calledFromDataflow);
-        if (fromAssignmentContext != null) {
-          return fromAssignmentContext;
+      if (TreeInfo.isDiamond((JCTree) newClassTree) && newClassTree.getClassBody() != null) {
+        // Keep existing behavior for diamond anonymous classes, which are not yet fully supported.
+        // Tracked in https://github.com/uber/NullAway/issues/1475
+        return null;
+      }
+      if (hasInferredClassTypeArguments(newClassTree)) {
+        TreePath currentPath = state.getPath();
+        @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
+        boolean currentPathLeafIsTree =
+            currentPath != null && ASTHelpers.stripParentheses(currentPath.getLeaf()) == tree;
+        if (currentPathLeafIsTree) {
+          DirectCallContext directContext =
+              getDirectCallContextForInference(currentPath, state, calledFromDataflow);
+          Type constructorAssignmentContext =
+              sanitizeAssignmentContextForDiamondConstructor(
+                  directContext.typeFromAssignmentContext);
+          return inferCallType(
+              state,
+              newClassTree,
+              currentPath,
+              constructorAssignmentContext,
+              directContext.assignedToLocal,
+              calledFromDataflow);
         }
       }
       if (newClassTree.getIdentifier() instanceof ParameterizedTypeTree paramTypedTree
@@ -874,27 +884,6 @@ public final class GenericsChecks {
       return null;
     }
     return type;
-  }
-
-  /**
-   * Gets the type of a constructor call using a diamond operator from its assignment context, if
-   * available.
-   */
-  private @Nullable Type getDiamondTypeFromContext(
-      NewClassTree tree, VisitorState state, boolean calledFromDataflow) {
-    return getDiamondTypeFromParentContext(
-        tree, state, castToNonNull(state.getPath().getParentPath()), calledFromDataflow);
-  }
-
-  /**
-   * Computes the assignment-context type for an inferred constructor call, given a path to its
-   * parent context.
-   */
-  private @Nullable Type getDiamondTypeFromParentContext(
-      NewClassTree tree, VisitorState state, TreePath parentPath, boolean calledFromDataflow) {
-    return getTargetTypeFromParentContext(
-            tree, new TreePath(parentPath, tree), state, calledFromDataflow)
-        .typeFromAssignmentContext();
   }
 
   /**
@@ -1367,6 +1356,16 @@ public final class GenericsChecks {
   }
 
   /**
+   * A bare method type variable does not provide useful structure for inferring nullability of a
+   * diamond constructor's class type arguments. In such cases we let constructor inference rely on
+   * constructor arguments and any more structured surrounding context instead.
+   */
+  private @Nullable Type sanitizeAssignmentContextForDiamondConstructor(
+      @Nullable Type contextType) {
+    return contextType instanceof Type.TypeVar ? null : contextType;
+  }
+
+  /**
    * Generates inference constraints for a generic call, including nested generic method calls and
    * diamond constructor calls.
    *
@@ -1829,9 +1828,6 @@ public final class GenericsChecks {
   }
 
   private static boolean isCallNeedingInference(ExpressionTree argument) {
-    // For now, we only support calls to generic methods.
-    // TODO also support calls to generic constructors that use the diamond operator
-    // https://github.com/uber/NullAway/issues/1470
     if (argument instanceof MethodInvocationTree methodInvocation) {
       Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodInvocation);
       // true for generic method calls with no explicit type arguments
@@ -1839,7 +1835,8 @@ public final class GenericsChecks {
           && methodSymbol.type instanceof Type.ForAll
           && methodInvocation.getTypeArguments().isEmpty();
     }
-    return false;
+    return argument instanceof NewClassTree newClassTree
+        && hasInferredClassTypeArguments(newClassTree);
   }
 
   /**
@@ -2289,17 +2286,6 @@ public final class GenericsChecks {
     }
     Type invokedMethodType = methodSymbol.type;
     Type enclosingType = null;
-    if (tree instanceof NewClassTree newClassTree) {
-      if (hasInferredClassTypeArguments(newClassTree)) {
-        TreePath currentPath = state.getPath();
-        if (currentPath != null && ASTHelpers.stripParentheses(currentPath.getLeaf()) == tree) {
-          TreePath parentPath = currentPath.getParentPath();
-          if (parentPath != null) {
-            enclosingType = getDiamondTypeFromParentContext(newClassTree, state, parentPath, false);
-          }
-        }
-      }
-    }
     if (enclosingType == null) {
       enclosingType = getEnclosingTypeForCallExpression(methodSymbol, tree, null, state, false);
     }
@@ -2897,6 +2883,9 @@ public final class GenericsChecks {
   private record CallAndContext(
       ExpressionTree call, @Nullable Type typeFromAssignmentContext, boolean assignedToLocal) {}
 
+  private record DirectCallContext(
+      @Nullable Type typeFromAssignmentContext, boolean assignedToLocal) {}
+
   /**
    * Given a {@link TreePath} to an invocation of a generic method, collect information about the
    * appropriate invocation on which to perform type inference, and the relevant information from
@@ -2924,11 +2913,34 @@ public final class GenericsChecks {
       parentPath = parentPath.getParentPath();
       parent = parentPath.getLeaf();
     }
+    if (call instanceof MethodInvocationTree
+        && parent instanceof MethodInvocationTree parentInvocation
+        && isCallNeedingInference(parentInvocation)) {
+      return getCallAndContextForInference(
+          parentPath, state.withPath(parentPath), calledFromDataflow);
+    }
+    DirectCallContext directContext =
+        getDirectCallContextForInference(path, state, calledFromDataflow);
+    return new CallAndContext(
+        call, directContext.typeFromAssignmentContext, directContext.assignedToLocal);
+  }
+
+  /**
+   * Returns the context immediately surrounding a call, without traversing nested generic calls.
+   */
+  private DirectCallContext getDirectCallContextForInference(
+      TreePath path, VisitorState state, boolean calledFromDataflow) {
+    ExpressionTree call = (ExpressionTree) path.getLeaf();
+    TreePath parentPath = path.getParentPath();
+    Tree parent = parentPath.getLeaf();
+    while (parent instanceof ParenthesizedTree) {
+      parentPath = parentPath.getParentPath();
+      parent = parentPath.getLeaf();
+    }
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
       TargetTypeAndAssignmentKind targetTypeAndAssignmentKind =
           getTargetTypeForAssignmentContext(parent, state.withPath(parentPath), calledFromDataflow);
-      return new CallAndContext(
-          call,
+      return new DirectCallContext(
           targetTypeAndAssignmentKind.typeFromAssignmentContext(),
           targetTypeAndAssignmentKind.assignedToLocal());
     } else if (parent instanceof ReturnTree) {
@@ -2940,22 +2952,13 @@ public final class GenericsChecks {
           && enclosingMethodOrLambda.getLeaf() instanceof MethodTree enclosingMethod) {
         Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(enclosingMethod);
         if (methodSymbol != null) {
-          return new CallAndContext(call, methodSymbol.getReturnType(), false);
+          return new DirectCallContext(methodSymbol.getReturnType(), false);
         }
       }
     } else if (parent instanceof ExpressionTree exprParent) {
       // could be a parameter to another method call, or part of a conditional expression, etc.
       // in any case, just return the type of the parent expression
       if (exprParent instanceof MethodInvocationTree parentInvocation) {
-        if (isCallNeedingInference(parentInvocation)) {
-          // this is the case of a nested generic call, e.g., id(id(x)) where id is generic
-          // we want to find the outermost call that requires inference, since that is the one whose
-          // assignment context is relevant
-          return getCallAndContextForInference(
-              parentPath, state.withPath(parentPath), calledFromDataflow);
-        }
-        // the generic call is either a regular parameter to the parent call, or the receiver
-        // expression
         Type formalParamType =
             getFormalParameterTypeForArgument(
                 parentInvocation,
@@ -2989,7 +2992,7 @@ public final class GenericsChecks {
             }
           }
         }
-        return new CallAndContext(call, formalParamType, false);
+        return new DirectCallContext(formalParamType, false);
       } else if (exprParent instanceof ConditionalExpressionTree) {
         TreePath conditionalPath = getOutermostConditionalExpressionPath(parentPath);
         TargetTypeAndAssignmentKind targetTypeAndAssignmentKind =
@@ -2997,14 +3000,12 @@ public final class GenericsChecks {
                 (ConditionalExpressionTree) conditionalPath.getLeaf(),
                 state.withPath(conditionalPath),
                 calledFromDataflow);
-        return new CallAndContext(
-            call,
+        return new DirectCallContext(
             targetTypeAndAssignmentKind.typeFromAssignmentContext(),
             targetTypeAndAssignmentKind.assignedToLocal());
       }
     }
-    // an unhandled case; for now, give up and return no assignment context
-    return new CallAndContext(call, null, false);
+    return new DirectCallContext(null, false);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -760,23 +760,17 @@ public final class GenericsChecks {
       }
       if (isDiamondAndNotAnonymousClass(newClassTree)) {
         TreePath currentPath = state.getPath();
-        @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
-        boolean currentPathLeafIsTree =
-            currentPath != null && ASTHelpers.stripParentheses(currentPath.getLeaf()) == tree;
-        if (currentPathLeafIsTree) {
-          DirectCallContext directContext =
-              getDirectCallContextForInference(currentPath, state, calledFromDataflow);
-          Type constructorAssignmentContext =
-              sanitizeAssignmentContextForDiamondConstructor(
-                  directContext.typeFromAssignmentContext);
-          return inferCallType(
-              state,
-              newClassTree,
-              currentPath,
-              constructorAssignmentContext,
-              directContext.assignedToLocal,
-              calledFromDataflow);
-        }
+        CallAndContext directContext =
+            getDirectCallContextForInference(currentPath, state, calledFromDataflow);
+        Type constructorAssignmentContext =
+            sanitizeAssignmentContextForDiamondConstructor(directContext.typeFromAssignmentContext);
+        return inferCallType(
+            state,
+            newClassTree,
+            currentPath,
+            constructorAssignmentContext,
+            directContext.assignedToLocal,
+            calledFromDataflow);
       }
       if (newClassTree.getIdentifier() instanceof ParameterizedTypeTree paramTypedTree
           && !paramTypedTree.getTypeArguments().isEmpty()) {
@@ -2874,9 +2868,6 @@ public final class GenericsChecks {
   private record CallAndContext(
       ExpressionTree call, @Nullable Type typeFromAssignmentContext, boolean assignedToLocal) {}
 
-  private record DirectCallContext(
-      @Nullable Type typeFromAssignmentContext, boolean assignedToLocal) {}
-
   /**
    * Given a {@link TreePath} to an invocation of a generic method, collect information about the
    * appropriate invocation on which to perform type inference, and the relevant information from
@@ -2910,16 +2901,13 @@ public final class GenericsChecks {
       return getCallAndContextForInference(
           parentPath, state.withPath(parentPath), calledFromDataflow);
     }
-    DirectCallContext directContext =
-        getDirectCallContextForInference(path, state, calledFromDataflow);
-    return new CallAndContext(
-        call, directContext.typeFromAssignmentContext, directContext.assignedToLocal);
+    return getDirectCallContextForInference(path, state, calledFromDataflow);
   }
 
   /**
    * Returns the context immediately surrounding a call, without traversing nested generic calls.
    */
-  private DirectCallContext getDirectCallContextForInference(
+  private CallAndContext getDirectCallContextForInference(
       TreePath path, VisitorState state, boolean calledFromDataflow) {
     ExpressionTree call = (ExpressionTree) path.getLeaf();
     TreePath parentPath = path.getParentPath();
@@ -2931,7 +2919,8 @@ public final class GenericsChecks {
     if (parent instanceof AssignmentTree || parent instanceof VariableTree) {
       TargetTypeAndAssignmentKind targetTypeAndAssignmentKind =
           getTargetTypeForAssignmentContext(parent, state.withPath(parentPath), calledFromDataflow);
-      return new DirectCallContext(
+      return new CallAndContext(
+          call,
           targetTypeAndAssignmentKind.typeFromAssignmentContext(),
           targetTypeAndAssignmentKind.assignedToLocal());
     } else if (parent instanceof ReturnTree) {
@@ -2943,7 +2932,7 @@ public final class GenericsChecks {
           && enclosingMethodOrLambda.getLeaf() instanceof MethodTree enclosingMethod) {
         Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(enclosingMethod);
         if (methodSymbol != null) {
-          return new DirectCallContext(methodSymbol.getReturnType(), false);
+          return new CallAndContext(call, methodSymbol.getReturnType(), false);
         }
       }
     } else if (parent instanceof ExpressionTree exprParent) {
@@ -2983,7 +2972,7 @@ public final class GenericsChecks {
             }
           }
         }
-        return new DirectCallContext(formalParamType, false);
+        return new CallAndContext(call, formalParamType, false);
       } else if (exprParent instanceof ConditionalExpressionTree) {
         TreePath conditionalPath = getOutermostConditionalExpressionPath(parentPath);
         TargetTypeAndAssignmentKind targetTypeAndAssignmentKind =
@@ -2991,12 +2980,13 @@ public final class GenericsChecks {
                 (ConditionalExpressionTree) conditionalPath.getLeaf(),
                 state.withPath(conditionalPath),
                 calledFromDataflow);
-        return new DirectCallContext(
+        return new CallAndContext(
+            call,
             targetTypeAndAssignmentKind.typeFromAssignmentContext(),
             targetTypeAndAssignmentKind.assignedToLocal());
       }
     }
-    return new DirectCallContext(null, false);
+    return new CallAndContext(call, null, false);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -753,12 +753,12 @@ public final class GenericsChecks {
       return typeOrNullIfRaw(result);
     }
     if (tree instanceof NewClassTree newClassTree) {
-      if (TreeInfo.isDiamond((JCTree) newClassTree) && newClassTree.getClassBody() != null) {
+      if (isDiamondAndNotAnonymousClass(newClassTree)) {
         // Keep existing behavior for diamond anonymous classes, which are not yet fully supported.
         // Tracked in https://github.com/uber/NullAway/issues/1475
         return null;
       }
-      if (hasInferredClassTypeArguments(newClassTree)) {
+      if (isDiamondAndNotAnonymousClass(newClassTree)) {
         TreePath currentPath = state.getPath();
         @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
         boolean currentPathLeafIsTree =
@@ -908,7 +908,7 @@ public final class GenericsChecks {
    * Returns true when javac inferred class type arguments for a constructor call, i.e. there are
    * instantiated type arguments at the type level, but no explicit non-diamond source type args.
    */
-  private static boolean hasInferredClassTypeArguments(NewClassTree newClassTree) {
+  private static boolean isDiamondAndNotAnonymousClass(NewClassTree newClassTree) {
     if (newClassTree.getClassBody() != null) {
       // we still need to properly handle anonymous classes
       return false;
@@ -1831,7 +1831,7 @@ public final class GenericsChecks {
           && methodInvocation.getTypeArguments().isEmpty();
     }
     return argument instanceof NewClassTree newClassTree
-        && hasInferredClassTypeArguments(newClassTree);
+        && isDiamondAndNotAnonymousClass(newClassTree);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -753,7 +753,7 @@ public final class GenericsChecks {
       return typeOrNullIfRaw(result);
     }
     if (tree instanceof NewClassTree newClassTree) {
-      if (isDiamondAndNotAnonymousClass(newClassTree)) {
+      if (TreeInfo.isDiamond((JCTree) newClassTree) && newClassTree.getClassBody() != null) {
         // Keep existing behavior for diamond anonymous classes, which are not yet fully supported.
         // Tracked in https://github.com/uber/NullAway/issues/1475
         return null;
@@ -909,11 +909,7 @@ public final class GenericsChecks {
    * instantiated type arguments at the type level, but no explicit non-diamond source type args.
    */
   private static boolean isDiamondAndNotAnonymousClass(NewClassTree newClassTree) {
-    if (newClassTree.getClassBody() != null) {
-      // we still need to properly handle anonymous classes
-      return false;
-    }
-    return TreeInfo.isDiamond((JCTree) newClassTree);
+    return TreeInfo.isDiamond((JCTree) newClassTree) && newClassTree.getClassBody() == null;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -913,12 +913,7 @@ public final class GenericsChecks {
       // we still need to properly handle anonymous classes
       return false;
     }
-    if (!TreeInfo.isDiamond((JCTree) newClassTree)) {
-      // explicit class type arguments in source
-      return false;
-    }
-    Type newClassType = ASTHelpers.getType(newClassTree);
-    return newClassType != null && !newClassType.getTypeArguments().isEmpty();
+    return TreeInfo.isDiamond((JCTree) newClassTree);
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
@@ -273,10 +273,6 @@ public class ConditionalExprTests extends NullAwayTestsBase {
                 }
               }
               void test(boolean flag) {
-                // TODO: we should infer Box<@Nullable Object> (or something like that) as the type
-                // of inferredFromInitializer, but currently we do not.  When we do, the warning on
-                // the next line should go away.  https://github.com/uber/NullAway/issues/1633
-                // BUG: Diagnostic contains: passing @Nullable parameter
                 var inferredFromInitializer = flag ? new Box<>(null) : new Box<>("fallback");
                 Box<@Nullable String> explicitNullableTarget =
                     flag ? new Box<>(null) : new Box<>("fallback");

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
@@ -63,9 +63,6 @@ public class GenericDiamondTests extends NullAwayTestsBase {
                 }
               }
               void test() {
-                // NOTE: reporting a warning on the next line is a current limitation
-                // of NullAway; there should be no warning. See https://github.com/uber/NullAway/issues/1633.
-                // BUG: Diagnostic contains: passing @Nullable parameter
                 var inferredFromInitializer = new Box<>(null);
                 // BUG: Diagnostic contains: passing @Nullable parameter
                 Box<String> explicitNonNullTarget = new Box<>(null);
@@ -237,6 +234,59 @@ public class GenericDiamondTests extends NullAwayTestsBase {
               }
               static <V> List<@Nullable V> test(Class<V> cls) {
                 return make(new FooImpl<>(cls));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void inferFromReturn() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              interface Supplier<T extends @Nullable Object> { public T get(); }
+              public interface LazyValue<T extends @Nullable Object> extends Supplier<T> {}
+              record NullableLazyValue<T extends @Nullable Object>(Supplier<T> supplier) implements LazyValue<T> {
+                public T get() {
+                  return supplier.get();
+                }
+              }
+              static <K> LazyValue<@Nullable K> nullable(Supplier<@Nullable K> supplier) {
+                return new NullableLazyValue<>(supplier);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void inferFromParams() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.*;
+            @NullMarked
+            public class Test {
+              static class Foo<T extends @Nullable Object> {}
+              static class Bar<T extends @Nullable Object> {
+                Bar(Foo<T> foo1, Foo<T> foo2) {
+                }
+              }
+              static void testNegative1(Foo<String> f1, Foo<String> f2) {
+                new Bar<>(f1, f2);
+              }
+              static void testNegative2(Foo<@Nullable String> f1, Foo<@Nullable String> f2) {
+                new Bar<>(f1, f2);
+              }
+              static void testPositive(Foo<String> f1, Foo<@Nullable String> f2) {
+                // BUG: Diagnostic contains: incompatible types
+                new Bar<>(f1, f2);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -947,8 +947,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 }
               }
               static void testPositive() {
-                // TODO: we should report an error here, since B's type parameter
-                // cannot be @Nullable; we do not catch this yet
+                // BUG: Diagnostic contains: incompatible types: B<Object> cannot be converted to A<@Nullable Object>
                 A<@Nullable Object> p = new B<>();
               }
               static void testNegative() {


### PR DESCRIPTION
See the new tests.  To shrink this PR a bit, we don't handle nested diamond constructor calls; those are handled in follow-up #1544.

The main new logic is around line 765 where we now call into inference for diamonds.  Also, we add `getDirectCallContextForInference` to separate traversing up through containing calls from other cases.

Failed integration tests are expected; we report new errors due to this change and they are valid.  Will try to cut a new release soon and help the projects get these fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability inference for generic diamond constructor calls in assignments, method arguments, return values, conditional expressions, and nested calls.
  * Improved detection of incompatible inferred generic types, including nullable and non-nullable combinations.
  * Removed outdated limitations and diagnostics related to diamond inference.

* **Tests**
  * Added coverage for inference from return types and multiple constructor parameters.
  * Updated expectations for newly reported incompatible-type diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->