### PR TITLE
JSpecify: preserve all dimensions of multi-dimensional array creation expressions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -39,7 +39,32 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, @Nul
   @Override
   public Type visitNewArray(NewArrayTree tree, @Nullable Void p) {
     Type elemType = tree.getType().accept(this, null);
-    return new Type.ArrayType(elemType, castToNonNull(ASTHelpers.getType(tree)).tsym);
+    Type javacArrayType = castToNonNull(ASTHelpers.getType(tree));
+    // tree.getType() yields the element type of the innermost dimension only; e.g., for
+    // `new @Nullable Integer[3][4]` it is `@Nullable Integer`.  So we add one array level for each
+    // dimension of the type javac computed for the whole creation expression that is not already
+    // present in elemType.
+    Type result = elemType;
+    for (int i = arrayDimensionCount(elemType); i < arrayDimensionCount(javacArrayType); i++) {
+      result = new Type.ArrayType(result, javacArrayType.tsym);
+    }
+    return result;
+  }
+
+  /**
+   * Computes the number of array dimensions of a type, e.g., 2 for {@code String[][]}.
+   *
+   * @param type the type to inspect
+   * @return the number of array dimensions of {@code type}, or 0 if it is not an array type
+   */
+  private static int arrayDimensionCount(Type type) {
+    int count = 0;
+    Type current = type;
+    while (current instanceof Type.ArrayType arrayType) {
+      count++;
+      current = arrayType.getComponentType();
+    }
+    return count;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/PreservedAnnotationTreeVisitor.java
@@ -36,14 +36,25 @@ public class PreservedAnnotationTreeVisitor extends SimpleTreeVisitor<Type, @Nul
     this.config = config;
   }
 
+  /**
+   * Computes the type of an array creation expression, preserving nullability annotations on the
+   * element type.
+   *
+   * <p>{@link NewArrayTree#getType()} yields the element type of the innermost dimension only,
+   * e.g., {@code @Nullable Integer} for {@code new @Nullable Integer[3][4]}. So the rank of the
+   * created array is taken from the type javac computed for the whole expression, and the element
+   * type is wrapped in one array level for each dimension it does not already have. Taking the rank
+   * from javac's type rather than from {@link NewArrayTree#getDimensions()} also handles the
+   * array-initializer form {@code new @Nullable Integer[]{null}}, which has no explicit dimension
+   * expressions but still creates a one-dimensional array.
+   *
+   * @param tree the array creation expression
+   * @return the type of {@code tree}, with nullability annotations preserved on the element type
+   */
   @Override
   public Type visitNewArray(NewArrayTree tree, @Nullable Void p) {
     Type elemType = tree.getType().accept(this, null);
     Type javacArrayType = castToNonNull(ASTHelpers.getType(tree));
-    // tree.getType() yields the element type of the innermost dimension only; e.g., for
-    // `new @Nullable Integer[3][4]` it is `@Nullable Integer`.  So we add one array level for each
-    // dimension of the type javac computed for the whole creation expression that is not already
-    // present in elemType.
     Type result = elemType;
     for (int i = arrayDimensionCount(elemType); i < arrayDimensionCount(javacArrayType); i++) {
       result = new Type.ArrayType(result, javacArrayType.tsym);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -305,6 +305,33 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void multiDimensionalArraySubtypingWithNewExpression() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static void test() {
+                // legal; the nullability of the element type must be preserved across every
+                // dimension of the creation expression
+                @Nullable Integer[][] x1 = new @Nullable Integer[3][4];
+                @Nullable Integer[][][] x2 = new @Nullable Integer[1][2][3];
+                // BUG: Diagnostic contains: incompatible types: @Nullable Integer [] [] cannot be converted to Integer [] []
+                Integer[][] x3 = new @Nullable Integer[3][4];
+                // an array creation with an initializer has no explicit dimension expressions, but
+                // still creates a single-dimension array
+                @Nullable Integer[] x4 = new @Nullable Integer[]{null};
+                // BUG: Diagnostic contains: incompatible types: @Nullable Integer [] cannot be converted to Integer []
+                Integer[] x5 = new @Nullable Integer[]{null};
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void arraysAndGenerics() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
`PreservedAnnotationTreeVisitor.visitNewArray` wraps the element type in a single
array level, so for an array creation with an explicitly annotated element type and
two or more explicit dimensions, the computed type comes out with the wrong rank:

```java
@Nullable Integer[][] x = new @Nullable Integer[3][4];
// [NullAway] incompatible types: @Nullable Integer [] cannot be converted to @Nullable Integer [] []
```

The `@Nullable` is preserved correctly; what is lost is a dimension.
`NewArrayTree.getType()` returns the element type of the innermost dimension only
(`@Nullable Integer` here), so a single wrap is correct only for one-dimensional
creations.

This has two visible effects. An assignment that should be legal is reported as an
error, and a genuine error such as

```java
Integer[][] y = new @Nullable Integer[3][4];
```

is reported with a truncated type in the message (`@Nullable Integer []` rather than
`@Nullable Integer [] []`).

**Fix:** wrap the element type once per array dimension of the type javac computed
for the whole creation expression that is not already present in the element type.
Deriving the count from javac's type rather than from `NewArrayTree.getDimensions()`
also handles the array-initializer form `new @Nullable Integer[]{null}`, which
reaches this visitor with an empty dimension list and must still produce a
one-dimensional array.

Only creations whose element type tree is an `AnnotatedTypeTree` reach this code (see
the guard in `GenericsChecks`). Forms such as `new @Nullable Integer[3][]` and
`new @Nullable Integer[][]{}` fold a bracket pair into the element type tree, so they
bypass this path, take javac's type directly, and were already correct.

Tests are added in `JSpecifyArrayTests#multiDimensionalArraySubtypingWithNewExpression`
covering the two- and three-dimensional cases, the corrected message on the true
positive, and the initializer form as a regression guard.

**Relationship to #1150:** this was found while investigating #1150 but does not fix
it. #1150 concerns covariant assignment at nested dimensions (e.g.
`@Nullable Integer[][] x = someNonNullInteger2DArray`), which lives in
`GenericsChecks#subtypeParameterNullability` and is untouched here. Merging this
first keeps that work from tripping over unrelated rank mismatches in its own test
cases. I plan to follow up with a fix for #1150 next, once this is merged.

**AI usage disclosure**

I used Claude Code to triage open JSpecify-mode issues, reproduce candidates against
master, and diagnose this bug, which surfaced while investigating #1150. It explained
the mechanism and laid out two implementation options; I chose the one used here
(deriving the dimension count from javac's computed type rather than from
`getDimensions()`), and it wrote the diff and the tests. I reviewed every line and
verified the full `:nullaway:test` suite passes locally. I have read and understood
all the changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nullable annotations in multidimensional array creation expressions.
  * Preserved array dimensions and element nullability more accurately during type analysis.
  * Correctly rejects assignments when arrays require non-null elements.
  * Improved support for arrays created with explicit dimensions and array initializers.

* **Tests**
  * Added coverage for multidimensional arrays and initialized arrays using JSpecify annotations.
  * Verified nullable and non-null array assignment behavior across multiple dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->