### PR TITLE
Fix for restoring nullness annotations from unbounded wildcard to captured type

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -448,7 +448,23 @@ public class TypeSubstitutionUtils {
       Type.WildcardType otherWildcard = GenericsUtils.asWildcard(other);
       Type.WildcardType updatedWildcard;
       if (otherWildcard != null) {
-        updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, otherWildcard);
+        if (t.wildcard.kind == BoundKind.EXTENDS && otherWildcard.kind == BoundKind.UNBOUND) {
+          // Substitution can turn the capture's backing wildcard into an explicit extends
+          // wildcard while the corresponding declared wildcard remains unbounded. Its `type`
+          // field is just an Object placeholder; annotations must be restored from the implicit
+          // upper bound of its formal type variable instead.
+          Type.TypeVar formalTypeVariable = otherWildcard.bound;
+          if (formalTypeVariable == null) {
+            return updated;
+          }
+          Type updatedBound = t.wildcard.type.accept(this, formalTypeVariable.getUpperBound());
+          if (updatedBound == t.wildcard.type) {
+            return updated;
+          }
+          updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
+        } else {
+          updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, otherWildcard);
+        }
       } else if (t.wildcard.kind == BoundKind.EXTENDS) {
         Type updatedBound = t.wildcard.type.accept(this, other);
         if (updatedBound == t.wildcard.type) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -550,6 +550,40 @@ public class WildcardTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1715() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface I1<X> {}
+              interface I2<X, Y extends I1<X>> {
+                Y get();
+              }
+              I1<Object> crash(I2<Object, ?> i2) {
+                var i2var = i2;
+                return i2var.get();
+              }
+
+              interface NullableI1<X extends @Nullable Object> {}
+              interface NullableI2<
+                  X extends @Nullable Object, Y extends NullableI1<@Nullable X>> {
+                Y get();
+              }
+              NullableI1<Object> incompatible(NullableI2<Object, ?> i2) {
+                var i2var = i2;
+                // BUG: Diagnostic contains: incompatible types
+                return i2var.get();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void wildcardCaptureLocals() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of wildcard type captures when generic bounds are implicit or unbounded.
  * Prevented incorrect type compatibility results in cases involving dependent generic bounds and nullable types.

* **Tests**
  * Added regression coverage for wildcard capture with generic interfaces and dependent bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->