### PR TITLE
Apply library models to overridden method type when checking overrides

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1228,10 +1228,10 @@ public class NullAway extends BugChecker
             tree.getParameters().stream().map(ASTHelpers::getSymbol).collect(Collectors.toList()),
             funcInterfaceMethod,
             tree,
-            null,
-            null,
+            /* memberReferenceTree= */ null,
+            /* modeledOverriddenMethodType= */ null,
             state,
-            null);
+            /* overridingMethod= */ null);
     if (!description.equals(Description.NO_MATCH)) {
       state.reportMatch(description);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -699,13 +699,18 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol closestOverriddenMethod =
           NullabilityUtil.getClosestOverriddenMethod(methodSymbol, state.getTypes());
       if (closestOverriddenMethod != null) {
+        Type modeledOverriddenMethodType = null;
         if (config.isJSpecifyMode()) {
+          modeledOverriddenMethodType =
+              genericsChecks.getModeledOverriddenMethodType(
+                  methodSymbol, closestOverriddenMethod, state);
           // Check that any generic type parameters in the return type and parameter types are
           // identical (invariant) across the overriding and overridden methods
           genericsChecks.checkTypeParameterNullnessForMethodOverriding(
-              tree, methodSymbol, closestOverriddenMethod, state);
+              tree, methodSymbol, closestOverriddenMethod, modeledOverriddenMethodType, state);
         }
-        return checkOverriding(closestOverriddenMethod, methodSymbol, null, state);
+        return checkOverriding(
+            closestOverriddenMethod, methodSymbol, modeledOverriddenMethodType, null, state);
       }
     }
     return Description.NO_MATCH;
@@ -805,6 +810,8 @@ public class NullAway extends BugChecker
    *     LambdaExpressionTree}; otherwise {@code null}
    * @param memberReferenceTree if the overriding method is a member reference (which "overrides" a
    *     functional interface method), the {@link MemberReferenceTree}; otherwise {@code null}
+   * @param modeledOverriddenMethodType overridden method type after substitution and application of
+   *     library models, for a regular override in JSpecify mode; otherwise {@code null}
    * @param state visitor state
    * @param overridingMethod if available, the symbol for the overriding method
    * @return discovered error, or {@link Description#NO_MATCH} if no error
@@ -814,6 +821,7 @@ public class NullAway extends BugChecker
       Symbol.MethodSymbol overriddenMethod,
       @Nullable LambdaExpressionTree lambdaExpressionTree,
       @Nullable MemberReferenceTree memberReferenceTree,
+      @Nullable Type modeledOverriddenMethodType,
       VisitorState state,
       Symbol.@Nullable MethodSymbol overridingMethod) {
     com.sun.tools.javac.util.List<VarSymbol> superParamSymbols = overriddenMethod.getParameters();
@@ -866,7 +874,15 @@ public class NullAway extends BugChecker
       boolean overriddenMethodIsVarArgs = overriddenMethod.isVarArgs();
       for (int i = 0; i < superParamSymbols.size(); i++) {
         Nullness paramNullness;
-        if (overriddenMethodIsVarArgs && i == superParamSymbols.size() - 1) {
+        Type modeledParameterType =
+            modeledOverriddenMethodType == null
+                ? null
+                : modeledOverriddenMethodType.getParameterTypes().get(i);
+        if (modeledParameterType != null
+            && Nullness.hasNullableAnnotation(
+                modeledParameterType.getAnnotationMirrors().stream(), config)) {
+          paramNullness = Nullness.NULLABLE;
+        } else if (overriddenMethodIsVarArgs && i == superParamSymbols.size() - 1) {
           // For a varargs position, we need to check if the array itself is @Nullable
           paramNullness =
               Nullness.varargsArrayIsNullable(superParamSymbols.get(i), config)
@@ -1213,6 +1229,7 @@ public class NullAway extends BugChecker
             funcInterfaceMethod,
             tree,
             null,
+            null,
             state,
             null);
     if (!description.equals(Description.NO_MATCH)) {
@@ -1252,7 +1269,7 @@ public class NullAway extends BugChecker
     Symbol.MethodSymbol funcInterfaceSymbol =
         NullabilityUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
     handler.onMatchMethodReference(tree, new MethodAnalysisContext(this, state, referencedMethod));
-    return checkOverriding(funcInterfaceSymbol, referencedMethod, tree, state);
+    return checkOverriding(funcInterfaceSymbol, referencedMethod, null, tree, state);
   }
 
   /**
@@ -1261,6 +1278,8 @@ public class NullAway extends BugChecker
    *
    * @param overriddenMethod method being overridden
    * @param overridingMethod overriding method
+   * @param modeledOverriddenMethodType overridden method type after substitution and application of
+   *     library models, for a regular override in JSpecify mode; otherwise {@code null}
    * @param memberReferenceTree if override is via a method reference, the relevant {@link
    *     MemberReferenceTree}; otherwise {@code null}. If non-null, overridingTree is the AST of the
    *     referenced method
@@ -1270,13 +1289,18 @@ public class NullAway extends BugChecker
   private Description checkOverriding(
       Symbol.MethodSymbol overriddenMethod,
       Symbol.MethodSymbol overridingMethod,
+      @Nullable Type modeledOverriddenMethodType,
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
     // if the super method returns nonnull, overriding method better not return nullable
     // Note that, for the overriding method, the permissive default is non-null,
     // but it's nullable for the overridden one.
     if (overriddenMethodReturnsNonNull(
-            overriddenMethod, overridingMethod.owner, memberReferenceTree, state)
+            overriddenMethod,
+            overridingMethod.owner,
+            modeledOverriddenMethodType,
+            memberReferenceTree,
+            state)
         && getMethodReturnNullness(overridingMethod, state, Nullness.NONNULL)
             .equals(Nullness.NULLABLE)
         && (memberReferenceTree == null
@@ -1321,6 +1345,7 @@ public class NullAway extends BugChecker
         overriddenMethod,
         null,
         memberReferenceTree,
+        modeledOverriddenMethodType,
         state,
         overridingMethod);
   }
@@ -1328,8 +1353,16 @@ public class NullAway extends BugChecker
   private boolean overriddenMethodReturnsNonNull(
       Symbol.MethodSymbol overriddenMethod,
       Symbol enclosingSymbol,
+      @Nullable Type modeledOverriddenMethodType,
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
+    if (modeledOverriddenMethodType != null) {
+      Type modeledReturnType = modeledOverriddenMethodType.getReturnType();
+      if (Nullness.hasNullableAnnotation(
+          modeledReturnType.getAnnotationMirrors().stream(), config)) {
+        return false;
+      }
+    }
     Nullness methodReturnNullness =
         getMethodReturnNullness(overriddenMethod, state, Nullness.NULLABLE);
     if (!methodReturnNullness.equals(Nullness.NONNULL)) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2436,10 +2436,11 @@ public final class GenericsChecks {
       Symbol.MethodSymbol overridingMethod,
       Symbol.MethodSymbol overriddenMethod,
       VisitorState state) {
+    Type typeForSymbol = getTypeForSymbol(overridingMethod.owner, state);
     Type substitutedMethodType =
         TypeSubstitutionUtils.memberType(
             state.getTypes(),
-            getTypeForSymbol(overridingMethod.owner, state),
+            typeForSymbol != null ? typeForSymbol : overridingMethod.owner.type,
             overriddenMethod,
             analysis.getConfig());
     Type.MethodType methodType = substitutedMethodType.asMethodType();

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2438,7 +2438,10 @@ public final class GenericsChecks {
       VisitorState state) {
     Type substitutedMethodType =
         TypeSubstitutionUtils.memberType(
-            state.getTypes(), overridingMethod.owner.type, overriddenMethod, analysis.getConfig());
+            state.getTypes(),
+            getTypeForSymbol(overridingMethod.owner, state),
+            overriddenMethod,
+            analysis.getConfig());
     Type.MethodType methodType = substitutedMethodType.asMethodType();
     Type.MethodType modeledMethodType =
         handler.onOverrideMethodType(overriddenMethod, methodType, state, null);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2401,26 +2401,54 @@ public final class GenericsChecks {
    * @param tree A method tree to check
    * @param overridingMethod A symbol of the overriding method
    * @param overriddenMethod A symbol of the overridden method
+   * @param overriddenMethodType type of the overridden method after member-type substitution and
+   *     application of library models
    * @param state the visitor state
    */
   public void checkTypeParameterNullnessForMethodOverriding(
       MethodTree tree,
       Symbol.MethodSymbol overridingMethod,
       Symbol.MethodSymbol overriddenMethod,
+      Type overriddenMethodType,
       VisitorState state) {
     if (!analysis.getConfig().isJSpecifyMode()) {
       return;
     }
-    // Obtain type parameters for the overridden method within the context of the overriding
-    // method's class
-    Type methodWithTypeParams =
+    checkTypeParameterNullnessForOverridingMethodReturnType(tree, overriddenMethodType, state);
+    checkTypeParameterNullnessForOverridingMethodParameterType(tree, overriddenMethodType, state);
+    checkMethodTypeVariableUpperBoundNullnessForOverriding(
+        tree, overridingMethod, overriddenMethod, overriddenMethodType, state);
+  }
+
+  /**
+   * Returns the overridden method type in the overriding class context with library models applied.
+   *
+   * <p>The {@link Type.ForAll} wrapper must be retained for subsequent checks of method type
+   * variable bounds, while handlers operate on its underlying {@link Type.MethodType}.
+   *
+   * @param overridingMethod symbol of the overriding method
+   * @param overriddenMethod symbol of the overridden method
+   * @param state visitor state
+   * @return the substituted, modeled overridden method type
+   */
+  @SuppressWarnings({"ReferenceEquality", "TypeEquals"})
+  public Type getModeledOverriddenMethodType(
+      Symbol.MethodSymbol overridingMethod,
+      Symbol.MethodSymbol overriddenMethod,
+      VisitorState state) {
+    Type substitutedMethodType =
         TypeSubstitutionUtils.memberType(
             state.getTypes(), overridingMethod.owner.type, overriddenMethod, analysis.getConfig());
-
-    checkTypeParameterNullnessForOverridingMethodReturnType(tree, methodWithTypeParams, state);
-    checkTypeParameterNullnessForOverridingMethodParameterType(tree, methodWithTypeParams, state);
-    checkMethodTypeVariableUpperBoundNullnessForOverriding(
-        tree, overridingMethod, overriddenMethod, methodWithTypeParams, state);
+    Type.MethodType methodType = substitutedMethodType.asMethodType();
+    Type.MethodType modeledMethodType =
+        handler.onOverrideMethodType(overriddenMethod, methodType, state, null);
+    if (modeledMethodType == methodType) {
+      return substitutedMethodType;
+    }
+    if (substitutedMethodType instanceof Type.ForAll forAll) {
+      return new Type.ForAll(forAll.tvars, modeledMethodType);
+    }
+    return modeledMethodType;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -1890,8 +1890,6 @@ public class LibraryModelsHandler implements Handler {
           for (Map.Entry<Integer, Set<String>> entry : innerEntry.getValue().entrySet()) {
             Integer index = entry.getKey();
             if (index >= 0 && entry.getValue().stream().anyMatch(a -> a.contains("Nullable"))) {
-              // remove spaces after commas
-              methodNameAndSignature = methodNameAndSignature.replaceAll(",\\s", ",");
               mapBuilder.put(methodRef(className, methodNameAndSignature), index);
             }
           }
@@ -1921,8 +1919,6 @@ public class LibraryModelsHandler implements Handler {
                           + methodEntry.getKey()
                           + " arg "
                           + argEntry.getKey());
-                  // remove spaces after commas
-                  methodNameAndSignature = methodNameAndSignature.replaceAll(",\\s", ",");
                   mapBuilder.put(methodRef(className, methodNameAndSignature), index);
                 }
               }
@@ -1937,7 +1933,9 @@ public class LibraryModelsHandler implements Handler {
       int openParenIndex = methodInfo.indexOf('(');
       Verify.verify(openParenIndex != -1, "Malformed method info: %s", methodInfo);
       int methodNameIndex = methodInfo.lastIndexOf(' ', openParenIndex) + 1;
-      return methodInfo.substring(methodNameIndex);
+      // MethodRef signatures omit spaces after commas, but spaces in wildcard bounds (for example,
+      // "? super T") are significant and must be preserved.
+      return methodInfo.substring(methodNameIndex).replaceAll(",\\s", ",");
     }
 
     @Override
@@ -1968,7 +1966,6 @@ public class LibraryModelsHandler implements Handler {
               Set<String> annotations = argEntry.getValue();
               if (annotations.contains("javax.annotation.Nullable")
                   || annotations.contains("org.jspecify.annotations.Nullable")) {
-                methodNameAndSignature = methodNameAndSignature.replaceAll("\\s", "");
                 builder.add(methodRef(className, methodNameAndSignature));
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -211,6 +211,82 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void mapComputeOverrideUsesJSpecifyModel() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Map;
+            import java.util.function.BiFunction;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            abstract class Test implements Map<String, String> {
+              static void callSite(
+                  Map<String, String> map,
+                  BiFunction<String, @Nullable String, @Nullable String> remappingFunction) {
+                map.compute("key", remappingFunction);
+              }
+              @Override
+              public @Nullable String compute(
+                  String key,
+                  BiFunction<
+                          ? super String,
+                          ? super @Nullable String,
+                          ? extends @Nullable String>
+                      remappingFunction) {
+                return null;
+              }
+            }
+            @NullMarked
+            abstract class InvalidTest implements Map<String, String> {
+              @Override
+              public @Nullable String compute(
+                  String key,
+                  BiFunction<? super String, ? super String, ? extends String>
+                      // BUG: Diagnostic contains: Parameter has type BiFunction<? super String, ? super String, ? extends String>, but overridden method has parameter type BiFunction<? super String, ? super @Nullable String, ? extends @Nullable String>
+                      remappingFunction) {
+                return null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void modeledMethodTypeVariableBoundUsedForOverride() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.io.IOException;
+            import java.net.ServerSocket;
+            import java.net.SocketOption;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class ValidOverride extends ServerSocket {
+              ValidOverride() throws IOException {}
+              @Override
+              public <T extends @Nullable Object> ServerSocket setOption(
+                  SocketOption<T> name, T value) throws IOException {
+                return this;
+              }
+            }
+            @NullMarked
+            class InvalidOverride extends ServerSocket {
+              InvalidOverride() throws IOException {}
+              @Override
+              // BUG: Diagnostic contains: Method type variable T has a non-null upper bound
+              public <T> ServerSocket setOption(SocketOption<T> name, T value) throws IOException {
+                return this;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=true")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1617,6 +1617,41 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void overrideExplicitlyTypedAnonymousClassWithNestedGenericTypes() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              interface Foo<T extends @Nullable Object> {
+                List<T> get();
+                void accept(List<T> values);
+              }
+              static void test() {
+                Foo<@Nullable String> foo = new Foo<@Nullable String>() {
+                  @Override
+                  public List<@Nullable String> get() { throw new AssertionError(); }
+                  @Override
+                  public void accept(List<@Nullable String> values) {}
+                };
+                Foo<@Nullable String> badFoo = new Foo<@Nullable String>() {
+                  @Override
+                  // BUG: Diagnostic contains: mismatched type parameter nullability
+                  public List<String> get() { throw new AssertionError(); }
+                  @Override
+                  // BUG: Diagnostic contains: mismatched type parameter nullability
+                  public void accept(List<String> values) {}
+                };
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void overrideAnonymousNestedClass() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1718 

We were missing a case where we needed to apply the handler in order to apply library models to the overridden method type when checking for overrides.  We also weren't parsing `@Nullable` return types correctly in `LibraryModelsHandler` for astubx models when the signature contained an explicit wildcard bound; fix that parsing as well and consolidate the logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability validation for methods overriding JSpecify-modeled APIs.
  * Correctly accounts for modeled parameter and return nullability, including substituted generic types and nested generics.
  * Improved handling of library model signatures with wildcard bounds and formatting variations.

* **Tests**
  * Added coverage for valid and invalid overrides involving modeled JDK methods, nullable function parameters, type-variable bounds, and explicitly typed anonymous classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->