### PR TITLE
Fix attribute errors reported during dataflow

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -59,6 +59,7 @@ import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.EnhancedForLoopTree;
@@ -188,7 +189,8 @@ public class NullAway extends BugChecker
         BugChecker.TypeCastTreeMatcher,
         BugChecker.ParameterizedTypeTreeMatcher,
         BugChecker.AnnotatedTypeTreeMatcher,
-        BugChecker.SynchronizedTreeMatcher {
+        BugChecker.SynchronizedTreeMatcher,
+        BugChecker.CompilationUnitTreeMatcher {
 
   static final String INITIALIZATION_CHECK_NAME = "NullAway.Init";
   static final String OPTIONAL_CHECK_NAME = "NullAway.Optional";
@@ -1840,6 +1842,15 @@ public class NullAway extends BugChecker
         || (nullMarkingForTopLevelClass == NullMarking.FULLY_MARKED
             && hasDirectAnnotationWithSimpleName(
                 classSymbol, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME));
+  }
+
+  @Override
+  public Description matchCompilationUnit(
+      CompilationUnitTree tree, VisitorState stateForNewCompilationUnit) {
+
+    getNullnessAnalysis(stateForNewCompilationUnit)
+        .updateForNewCompilationUnit(stateForNewCompilationUnit);
+    return Description.NO_MATCH;
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1847,7 +1847,6 @@ public class NullAway extends BugChecker
   @Override
   public Description matchCompilationUnit(
       CompilationUnitTree tree, VisitorState stateForNewCompilationUnit) {
-
     getNullnessAnalysis(stateForNewCompilationUnit)
         .updateForNewCompilationUnit(stateForNewCompilationUnit);
     return Description.NO_MATCH;

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1844,6 +1844,14 @@ public class NullAway extends BugChecker
                 classSymbol, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME));
   }
 
+  /**
+   * Performs any state updates required before checking a new compilation unit. Does not report any
+   * warnings directly.
+   *
+   * @param tree the {@link CompilationUnitTree}
+   * @param stateForNewCompilationUnit the {@link VisitorState} for the new compilation unit
+   * @return {@link Description#NO_MATCH}
+   */
   @Override
   public Description matchCompilationUnit(
       CompilationUnitTree tree, VisitorState stateForNewCompilationUnit) {

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -459,4 +459,19 @@ public final class AccessPathNullnessAnalysis {
         leaf.getClass().getName());
     return dataFlow.isRunning(path, context, nullnessPropagation);
   }
+
+  /**
+   * Updates any stored {@link VisitorState} objects to account for the fact that we are checking a
+   * new compilation unit. Required since {@link VisitorState} objects internally contain a {@link
+   * com.google.errorprone.DescriptionListener} tied to a compilation unit that cannot be updated
+   * via public APIs.
+   *
+   * @param state the new visitor state
+   */
+  public void updateForNewCompilationUnit(VisitorState state) {
+    nullnessPropagation.updateForNewCompilationUnit(state);
+    if (contractNullnessPropagation != null) {
+      contractNullnessPropagation.updateForNewCompilationUnit(state);
+    }
+  }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -163,7 +163,7 @@ public class AccessPathNullnessPropagation
 
   private final Predicate<MethodInvocationNode> methodReturnsNonNull;
 
-  private final VisitorState state;
+  private VisitorState state;
 
   private final AccessPath.AccessPathContext apContext;
 
@@ -174,6 +174,20 @@ public class AccessPathNullnessPropagation
   private final GenericsChecks genericsChecks;
 
   private final NullnessStoreInitializer nullnessStoreInitializer;
+
+  /**
+   * Updates the stored {@link VisitorState} to account for the fact that we are checking a new
+   * compilation unit. Required since {@link VisitorState} objects internally contain a {@link
+   * com.google.errorprone.DescriptionListener} tied to a compilation unit that cannot be updated
+   * via public APIs.
+   *
+   * @param stateForNewCompilationUnit the new visitor state
+   */
+  public void updateForNewCompilationUnit(VisitorState stateForNewCompilationUnit) {
+    this.state =
+        stateForNewCompilationUnit.withPath(
+            new FailingTreePath(stateForNewCompilationUnit.getPath().getCompilationUnit()));
+  }
 
   /**
    * A stub {@link TreePath} implementation where every method fails immediately. Used to ensure the

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -2122,7 +2122,6 @@ public class GenericMethodTests extends NullAwayTestsBase {
    * unit that happened to create the dataflow analysis; see
    * https://github.com/uber/NullAway/issues/1725
    */
-  @Ignore("to be fixed in a follow up")
   @Test
   public void inferenceFailureReportedInFileWithCall() {
     makeHelper()
@@ -2153,7 +2152,6 @@ public class GenericMethodTests extends NullAwayTestsBase {
    * raises: no other pass reports it, so the misattributed diagnostic is the whole NullAway output
    * of the build; see https://github.com/uber/NullAway/issues/1733
    */
-  @Ignore("to be fixed in a follow up")
   @Test
   public void inferenceFailureFromDataflowReportedInFileWithCall() {
     makeHelper()
@@ -2190,7 +2188,6 @@ public class GenericMethodTests extends NullAwayTestsBase {
    * function of the contract-checking analysis, which is a second instance carrying its own {@link
    * com.google.errorprone.VisitorState} and needs the same update.
    */
-  @Ignore("to be fixed in a follow up")
   @Test
   public void inferenceFailureFromContractDataflowReportedInFileWithCall() {
     makeTestHelperWithArgs(


### PR DESCRIPTION
Refresh the state used by cached dataflow analyses for each compilation unit so diagnostics are attributed to the file containing the failing call. Apply the same update to contract-checking dataflow and enable the associated regression tests.

Fixes #1733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis consistency when processing multiple source files in a single compilation.
  * Restored accurate inference diagnostics across files, including dataflow and contract-based analysis.
  * Improved reliability when carrying nullness information between source files.

* **Tests**
  * Re-enabled regression tests covering inference failures reported from files containing method calls.
  * Expanded coverage for dataflow- and contract-based inference diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->