### PR TITLE
Check nested nullness for functional interface implementations

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -840,6 +840,7 @@ public class NullAway extends BugChecker
     // signature in error messages.  Remains null for a regular (non-generic-interface) override.
     ExpressionTree functionalInterfaceImplementation = null;
     Type functionalInterfaceType = null;
+    Type.MethodType functionalInterfaceMethodType = null;
     if (memberReferenceTree != null || lambdaExpressionTree != null) {
       functionalInterfaceImplementation =
           castToNonNull(memberReferenceTree != null ? memberReferenceTree : lambdaExpressionTree);
@@ -847,6 +848,13 @@ public class NullAway extends BugChecker
           genericsChecks.getInferredPolyExpressionType(functionalInterfaceImplementation);
       if (functionalInterfaceType == null) {
         functionalInterfaceType = ASTHelpers.getType(functionalInterfaceImplementation);
+      }
+      if (config.isJSpecifyMode()) {
+        functionalInterfaceMethodType =
+            modeledOverriddenMethodType != null
+                ? modeledOverriddenMethodType.asMethodType()
+                : genericsChecks.getFunctionalInterfaceMethodType(
+                    functionalInterfaceImplementation, state);
       }
     }
 
@@ -856,10 +864,10 @@ public class NullAway extends BugChecker
     MethodParameterNullness referencedMethodParameterNullnessOverrides = null;
     if (memberReferenceTree != null) {
       Symbol.MethodSymbol referencedMethod = castToNonNull(overridingMethod);
-      if (functionalInterfaceType != null) {
+      if (functionalInterfaceMethodType != null) {
         GenericsChecks.ResolvedMethodReference resolvedMethodReference =
             genericsChecks.resolveMemberReference(
-                memberReferenceTree, referencedMethod, functionalInterfaceType, state);
+                memberReferenceTree, referencedMethod, functionalInterfaceMethodType, state);
         if (resolvedMethodReference != null) {
           jspecifyMemberReferenceMethodType = resolvedMethodReference.methodType();
         }
@@ -1024,16 +1032,9 @@ public class NullAway extends BugChecker
             paramSymbol);
       }
     }
-    if (config.isJSpecifyMode() && functionalInterfaceImplementation != null) {
-      Type.MethodType functionalInterfaceMethodType =
-          modeledOverriddenMethodType != null
-              ? modeledOverriddenMethodType.asMethodType()
-              : genericsChecks.getFunctionalInterfaceMethodType(
-                  functionalInterfaceImplementation, state);
-      if (functionalInterfaceMethodType != null) {
-        genericsChecks.checkTypeParameterNullnessForFunctionalInterfaceImplementation(
-            functionalInterfaceImplementation, functionalInterfaceMethodType, state);
-      }
+    if (functionalInterfaceImplementation != null && functionalInterfaceMethodType != null) {
+      genericsChecks.checkTypeParameterNullnessForFunctionalInterfaceImplementation(
+          functionalInterfaceImplementation, functionalInterfaceMethodType, state);
     }
     return Description.NO_MATCH;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -838,13 +838,15 @@ public class NullAway extends BugChecker
     // tree, falling back on the type inferred by javac.  Used both to compute parameter
     // nullability below and to pretty-print the functional interface method's substituted
     // signature in error messages.  Remains null for a regular (non-generic-interface) override.
+    ExpressionTree functionalInterfaceImplementation = null;
     Type functionalInterfaceType = null;
     if (memberReferenceTree != null || lambdaExpressionTree != null) {
-      Tree polyExprTree =
+      functionalInterfaceImplementation =
           castToNonNull(memberReferenceTree != null ? memberReferenceTree : lambdaExpressionTree);
-      functionalInterfaceType = genericsChecks.getInferredPolyExpressionType(polyExprTree);
+      functionalInterfaceType =
+          genericsChecks.getInferredPolyExpressionType(functionalInterfaceImplementation);
       if (functionalInterfaceType == null) {
-        functionalInterfaceType = ASTHelpers.getType(polyExprTree);
+        functionalInterfaceType = ASTHelpers.getType(functionalInterfaceImplementation);
       }
     }
 
@@ -1022,6 +1024,17 @@ public class NullAway extends BugChecker
             paramSymbol);
       }
     }
+    if (config.isJSpecifyMode() && functionalInterfaceImplementation != null) {
+      Type.MethodType functionalInterfaceMethodType =
+          modeledOverriddenMethodType != null
+              ? modeledOverriddenMethodType.asMethodType()
+              : genericsChecks.getFunctionalInterfaceMethodType(
+                  functionalInterfaceImplementation, state);
+      if (functionalInterfaceMethodType != null) {
+        genericsChecks.checkTypeParameterNullnessForFunctionalInterfaceImplementation(
+            functionalInterfaceImplementation, functionalInterfaceMethodType, state);
+      }
+    }
     return Description.NO_MATCH;
   }
 
@@ -1167,6 +1180,13 @@ public class NullAway extends BugChecker
       Tree errorTree,
       VisitorState state) {
     Type returnType = methodSymbol.getReturnType();
+    if (config.isJSpecifyMode() && lambdaTree != null) {
+      Type.MethodType functionalInterfaceMethodType =
+          genericsChecks.getFunctionalInterfaceMethodType(lambdaTree, state);
+      if (functionalInterfaceMethodType != null) {
+        returnType = functionalInterfaceMethodType.getReturnType();
+      }
+    }
     if (returnType.isPrimitive()) {
       // check for unboxing
       doUnboxingCheck(state, retExpr);
@@ -1181,7 +1201,7 @@ public class NullAway extends BugChecker
 
     // Check generic type arguments for returned expression here, since we need to check the type
     // arguments regardless of the top-level nullability of the return type
-    genericsChecks.checkTypeParameterNullnessForFunctionReturnType(retExpr, methodSymbol, state);
+    genericsChecks.checkTypeParameterNullnessForFunctionReturnType(retExpr, returnType, state);
 
     // Now, perform the check for returning @Nullable from @NonNull.  First, we check if the return
     // type is @Nullable, and if so, bail out.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -40,7 +40,6 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.TargetType;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.util.Name;
@@ -138,6 +137,39 @@ public final class GenericsChecks {
         "Expected lambda or method reference tree but got: %s",
         tree.getKind());
     return inferredPolyExpressionTypes.get(tree);
+  }
+
+  /**
+   * Returns the functional-interface method type for a poly expression after target-type
+   * substitution.
+   *
+   * @param polyExpressionTree lambda or method-reference tree
+   * @param state visitor state
+   * @return the method type, or {@code null} if the expression's target type is unavailable or raw
+   */
+  public Type.@Nullable MethodType getFunctionalInterfaceMethodType(
+      ExpressionTree polyExpressionTree, VisitorState state) {
+    Type functionalInterfaceType = getInferredPolyExpressionType(polyExpressionTree);
+    if (functionalInterfaceType == null) {
+      functionalInterfaceType = ASTHelpers.getType(polyExpressionTree);
+    }
+    if (functionalInterfaceType == null || functionalInterfaceType.isRaw()) {
+      return null;
+    }
+    return getFunctionalInterfaceMethodType(functionalInterfaceType, polyExpressionTree, state);
+  }
+
+  /** Returns a functional-interface method type as a member of {@code functionalInterfaceType}. */
+  private Type.MethodType getFunctionalInterfaceMethodType(
+      Type functionalInterfaceType,
+      ExpressionTree functionalInterfaceImplementation,
+      VisitorState state) {
+    Symbol.MethodSymbol functionalInterfaceMethod =
+        NullabilityUtil.getFunctionalInterfaceMethod(
+            functionalInterfaceImplementation, state.getTypes());
+    return TypeSubstitutionUtils.memberType(
+            state.getTypes(), functionalInterfaceType, functionalInterfaceMethod, config)
+        .asMethodType();
   }
 
   /**
@@ -676,6 +708,54 @@ public final class GenericsChecks {
             errorMessage, analysis.buildDescription(memberReferenceTree), state, null));
   }
 
+  /**
+   * Checks nested nullability for a lambda or method reference against its substituted
+   * functional-interface method type.
+   *
+   * <p>Lambda return expressions are checked separately as they are visited; this method checks
+   * explicitly typed lambda parameters. For method references, it checks both parameter and return
+   * type relations.
+   *
+   * @param functionalInterfaceImplementation lambda or method reference being checked
+   * @param functionalInterfaceMethodType substituted functional-interface method type
+   * @param state visitor state
+   */
+  public void checkTypeParameterNullnessForFunctionalInterfaceImplementation(
+      Tree functionalInterfaceImplementation,
+      Type.MethodType functionalInterfaceMethodType,
+      VisitorState state) {
+    if (!config.isJSpecifyMode()) {
+      return;
+    }
+    if (functionalInterfaceImplementation instanceof LambdaExpressionTree lambdaExpressionTree) {
+      checkTypeParameterNullnessForOverridingParameters(
+          lambdaExpressionTree.getParameters(), functionalInterfaceMethodType, true, state);
+      return;
+    }
+    Verify.verify(
+        functionalInterfaceImplementation instanceof MemberReferenceTree,
+        "Expected lambda or method reference, got %s",
+        functionalInterfaceImplementation.getKind());
+    MemberReferenceTree memberReferenceTree =
+        (MemberReferenceTree) functionalInterfaceImplementation;
+    GenericsUtils.processMethodRefTypeRelations(
+        this,
+        functionalInterfaceMethodType,
+        memberReferenceTree,
+        state,
+        (subtype, supertype, relationKind) -> {
+          if (!subtypeParameterNullability(supertype, subtype, state)) {
+            if (relationKind == MethodRefTypeRelationKind.RETURN) {
+              reportInvalidMethodReferenceReturnTypeError(
+                  memberReferenceTree, supertype, subtype, state);
+            } else {
+              reportInvalidMethodReferenceParameterTypeError(
+                  memberReferenceTree, subtype, supertype, state);
+            }
+          }
+        });
+  }
+
   private void reportInvalidOverridingMethodReturnTypeError(
       Tree methodTree,
       Type overriddenMethodReturnType,
@@ -953,15 +1033,8 @@ public final class GenericsChecks {
               VariableTree param = params.get(i);
               Symbol paramSymbol = ASTHelpers.getSymbol(param);
               if (paramSymbol != null && paramSymbol.equals(symbol)) {
-                // get the type of the functional interface method as a member of the inferred type
-                // of the lambda
-                Types types = state.getTypes();
-                var fiMethodType =
-                    TypeSubstitutionUtils.memberType(
-                        types,
-                        inferredLambdaType,
-                        NullabilityUtil.getFunctionalInterfaceMethod(lambdaTree, types),
-                        config);
+                Type.MethodType fiMethodType =
+                    getFunctionalInterfaceMethodType(inferredLambdaType, lambdaTree, state);
                 return fiMethodType.getParameterTypes().get(i);
               }
             }
@@ -1674,9 +1747,14 @@ public final class GenericsChecks {
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
     Type groundTargetType = GenericsUtils.groundTargetType(lhsType, state, config, handler);
+    if (groundTargetType.isRaw()) {
+      return;
+    }
+    Type.MethodType functionalInterfaceMethodType =
+        getFunctionalInterfaceMethodType(groundTargetType, memberReferenceTree, state);
     GenericsUtils.processMethodRefTypeRelations(
         this,
-        groundTargetType,
+        functionalInterfaceMethodType,
         memberReferenceTree,
         state,
         (subtype, supertype, unused) -> {
@@ -1708,6 +1786,22 @@ public final class GenericsChecks {
       return null;
     }
     Type groundTargetType = GenericsUtils.groundTargetType(targetType, state, config, handler);
+    return resolveMemberReference(
+        memberReferenceTree,
+        referencedMethod,
+        getFunctionalInterfaceMethodType(groundTargetType, memberReferenceTree, state),
+        state);
+  }
+
+  /** Resolves a method reference using the substituted functional-interface method type. */
+  public @Nullable ResolvedMethodReference resolveMemberReference(
+      MemberReferenceTree memberReferenceTree,
+      Symbol.MethodSymbol referencedMethod,
+      Type.MethodType fiMethodTypeAsMember,
+      VisitorState state) {
+    if (!config.isJSpecifyMode() || referencedMethod.isConstructor()) {
+      return null;
+    }
     Type qualifierType = null;
     if (!referencedMethod.isStatic()) {
       ExpressionTree qualifierExpression = memberReferenceTree.getQualifierExpression();
@@ -1723,11 +1817,6 @@ public final class GenericsChecks {
           qualifierType = referencedMethod.owner.type;
         }
         if (qualifierType instanceof Type.ClassType qualifierClassType) {
-          Symbol.MethodSymbol fiMethod =
-              NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, state.getTypes());
-          Type.MethodType fiMethodTypeAsMember =
-              TypeSubstitutionUtils.memberType(state.getTypes(), groundTargetType, fiMethod, config)
-                  .asMethodType();
           com.sun.tools.javac.util.List<Type> fiParamTypes =
               fiMethodTypeAsMember.getParameterTypes();
           Verify.verify(
@@ -2022,21 +2111,19 @@ public final class GenericsChecks {
   }
 
   /**
-   * Checks that the nullability of type parameters for a returned expression matches that of the
-   * type parameters of the enclosing method's return type.
+   * Checks that nested nullability in a returned expression is compatible with a supplied formal
+   * return type.
    *
-   * @param retExpr the returned expression
-   * @param methodSymbol symbol for enclosing method
-   * @param state the visitor state
+   * @param retExpr returned expression
+   * @param formalReturnType effective formal return type, including substitutions
+   * @param state visitor state
    */
   public void checkTypeParameterNullnessForFunctionReturnType(
-      ExpressionTree retExpr, Symbol.MethodSymbol methodSymbol, VisitorState state) {
+      ExpressionTree retExpr, Type formalReturnType, VisitorState state) {
     Config config = analysis.getConfig();
     if (!config.isJSpecifyMode()) {
       return;
     }
-
-    Type formalReturnType = methodSymbol.getReturnType();
     if (formalReturnType.isRaw()) {
       // bail out of any checking involving raw types for now
       return;
@@ -2504,31 +2591,13 @@ public final class GenericsChecks {
                   NullabilityUtil.stripParensAndUpdateTreePath(
                       currentActualParam, state.withPath(pathToParam));
               ExpressionTree actualParameterWithoutParentheses = actualParameterAndState.expr();
-              if (actualParameterWithoutParentheses
-                  instanceof MemberReferenceTree memberReferenceTree) {
-                Type groundFormalParameter =
-                    GenericsUtils.groundTargetType(formalParameter, state, config, handler);
-                // the type of the method reference tree provided by javac may not capture
-                // nullability of nested types. So, do explicit type checks based on the return and
-                // parameter types of the referenced method
-                GenericsUtils.processMethodRefTypeRelations(
-                    this,
-                    groundFormalParameter,
-                    memberReferenceTree,
-                    actualParameterAndState.state(),
-                    (subtype, supertype, relationKind) -> {
-                      if (!subtypeParameterNullability(supertype, subtype, state)) {
-                        if (relationKind == MethodRefTypeRelationKind.RETURN) {
-                          reportInvalidMethodReferenceReturnTypeError(
-                              memberReferenceTree, supertype, subtype, state);
-                        } else {
-                          reportInvalidMethodReferenceParameterTypeError(
-                              memberReferenceTree, subtype, supertype, state);
-                        }
-                      }
-                    });
+              if (actualParameterWithoutParentheses instanceof MemberReferenceTree) {
+                // The member-reference matcher performs the explicit nested parameter and return
+                // checks. Store its target type here so that matcher sees the final call-site type.
                 maybeStorePolyExpressionTypeFromTarget(
-                    actualParameterWithoutParentheses, formalParameter, state);
+                    actualParameterWithoutParentheses,
+                    formalParameter,
+                    actualParameterAndState.state());
                 return;
               }
 
@@ -3507,17 +3576,31 @@ public final class GenericsChecks {
    */
   private void checkTypeParameterNullnessForOverridingMethodParameterType(
       MethodTree tree, Type overriddenMethodType, VisitorState state) {
-    List<? extends VariableTree> methodParameters = tree.getParameters();
+    checkTypeParameterNullnessForOverridingParameters(
+        tree.getParameters(), overriddenMethodType, false, state);
+  }
+
+  /** Checks nested nullability compatibility for overriding parameter declarations. */
+  private void checkTypeParameterNullnessForOverridingParameters(
+      List<? extends VariableTree> overridingParameters,
+      Type overriddenMethodType,
+      boolean skipImplicitLambdaParameters,
+      VisitorState state) {
     List<Type> overriddenMethodParameterTypes = overriddenMethodType.getParameterTypes();
-    for (int i = 0; i < methodParameters.size(); i++) {
-      Type overridingMethodParameterType = getTreeType(methodParameters.get(i), state);
+    for (int i = 0; i < overridingParameters.size(); i++) {
+      VariableTree overridingParameter = overridingParameters.get(i);
+      if (skipImplicitLambdaParameters
+          && NullabilityUtil.lambdaParamIsImplicitlyTyped(overridingParameter)) {
+        continue;
+      }
+      Type overridingMethodParameterType = getTreeType(overridingParameter, state);
       Type overriddenMethodParameterType = overriddenMethodParameterTypes.get(i);
       if (overridingMethodParameterType != null) {
         // allow contravariant subtyping
         if (!subtypeParameterNullability(
             overridingMethodParameterType, overriddenMethodParameterType, state)) {
           reportInvalidOverridingMethodParamTypeError(
-              methodParameters.get(i),
+              overridingParameter,
               overriddenMethodParameterType,
               overridingMethodParameterType,
               state);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -19,7 +19,6 @@ import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
 import com.uber.nullaway.CodeAnnotationInfo;
 import com.uber.nullaway.Config;
-import com.uber.nullaway.NullabilityUtil;
 import com.uber.nullaway.Nullness;
 import com.uber.nullaway.handlers.Handler;
 import javax.lang.model.element.Element;
@@ -234,9 +233,9 @@ public class GenericsUtils {
   }
 
   /**
-   * Handler for method reference type relations, used by {{@link
-   * #processMethodRefTypeRelations(GenericsChecks, Type, MemberReferenceTree, VisitorState,
-   * MethodRefTypeRelationHandler)}}
+   * Handler for method reference type relations, used by {@link
+   * #processMethodRefTypeRelations(GenericsChecks, Type.MethodType, MemberReferenceTree,
+   * VisitorState, MethodRefTypeRelationHandler)}.
    */
   @FunctionalInterface
   interface MethodRefTypeRelationHandler {
@@ -244,12 +243,12 @@ public class GenericsUtils {
   }
 
   /**
-   * Utility method to process relationships between return types and corresponding parameter types
-   * for a method reference and the functional interface method it is being assigned to. Handles
-   * unbound method references and varargs.
+   * Processes relationships between return types and corresponding parameter types for a method
+   * reference and the functional interface method it is being assigned to. Handles unbound method
+   * references and varargs.
    *
    * @param genericsChecks generics checks object
-   * @param targetType type to which method reference is being assigned
+   * @param fiMethodTypeAsMember substituted functional-interface method type
    * @param memberReferenceTree the method reference tree
    * @param state visitor state whose current path ends at {@code memberReferenceTree}
    * @param relationHandler handler to invoke for each type relation
@@ -257,7 +256,7 @@ public class GenericsUtils {
   @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
   static void processMethodRefTypeRelations(
       GenericsChecks genericsChecks,
-      Type targetType,
+      Type.MethodType fiMethodTypeAsMember,
       MemberReferenceTree memberReferenceTree,
       VisitorState state,
       MethodRefTypeRelationHandler relationHandler) {
@@ -266,9 +265,6 @@ public class GenericsUtils {
         "Expected current path to end at member reference %s, but found %s",
         memberReferenceTree,
         state.getPath().getLeaf());
-    if (targetType.isRaw()) {
-      return;
-    }
     Types types = state.getTypes();
 
     // First, resolve the referenced method and its qualifier type.
@@ -280,19 +276,13 @@ public class GenericsUtils {
     }
     GenericsChecks.ResolvedMethodReference resolvedMethodReference =
         genericsChecks.resolveMemberReference(
-            memberReferenceTree, referencedMethod, targetType, state);
+            memberReferenceTree, referencedMethod, fiMethodTypeAsMember, state);
     if (resolvedMethodReference == null) {
       return;
     }
     Type qualifierType = resolvedMethodReference.qualifierType();
     Type.MethodType referencedMethodType = resolvedMethodReference.methodType();
 
-    // Get the type of the corresponding functional interface method as a member of targetType.
-    Symbol.MethodSymbol fiMethod =
-        NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, types);
-    Type.MethodType fiMethodTypeAsMember =
-        TypeSubstitutionUtils.memberType(types, targetType, fiMethod, genericsChecks.getConfig())
-            .asMethodType();
     com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
     boolean unbound = ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
 

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -986,6 +986,39 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void unboundMethodReferenceUsesReceiverTypeArguments() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                @Nullable T get() {
+                  return null;
+                }
+                List<T> getAll() {
+                  throw new UnsupportedOperationException();
+                }
+              }
+
+              Function<Box<@Nullable String>, @Nullable String> lambda = box -> box.get();
+              Function<Box<@Nullable String>, @Nullable String> getter = Box::get;
+              Function<Box<@Nullable String>, List<@Nullable String>> getAll = Box::getAll;
+              Function<Box<@Nullable String>, @Nullable String> explicitGetter =
+                  // BUG: Diagnostic contains: parameter type of referenced method is Box<String>
+                  Box<String>::get;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void rawFunctionalInterfaceImplementationSkipsNestedNullnessChecks() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -929,6 +929,87 @@ public class GenericsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void functionalInterfaceImplementationChecksNestedNullness() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Consumer<T extends @Nullable Object> {
+                void accept(T value);
+              }
+              interface Provider<T extends @Nullable Object> {
+                T get();
+              }
+
+              static void consumeNonNullElements(Object @Nullable [] values) {}
+              static void consumeNullableElements(@Nullable Object @Nullable [] values) {}
+              static Object @Nullable [] provideNonNullElements() {
+                return new Object[0];
+              }
+              static @Nullable Object @Nullable [] provideNullableElements() {
+                return null;
+              }
+
+              void test() {
+                Consumer<@Nullable Object @Nullable []> badLambdaParameter =
+                    // BUG: Diagnostic contains: mismatched type parameter nullability
+                    (Object @Nullable [] values) -> {};
+                Consumer<@Nullable Object @Nullable []> safeLambdaParameter =
+                    (@Nullable Object @Nullable [] values) -> {};
+
+                Consumer<@Nullable Object @Nullable []> badMethodReferenceParameter =
+                    // BUG: Diagnostic contains: mismatched type parameter nullability
+                    Test::consumeNonNullElements;
+                Consumer<@Nullable Object @Nullable []> safeMethodReferenceParameter =
+                    Test::consumeNullableElements;
+
+                Provider<Object @Nullable []> badLambdaReturn =
+                    // BUG: Diagnostic contains: incompatible types
+                    () -> provideNullableElements();
+                Provider<Object @Nullable []> safeLambdaReturn =
+                    () -> provideNonNullElements();
+
+                Provider<Object @Nullable []> badMethodReferenceReturn =
+                    // BUG: Diagnostic contains: mismatched type parameter nullability
+                    Test::provideNullableElements;
+                Provider<Object @Nullable []> safeMethodReferenceReturn =
+                    Test::provideNonNullElements;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void rawFunctionalInterfaceImplementationSkipsNestedNullnessChecks() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              interface Consumer<T extends @Nullable Object> {
+                void accept(Box<T> value);
+              }
+              static void consumeNullable(Box<@Nullable Object> value) {}
+
+              @SuppressWarnings("rawtypes")
+              Consumer rawConsumer = Test::consumeNullable;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void testForDiamondInAnAssignment() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
This closes an important gap in checking, but it causes new errors, and we have other high-priority issues to fix, so going to hold off on landing for a bit