### PR TITLE
Preserve nested nullness annotations through inheritance

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -176,6 +176,10 @@ def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     classpath = configurations.errorProneOldest + testTask.classpath
 
     testClassesDirs = testTask.testClassesDirs
+    filter {
+        // Error Prone 2.36.0 loses a nullness annotation on an intersection cast in this test.
+        excludeTestsMatching "com.uber.nullaway.jspecify.GenericsTests.intersectionTypeInvalidAssign"
+    }
 
     jvmArgs += [
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -176,10 +176,6 @@ def epOldestTest = tasks.register("testErrorProneOldest", Test) {
     classpath = configurations.errorProneOldest + testTask.classpath
 
     testClassesDirs = testTask.testClassesDirs
-    filter {
-        // Error Prone 2.36.0 loses a nullness annotation on an intersection cast in this test.
-        excludeTestsMatching "com.uber.nullaway.jspecify.GenericsTests.intersectionTypeInvalidAssign"
-    }
 
     jvmArgs += [
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ClassDeclarationNullnessAnnotUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ClassDeclarationNullnessAnnotUtils.java
@@ -1,8 +1,5 @@
 package com.uber.nullaway.generics;
 
-import static com.uber.nullaway.Nullness.isNonNullAnnotation;
-import static com.uber.nullaway.Nullness.isNullableAnnotation;
-
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
@@ -10,13 +7,9 @@ import com.uber.nullaway.Config;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,42 +19,46 @@ import org.jspecify.annotations.Nullable;
 public class ClassDeclarationNullnessAnnotUtils {
 
   /**
-   * Given a type {@code t} and a method symbol {@code method}, let {@code t'} be the supertype of
-   * {@code t} that declares {@code method}. This method returns a map from each type variable
-   * {@code X} of {@code t'} to the nullness annotation for {@code X} implied by the inheritance
-   * path from {@code t} to {@code t'}, accounting for nullness annotations in {@code extends} /
-   * {@code implements} clauses. If there is no entry for {@code X}, the inheritance path adds no
-   * annotation to {@code X}.
+   * Returns the type of {@code subtype} viewed as {@code supertypeSymbol}, preserving explicit
+   * nullness annotations in {@code extends} and {@code implements} clauses.
    *
-   * @param t the type to start from
-   * @param method the method symbol
+   * <p>This method differs from {@link Types#asSuper(Type, Symbol)} in that it applies each
+   * inheritance-edge substitution separately with NullAway's annotation-preserving substitution.
+   * Consequently, it preserves annotations nested inside a type argument, such as the annotation in
+   * {@code class C<T> implements I<List<@Nullable T>>}.
+   *
+   * @param subtype the type to start from
+   * @param supertypeSymbol the symbol of the desired supertype
    * @param types the types instance
    * @param config the NullAway config
-   * @return the map from type variable symbols to their nullness annotations
+   * @return the annotated supertype, or {@code null} if no inheritance path exists or a raw type
+   *     prevents annotation-preserving substitution
    */
-  public static Map<Symbol.TypeVariableSymbol, AnnotationMirror> getAnnotsOnTypeVarsFromSubtypes(
-      DeclaredType t, Symbol.MethodSymbol method, Types types, Config config) {
-    List<DeclaredType> path = inheritancePath(t, method, types);
-    return annotsFromSubtypesForInheritancePath(path, config);
-  }
-
-  /**
-   * Given a type {@code t} and a symbol {@code supertypeSymbol} for a supertype {@code t'} of
-   * {@code t}. This method returns a map from each type variable {@code X} of {@code t'} to the
-   * nullness annotation for {@code X} implied by the inheritance path from {@code t} to {@code t'},
-   * accounting for nullness annotations in {@code extends} / {@code implements} clauses. If there
-   * is no entry for {@code X}, the inheritance path adds no annotation to {@code X}.
-   *
-   * @param t the type to start from
-   * @param supertypeSymbol the supertype symbol
-   * @param types the types instance
-   * @param config the NullAway config
-   * @return the map from type variable symbols to their nullness annotations
-   */
-  public static Map<Symbol.TypeVariableSymbol, AnnotationMirror> getAnnotsOnTypeVarsFromSubtypes(
-      DeclaredType t, Symbol.ClassSymbol supertypeSymbol, Types types, Config config) {
-    List<DeclaredType> path = inheritancePath(t, supertypeSymbol, types);
-    return annotsFromSubtypesForInheritancePath(path, config);
+  public static @Nullable Type getAnnotatedSupertype(
+      DeclaredType subtype, Symbol.ClassSymbol supertypeSymbol, Types types, Config config) {
+    Type currentType = (Type) subtype;
+    if (currentType.tsym.equals(supertypeSymbol)) {
+      return currentType;
+    }
+    List<DeclaredType> path = inheritancePath(subtype, supertypeSymbol, types);
+    if (path.isEmpty()) {
+      return null;
+    }
+    for (int i = 1; i < path.size(); i++) {
+      Type.ClassType currentClassType = (Type.ClassType) currentType;
+      Type.ClassType currentFormalType = (Type.ClassType) currentClassType.tsym.type;
+      if (currentFormalType.allparams().size() != currentClassType.allparams().size()) {
+        return null;
+      }
+      currentType =
+          TypeSubstitutionUtils.subst(
+              types,
+              (Type) path.get(i),
+              currentFormalType.allparams(),
+              currentClassType.allparams(),
+              config);
+    }
+    return currentType;
   }
 
   private static boolean dfsWithFormals(
@@ -90,23 +87,6 @@ public class ClassDeclarationNullnessAnnotUtils {
   }
 
   /**
-   * Computes the inheritance path from {@code t} to the class that declares {@code method}. Each
-   * {@link DeclaredType} in the list is the type as it appears in the relevant {@code extends} or
-   * {@code implements} clause along the path, including any annotations on type arguments in the
-   * clauses.
-   *
-   * @param t the type to start from
-   * @param method the method symbol
-   * @param types the types instance
-   * @return the inheritance path from {@code t} to the class that declares {@code method}
-   */
-  private static List<DeclaredType> inheritancePath(
-      DeclaredType t, Symbol.MethodSymbol method, Types types) {
-
-    return inheritancePath(t, (Symbol.ClassSymbol) method.owner, types);
-  }
-
-  /**
    * Computes the inheritance path from {@code t} to {@code supertypeSymbol}. Each {@link
    * DeclaredType} in the list is the type as it appears in the relevant {@code extends} or {@code
    * implements} clause along the path, including any annotations on type arguments in the clauses.
@@ -130,57 +110,5 @@ public class ClassDeclarationNullnessAnnotUtils {
       return Collections.unmodifiableList(res);
     }
     return Collections.emptyList();
-  }
-
-  private static Map<Symbol.TypeVariableSymbol, AnnotationMirror>
-      annotsFromSubtypesForInheritancePath(List<DeclaredType> path, Config config) {
-
-    if (path.isEmpty()) {
-      return Collections.emptyMap();
-    }
-
-    Map<Symbol.TypeVariableSymbol, AnnotationMirror> typeVarToAnnotations = new LinkedHashMap<>();
-    for (int idx = 0; idx < path.size(); idx++) {
-      DeclaredType dt = path.get(idx);
-      Type.ClassType ct = (Type.ClassType) dt;
-      Symbol.ClassSymbol cls = (Symbol.ClassSymbol) ct.tsym;
-
-      List<? extends Symbol.TypeVariableSymbol> formals = cls.getTypeParameters();
-      List<? extends TypeMirror> actuals = dt.getTypeArguments();
-
-      Map<Symbol.TypeVariableSymbol, AnnotationMirror> curNullnessAnnotations =
-          new LinkedHashMap<>();
-
-      for (int j = 0; j < actuals.size(); j++) {
-        TypeMirror arg = actuals.get(j);
-        // if there is a direct nullness annotation, that wins
-        AnnotationMirror nullnessAnnotation =
-            getNullnessAnnotation(arg.getAnnotationMirrors(), config);
-        // otherwise, see if we have a type variable argument with a previous nullness annotation
-        if (nullnessAnnotation == null) {
-          Symbol.TypeSymbol argtsym = ((Type) arg).tsym;
-          if (argtsym instanceof Symbol.TypeVariableSymbol) {
-            nullnessAnnotation = typeVarToAnnotations.get(argtsym);
-          }
-        }
-        if (nullnessAnnotation != null) {
-          curNullnessAnnotations.put(formals.get(j), nullnessAnnotation);
-        }
-      }
-      /* Push info upward. */
-      typeVarToAnnotations = curNullnessAnnotations;
-    }
-    return Collections.unmodifiableMap(typeVarToAnnotations);
-  }
-
-  private static @Nullable AnnotationMirror getNullnessAnnotation(
-      List<? extends AnnotationMirror> annotations, Config config) {
-    for (AnnotationMirror annotation : annotations) {
-      String annotTypeStr = annotation.getAnnotationType().toString();
-      if (isNullableAnnotation(annotTypeStr, config) || isNonNullAnnotation(annotTypeStr, config)) {
-        return annotation;
-      }
-    }
-    return null;
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ClassDeclarationNullnessAnnotUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ClassDeclarationNullnessAnnotUtils.java
@@ -47,7 +47,7 @@ public class ClassDeclarationNullnessAnnotUtils {
     for (int i = 1; i < path.size(); i++) {
       Type.ClassType currentClassType = (Type.ClassType) currentType;
       Type.ClassType currentFormalType = (Type.ClassType) currentClassType.tsym.type;
-      if (currentFormalType.allparams().size() != currentClassType.allparams().size()) {
+      if (currentClassType.isRaw()) {
         return null;
       }
       currentType =

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -59,7 +59,6 @@ import com.uber.nullaway.generics.ConstraintSolver.UnsatisfiableConstraintsExcep
 import com.uber.nullaway.generics.GenericsUtils.MethodRefTypeRelationKind;
 import com.uber.nullaway.handlers.Handler;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -193,7 +192,7 @@ public final class GenericsChecks {
           GenericsUtils.groundTargetType(formalParameterType, state, config, handler);
       Type modeledPolyExpressionType =
           TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-              groundTargetType, polyExpressionType, config, Collections.emptyMap());
+              groundTargetType, polyExpressionType, config);
       inferredPolyExpressionTypes.put(polyExpressionTree, modeledPolyExpressionType);
     }
   }
@@ -856,7 +855,7 @@ public final class GenericsChecks {
             Type returnType = methodType.getReturnType();
             result =
                 TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-                    returnType, result, config, Collections.emptyMap());
+                    returnType, result, config);
           } else if (tree instanceof MemberSelectTree memberSelectTree) {
             Symbol memberSelectSymbol = ASTHelpers.getSymbol(memberSelectTree);
             if (memberSelectSymbol != null && memberSelectSymbol.getKind().isField()) {
@@ -864,7 +863,7 @@ public final class GenericsChecks {
               Type fieldType = memberSelectSymbol.type;
               result =
                   TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-                      fieldType, result, config, Collections.emptyMap());
+                      fieldType, result, config);
             }
           }
         }
@@ -3519,7 +3518,7 @@ public final class GenericsChecks {
     Type groundTargetType = GenericsUtils.groundTargetType(targetType, state, config, handler);
     Type polyExpressionTypeWithTargetAnnotations =
         TypeSubstitutionUtils.restoreExplicitNullabilityAnnotations(
-            groundTargetType, polyExpressionType, config, Collections.emptyMap());
+            groundTargetType, polyExpressionType, config);
     inferredPolyExpressionTypes.put(polyExpressionTree, polyExpressionTypeWithTargetAnnotations);
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -69,24 +69,28 @@ public class TypeSubstitutionUtils {
    */
   public static Type memberType(Types types, Type t, Symbol sym, Config config) {
     Type origType = sym.type;
-    // This is the authoritative member type for the actual receiver, but javac may drop
-    // annotations from extends / implements clauses while traversing to an inherited member.
     Type memberType = types.memberType(t, sym);
     Type annotationSource = origType;
     if (t instanceof DeclaredType declaredType
         && sym.owner instanceof Symbol.ClassSymbol owner
         && !t.tsym.equals(owner)) {
+      // annotatedOwner is the type of the class containing sym (a supertype of t), capturing any
+      // annotations in extends / inherits clauses on the inheritance path from subtype t
       Type annotatedOwner = getAnnotatedSupertype(declaredType, owner, types, config);
       if (annotatedOwner instanceof Type.ClassType annotatedOwnerClassType) {
-        // Looking up the member directly on the reconstructed owner avoids the inheritance
-        // traversal that loses annotations. Use this second result only as an annotation template,
-        // while retaining memberType's authoritative type structure and compiler metadata.
+        Type asMemberOfAnnotatedOwner = types.memberType(annotatedOwnerClassType, sym);
+        // this call restores any explicit nullability annotations from the member itself, e.g.,
+        // if its return type is declared as @NonNull T
         annotationSource =
-            restoreExplicitNullabilityAnnotations(
-                origType, types.memberType(annotatedOwnerClassType, sym), config);
+            restoreExplicitNullabilityAnnotations(origType, asMemberOfAnnotatedOwner, config);
       }
     }
-    return restoreExplicitNullabilityAnnotations(annotationSource, memberType, config);
+    // Here, annotationSource is the type of the member in the superclass with all proper
+    // annotations.  But, it might still have generic type variables, which have been properly
+    // instantiated in memberType.  So, as a final step, restore the annotations from
+    // annotationSource onto memberType.
+    Type result = restoreExplicitNullabilityAnnotations(annotationSource, memberType, config);
+    return result;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -1,6 +1,6 @@
 package com.uber.nullaway.generics;
 
-import static com.uber.nullaway.generics.ClassDeclarationNullnessAnnotUtils.getAnnotsOnTypeVarsFromSubtypes;
+import static com.uber.nullaway.generics.ClassDeclarationNullnessAnnotUtils.getAnnotatedSupertype;
 import static com.uber.nullaway.generics.ConstraintSolver.InferredNullability.NULLABLE;
 import static com.uber.nullaway.generics.TypeMetadataBuilder.TYPE_METADATA_BUILDER;
 
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
 import org.jspecify.annotations.Nullable;
@@ -31,7 +30,7 @@ public class TypeSubstitutionUtils {
 
   /**
    * Like {@link Types#asSuper(Type, Symbol)}, but restores explicit nullability annotations on type
-   * variables from the subtype to the resulting supertype.
+   * arguments from the subtype's inheritance path to the resulting supertype.
    *
    * @param types the {@link Types} instance
    * @param subtype the subtype
@@ -46,16 +45,17 @@ public class TypeSubstitutionUtils {
     if (asSuper == null) {
       return null;
     }
-    Map<Symbol.TypeVariableSymbol, AnnotationMirror> annotsOnTypeVarsFromSubtypes =
+    if (subtype.tsym.equals(superTypeSymbol)) {
+      return asSuper;
+    }
+    Type annotatedSupertype =
         subtype instanceof DeclaredType declaredType
-            ? getAnnotsOnTypeVarsFromSubtypes(declaredType, superTypeSymbol, types, config)
-            : Map.of();
-    // superTypeSymbol.asType() is the unsubstituted type of the supertype, which has the
-    // same type variables as asSuper; we use it to find the positions corresponding to type
-    // variables in asSuper to substitute nullability annotations based on
-    // annotsOnTypeVarsFromSubtypes.
-    return restoreExplicitNullabilityAnnotations(
-        superTypeSymbol.asType(), asSuper, config, annotsOnTypeVarsFromSubtypes);
+            ? getAnnotatedSupertype(declaredType, superTypeSymbol, types, config)
+            : null;
+    if (annotatedSupertype == null) {
+      return asSuper;
+    }
+    return restoreExplicitNullabilityAnnotations(annotatedSupertype, asSuper, config);
   }
 
   /**
@@ -70,13 +70,18 @@ public class TypeSubstitutionUtils {
   public static Type memberType(Types types, Type t, Symbol sym, Config config) {
     Type origType = sym.type;
     Type memberType = types.memberType(t, sym);
-    Map<Symbol.TypeVariableSymbol, AnnotationMirror> annotsOnTypeVarsFromSubtypes =
-        t instanceof DeclaredType declaredType
-            ? getAnnotsOnTypeVarsFromSubtypes(
-                declaredType, (Symbol.MethodSymbol) sym, types, config)
-            : Map.of();
-    return restoreExplicitNullabilityAnnotations(
-        origType, memberType, config, annotsOnTypeVarsFromSubtypes);
+    Type annotationSource = origType;
+    if (t instanceof DeclaredType declaredType
+        && sym.owner instanceof Symbol.ClassSymbol owner
+        && !t.tsym.equals(owner)) {
+      Type annotatedOwner = getAnnotatedSupertype(declaredType, owner, types, config);
+      if (annotatedOwner instanceof Type.ClassType annotatedOwnerClassType) {
+        annotationSource =
+            restoreExplicitNullabilityAnnotations(
+                origType, types.memberType(annotatedOwnerClassType, sym), config);
+      }
+    }
+    return restoreExplicitNullabilityAnnotations(annotationSource, memberType, config);
   }
 
   /**
@@ -86,20 +91,11 @@ public class TypeSubstitutionUtils {
    * @param origType the original type
    * @param newType the new type, a result of applying some substitution to {@code origType}
    * @param config the NullAway config
-   * @param extraTypeVariableAnnotations Additional annotations to consider for type variables. If
-   *     there is no explicit nullability annotation on a type variable {@code X} in {@code
-   *     origType}, but {@code X} is present as a key in this map, the corresponding annotation will
-   *     be used when substituting in {@code newType}. If {@code X} has an explicit nullability
-   *     annotation in {@code origType}, that takes precedence over this map.
    * @return the new type with explicit nullability annotations restored
    */
   public static Type restoreExplicitNullabilityAnnotations(
-      Type origType,
-      Type newType,
-      Config config,
-      Map<Symbol.TypeVariableSymbol, AnnotationMirror> extraTypeVariableAnnotations) {
-    return new RestoreNullnessAnnotationsVisitor(config, extraTypeVariableAnnotations)
-        .visit(newType, origType);
+      Type origType, Type newType, Config config) {
+    return new RestoreNullnessAnnotationsVisitor(config).visit(newType, origType);
   }
 
   /**
@@ -191,12 +187,11 @@ public class TypeSubstitutionUtils {
         substituteInferredNullabilityForTypeVariables(origType, typeVarNullability, state, config);
     // step 2
     Type origExplicitAnnotationsRestored =
-        restoreExplicitNullabilityAnnotations(
-            origType, inferredNullabilitySubstituted, config, Collections.emptyMap());
+        restoreExplicitNullabilityAnnotations(origType, inferredNullabilitySubstituted, config);
     // step 3
     // TODO optimize these steps to avoid doing so many substitutions in the future, if needed
     return restoreExplicitNullabilityAnnotations(
-        origExplicitAnnotationsRestored, typeToUpdate, config, Collections.emptyMap());
+        origExplicitAnnotationsRestored, typeToUpdate, config);
   }
 
   /**
@@ -316,19 +311,8 @@ public class TypeSubstitutionUtils {
     private final IdentityHashMap<Type.TypeVar, Set<Type.TypeVar>> activeUnboundedWildcardBounds =
         new IdentityHashMap<>();
 
-    /**
-     * Additional annotations to consider for type variables. If there is no explicit nullability
-     * annotation on a type variable {@code X}, but {@code X} is present as a key in this map, the
-     * corresponding annotation will be used when substituting in the visited type. If {@code X} has
-     * an explicit nullability annotation, that takes precedence over this map.
-     */
-    private final Map<Symbol.TypeVariableSymbol, AnnotationMirror> extraTypeVariableAnnotations;
-
-    RestoreNullnessAnnotationsVisitor(
-        Config config,
-        Map<Symbol.TypeVariableSymbol, AnnotationMirror> extraTypeVariableAnnotations) {
+    RestoreNullnessAnnotationsVisitor(Config config) {
       this.config = config;
-      this.extraTypeVariableAnnotations = extraTypeVariableAnnotations;
     }
 
     @Override
@@ -503,8 +487,7 @@ public class TypeSubstitutionUtils {
 
     /**
      * Updates the nullability annotations on a type {@code t} based on the nullability annotations
-     * on a type {@code other}. If {@code other} is a type variable, we also check {@code
-     * extraTypeVariableAnnotations} for any additional annotations to consider.
+     * on a type {@code other}.
      *
      * @param t the type to update
      * @param other the type to update from
@@ -521,12 +504,6 @@ public class TypeSubstitutionUtils {
             || Nullness.isNonNullAnnotation(qualifiedName, config)) {
           return typeWithAnnot(t, annot);
         }
-      }
-      // then see if there are any extra annotations to consider
-      Attribute.TypeCompound typeArgAnnot =
-          (Attribute.TypeCompound) extraTypeVariableAnnotations.get(other.tsym);
-      if (typeArgAnnot != null) {
-        return typeWithAnnot(t, typeArgAnnot);
       }
       return t;
     }
@@ -620,6 +597,6 @@ public class TypeSubstitutionUtils {
    */
   public static Type subst(Types types, Type t, List<Type> from, List<Type> to, Config config) {
     Type substResult = types.subst(t, from, to);
-    return restoreExplicitNullabilityAnnotations(t, substResult, config, Collections.emptyMap());
+    return restoreExplicitNullabilityAnnotations(t, substResult, config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -69,6 +69,8 @@ public class TypeSubstitutionUtils {
    */
   public static Type memberType(Types types, Type t, Symbol sym, Config config) {
     Type origType = sym.type;
+    // This is the authoritative member type for the actual receiver, but javac may drop
+    // annotations from extends / implements clauses while traversing to an inherited member.
     Type memberType = types.memberType(t, sym);
     Type annotationSource = origType;
     if (t instanceof DeclaredType declaredType
@@ -76,6 +78,9 @@ public class TypeSubstitutionUtils {
         && !t.tsym.equals(owner)) {
       Type annotatedOwner = getAnnotatedSupertype(declaredType, owner, types, config);
       if (annotatedOwner instanceof Type.ClassType annotatedOwnerClassType) {
+        // Looking up the member directly on the reconstructed owner avoids the inheritance
+        // traversal that loses annotations. Use this second result only as an annotation template,
+        // while retaining memberType's authoritative type structure and compiler metadata.
         annotationSource =
             restoreExplicitNullabilityAnnotations(
                 origType, types.memberType(annotatedOwnerClassType, sym), config);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -271,6 +271,96 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void nestedNullableTypeArgInImplements() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface MyFuture<T extends @Nullable Object> {}
+              static class ListFuture<V extends @Nullable Object>
+                  implements MyFuture<List<@Nullable V>> {}
+
+              static <V extends @Nullable Object> MyFuture<List<@Nullable V>> valid() {
+                return new ListFuture<V>();
+              }
+
+              static <V extends @Nullable Object> MyFuture<List<V>> invalid() {
+                // BUG: Diagnostic contains: incompatible types: ListFuture<V> cannot be converted to MyFuture<List<V>> (ListFuture<V> is a subtype of MyFuture<List<@Nullable V>>)
+                return new ListFuture<V>();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nestedNullableTypeArgInInheritedMemberType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Box<T extends @Nullable Object> {
+                T get();
+                void set(T value);
+              }
+              interface IntermediateBox<W extends @Nullable Object>
+                  extends Box<List<@Nullable W>> {}
+              interface ListBox<V extends @Nullable Object> extends IntermediateBox<V> {}
+
+              static void test(
+                  ListBox<String> box,
+                  List<@Nullable String> nullableList,
+                  List<String> nonNullList) {
+                List<@Nullable String> valid = box.get();
+                // BUG: Diagnostic contains: incompatible types: List<@Nullable String> cannot be converted to List<String>
+                List<String> invalid = box.get();
+                box.set(nullableList);
+                // BUG: Diagnostic contains: incompatible types: List<String> cannot be converted to List<@Nullable String>
+                box.set(nonNullList);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nestedNullableTypeArgWithGenericEnclosingClass() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test<O extends @Nullable Object> {
+              abstract class Parent<T extends @Nullable Object> {
+                abstract T get();
+              }
+              abstract class Child<V extends @Nullable Object>
+                  extends Parent<List<@Nullable O>> {}
+
+              void test(Child<String> child) {
+                List<@Nullable O> valid = child.get();
+                // BUG: Diagnostic contains: incompatible types: List<@Nullable O> cannot be converted to List<O>
+                List<O> invalid = child.get();
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -361,6 +361,28 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void rawTypeInInheritancePath() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              static class Parent<T> {}
+              static class Intermediate<T> extends Parent<T> {}
+              static class Child extends Intermediate {}
+
+              static void test() {
+                // The annotated-supertype reconstruction should bail out at raw Intermediate.
+                Parent<String> parent = new Child();
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -5,6 +5,7 @@ import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -2437,6 +2438,9 @@ public class GenericsTests extends NullAwayTestsBase {
 
   @Test
   public void intersectionTypeInvalidAssign() {
+    // javac does not preserve type use annotations in the intersection type within the cast before
+    // JDK 25.  Corner case; not going to fix for now.
+    Assume.assumeTrue(Runtime.version().feature() >= 25);
     makeHelper()
         .addSourceLines(
             "Test.java",


### PR DESCRIPTION
Fixes #1716 by preserving nested nullness annotations from `extends` and `implements` clauses when computing supertypes and inherited member types.

The previous implementation tracked only direct annotations on type variables, so annotations nested in types such as `MyFuture<List<@Nullable V>>` were lost. This replaces that mapping with annotation-preserving supertype reconstruction and adds test coverage for inherited members, multi-level inheritance, enclosing generics, and raw types.  This change is actually about equally complex to what we had before, since we can simplify and remove some code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested nullability annotations across generic inheritance and inherited member types.
  * Preserved nullability through generic enclosing classes and annotated supertypes.
  * Safely handled inheritance paths containing raw types.

* **Tests**
  * Added coverage for nested nullable type arguments, inherited members, enclosing generics, and raw-type inheritance paths.
  * Limited a platform-specific test to supported JDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->