### PR TITLE
Fix crash for generic qualifiers in method references

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2291,8 +2291,11 @@ public final class GenericsChecks {
                 return;
               }
 
-              ExpressionTree actualParameterWithoutParentheses =
-                  ASTHelpers.stripParentheses(currentActualParam);
+              TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
+              NullabilityUtil.ExprTreeAndState actualParameterAndState =
+                  NullabilityUtil.stripParensAndUpdateTreePath(
+                      currentActualParam, state.withPath(pathToParam));
+              ExpressionTree actualParameterWithoutParentheses = actualParameterAndState.expr();
               if (actualParameterWithoutParentheses
                   instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
@@ -2304,7 +2307,7 @@ public final class GenericsChecks {
                     this,
                     groundFormalParameter,
                     memberReferenceTree,
-                    state,
+                    actualParameterAndState.state(),
                     (subtype, supertype, relationKind) -> {
                       if (!subtypeParameterNullability(supertype, subtype, state)) {
                         if (relationKind == MethodRefTypeRelationKind.RETURN) {
@@ -2321,7 +2324,6 @@ public final class GenericsChecks {
                 return;
               }
 
-              TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
               Type actualParameterType;
               if (actualParameterWithoutParentheses instanceof LambdaExpressionTree) {
                 maybeStorePolyExpressionTypeFromTarget(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -223,15 +223,21 @@ public class GenericsUtils {
    * @param genericsChecks generics checks object
    * @param targetType type to which method reference is being assigned
    * @param memberReferenceTree the method reference tree
-   * @param state visitor state
+   * @param state visitor state whose current path ends at {@code memberReferenceTree}
    * @param relationHandler handler to invoke for each type relation
    */
+  @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
   static void processMethodRefTypeRelations(
       GenericsChecks genericsChecks,
       Type targetType,
       MemberReferenceTree memberReferenceTree,
       VisitorState state,
       MethodRefTypeRelationHandler relationHandler) {
+    Verify.verify(
+        state.getPath().getLeaf() == memberReferenceTree,
+        "Expected current path to end at member reference %s, but found %s",
+        memberReferenceTree,
+        state.getPath().getLeaf());
     if (targetType.isRaw()) {
       return;
     }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1254,6 +1254,48 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void genericMethodCallQualifierForMethodReference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.Consumer;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              interface Flow {
+                Flow handle(Consumer<Object> consumer);
+              }
+
+              static <T> Consumer<T> id(Consumer<T> consumer) {
+                return consumer;
+              }
+
+              static <T> @Nullable Consumer<T> nullableId(Consumer<T> consumer) {
+                return null;
+              }
+
+              static Flow methodReferenceArgument(Flow flow, Consumer<Object> consumer) {
+                return flow.handle(id(consumer)::accept);
+              }
+
+              static Flow parenthesizedMethodReferenceArgument(
+                  Flow flow, Consumer<Object> consumer) {
+                return flow.handle((id(consumer)::accept));
+              }
+
+              static Flow nullableQualifier(Flow flow, Consumer<Object> consumer) {
+                // BUG: Diagnostic contains: dereferenced expression 'nullableId(consumer)' is @Nullable
+                return flow.handle(nullableId(consumer)::accept);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Fixes #1743

For `MemberReferenceTree`s passed as parameters, we weren't using a `VisitorState` with the right `TreePath` in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullness checking for generic method references and method-call qualifiers, including parenthesized expressions.
  * Ensured nullable qualifiers produce the appropriate null-dereference diagnostic.

* **Tests**
  * Added regression coverage for ordinary, parenthesized, and nullable qualifiers in generic method references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->