### PR TITLE
Cache immutable stubx library models

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2291,8 +2291,11 @@ public final class GenericsChecks {
                 return;
               }
 
-              ExpressionTree actualParameterWithoutParentheses =
-                  ASTHelpers.stripParentheses(currentActualParam);
+              TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
+              NullabilityUtil.ExprTreeAndState actualParameterAndState =
+                  NullabilityUtil.stripParensAndUpdateTreePath(
+                      currentActualParam, state.withPath(pathToParam));
+              ExpressionTree actualParameterWithoutParentheses = actualParameterAndState.expr();
               if (actualParameterWithoutParentheses
                   instanceof MemberReferenceTree memberReferenceTree) {
                 Type groundFormalParameter =
@@ -2304,7 +2307,7 @@ public final class GenericsChecks {
                     this,
                     groundFormalParameter,
                     memberReferenceTree,
-                    state,
+                    actualParameterAndState.state(),
                     (subtype, supertype, relationKind) -> {
                       if (!subtypeParameterNullability(supertype, subtype, state)) {
                         if (relationKind == MethodRefTypeRelationKind.RETURN) {
@@ -2321,7 +2324,6 @@ public final class GenericsChecks {
                 return;
               }
 
-              TreePath pathToParam = pathWithLeaf(state.getPath(), currentActualParam);
               Type actualParameterType;
               if (actualParameterWithoutParentheses instanceof LambdaExpressionTree) {
                 maybeStorePolyExpressionTypeFromTarget(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -223,15 +223,21 @@ public class GenericsUtils {
    * @param genericsChecks generics checks object
    * @param targetType type to which method reference is being assigned
    * @param memberReferenceTree the method reference tree
-   * @param state visitor state
+   * @param state visitor state whose current path ends at {@code memberReferenceTree}
    * @param relationHandler handler to invoke for each type relation
    */
+  @SuppressWarnings("ReferenceEquality") // deliberate reference equality check
   static void processMethodRefTypeRelations(
       GenericsChecks genericsChecks,
       Type targetType,
       MemberReferenceTree memberReferenceTree,
       VisitorState state,
       MethodRefTypeRelationHandler relationHandler) {
+    Verify.verify(
+        state.getPath().getLeaf() == memberReferenceTree,
+        "Expected current path to end at member reference %s, but found %s",
+        memberReferenceTree,
+        state.getPath().getLeaf());
     if (targetType.isRaw()) {
       return;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -630,9 +630,15 @@ public class LibraryModelsHandler implements Handler {
         ServiceLoader.load(LibraryModels.class, LibraryModels.class.getClassLoader());
     ImmutableSet.Builder<LibraryModels> libModelsBuilder = new ImmutableSet.Builder<>();
     libModelsBuilder.add(new DefaultLibraryModels(config)).addAll(externalLibraryModels);
-    if (config.isJarInferEnabled() || config.isJSpecifyJDKModels()) {
-      libModelsBuilder.add(
-          new ExternalStubxLibraryModels(config.isJarInferEnabled(), config.isJSpecifyJDKModels()));
+    if (config.isJarInferEnabled()) {
+      // JarInfer models come from service-loaded providers and must be discovered for each
+      // checker instance rather than cached in static state.
+      libModelsBuilder.add(loadExternalStubxLibraryModels(true, false));
+    }
+    if (config.isJSpecifyJDKModels()) {
+      // This model is bundled with NullAway and contains only immutable, context-independent
+      // values, so it is safe to share across javac invocations in this classloader.
+      libModelsBuilder.add(JSpecifyJdkModelsHolder.INSTANCE);
     }
     return new CombinedLibraryModels(libModelsBuilder.build(), config);
   }
@@ -1762,180 +1768,38 @@ public class LibraryModelsHandler implements Handler {
     }
   }
 
-  /** Constructs Library Models from stubx files */
-  private static class ExternalStubxLibraryModels implements LibraryModels {
+  /** astubx file name used in our Android SDK JarInfer models. */
+  private static final String ANDROID_ASTUBX_LOCATION = "jarinfer.astubx";
 
-    /** astubx file name used in our Android SDK JarInfer models */
-    private static final String ANDROID_ASTUBX_LOCATION = "jarinfer.astubx";
+  /** astubx file name used for the JSpecify JDK models. */
+  private static final String JSPECIFY_JDK_ASTUBX_FILENAME = "jspecify-jdk.astubx";
 
-    /** astubx file name used for the JSpecify JDK models */
-    private static final String JSPECIFY_JDK_ASTUBX_FILENAME = "jspecify-jdk.astubx";
+  /** Class we expect to be present in a jar containing Android SDK JarInfer models. */
+  private static final String ANDROID_MODEL_CLASS =
+      "com.uber.nullaway.jarinfer.AndroidJarInferModels";
 
-    /** Class we expect to be present in a jar containing Android SDK JarInfer models */
-    private static final String ANDROID_MODEL_CLASS =
-        "com.uber.nullaway.jarinfer.AndroidJarInferModels";
+  /**
+   * Immutable, javac-context-independent model data converted from one or more stubx resources.
+   * Instances are safe to read concurrently from multiple javac invocations.
+   */
+  private record ImmutableStubxLibraryModels(
+      ImmutableSet<String> nullMarkedClasses,
+      ImmutableMap<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
+          nestedAnnotationsForMethods,
+      ImmutableSetMultimap<String, Integer> typeVariablesWithNullableUpperBounds,
+      ImmutableSetMultimap<MethodRef, Integer> methodTypeVariablesWithNullableUpperBounds,
+      ImmutableSetMultimap<MethodRef, Integer> explicitlyNullableParameters,
+      ImmutableSetMultimap<MethodRef, Integer> nonNullParameters,
+      ImmutableSet<MethodRef> nullableReturns)
+      implements LibraryModels {
 
-    private final Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache;
-    private final Set<String> nullMarkedClassesCache;
-    private final SetMultimap<String, Integer> upperBoundsCache;
-    private final SetMultimap<String, Integer> methodTypeParamNullableUpperBoundCache;
-    private final Map<String, SetMultimap<Integer, NestedAnnotationInfo>> nestedAnnotationInfo;
-
-    ExternalStubxLibraryModels(boolean isJarInferEnabled, boolean isJSpecifyJDKEnabled) {
-      String libraryModelLogName = "LM";
-      StubxCacheUtil cacheUtil = new StubxCacheUtil(libraryModelLogName, isJarInferEnabled);
-      if (isJarInferEnabled) {
-        // hardcoded loading of stubx files from android-jarinfer-models-sdkXX artifacts
-        try (InputStream androidStubxIS =
-            castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader())
-                .getResourceAsStream(ANDROID_ASTUBX_LOCATION)) {
-          if (androidStubxIS != null) {
-            cacheUtil.parseStubStream(androidStubxIS, "android.jar: " + ANDROID_ASTUBX_LOCATION);
-            astubxLoadLog("Loaded Android RT models.");
-          }
-        } catch (ClassNotFoundException e) {
-          astubxLoadLog(
-              "Cannot find Android RT models locator class."
-                  + " This is expected if not in an Android project, or the Android SDK JarInfer models Jar has not been set up for this build.");
-
-        } catch (IOException e) {
-          astubxLoadLog("Loading Android RT models failed: " + e.getMessage());
-        }
-      }
-
-      if (isJSpecifyJDKEnabled) {
-        // hardcoded loading of JSpecify JDK astubx from jspecify-jdk.astubx
-        try (InputStream in =
-            castToNonNull(getClass().getClassLoader())
-                .getResourceAsStream(JSPECIFY_JDK_ASTUBX_FILENAME)) {
-          if (in == null) {
-            throw new IllegalStateException(
-                "JDK astubx model not found on classpath: %s"
-                    .formatted(JSPECIFY_JDK_ASTUBX_FILENAME));
-          } else {
-            cacheUtil.parseStubStream(in, JSPECIFY_JDK_ASTUBX_FILENAME);
-            astubxLoadLog("Loaded JDK astubx model.");
-          }
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
-        }
-      }
-
-      argAnnotCache = cacheUtil.getArgAnnotCache();
-      nullMarkedClassesCache = cacheUtil.getNullMarkedClassesCache();
-      upperBoundsCache = cacheUtil.getUpperBoundCache();
-      methodTypeParamNullableUpperBoundCache =
-          cacheUtil.getMethodTypeParamNullableUpperBoundCache();
-      nestedAnnotationInfo = cacheUtil.getNestedAnnotationInfoCache();
-    }
-
-    @Override
-    public ImmutableSet<String> nullMarkedClasses() {
-      return new ImmutableSet.Builder<String>().addAll(nullMarkedClassesCache).build();
-    }
-
-    @Override
-    public ImmutableMap<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
-        nestedAnnotationsForMethods() {
-      ImmutableMap.Builder<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
-          mapBuilder = new ImmutableMap.Builder<>();
-      for (Map.Entry<String, SetMultimap<Integer, NestedAnnotationInfo>> entry :
-          nestedAnnotationInfo.entrySet()) {
-        String className = entry.getKey().split(":")[0].replace('$', '.');
-        String methodSig = getMethodNameAndSignature(entry.getKey());
-        mapBuilder.put(
-            MethodRef.methodRef(className, methodSig),
-            ImmutableSetMultimap.copyOf(entry.getValue()));
-      }
-      return mapBuilder.build();
-    }
-
-    @Override
-    public ImmutableSetMultimap<String, Integer> typeVariablesWithNullableUpperBounds() {
-      ImmutableSetMultimap.Builder<String, Integer> mapBuilder =
-          new ImmutableSetMultimap.Builder<>();
-      for (Map.Entry<String, Integer> entry : upperBoundsCache.entries()) {
-        mapBuilder.put(entry.getKey(), entry.getValue());
-      }
-      return mapBuilder.build();
-    }
-
-    @Override
-    public ImmutableSetMultimap<MethodRef, Integer> methodTypeVariablesWithNullableUpperBounds() {
-      ImmutableSetMultimap.Builder<MethodRef, Integer> mapBuilder =
-          new ImmutableSetMultimap.Builder<>();
-      for (Map.Entry<String, Integer> entry : methodTypeParamNullableUpperBoundCache.entries()) {
-        String className = entry.getKey().split(":")[0].replace('$', '.');
-        String methodSig = getMethodNameAndSignature(entry.getKey());
-        mapBuilder.put(MethodRef.methodRef(className, methodSig), entry.getValue());
-      }
-      return mapBuilder.build();
-    }
+    // The record accessors implement the populated LibraryModels methods declared as components
+    // above. Stubx files do not represent the remaining model categories, so those methods retain
+    // the empty results returned by the previous ExternalStubxLibraryModels implementation.
 
     @Override
     public ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters() {
       return ImmutableSetMultimap.of();
-    }
-
-    @Override
-    public ImmutableSetMultimap<MethodRef, Integer> explicitlyNullableParameters() {
-      ImmutableSetMultimap.Builder<MethodRef, Integer> mapBuilder =
-          new ImmutableSetMultimap.Builder<>();
-      for (Map.Entry<String, Map<String, Map<Integer, Set<String>>>> outerEntry :
-          argAnnotCache.entrySet()) {
-        String className = outerEntry.getKey();
-        for (Map.Entry<String, Map<Integer, Set<String>>> innerEntry :
-            outerEntry.getValue().entrySet()) {
-          String methodNameAndSignature = getMethodNameAndSignature(innerEntry.getKey());
-          for (Map.Entry<Integer, Set<String>> entry : innerEntry.getValue().entrySet()) {
-            Integer index = entry.getKey();
-            if (index >= 0 && entry.getValue().stream().anyMatch(a -> a.contains("Nullable"))) {
-              mapBuilder.put(methodRef(className, methodNameAndSignature), index);
-            }
-          }
-        }
-      }
-      return mapBuilder.build();
-    }
-
-    @Override
-    public ImmutableSetMultimap<MethodRef, Integer> nonNullParameters() {
-      ImmutableSetMultimap.Builder<MethodRef, Integer> mapBuilder =
-          new ImmutableSetMultimap.Builder<>();
-      for (String className : argAnnotCache.keySet()) {
-        for (Map.Entry<String, Map<Integer, Set<String>>> methodEntry :
-            argAnnotCache.get(className).entrySet()) {
-          String methodNameAndSignature = getMethodNameAndSignature(methodEntry.getKey());
-          for (Map.Entry<Integer, Set<String>> argEntry : methodEntry.getValue().entrySet()) {
-            Integer index = argEntry.getKey();
-            if (index >= 0) {
-              for (String annotation : argEntry.getValue()) {
-                if (annotation.contains("NonNull")
-                    || annotation.equals("javax.annotation.Nonnull")) {
-                  astubxLoadLog(
-                      "Found non-null parameter: "
-                          + className
-                          + "."
-                          + methodEntry.getKey()
-                          + " arg "
-                          + argEntry.getKey());
-                  mapBuilder.put(methodRef(className, methodNameAndSignature), index);
-                }
-              }
-            }
-          }
-        }
-      }
-      return mapBuilder.build();
-    }
-
-    private static String getMethodNameAndSignature(String methodInfo) {
-      int openParenIndex = methodInfo.indexOf('(');
-      Verify.verify(openParenIndex != -1, "Malformed method info: %s", methodInfo);
-      int methodNameIndex = methodInfo.lastIndexOf(' ', openParenIndex) + 1;
-      // MethodRef signatures omit spaces after commas, but spaces in wildcard bounds (for example,
-      // "? super T") are significant and must be preserved.
-      return methodInfo.substring(methodNameIndex).replaceAll(",\\s", ",");
     }
 
     @Override
@@ -1954,28 +1818,6 @@ public class LibraryModelsHandler implements Handler {
     }
 
     @Override
-    public ImmutableSet<MethodRef> nullableReturns() {
-      ImmutableSet.Builder<MethodRef> builder = new ImmutableSet.Builder<>();
-      for (String className : argAnnotCache.keySet()) {
-        for (Map.Entry<String, Map<Integer, Set<String>>> methodEntry :
-            argAnnotCache.get(className).entrySet()) {
-          String methodNameAndSignature = getMethodNameAndSignature(methodEntry.getKey());
-          for (Map.Entry<Integer, Set<String>> argEntry : methodEntry.getValue().entrySet()) {
-            Integer index = argEntry.getKey();
-            if (index == -1) {
-              Set<String> annotations = argEntry.getValue();
-              if (annotations.contains("javax.annotation.Nullable")
-                  || annotations.contains("org.jspecify.annotations.Nullable")) {
-                builder.add(methodRef(className, methodNameAndSignature));
-              }
-            }
-          }
-        }
-      }
-      return builder.build();
-    }
-
-    @Override
     public ImmutableSet<MethodRef> nonNullReturns() {
       return ImmutableSet.of();
     }
@@ -1984,6 +1826,142 @@ public class LibraryModelsHandler implements Handler {
     public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
       return ImmutableSetMultimap.of();
     }
+  }
+
+  /** Lazily initializes the bundled JSpecify JDK models once per NullAway classloader. */
+  private static final class JSpecifyJdkModelsHolder {
+    private static final LibraryModels INSTANCE = loadExternalStubxLibraryModels(false, true);
+  }
+
+  /**
+   * Loads stubx resources and converts all parsed state to deeply immutable value data.
+   *
+   * <p>JarInfer resources are intentionally loaded for each checker instance because they come from
+   * dynamic service providers. The bundled JSpecify resource is loaded only by {@link
+   * JSpecifyJdkModelsHolder}.
+   */
+  private static LibraryModels loadExternalStubxLibraryModels(
+      boolean isJarInferEnabled, boolean isJSpecifyJDKEnabled) {
+    String libraryModelLogName = "LM";
+    StubxCacheUtil cacheUtil = new StubxCacheUtil(libraryModelLogName, isJarInferEnabled);
+    if (isJarInferEnabled) {
+      // hardcoded loading of stubx files from android-jarinfer-models-sdkXX artifacts
+      try (InputStream androidStubxIS =
+          castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader())
+              .getResourceAsStream(ANDROID_ASTUBX_LOCATION)) {
+        if (androidStubxIS != null) {
+          cacheUtil.parseStubStream(androidStubxIS, "android.jar: " + ANDROID_ASTUBX_LOCATION);
+          astubxLoadLog("Loaded Android RT models.");
+        }
+      } catch (ClassNotFoundException e) {
+        astubxLoadLog(
+            "Cannot find Android RT models locator class."
+                + " This is expected if not in an Android project, or the Android SDK JarInfer models Jar has not been set up for this build.");
+      } catch (IOException e) {
+        astubxLoadLog("Loading Android RT models failed: " + e.getMessage());
+      }
+    }
+
+    if (isJSpecifyJDKEnabled) {
+      try (InputStream in =
+          castToNonNull(LibraryModelsHandler.class.getClassLoader())
+              .getResourceAsStream(JSPECIFY_JDK_ASTUBX_FILENAME)) {
+        if (in == null) {
+          throw new IllegalStateException(
+              "JDK astubx model not found on classpath: %s"
+                  .formatted(JSPECIFY_JDK_ASTUBX_FILENAME));
+        }
+        cacheUtil.parseStubStream(in, JSPECIFY_JDK_ASTUBX_FILENAME);
+        astubxLoadLog("Loaded JDK astubx model.");
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    return createImmutableStubxLibraryModels(cacheUtil);
+  }
+
+  /** Converts mutable parser caches into context-independent immutable library-model values. */
+  private static ImmutableStubxLibraryModels createImmutableStubxLibraryModels(
+      StubxCacheUtil cacheUtil) {
+    Map<String, Map<String, Map<Integer, Set<String>>>> argAnnotCache =
+        cacheUtil.getArgAnnotCache();
+
+    ImmutableMap.Builder<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
+        nestedAnnotationsBuilder = ImmutableMap.builder();
+    for (Map.Entry<String, SetMultimap<Integer, NestedAnnotationInfo>> entry :
+        cacheUtil.getNestedAnnotationInfoCache().entrySet()) {
+      String className = entry.getKey().split(":")[0].replace('$', '.');
+      nestedAnnotationsBuilder.put(
+          methodRef(className, getMethodNameAndSignature(entry.getKey())),
+          ImmutableSetMultimap.copyOf(entry.getValue()));
+    }
+
+    ImmutableSetMultimap.Builder<MethodRef, Integer> methodTypeUpperBoundsBuilder =
+        ImmutableSetMultimap.builder();
+    for (Map.Entry<String, Integer> entry :
+        cacheUtil.getMethodTypeParamNullableUpperBoundCache().entries()) {
+      String className = entry.getKey().split(":")[0].replace('$', '.');
+      methodTypeUpperBoundsBuilder.put(
+          methodRef(className, getMethodNameAndSignature(entry.getKey())), entry.getValue());
+    }
+
+    ImmutableSetMultimap.Builder<MethodRef, Integer> explicitlyNullableParametersBuilder =
+        ImmutableSetMultimap.builder();
+    ImmutableSetMultimap.Builder<MethodRef, Integer> nonNullParametersBuilder =
+        ImmutableSetMultimap.builder();
+    ImmutableSet.Builder<MethodRef> nullableReturnsBuilder = ImmutableSet.builder();
+    for (Map.Entry<String, Map<String, Map<Integer, Set<String>>>> classEntry :
+        argAnnotCache.entrySet()) {
+      String className = classEntry.getKey();
+      for (Map.Entry<String, Map<Integer, Set<String>>> methodEntry :
+          classEntry.getValue().entrySet()) {
+        String methodSignature = getMethodNameAndSignature(methodEntry.getKey());
+        MethodRef ref = methodRef(className, methodSignature);
+        for (Map.Entry<Integer, Set<String>> argumentEntry : methodEntry.getValue().entrySet()) {
+          int index = argumentEntry.getKey();
+          Set<String> annotations = argumentEntry.getValue();
+          if (index >= 0 && annotations.stream().anyMatch(a -> a.contains("Nullable"))) {
+            explicitlyNullableParametersBuilder.put(ref, index);
+          }
+          if (index >= 0
+              && annotations.stream()
+                  .anyMatch(a -> a.contains("NonNull") || a.equals("javax.annotation.Nonnull"))) {
+            astubxLoadLog(
+                "Found non-null parameter: "
+                    + className
+                    + "."
+                    + methodEntry.getKey()
+                    + " arg "
+                    + index);
+            nonNullParametersBuilder.put(ref, index);
+          }
+          if (index == -1
+              && (annotations.contains("javax.annotation.Nullable")
+                  || annotations.contains("org.jspecify.annotations.Nullable"))) {
+            nullableReturnsBuilder.add(ref);
+          }
+        }
+      }
+    }
+
+    return new ImmutableStubxLibraryModels(
+        ImmutableSet.copyOf(cacheUtil.getNullMarkedClassesCache()),
+        nestedAnnotationsBuilder.buildOrThrow(),
+        ImmutableSetMultimap.copyOf(cacheUtil.getUpperBoundCache()),
+        methodTypeUpperBoundsBuilder.build(),
+        explicitlyNullableParametersBuilder.build(),
+        nonNullParametersBuilder.build(),
+        nullableReturnsBuilder.build());
+  }
+
+  /** Extracts a model method signature from the fuller signature stored in a stubx file. */
+  private static String getMethodNameAndSignature(String methodInfo) {
+    int openParenIndex = methodInfo.indexOf('(');
+    Verify.verify(openParenIndex != -1, "Malformed method info: %s", methodInfo);
+    int methodNameIndex = methodInfo.lastIndexOf(' ', openParenIndex) + 1;
+    // MethodRef signatures omit spaces after commas, but spaces in wildcard bounds (for example,
+    // "? super T") are significant and must be preserved.
+    return methodInfo.substring(methodNameIndex).replaceAll(",\\s", ",");
   }
 
   private static boolean DEBUG_ASTUBX_LOADING = false;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1254,6 +1254,48 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void genericMethodCallQualifierForMethodReference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.Consumer;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              interface Flow {
+                Flow handle(Consumer<Object> consumer);
+              }
+
+              static <T> Consumer<T> id(Consumer<T> consumer) {
+                return consumer;
+              }
+
+              static <T> @Nullable Consumer<T> nullableId(Consumer<T> consumer) {
+                return null;
+              }
+
+              static Flow methodReferenceArgument(Flow flow, Consumer<Object> consumer) {
+                return flow.handle(id(consumer)::accept);
+              }
+
+              static Flow parenthesizedMethodReferenceArgument(
+                  Flow flow, Consumer<Object> consumer) {
+                return flow.handle((id(consumer)::accept));
+              }
+
+              static Flow nullableQualifier(Flow flow, Consumer<Object> consumer) {
+                // BUG: Diagnostic contains: dereferenced expression 'nullableId(consumer)' is @Nullable
+                return flow.handle(nullableId(consumer)::accept);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(

--- a/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
+++ b/test-library-models/src/main/java/com/uber/nullaway/testlibrarymodels/TestLibraryModels.java
@@ -36,6 +36,30 @@ import com.uber.nullaway.libmodel.NestedAnnotationInfo.TypePathEntry;
 @AutoService(LibraryModels.class)
 public class TestLibraryModels implements LibraryModels {
 
+  // These values contain only strings, integers, and immutable model records. They are safe to
+  // share across concurrent javac invocations in the same classloader. Stream models are excluded
+  // because their TypePredicates contain invocation-aware memoizing suppliers.
+  private static final ImmutableSetMultimap<MethodRef, Integer> EXPLICITLY_NULLABLE_PARAMETERS =
+      createExplicitlyNullableParameters();
+  private static final ImmutableSetMultimap<MethodRef, Integer> NON_NULL_PARAMETERS =
+      createNonNullParameters();
+  private static final ImmutableSetMultimap<MethodRef, Integer> NULL_IMPLIES_FALSE_PARAMETERS =
+      createNullImpliesFalseParameters();
+  private static final ImmutableSetMultimap<MethodRef, MethodRef>
+      ENSURES_NON_NULL_IF_TRUE_METHOD_CALLS = createEnsuresNonNullIfTrueMethodCalls();
+  private static final ImmutableSet<MethodRef> NULLABLE_RETURNS = createNullableReturns();
+  private static final ImmutableSetMultimap<MethodRef, Integer> CAST_TO_NON_NULL_METHODS =
+      createCastToNonNullMethods();
+  private static final ImmutableSet<FieldRef> NULLABLE_FIELDS = createNullableFields();
+  private static final ImmutableSetMultimap<String, Integer>
+      TYPE_VARIABLES_WITH_NULLABLE_UPPER_BOUNDS = createTypeVariablesWithNullableUpperBounds();
+  private static final ImmutableSet<String> NULL_MARKED_CLASSES = createNullMarkedClasses();
+  private static final ImmutableSetMultimap<MethodRef, Integer>
+      METHOD_TYPE_VARIABLES_WITH_NULLABLE_UPPER_BOUNDS =
+          createMethodTypeVariablesWithNullableUpperBounds();
+  private static final ImmutableMap<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
+      NESTED_ANNOTATIONS_FOR_METHODS = createNestedAnnotationsForMethods();
+
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters() {
     return ImmutableSetMultimap.of();
@@ -43,6 +67,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> explicitlyNullableParameters() {
+    return EXPLICITLY_NULLABLE_PARAMETERS;
+  }
+
+  /** Creates the immutable explicitly-nullable parameter models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, Integer> createExplicitlyNullableParameters() {
     return ImmutableSetMultimap.of(
         methodRef(
             "com.uber.lib.unannotated.NullMarkedVarargsWithModel",
@@ -60,6 +89,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> nonNullParameters() {
+    return NON_NULL_PARAMETERS;
+  }
+
+  /** Creates the immutable non-null parameter models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, Integer> createNonNullParameters() {
     return new ImmutableSetMultimap.Builder<MethodRef, Integer>()
         .put(
             methodRef(
@@ -86,6 +120,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters() {
+    return NULL_IMPLIES_FALSE_PARAMETERS;
+  }
+
+  /** Creates the immutable null-implies-false models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, Integer> createNullImpliesFalseParameters() {
     return ImmutableSetMultimap.of(
         methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "isNonNull(java.lang.Object)"),
         0);
@@ -98,6 +137,12 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, MethodRef> ensuresNonNullIfTrueMethodCalls() {
+    return ENSURES_NON_NULL_IF_TRUE_METHOD_CALLS;
+  }
+
+  /** Creates the immutable ensures-non-null models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, MethodRef>
+      createEnsuresNonNullIfTrueMethodCalls() {
     return ImmutableSetMultimap.of(
         methodRef("com.uber.lib.unannotated.CustomInterface", "hasContent()"),
         methodRef("com.uber.lib.unannotated.CustomInterface", "getContent()"));
@@ -105,6 +150,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSet<MethodRef> nullableReturns() {
+    return NULLABLE_RETURNS;
+  }
+
+  /** Creates the immutable nullable-return models used by this test provider. */
+  private static ImmutableSet<MethodRef> createNullableReturns() {
     return ImmutableSet.of(
         methodRef("com.uber.AnnotatedWithModels", "returnsNullFromModel()"),
         methodRef("com.uber.lib.unannotated.UnannotatedWithModels", "returnsNullUnannotated()"),
@@ -120,6 +170,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> castToNonNullMethods() {
+    return CAST_TO_NON_NULL_METHODS;
+  }
+
+  /** Creates the immutable cast-to-non-null models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, Integer> createCastToNonNullMethods() {
     return ImmutableSetMultimap.<MethodRef, Integer>builder()
         .put(
             methodRef("com.uber.nullaway.testdata.Util", "<T>castToNonNull(T,java.lang.String)"), 0)
@@ -165,6 +220,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSet<FieldRef> nullableFields() {
+    return NULLABLE_FIELDS;
+  }
+
+  /** Creates the immutable nullable-field models used by this test provider. */
+  private static ImmutableSet<FieldRef> createNullableFields() {
     return ImmutableSet.<FieldRef>builder()
         .add(
             fieldRef("com.uber.lib.unannotated.UnannotatedWithModels", "nullableFieldUnannotated1"),
@@ -174,6 +234,12 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<String, Integer> typeVariablesWithNullableUpperBounds() {
+    return TYPE_VARIABLES_WITH_NULLABLE_UPPER_BOUNDS;
+  }
+
+  /** Creates the immutable class type-variable models used by this test provider. */
+  private static ImmutableSetMultimap<String, Integer>
+      createTypeVariablesWithNullableUpperBounds() {
     return ImmutableSetMultimap.of(
         "com.uber.lib.unannotated.ProviderNullMarkedViaModel",
         0,
@@ -185,6 +251,11 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSet<String> nullMarkedClasses() {
+    return NULL_MARKED_CLASSES;
+  }
+
+  /** Creates the immutable null-marked class models used by this test provider. */
+  private static ImmutableSet<String> createNullMarkedClasses() {
     return ImmutableSet.of(
         "com.uber.lib.unannotated.ProviderNullMarkedViaModel",
         "com.uber.lib.unannotated.LambdaBox",
@@ -197,6 +268,12 @@ public class TestLibraryModels implements LibraryModels {
 
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> methodTypeVariablesWithNullableUpperBounds() {
+    return METHOD_TYPE_VARIABLES_WITH_NULLABLE_UPPER_BOUNDS;
+  }
+
+  /** Creates the immutable method type-variable models used by this test provider. */
+  private static ImmutableSetMultimap<MethodRef, Integer>
+      createMethodTypeVariablesWithNullableUpperBounds() {
     return ImmutableSetMultimap.of(
         methodRef("com.uber.lib.unannotated.ProviderNullMarkedViaModel", "<U>of(U)"),
         0,
@@ -207,6 +284,12 @@ public class TestLibraryModels implements LibraryModels {
   @Override
   public ImmutableMap<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
       nestedAnnotationsForMethods() {
+    return NESTED_ANNOTATIONS_FOR_METHODS;
+  }
+
+  /** Creates the immutable nested-annotation models used by this test provider. */
+  private static ImmutableMap<MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>
+      createNestedAnnotationsForMethods() {
     return new ImmutableMap.Builder<
             MethodRef, ImmutableSetMultimap<Integer, NestedAnnotationInfo>>()
         .put(


### PR DESCRIPTION
Repeated CompilationTestHelper invocations construct a fresh NullAway checker, causing the bundled JSpecify JDK astubx resource and test library-model tables to be parsed and converted hundreds of times during the unit suite.

Split bundled JSpecify model loading from the dynamic JarInfer path. Lazily parse the bundled resource once per NullAway classloader and publish only deeply immutable, javac-context-independent values. Keep ServiceLoader discovery, configuration filtering, optimized Name-based indexes, and all other compiler state local to each checker and javac Context.

Cache the context-independent TestLibraryModels tables as immutable constants, while deliberately leaving stream models per instance because their TypePredicates contain invocation-aware memoizing suppliers.

This preserves behavior for concurrent javac instances in Bazel workers and long-lived Gradle daemons while avoiding repeated model construction. Local profiling reduced the nullaway:test task from a best comparable 17.268 seconds to 15.876 and 15.849 seconds.  For CI, we run the test suite multiple times on different JDKs, so this should give some kind of perceptible win.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and interpretation of external library nullability models.
  * Added support for additional annotations, nullable returns and fields, type-variable bounds, parameter nullability, and null-marked classes.
  * Improved handling of JSpecify, JarInfer, Stubx, and Android model data.
  * Missing JSpecify resources now report clear failures, while unavailable Android model data is handled gracefully.

* **Performance**
  * Reduced repeated model parsing and improved reuse of loaded model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->