### PR TITLE
Allow nullable method references for void functions

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1356,6 +1356,9 @@ public class NullAway extends BugChecker
       @Nullable Type modeledOverriddenMethodType,
       @Nullable MemberReferenceTree memberReferenceTree,
       VisitorState state) {
+    if (overriddenMethod.getReturnType().getKind() == TypeKind.VOID) {
+      return false;
+    }
     if (modeledOverriddenMethodType != null) {
       Type modeledReturnType = modeledOverriddenMethodType.getReturnType();
       if (Nullness.hasNullableAnnotation(

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -138,6 +138,47 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void nullableMethodReferenceReturnForVoidFunctionalInterface() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Collection;
+            import java.util.Map;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static @Nullable String nullable(String value) {
+                return null;
+              }
+
+              void test(
+                  Map<String, String> source,
+                  Map<String, String> destination,
+                  Collection<String> collection) {
+                source.forEach(destination::put);
+                collection.forEach(Test::nullable);
+                source.forEach((key, value) -> destination.put(key, value));
+              }
+
+              interface NullableConsumer {
+                void accept(@Nullable String value);
+              }
+
+              static void consumeNonNull(String value) {}
+
+              void testParameterChecking() {
+                // BUG: Diagnostic contains: parameter value of referenced method is @NonNull, but parameter in functional interface method
+                NullableConsumer consumer = Test::consumeNonNull;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Ignore(
       "We need to merge https://github.com/uber/NullAway/pull/1689 and re-generate JSpecify JDK models before this will work")
   @Test


### PR DESCRIPTION
Treat void functional-interface return types as having no nullness contract when checking method references. This permits references to nullable-returning methods when Java discards the returned value, while leaving parameter compatibility checks intact.

Add JSpecify JDK model regression coverage for bound and static method references used by Map.forEach and Collection.forEach, the equivalent lambda form, and continued reporting of parameter-nullability mismatches.

Fixes #1719


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for methods returning `void`, preventing incorrect override checks.
  * Correctly handles nullable method references used with void-compatible functional interfaces.

* **Tests**
  * Added coverage for nullable method references with collection iteration APIs, including valid and diagnostic cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->