### PR TITLE
Preserve nested nullness in enhanced for var types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1100,12 +1100,15 @@ public final class GenericsChecks {
    */
   private @Nullable Type getEnhancedForLoopElementType(
       Symbol symbol, VisitorState state, boolean calledFromDataflow) {
-    TreePath loopPath = state.getPath();
-    while (loopPath != null) {
-      if (loopPath.getLeaf() instanceof EnhancedForLoopTree enhancedForLoop
+    TreePath currentPath = state.getPath();
+    // currentPath points to some use of the loop variable inside the loop.  So, we need to traverse
+    // up the path to parents until we find the EnhancedForLoopTree.  This only happens once per
+    // variable so shouldn't be too costly.
+    while (currentPath != null) {
+      if (currentPath.getLeaf() instanceof EnhancedForLoopTree enhancedForLoop
           && symbol.equals(ASTHelpers.getSymbol(enhancedForLoop.getVariable()))) {
         ExpressionTree expression = enhancedForLoop.getExpression();
-        TreePath expressionPath = new TreePath(loopPath, expression);
+        TreePath expressionPath = new TreePath(currentPath, expression);
         Type expressionType =
             getTreeType(expression, state.withPath(expressionPath), calledFromDataflow);
         if (expressionType instanceof Type.ArrayType arrayType) {
@@ -1114,6 +1117,8 @@ public final class GenericsChecks {
         if (expressionType == null || expressionType.isRaw()) {
           return null;
         }
+        // We have an enhanced for over an Iterable.  So, we want the effective upper bound of the
+        // type argument (JLS 14.14.2)
         Type iterableType =
             TypeSubstitutionUtils.asSuper(
                 state.getTypes(),
@@ -1124,11 +1129,11 @@ public final class GenericsChecks {
           return null;
         }
         com.sun.tools.javac.util.List<Type> typeArguments = iterableType.getTypeArguments();
-        return typeArguments.isEmpty()
-            ? null
-            : GenericsUtils.effectiveWildcardUpperBound(typeArguments.head, state, config, handler);
+        return GenericsUtils.effectiveWildcardUpperBound(
+            typeArguments.head, state, config, handler);
       }
-      loopPath = loopPath.getParentPath();
+      // not the EnhancedForLoopTree; keep going
+      currentPath = currentPath.getParentPath();
     }
     return null;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1135,7 +1135,11 @@ public final class GenericsChecks {
       // not the EnhancedForLoopTree; keep going
       currentPath = currentPath.getParentPath();
     }
-    return null;
+    // unreachable; we should have always been asking about a variable inside an enhanced for loop
+    throw new IllegalStateException(
+        String.format(
+            "%s is unexpectedly outside an enhanced for loop",
+            state.getSourceForNode(state.getPath().getLeaf())));
   }
 
   private @Nullable Type getInferredTypeForVarLocalDeclaration(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -16,6 +16,7 @@ import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ConditionalExpressionTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.LambdaExpressionTree;
@@ -1068,13 +1069,68 @@ public final class GenericsChecks {
     }
     ExpressionTree initializer = variableDecl.getInitializer();
     if (initializer == null) {
-      // this can happen for enhanced for loops
-      // TODO handle this properly; see https://github.com/uber/NullAway/issues/1581
+      Type enhancedForElementType =
+          getEnhancedForLoopElementType(symbol, state, calledFromDataflow);
+      if (enhancedForElementType != null) {
+        if (!calledFromDataflow) {
+          inferredVarLocalTypes.put(symbol, enhancedForElementType);
+        }
+        return enhancedForElementType;
+      }
       return typeOrNullIfRaw(symbol.type);
     }
     TreePath pathToInitializer = pathWithLeaf(state.getPath(), initializer);
     return getInferredTypeForVarLocalDeclaration(
         variableDecl, initializer, pathToInitializer, state, calledFromDataflow);
+  }
+
+  /**
+   * Gets the inferred element type for a {@code var}-declared enhanced-for loop variable.
+   *
+   * <p>javac may drop nested type-use annotations from the loop variable's symbol, so this method
+   * reconstructs the element type from the annotated type of the loop expression. For an iterable,
+   * the element type is the effective upper bound of its {@code Iterable} type argument, as
+   * specified by JLS 14.14.2.
+   *
+   * @param symbol symbol for the enhanced-for loop variable
+   * @param state visitor state whose path is within the loop
+   * @param calledFromDataflow whether this method was called as part of dataflow analysis
+   * @return the inferred element type, or {@code null} if no matching loop or usable expression
+   *     type can be found
+   */
+  private @Nullable Type getEnhancedForLoopElementType(
+      Symbol symbol, VisitorState state, boolean calledFromDataflow) {
+    TreePath loopPath = state.getPath();
+    while (loopPath != null) {
+      if (loopPath.getLeaf() instanceof EnhancedForLoopTree enhancedForLoop
+          && symbol.equals(ASTHelpers.getSymbol(enhancedForLoop.getVariable()))) {
+        ExpressionTree expression = enhancedForLoop.getExpression();
+        TreePath expressionPath = new TreePath(loopPath, expression);
+        Type expressionType =
+            getTreeType(expression, state.withPath(expressionPath), calledFromDataflow);
+        if (expressionType instanceof Type.ArrayType arrayType) {
+          return arrayType.getComponentType();
+        }
+        if (expressionType == null || expressionType.isRaw()) {
+          return null;
+        }
+        Type iterableType =
+            TypeSubstitutionUtils.asSuper(
+                state.getTypes(),
+                expressionType,
+                (Symbol.ClassSymbol) state.getSymtab().iterableType.tsym,
+                config);
+        if (iterableType == null || iterableType.isRaw()) {
+          return null;
+        }
+        com.sun.tools.javac.util.List<Type> typeArguments = iterableType.getTypeArguments();
+        return typeArguments.isEmpty()
+            ? null
+            : GenericsUtils.effectiveWildcardUpperBound(typeArguments.head, state, config, handler);
+      }
+      loopPath = loopPath.getParentPath();
+    }
+    return null;
   }
 
   private @Nullable Type getInferredTypeForVarLocalDeclaration(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -255,10 +255,56 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
               void test(List<Foo<@Nullable String>> l) {
                 for (var foo : l) {
                   var x = foo.get();
-                  // TODO we should be reporting a warning here consistently
-                  // See https://github.com/uber/NullAway/issues/1581
-                  // commented out since we only report a warning on JDK 27+
-                  // x.hashCode();
+                  // BUG: Diagnostic contains: dereferenced expression 'x' is @Nullable
+                  x.hashCode();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void enhancedForLoopMapEntryPreservesValueTypeNullness() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            import java.util.LinkedHashMap;
+            import java.util.concurrent.CompletableFuture;
+            @NullMarked
+            class Test {
+              static <K, V> void put(
+                  LinkedHashMap<K, @Nullable V> map, K key, @Nullable V value) {
+                map.put(key, value);
+              }
+              static <K, V> void setValue(
+                  LinkedHashMap<K, @Nullable V> map, @Nullable V value) {
+                for (var entry : map.entrySet()) {
+                  entry.setValue(value);
+                }
+              }
+              static <K, V> void setNestedValue(
+                  LinkedHashMap<K, CompletableFuture<@Nullable V>> map) {
+                for (var entry : map.entrySet()) {
+                  entry.getValue().obtrudeValue(null);
+                }
+              }
+              static <K, V> void rejectNullableValue(
+                  LinkedHashMap<K, V> map, @Nullable V value) {
+                for (var entry : map.entrySet()) {
+                  // BUG: Diagnostic contains: passing @Nullable parameter 'value' where @NonNull is required
+                  entry.setValue(value);
+                }
+              }
+              static <K, V> void rejectNestedNullableValue(
+                  LinkedHashMap<K, CompletableFuture<V>> map) {
+                for (var entry : map.entrySet()) {
+                  // BUG: Diagnostic contains: passing @Nullable parameter 'null' where @NonNull is required
+                  entry.getValue().obtrudeValue(null);
                 }
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -312,6 +312,34 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void enhancedForLoopOverArrayPreservesElementTypeNullness() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<T extends @Nullable Object> {
+                T get();
+              }
+              void test(Foo<@Nullable String>[] nullableArray, Foo<String>[] nonNullArray) {
+                for (var foo : nullableArray) {
+                  // BUG: Diagnostic contains: dereferenced expression 'foo.get()' is @Nullable
+                  foo.get().hashCode();
+                }
+                for (var foo : nonNullArray) {
+                  foo.get().hashCode();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Fixes #1720

Preserve nested nullness in enhanced for var types

Reconstruct the inferred type of a var-declared enhanced-for loop variable from the loop expression rather than relying on javac's variable symbol, which can omit nested type-use annotations.

Handle both arrays and Iterable subtypes. For iterables, view the annotation-preserving expression type as Iterable and use the effective upper bound of its element argument, matching the enhanced-for typing rules. Continue to fall back to javac's symbol type when reconstruction is unavailable, and avoid caching types computed during dataflow.

Add regressions for Map.Entry.setValue with nullable map values, nested nullable CompletableFuture values reached through Map.Entry.getValue, and non-null controls. Also enable the existing enhanced-for nested-nullness assertion that was previously JDK-dependent.

