### PR TITLE
Track nullable elements in enhanced for dataflow

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -25,6 +25,7 @@ import static javax.lang.model.element.ElementKind.EXCEPTION_PARAMETER;
 import static org.checkerframework.nullaway.javacutil.TreeUtils.elementFromDeclaration;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import com.google.common.base.VerifyException;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
@@ -33,6 +34,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
@@ -1202,6 +1204,11 @@ public class AccessPathNullnessPropagation
       // we have a model saying return value is nullable.
       // still, rely on dataflow fact if there is one available
       nullness = input.getRegularStore().valueOfMethodCall(node, state, NULLABLE, apContext);
+    } else if (node != null && enhancedForLoopElementIsNullable(node)) {
+      // The CFG represents a read from an Iterable in an enhanced-for loop as a synthetic call to
+      // Iterator.next(). Compute its nullness from the original iterable expression, whose type
+      // preserves annotations that may be missing from the synthetic iterator type.
+      nullness = input.getRegularStore().valueOfMethodCall(node, state, NULLABLE, apContext);
     } else if (node == null
         || methodReturnsNonNull.test(node)
         || (!Nullness.hasNullableAnnotation((Symbol) node.getTarget().getMethod(), config)
@@ -1213,6 +1220,31 @@ public class AccessPathNullnessPropagation
       nullness = input.getRegularStore().valueOfMethodCall(node, state, NULLABLE, apContext);
     }
     return nullness;
+  }
+
+  /** Returns whether {@code node} reads a nullable element for an enhanced-for loop. */
+  private boolean enhancedForLoopElementIsNullable(MethodInvocationNode node) {
+    if (!config.isJSpecifyMode()) {
+      return false;
+    }
+    ExpressionTree iterableExpression = node.getIterableExpression();
+    if (iterableExpression == null) {
+      return false;
+    }
+    TreePath loopPath = node.getTreePath();
+    while (!(loopPath.getLeaf() instanceof EnhancedForLoopTree enhancedForLoop)
+        || !enhancedForLoop.getExpression().equals(iterableExpression)) {
+      loopPath =
+          Verify.verifyNotNull(
+              loopPath.getParentPath(),
+              "No enhanced-for loop found for iterable expression %s",
+              iterableExpression);
+    }
+    TreePath expressionPath = new TreePath(loopPath, iterableExpression);
+    Nullness elementNullness =
+        genericsChecks.getEnhancedForLoopElementNullness(
+            iterableExpression, state.withPath(expressionPath));
+    return elementNullness.equals(NULLABLE);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessPropagation.java
@@ -1206,9 +1206,8 @@ public class AccessPathNullnessPropagation
       nullness = input.getRegularStore().valueOfMethodCall(node, state, NULLABLE, apContext);
     } else if (node != null && enhancedForLoopElementIsNullable(node)) {
       // The CFG represents a read from an Iterable in an enhanced-for loop as a synthetic call to
-      // Iterator.next(). Compute its nullness from the original iterable expression, whose type
-      // preserves annotations that may be missing from the synthetic iterator type.
-      nullness = input.getRegularStore().valueOfMethodCall(node, state, NULLABLE, apContext);
+      // Iterator.next(); treat it as nullable
+      nullness = NULLABLE;
     } else if (node == null
         || methodReturnsNonNull.test(node)
         || (!Nullness.hasNullableAnnotation((Symbol) node.getTarget().getMethod(), config)

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1109,28 +1109,8 @@ public final class GenericsChecks {
           && symbol.equals(ASTHelpers.getSymbol(enhancedForLoop.getVariable()))) {
         ExpressionTree expression = enhancedForLoop.getExpression();
         TreePath expressionPath = new TreePath(currentPath, expression);
-        Type expressionType =
-            getTreeType(expression, state.withPath(expressionPath), calledFromDataflow);
-        if (expressionType instanceof Type.ArrayType arrayType) {
-          return arrayType.getComponentType();
-        }
-        if (expressionType == null || expressionType.isRaw()) {
-          return null;
-        }
-        // We have an enhanced for over an Iterable.  So, we want the effective upper bound of the
-        // type argument (JLS 14.14.2)
-        Type iterableType =
-            TypeSubstitutionUtils.asSuper(
-                state.getTypes(),
-                expressionType,
-                (Symbol.ClassSymbol) state.getSymtab().iterableType.tsym,
-                config);
-        if (iterableType == null || iterableType.isRaw()) {
-          return null;
-        }
-        com.sun.tools.javac.util.List<Type> typeArguments = iterableType.getTypeArguments();
-        return GenericsUtils.effectiveWildcardUpperBound(
-            typeArguments.head, state, config, handler);
+        return getEnhancedForLoopElementType(
+            expression, state.withPath(expressionPath), calledFromDataflow);
       }
       // not the EnhancedForLoopTree; keep going
       currentPath = currentPath.getParentPath();
@@ -1140,6 +1120,47 @@ public final class GenericsChecks {
         String.format(
             "%s is unexpectedly outside an enhanced for loop",
             state.getSourceForNode(state.getPath().getLeaf())));
+  }
+
+  /**
+   * Gets the nullness of the element read from an enhanced-for expression during dataflow.
+   *
+   * @param expression expression iterated over by the enhanced-for loop
+   * @param state visitor state whose path points to {@code expression}
+   * @return the element nullness, or {@link Nullness#NONNULL} if the element type cannot be
+   *     resolved
+   */
+  public Nullness getEnhancedForLoopElementNullness(ExpressionTree expression, VisitorState state) {
+    Type elementType =
+        getEnhancedForLoopElementType(expression, state, /* calledFromDataflow= */ true);
+    return elementType == null ? Nullness.NONNULL : getReturnTypeNullness(elementType, state);
+  }
+
+  /**
+   * Gets the element type of an enhanced-for expression, preserving nested nullability annotations.
+   */
+  private @Nullable Type getEnhancedForLoopElementType(
+      ExpressionTree expression, VisitorState state, boolean calledFromDataflow) {
+    Type expressionType = getTreeType(expression, state, calledFromDataflow);
+    if (expressionType instanceof Type.ArrayType arrayType) {
+      return arrayType.getComponentType();
+    }
+    if (expressionType == null || expressionType.isRaw()) {
+      return null;
+    }
+    // We have an enhanced for over an Iterable.  So, we want the effective upper bound of the
+    // type argument (JLS 14.14.2)
+    Type iterableType =
+        TypeSubstitutionUtils.asSuper(
+            state.getTypes(),
+            expressionType,
+            (Symbol.ClassSymbol) state.getSymtab().iterableType.tsym,
+            config);
+    if (iterableType == null || iterableType.isRaw()) {
+      return null;
+    }
+    com.sun.tools.javac.util.List<Type> typeArguments = iterableType.getTypeArguments();
+    return GenericsUtils.effectiveWildcardUpperBound(typeArguments.head, state, config, handler);
   }
 
   private @Nullable Type getInferredTypeForVarLocalDeclaration(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1133,7 +1133,9 @@ public final class GenericsChecks {
   public Nullness getEnhancedForLoopElementNullness(ExpressionTree expression, VisitorState state) {
     Type elementType =
         getEnhancedForLoopElementType(expression, state, /* calledFromDataflow= */ true);
-    return elementType == null ? Nullness.NONNULL : getReturnTypeNullness(elementType, state);
+    return elementType == null
+        ? Nullness.NONNULL
+        : getReturnTypeNullness(elementType, state, /* followTypeVarUpperBound= */ true);
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -265,6 +265,39 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void explicitlyTypedEnhancedForLoop() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            import java.util.List;
+            @NullMarked
+            class Test {
+              void test(
+                  List<@Nullable String> nullableList,
+                  List<String> nonNullList,
+                  List<? extends @Nullable String> nullableWildcardList) {
+                for (String value : nullableList) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
+                  value.hashCode();
+                }
+                for (String value : nonNullList) {
+                  value.hashCode();
+                }
+                for (String value : nullableWildcardList) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
+                  value.hashCode();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void enhancedForLoopMapEntryPreservesValueTypeNullness() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -292,6 +292,28 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
                   value.hashCode();
                 }
               }
+              <T extends @Nullable Object> void testNullableTypeVariableUpperBound(
+                  List<T> nullableTypeVariableList,
+                  List<? extends T> nullableWildcardTypeVariableList) {
+                for (T value : nullableTypeVariableList) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
+                  value.hashCode();
+                }
+                for (T value : nullableWildcardTypeVariableList) {
+                  // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
+                  value.hashCode();
+                }
+              }
+              <T> void testNonNullTypeVariableUpperBound(
+                  List<T> nonNullTypeVariableList,
+                  List<? extends T> nonNullWildcardTypeVariableList) {
+                for (T value : nonNullTypeVariableList) {
+                  value.hashCode();
+                }
+                for (T value : nonNullWildcardTypeVariableList) {
+                  value.hashCode();
+                }
+              }
             }
             """)
         .doTest();


### PR DESCRIPTION
Checker Framework lowers Iterable-based enhanced-for loops to synthetic Iterator.next() calls. Derive the nullness of those calls from the original iterable expression so explicitly typed loop variables retain the nullness of the values assigned on each iteration.

Reuse the annotation-preserving enhanced-for element type computation introduced for var declarations, including effective wildcard upper bounds. Recover the source loop path from the synthetic CFG node before running generic inference, and retain existing fallbacks when the source element type cannot be resolved.

Add regressions for explicitly typed loops over nullable, non-null, and nullable-wildcard lists. Existing generic-call, var, and array loop tests protect the surrounding paths.

Fixes #1581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for enhanced `for` loops in JSpecify mode.
  * Nullable elements from nullable and nullable-wildcard lists now produce appropriate diagnostics.
  * Non-null elements continue to be accepted correctly.

* **Tests**
  * Added coverage for explicitly typed enhanced `for` loop variables and element nullability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->