### PR TITLE
Honor ignored methods in null-marked library models

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
+++ b/nullaway/src/main/java/com/uber/nullaway/CodeAnnotationInfo.java
@@ -181,7 +181,7 @@ public final class CodeAnnotationInfo {
     boolean inAnnotatedClass = classCacheRecord.isNullnessAnnotated;
     if (symbol.getKind().equals(ElementKind.METHOD)
         || symbol.getKind().equals(ElementKind.CONSTRUCTOR)) {
-      return !classCacheRecord.isMethodNullnessAnnotated((Symbol.MethodSymbol) symbol);
+      return !classCacheRecord.isMethodNullnessAnnotated((Symbol.MethodSymbol) symbol, handler);
     } else {
       return !inAnnotatedClass;
     }
@@ -236,7 +236,7 @@ public final class CodeAnnotationInfo {
         // Check if this class is annotated, recall that enclosed scopes override enclosing scopes
         boolean isAnnotated = recordForEnclosing.isNullnessAnnotated;
         if (enclosingMethod != null) {
-          isAnnotated = recordForEnclosing.isMethodNullnessAnnotated(enclosingMethod);
+          isAnnotated = recordForEnclosing.isMethodNullnessAnnotated(enclosingMethod, handler);
         }
         if (hasDirectAnnotationWithSimpleName(
             classSymbol, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME)) {
@@ -331,17 +331,22 @@ public final class CodeAnnotationInfo {
       this.methodNullnessCache = new HashMap<>();
     }
 
-    boolean isMethodNullnessAnnotated(Symbol.MethodSymbol methodSymbol) {
+    boolean isMethodNullnessAnnotated(Symbol.MethodSymbol methodSymbol, @Nullable Handler handler) {
       return methodNullnessCache.computeIfAbsent(
           methodSymbol,
           m -> {
+            boolean isAnnotated;
             if (hasDirectAnnotationWithSimpleName(m, NullabilityUtil.NULLUNMARKED_SIMPLE_NAME)) {
-              return false;
+              isAnnotated = false;
             } else if (this.isNullnessAnnotated) {
-              return true;
+              isAnnotated = true;
             } else {
-              return hasDirectAnnotationWithSimpleName(m, NullabilityUtil.NULLMARKED_SIMPLE_NAME);
+              isAnnotated =
+                  hasDirectAnnotationWithSimpleName(m, NullabilityUtil.NULLMARKED_SIMPLE_NAME);
             }
+            return handler == null
+                ? isAnnotated
+                : handler.onOverrideMethodNullMarkedness(m, isAnnotated);
           });
     }
   }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -354,6 +354,16 @@ class CompositeHandler implements Handler {
   }
 
   @Override
+  public boolean onOverrideMethodNullMarkedness(
+      Symbol.MethodSymbol methodSymbol, boolean currentNullMarkedness) {
+    boolean result = currentNullMarkedness;
+    for (Handler h : handlers) {
+      result = h.onOverrideMethodNullMarkedness(methodSymbol, result);
+    }
+    return result;
+  }
+
+  @Override
   public Type.MethodType onOverrideMethodType(
       Symbol.MethodSymbol methodSymbol,
       Type.MethodType methodType,

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -478,6 +478,21 @@ public interface Handler {
   }
 
   /**
+   * Updates whether a method should be treated as {@code @NullMarked}.
+   *
+   * <p>This hook supports method-level exceptions to null-markedness inherited from an enclosing
+   * class, including exceptions represented by library models.
+   *
+   * @param methodSymbol symbol for the method
+   * @param currentNullMarkedness null-markedness computed by the core and upstream handlers
+   * @return the possibly updated null-markedness
+   */
+  default boolean onOverrideMethodNullMarkedness(
+      Symbol.MethodSymbol methodSymbol, boolean currentNullMarkedness) {
+    return currentNullMarkedness;
+  }
+
+  /**
    * Method to override the type of a method.
    *
    * @param methodSymbol symbol of the method

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -491,6 +491,14 @@ public class LibraryModelsHandler implements Handler {
   }
 
   @Override
+  public boolean onOverrideMethodNullMarkedness(
+      Symbol.MethodSymbol methodSymbol, boolean currentNullMarkedness) {
+    String classDotMethod =
+        methodSymbol.enclClass().getQualifiedName() + "." + methodSymbol.getSimpleName();
+    return config.isSkippedLibraryModel(classDotMethod) ? false : currentNullMarkedness;
+  }
+
+  @Override
   public boolean isSingleArgNullImpliesFalseMethod(
       Symbol.MethodSymbol methodSymbol, VisitorState state) {
     return methodSymbol.getParameters().size() == 1

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -97,6 +97,46 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   }
 
   @Test
+  public void ignoredMethodDoesNotInheritNullMarkedLibraryModel() {
+    makeTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                List.of("-XepOpt:NullAway:OnlyNullMarked=true")))
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.lang.reflect.Field;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              Object getStaticField(Class<?> cls) throws ReflectiveOperationException {
+                // BUG: Diagnostic contains: returning @Nullable expression
+                return cls.getField("someNonNullStaticField").get(null);
+              }
+            }
+            """)
+        .doTest();
+
+    makeTestHelperWithArgs(
+            JSpecifyJavacConfig.withJSpecifyModeArgs(
+                List.of(
+                    "-XepOpt:NullAway:OnlyNullMarked=true",
+                    "-XepOpt:NullAway:IgnoreLibraryModelsFor=java.lang.reflect.Field.get")))
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.lang.reflect.Field;
+            import org.jspecify.annotations.NullMarked;
+            @NullMarked
+            class Test {
+              Object getStaticField(Class<?> cls) throws ReflectiveOperationException {
+                return cls.getField("someNonNullStaticField").get(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void defaultLibraryModelsClassIsArray() {
     makeTestHelperWithArgs(
             JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Treat methods named by IgnoreLibraryModelsFor as unmarked so class-level null-marking from library models does not impose non-null defaults after their method models are skipped.

Fixes #1723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handler support for overriding whether individual methods are treated as null-marked.
  * Added support for method-level exceptions to enclosing-class and library-model nullness settings.
  * Added consistent override handling across multiple registered handlers.

* **Bug Fixes**
  * Corrected nullness reporting for configured library-model methods, including reflective field access.
  * Ensured ignored methods no longer inherit null-marked behavior from library models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->