### PR TITLE
Avoid crashes on malformed @Contract arity (#1726)

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractCheckHandler.java
@@ -98,6 +98,9 @@ public class ContractCheckHandler implements Handler {
       String[] antecedent =
           getAntecedent(clause, tree, analysis, state, callee, tree.getParameters().size());
       String consequent = getConsequent(clause, tree, analysis, state, callee);
+      if (antecedent == null) {
+        return;
+      }
 
       boolean checkMethodBody = config.checkContracts();
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -253,6 +253,9 @@ public class ContractHandler implements Handler {
               storedVisitorState,
               callee,
               originalNode.getArguments().size());
+      if (antecedent == null) {
+        continue;
+      }
       // Find a single value constraint that is not already known. If more than one argument with
       // unknown nullness affects the method's result, then ignore this clause.
       Node arg = null;
@@ -321,6 +324,9 @@ public class ContractHandler implements Handler {
 
       String[] antecedent =
           getAntecedent(clause, tree, analysis, state, callee, node.getArguments().size());
+      if (antecedent == null) {
+        continue;
+      }
       String consequent = getConsequent(clause, tree, analysis, state, callee);
 
       // Find a single value constraint that is not already known. If more than one argument with

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractUtils.java
@@ -77,9 +77,10 @@ public class ContractUtils {
    * @param state The current visitor state.
    * @param callee Symbol for callee.
    * @param numOfArguments Number of arguments in the method associated with the contract.
-   * @return antecedents in the contract.
+   * @return antecedents in the contract, or {@code null} if their count does not match {@code
+   *     numOfArguments}
    */
-  static String[] getAntecedent(
+  static String @Nullable [] getAntecedent(
       String clause,
       Tree tree,
       NullAway analysis,
@@ -110,6 +111,9 @@ public class ContractUtils {
                   analysis.buildDescription(tree),
                   state,
                   null));
+    }
+    if (antecedent.length != numOfArguments) {
+      return null;
     }
     return antecedent;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -133,6 +133,35 @@ public class ContractsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void contractOnVarargsMethodIsNotReportedAsMalformed() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckContracts=true"))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jetbrains.annotations.Contract;
+            public class Test {
+              @Contract("_, !null -> !null")
+              static Object varargs(Object first, Object... rest) {
+                return new Object();
+              }
+              static void calls() {
+                varargs(new Object());
+                varargs(new Object(), new Object());
+                varargs(new Object(), new Object(), new Object());
+                varargs(new Object(), new Object[0]);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void noContractCheckErrorsWithoutFlag() {
     makeTestHelperWithArgs(
             Arrays.asList(

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsTests.java
@@ -109,6 +109,30 @@ public class ContractsTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void checkContractMismatchedArity() {
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:CheckContracts=true"))
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jetbrains.annotations.Contract;
+            public class Test {
+              @Contract("!null -> !null")
+              // BUG: Diagnostic contains: Invalid @Contract annotation
+              public Object[] toArray() {
+                return new Object[0];
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void noContractCheckErrorsWithoutFlag() {
     makeTestHelperWithArgs(
             Arrays.asList(
@@ -479,6 +503,12 @@ public class ContractsTests extends NullAwayTestsBase {
               @Contract("!null -> -> !null")
               // BUG: Diagnostic contains: Invalid @Contract annotation
               static @Nullable Object dontcare(@Nullable Object o) { return o; }
+              @Contract("!null -> !null")
+              // BUG: Diagnostic contains: Invalid @Contract annotation
+              static @Nullable Object tooManyConstraints() { return null; }
+              @Contract("true -> fail")
+              // BUG: Diagnostic contains: Invalid @Contract annotation
+              static void malformedFailContract() {}
               // don't report errors about invalid contract annotations at calls to these methods
               static Object test1() {
                 // BUG: Diagnostic contains: returning @Nullable expression
@@ -491,6 +521,13 @@ public class ContractsTests extends NullAwayTestsBase {
               static Object test3() {
                 // BUG: Diagnostic contains: returning @Nullable expression
                 return baz(null);
+              }
+              static Object test4() {
+                // BUG: Diagnostic contains: returning @Nullable expression
+                return tooManyConstraints();
+              }
+              static void test5() {
+                malformedFailContract();
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/contract/ContractUtilsTest.java
@@ -1,6 +1,7 @@
 package com.uber.nullaway.handlers.contract;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -32,6 +33,15 @@ public class ContractUtilsTest {
     String[] antecedent = ContractUtils.getAntecedent("->_", tree, analysis, state, symbol, 0);
 
     assertArrayEquals(new String[0], antecedent);
+    verifyNoInteractions(tree, state, analysis, symbol);
+  }
+
+  @Test
+  public void getMismatchedAntecedent() {
+    String[] antecedent =
+        ContractUtils.getAntecedent("!null -> !null", tree, analysis, state, symbol, 0);
+
+    assertNull(antecedent);
     verifyNoInteractions(tree, state, analysis, symbol);
   }
 }


### PR DESCRIPTION
NullAway reported an invalid `@Contract` when an antecedent's arity did not match the method arguments, but its handlers continued processing the mismatched constraints. Extra constraints could then cause out-of-bounds argument access during invocation dataflow or CFG construction, and contract body checking could fail while initializing dataflow.

Return null from the shared antecedent parser for mismatched arity and have each consumer skip the invalid clause after preserving the declaration diagnostic. Add regression coverage for declaration checking, invocation dataflow, fail-contract CFG handling, and the parser result.

Fixes #1726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed contract annotations with mismatched parameter counts.
  * Prevented invalid contract clauses from triggering additional analysis errors or crashes.
  * Ensured malformed `fail` contracts are reported at their declaration sites while preserving standard nullable-return diagnostics.
  * Improved support for valid contracts on varargs methods across different invocation patterns.

* **Tests**
  * Added regression coverage for invalid contract annotations, varargs contracts, and antecedent parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->