### PR TITLE
Fix inference for annotated type variable uses

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -331,10 +331,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
 
     /* top-level nullability rules */
     if (isKnownNonNull(t)) {
-      constrainAsNonNull(s, t);
+      constrainAsNonNull(s);
     }
     if (isKnownNullable(s)) {
-      constrainAsNullable(t, s);
+      constrainAsNullable(t);
     }
   }
 
@@ -359,37 +359,36 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   /**
-   * Constrain a type to be @Nullable due to its being a supertype of some known @Nullable type
+   * Constrains an inference variable to be {@code @Nullable}.
+   *
+   * <p>If {@code t} is a type-variable use with an explicit nullness annotation, the annotation
+   * fixes the nullness of that use without constraining the underlying inference variable. Any
+   * incompatibility involving that fixed annotation is handled by the normal type compatibility
+   * checks.
    *
    * @param t the type to constrain
-   * @param knownNullableType the known nullable type
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
    */
-  private void constrainAsNullable(Type t, Type knownNullableType)
-      throws UnsatisfiableConstraintsException {
+  private void constrainAsNullable(Type t) throws UnsatisfiableConstraintsException {
     if (treatAsTypeVariableForInference(t)) {
       updateNullness(t.asElement(), NullnessState.NULLABLE);
-    } else if (isKnownNonNull(t)) {
-      TypeVariable typeVar =
-          knownNullableType instanceof TypeVariable typeVariable ? typeVariable : (TypeVariable) t;
-      throw new UnsatisfiableConstraintsException(typeVar.asElement());
     }
   }
 
   /**
-   * Constrain a type to be @NonNull due to its being a subtype of some known @NonNull type
+   * Constrains an inference variable to be {@code @NonNull}.
+   *
+   * <p>If {@code t} is a type-variable use with an explicit nullness annotation, the annotation
+   * fixes the nullness of that use without constraining the underlying inference variable. Any
+   * incompatibility involving that fixed annotation is handled by the normal type compatibility
+   * checks.
    *
    * @param t the type to constrain
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
    */
-  private void constrainAsNonNull(Type t, Type knownNonNullType)
-      throws UnsatisfiableConstraintsException {
+  private void constrainAsNonNull(Type t) throws UnsatisfiableConstraintsException {
     if (treatAsTypeVariableForInference(t)) {
       updateNullness(t.asElement(), NullnessState.NONNULL);
-    } else if (isKnownNullable(t)) {
-      TypeVariable typeVar =
-          t instanceof TypeVariable typeVariable ? typeVariable : (TypeVariable) knownNonNullType;
-      throw new UnsatisfiableConstraintsException(typeVar.asElement());
     }
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -962,6 +962,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
             """
             import org.jspecify.annotations.NullMarked;
             import org.jspecify.annotations.Nullable;
+            import org.jspecify.annotations.NonNull;
             @NullMarked
             class Test {
               static <T extends @Nullable Object> @Nullable T id(T value) {
@@ -981,6 +982,13 @@ public class GenericMethodTests extends NullAwayTestsBase {
               static String nullableArgument(@Nullable String value) {
                 // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
                 return id(value);
+              }
+              static <T extends @Nullable Object> T nonNullParamId(@NonNull T value) {
+                return value;
+              }
+              static void testNonNullParamWarn(@Nullable String value) {
+                // BUG: Diagnostic contains: passing @Nullable parameter 'value' where @NonNull is required
+                nonNullParamId(value);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -945,9 +945,79 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 }
                 String field = "hello";
                 void testField() {
-                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                    // BUG: Diagnostic contains: assigning @Nullable expression to @NonNull field
                     field = f("hello");
                 }
+            }
+            """)
+        .doTest();
+  }
+
+  /** Regression test for https://github.com/uber/NullAway/issues/1730. */
+  @Test
+  public void nullableTypeVariableReturnDoesNotCauseInferenceFailure() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static <T extends @Nullable Object> @Nullable T id(T value) {
+                return value;
+              }
+              static String nonNullTarget() {
+                // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                return id("");
+              }
+              static @Nullable String nullableTarget() {
+                return id("");
+              }
+              static String witness() {
+                // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                return Test.<String>id("");
+              }
+              static String nullableArgument(@Nullable String value) {
+                // BUG: Diagnostic contains: returning @Nullable expression from method with @NonNull return type
+                return id(value);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /** Regression test for the {@code @Contract} case from issue 1730. */
+  @Test
+  public void nullableTypeVariableReturnWithContractDoesNotCauseInferenceFailure() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jetbrains.annotations.Contract;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              @Contract("_, !null -> !null")
+              static <T extends @Nullable Object> @Nullable T first(
+                  @Nullable T first, @Nullable T second) {
+                return first != null ? first : second;
+              }
+              @Contract("_, !null -> !null")
+              static @Nullable String firstString(
+                  @Nullable String first, @Nullable String second) {
+                return first != null ? first : second;
+              }
+              static String useGeneric(@Nullable String value) {
+                return first(value, "");
+              }
+              static String useConcrete(@Nullable String value) {
+                return firstString(value, "");
+              }
+              static String useWitness(@Nullable String value) {
+                return Test.<String>first(value, "");
+              }
             }
             """)
         .doTest();
@@ -1831,7 +1901,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
               static class Box<T extends @Nullable Object> {}
               static <T extends @Nullable Object> void accept(Box<@Nullable T> box) {}
               void test(Box<CompletableFuture<Object>> box) {
-                // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                // BUG: Diagnostic contains: incompatible types: Box<CompletableFuture<Object>> cannot be converted to Box<@Nullable CompletableFuture<Object>>
                 accept(box);
               }
             }""")


### PR DESCRIPTION
Do not treat an explicit nullness annotation on a type variable use (e.g., `@Nullable T`) as a constraint on the underlying inference variable at calls.  Instead, allow ordinary assignment compatibility checks to report any mismatches with the explicit annotations.  The previous constraints were leading to duplicative and misleading inference failure warnings.

Add regression coverage for both forms of issue #1730: the underlying nullable-return diagnostic and the false positive that remained after a @Contract refined the generic call result to non-null. Cover non-null and nullable targets, explicit type witnesses, nullable arguments, and generic versus concrete contract calls.

Update existing field-assignment and nested-generic expectations to assert the more precise compatibility diagnostics while retaining coverage for genuine inference conflicts.

Fixes #1730 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generic nullness analysis to avoid incorrect inference failures when nullable type variables are used.
  * Diagnostics now report the relevant nullability or type incompatibility directly.

* **Tests**
  * Added regression coverage for nullable generic method returns, including methods with contracts.
  * Updated expected diagnostics for nullable assignments and nested generic types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->