### PR TITLE
Prevent recursion on self-referential wildcard bounds

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -9,7 +9,10 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.Config;
 import com.uber.nullaway.handlers.Handler;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
 
@@ -23,6 +26,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private final GenericsChecks genericsChecks;
   private final Config config;
   private final Handler handler;
+
+  /** Wildcard argument pairs currently being checked for containment. */
+  private final IdentityHashMap<Type.WildcardType, Set<Type>> activeWildcardComparisons =
+      new IdentityHashMap<>();
 
   CheckIdenticalNullabilityVisitor(
       VisitorState state, GenericsChecks genericsChecks, Config config, Handler handler) {
@@ -189,13 +196,30 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * {@code B} is the corresponding type variable's upper bound.
    */
   private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
-    return switch (lhsWildcard.kind) {
-      case UNBOUND, EXTENDS ->
-          extendsBoundContains(
-              GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler),
-              rhsTypeArgument);
-      case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
-    };
+    Set<Type> activeRhsArguments = activeWildcardComparisons.get(lhsWildcard);
+    if (activeRhsArguments == null) {
+      activeRhsArguments = Collections.newSetFromMap(new IdentityHashMap<>());
+      activeWildcardComparisons.put(lhsWildcard, activeRhsArguments);
+    } else if (activeRhsArguments.contains(rhsTypeArgument)) {
+      // Recursive bounds can lead back to the exact same containment question. Re-entering that
+      // pair cannot reveal a mismatch that was not already handled on the first visit.
+      return true;
+    }
+    activeRhsArguments.add(rhsTypeArgument);
+    try {
+      return switch (lhsWildcard.kind) {
+        case UNBOUND, EXTENDS ->
+            extendsBoundContains(
+                GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler),
+                rhsTypeArgument);
+        case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
+      };
+    } finally {
+      activeRhsArguments.remove(rhsTypeArgument);
+      if (activeRhsArguments.isEmpty()) {
+        activeWildcardComparisons.remove(lhsWildcard);
+      }
+    }
   }
 
   /**
@@ -248,6 +272,6 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
       return false;
     }
-    return genericsChecks.subtypeParameterNullability(lhsType, rhsType, state);
+    return genericsChecks.subtypeParameterNullability(lhsType, rhsType, state, this);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1985,23 +1985,44 @@ public final class GenericsChecks {
    *
    * @param lhsType type for the lhs of the assignment
    * @param rhsType type for the rhs of the assignment
-   * @param state the visitor state
+   * @param visitor visitor carrying state for the recursive comparison
    */
+  @SuppressWarnings({"ReferenceEquality", "TypeEquals"}) // deliberate reference equality check
   private boolean identicalTypeParameterNullability(
-      Type lhsType, Type rhsType, VisitorState state) {
-    return lhsType.accept(
-        new CheckIdenticalNullabilityVisitor(state, this, config, handler), rhsType);
+      Type lhsType, Type rhsType, CheckIdenticalNullabilityVisitor visitor) {
+    if (lhsType == rhsType) {
+      return true;
+    }
+    return lhsType.accept(visitor, rhsType);
   }
 
   /**
-   * Like {@link #identicalTypeParameterNullability(Type, Type, VisitorState)}, but allows for
-   * covariant array subtyping at the top level.
+   * Like {@link #identicalTypeParameterNullability(Type, Type, CheckIdenticalNullabilityVisitor)},
+   * but allows for covariant array subtyping at the top level.
    *
    * @param lhsType type for the lhs of the assignment
    * @param rhsType type for the rhs of the assignment
    * @param state the visitor state
    */
   boolean subtypeParameterNullability(Type lhsType, Type rhsType, VisitorState state) {
+    return subtypeParameterNullability(
+        lhsType,
+        rhsType,
+        state,
+        new CheckIdenticalNullabilityVisitor(state, this, config, handler));
+  }
+
+  /**
+   * Continues a subtype nullability comparison with an existing visitor so recursive wildcard
+   * comparisons share cycle-detection state.
+   *
+   * @param lhsType type for the lhs of the assignment
+   * @param rhsType type for the rhs of the assignment
+   * @param state the visitor state
+   * @param visitor visitor carrying state for the recursive comparison
+   */
+  boolean subtypeParameterNullability(
+      Type lhsType, Type rhsType, VisitorState state, CheckIdenticalNullabilityVisitor visitor) {
     if (lhsType.isRaw()) {
       return true;
     }
@@ -2019,9 +2040,9 @@ public final class GenericsChecks {
       if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
         return false;
       }
-      return identicalTypeParameterNullability(lhsComponentType, rhsComponentType, state);
+      return identicalTypeParameterNullability(lhsComponentType, rhsComponentType, visitor);
     } else {
-      return identicalTypeParameterNullability(lhsType, rhsType, state);
+      return identicalTypeParameterNullability(lhsType, rhsType, visitor);
     }
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1384,6 +1384,29 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void issue1760() {
+    makeHelper()
+        .addSourceLines(
+            "Main.java",
+            """
+            package org.example;
+
+            import java.util.List;
+            import org.jspecify.annotations.NullMarked;
+
+            @NullMarked
+            class Main {
+              abstract static class Settings<S extends Settings<? extends S>> {}
+
+              static List<? extends Settings<?>> pass(List<? extends Settings<?>> in) {
+                return in;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
Wildcard containment checks can revisit the same pair of wildcard arguments when expanding a self-referential bound such as S extends Settings<? extends S>. The recursive subtype check previously created a fresh CheckIdenticalNullabilityVisitor, so there was no per-comparison state capable of recognizing the cycle and javac eventually failed with a StackOverflowError.

Reuse the active visitor across recursive subtype checks and track in-progress wildcard containment pairs by object identity. Treat re-entry of an exact active pair as coinductive success, while removing pairs in a finally block so independent comparisons continue to receive complete checking. Also short-circuit comparisons of identical javac Type objects.

Add the minimal reproduction from issue #1760 as a JSpecify wildcard regression test.

Fixes #1760
