### PR TITLE
Work around pre-JDK-25 limitations in reading upper bounds from wildcard arguments in bytecode

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -89,16 +89,19 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
     }
     List<Type> lhsTypeArguments = lhsType.getTypeArguments();
     List<Type> rhsTypeArguments = rhsTypeAsSuper.getTypeArguments();
+    List<Type> correspondingTypeVariables = lhsType.tsym.type.getTypeArguments();
     // This is impossible, considering the fact that standard Java subtyping succeeds before
     // running NullAway
-    if (lhsTypeArguments.size() != rhsTypeArguments.size()) {
+    if (lhsTypeArguments.size() != rhsTypeArguments.size()
+        || lhsTypeArguments.size() != correspondingTypeVariables.size()) {
       throw new RuntimeException(
           "Number of types arguments in " + rhsTypeAsSuper + " does not match " + lhsType);
     }
     for (int i = 0; i < lhsTypeArguments.size(); i++) {
       Type lhsTypeArgument = lhsTypeArguments.get(i);
       Type rhsTypeArgument = rhsTypeArguments.get(i);
-      if (!typeArgumentContainedBy(lhsTypeArgument, rhsTypeArgument)) {
+      Type.TypeVar correspondingTypeVariable = (Type.TypeVar) correspondingTypeVariables.get(i);
+      if (!typeArgumentContainedBy(lhsTypeArgument, rhsTypeArgument, correspondingTypeVariable)) {
         return false;
       }
     }
@@ -143,7 +146,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * relation</a>. Non-wildcard pairs require matching nullability annotations and recursively
    * matching nested type arguments. Wildcard formals are delegated to {@link #wildcardContains}.
    */
-  private boolean typeArgumentContainedBy(Type lhsTypeArgument, Type rhsTypeArgument) {
+  private boolean typeArgumentContainedBy(
+      Type lhsTypeArgument, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {
     if (!config.handleWildcardGenerics()) {
       if (lhsTypeArgument.getKind().equals(TypeKind.WILDCARD)
           || rhsTypeArgument.getKind().equals(TypeKind.WILDCARD)) {
@@ -159,7 +163,7 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
           lhsTypeArgument instanceof Type.WildcardType wildcardType ? wildcardType : null;
       Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
       if (lhsWildcard != null) {
-        return wildcardContains(lhsWildcard, rhsTypeArgument);
+        return wildcardContains(lhsWildcard, rhsTypeArgument, correspondingTypeVariable);
       }
       if (rhsWildcard != null) {
         // This case should only arise when generic method invocation inference / capture conversion
@@ -195,7 +199,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * super T} when {@code S <: T}; and a formal {@code ?} is treated as {@code ? extends B}, where
    * {@code B} is the corresponding type variable's upper bound.
    */
-  private boolean wildcardContains(Type.WildcardType lhsWildcard, Type rhsTypeArgument) {
+  private boolean wildcardContains(
+      Type.WildcardType lhsWildcard, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {
     Set<Type> activeRhsArguments = activeWildcardComparisons.get(lhsWildcard);
     if (activeRhsArguments == null) {
       activeRhsArguments = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -210,8 +215,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
       return switch (lhsWildcard.kind) {
         case UNBOUND, EXTENDS ->
             extendsBoundContains(
-                GenericsUtils.wildcardUpperBound(lhsWildcard, state, config, handler),
-                rhsTypeArgument);
+                GenericsUtils.wildcardUpperBound(
+                    lhsWildcard, correspondingTypeVariable, state, config, handler),
+                rhsTypeArgument,
+                correspondingTypeVariable);
         case SUPER -> superWildcardContains(lhsWildcard, rhsTypeArgument);
       };
     } finally {
@@ -227,10 +234,13 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * For concrete actuals {@code T}, wildcard actuals {@code ? extends T}, and non-extends wildcard
    * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}.
    */
-  private boolean extendsBoundContains(Type lhsBound, Type rhsTypeArgument) {
+  private boolean extendsBoundContains(
+      Type lhsBound, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
     if (rhsWildcard != null) {
-      Type rhsUpperBound = GenericsUtils.wildcardUpperBound(rhsWildcard, state, config, handler);
+      Type rhsUpperBound =
+          GenericsUtils.wildcardUpperBound(
+              rhsWildcard, correspondingTypeVariable, state, config, handler);
       return typeArgumentSubtype(lhsBound, rhsUpperBound);
     }
     return typeArgumentSubtype(lhsBound, rhsTypeArgument);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -145,6 +145,13 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * <a href="https://jspecify.dev/docs/spec/#subtyping">JSpecify's nullability-aware subtype
    * relation</a>. Non-wildcard pairs require matching nullability annotations and recursively
    * matching nested type arguments. Wildcard formals are delegated to {@link #wildcardContains}.
+   *
+   * @param lhsTypeArgument the formal type argument on the left
+   * @param rhsTypeArgument the actual type argument on the right whose containment is checked
+   * @param correspondingTypeVariable the formal type variable for this type-argument position,
+   *     passed to wildcard containment checks so they can compute effective wildcard bounds when
+   *     javac has not stored the corresponding formal type variable on the wildcard itself
+   * @return whether {@code rhsTypeArgument} is contained by {@code lhsTypeArgument}
    */
   private boolean typeArgumentContainedBy(
       Type lhsTypeArgument, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {
@@ -198,6 +205,13 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * formal {@code ? super S} contains concrete actuals {@code T} and wildcard actuals {@code ?
    * super T} when {@code S <: T}; and a formal {@code ?} is treated as {@code ? extends B}, where
    * {@code B} is the corresponding type variable's upper bound.
+   *
+   * @param lhsWildcard the formal wildcard type argument on the left
+   * @param rhsTypeArgument the actual type argument on the right whose containment is checked
+   * @param correspondingTypeVariable the formal type variable for the wildcard's type-argument
+   *     position, used to compute effective upper bounds when javac has not stored the
+   *     corresponding formal type variable on the wildcard itself
+   * @return whether {@code lhsWildcard} contains {@code rhsTypeArgument}
    */
   private boolean wildcardContains(
       Type.WildcardType lhsWildcard, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -148,9 +148,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    *
    * @param lhsTypeArgument the formal type argument on the left
    * @param rhsTypeArgument the actual type argument on the right whose containment is checked
-   * @param correspondingTypeVariable the formal type variable for this type-argument position,
-   *     passed to wildcard containment checks so they can compute effective wildcard bounds when
-   *     javac has not stored the corresponding formal type variable on the wildcard itself
+   * @param correspondingTypeVariable the formal type variable for this type-argument position, used
+   *     in wildcard containment checks so they can compute effective wildcard bounds when javac has
+   *     not stored the corresponding formal type variable on the wildcard itself (see <a
+   *     href="https://github.com/uber/NullAway/issues/1732">#1732</a>)
    * @return whether {@code rhsTypeArgument} is contained by {@code lhsTypeArgument}
    */
   private boolean typeArgumentContainedBy(
@@ -208,9 +209,10 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    *
    * @param lhsWildcard the formal wildcard type argument on the left
    * @param rhsTypeArgument the actual type argument on the right whose containment is checked
-   * @param correspondingTypeVariable the formal type variable for the wildcard's type-argument
-   *     position, used to compute effective upper bounds when javac has not stored the
-   *     corresponding formal type variable on the wildcard itself
+   * @param correspondingTypeVariable the formal type variable for this type-argument position, used
+   *     to compute effective wildcard bounds when javac has not stored the corresponding formal
+   *     type variable on the wildcard itself (see <a
+   *     href="https://github.com/uber/NullAway/issues/1732">#1732</a>)
    * @return whether {@code lhsWildcard} contains {@code rhsTypeArgument}
    */
   private boolean wildcardContains(
@@ -247,6 +249,15 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * Returns whether a formal {@code ? extends S} contains the actual type argument on the right.
    * For concrete actuals {@code T}, wildcard actuals {@code ? extends T}, and non-extends wildcard
    * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}.
+   *
+   * @param lhsBound the effective upper bound {@code S} of the formal wildcard on the left
+   * @param rhsTypeArgument the actual type argument on the right whose containment is checked
+   * @param correspondingTypeVariable the formal type variable for this type-argument position, used
+   *     to compute the effective upper bound of a wildcard actual when javac has not stored the
+   *     corresponding formal type variable on the wildcard itself (see <a
+   *     href="https://github.com/uber/NullAway/issues/1732">#1732</a>)
+   * @return whether a formal wildcard whose effective upper bound is {@code lhsBound} contains
+   *     {@code rhsTypeArgument}
    */
   private boolean extendsBoundContains(
       Type lhsBound, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -67,8 +67,9 @@ public class GenericsUtils {
    * javac has not stored one on the wildcard itself.
    *
    * <p>Before JDK 23, javac does not associate wildcard type arguments read from classfiles with
-   * their corresponding formal type variables. The caller can provide that association when it is
-   * available from the enclosing parameterized type.
+   * their corresponding formal type variables. The {@code correspondingTypeVariable} parameter
+   * allows the caller to provide that information, when available (see <a
+   * href="https://github.com/uber/NullAway/issues/1732">#1732</a>).
    */
   static Type wildcardUpperBound(
       WildcardType wildcardType,

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -59,6 +59,23 @@ public class GenericsUtils {
    */
   static Type wildcardUpperBound(
       WildcardType wildcardType, VisitorState state, Config config, Handler handler) {
+    return wildcardUpperBound(wildcardType, wildcardType.bound, state, config, handler);
+  }
+
+  /**
+   * Returns the effective upper bound of a wildcard, using {@code correspondingTypeVariable} when
+   * javac has not stored one on the wildcard itself.
+   *
+   * <p>Before JDK 23, javac does not associate wildcard type arguments read from classfiles with
+   * their corresponding formal type variables. The caller can provide that association when it is
+   * available from the enclosing parameterized type.
+   */
+  static Type wildcardUpperBound(
+      WildcardType wildcardType,
+      Type.@Nullable TypeVar correspondingTypeVariable,
+      VisitorState state,
+      Config config,
+      Handler handler) {
     Type upperBound;
     if (wildcardType.kind == BoundKind.EXTENDS) {
       upperBound = wildcardType.getExtendsBound();
@@ -68,7 +85,8 @@ public class GenericsUtils {
       // passed (confusingly stored in the `bound` field).  E.g., if we have class Foo<T extends
       // @Nullable Object>, and then see Foo<? super String>, we use @Nullable Object as the upper
       // bound.  If not present, default to Object.
-      Type.TypeVar formalTypeVar = wildcardType.bound;
+      Type.TypeVar formalTypeVar =
+          wildcardType.bound != null ? wildcardType.bound : correspondingTypeVariable;
       upperBound =
           formalTypeVar == null
               ? Symtab.instance(state.context).objectType

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -63,6 +63,57 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1732UnboundedWildcardInBytecode() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Collection;
+            import java.util.Collections;
+            import java.util.List;
+            import java.util.Set;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static boolean bulkOperations(
+                  List<String> list,
+                  Collection<@Nullable String> nullableCollection,
+                  Set<@Nullable String> nullableSet) {
+                return list.containsAll(nullableCollection)
+                    || list.removeAll(nullableSet)
+                    || list.retainAll(nullableCollection);
+              }
+
+              static boolean disjoint(
+                  Collection<@Nullable String> first,
+                  Collection<@Nullable String> second) {
+                return Collections.disjoint(first, second);
+              }
+
+              static boolean ownUnbounded(Collection<?> collection) {
+                return collection.isEmpty();
+              }
+
+              static boolean callOwnUnbounded(Collection<@Nullable String> collection) {
+                return ownUnbounded(collection);
+              }
+
+              static boolean ownExtendsObject(Collection<? extends Object> collection) {
+                return collection.isEmpty();
+              }
+
+              static boolean callOwnExtendsObject(Collection<@Nullable String> collection) {
+                // BUG: Diagnostic contains: incompatible types
+                return ownExtendsObject(collection);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void listContainingNullsWithoutModel() {
     makeTestHelperWithArgs(
             // We specifically exclude the JSpecifyJDKModels flag here (so we can't use


### PR DESCRIPTION
Fixes #1732

The underlying `javac` issue was fixed in https://github.com/openjdk/jdk/pull/19400, which was shipped as part of JDK 23, but we need to support JDK 21 and JDK 17.  Here, as a workaround, where available we pass through the type variable corresponding to a particular type argument position.  From that type variable, wildcard reasoning can accurately determine the nullability of the upper bound of the wildcard.