### PR TITLE
Assert the full set of diagnostics for annotated type-variable uses

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -359,12 +359,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   /**
-   * Constrains an inference variable to be {@code @Nullable}.
+   * Records that {@code t} must be {@code @Nullable}.
    *
-   * <p>If {@code t} is a type-variable use with an explicit nullness annotation, the annotation
-   * fixes the nullness of that use without constraining the underlying inference variable. Any
-   * incompatibility involving that fixed annotation is handled by the normal type compatibility
-   * checks.
+   * <p>Only an inference variable takes a constraint, meaning a type-variable use with no explicit
+   * nullness annotation. Every other type already has a fixed nullness, including a class type and
+   * an explicitly annotated type-variable use. For those cases, this method does not introduce any
+   * constraint, and the normal type compatibility checks report any incompatibility.
    *
    * @param t the type to constrain
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
@@ -376,12 +376,12 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   }
 
   /**
-   * Constrains an inference variable to be {@code @NonNull}.
+   * Records that {@code t} must be {@code @NonNull}.
    *
-   * <p>If {@code t} is a type-variable use with an explicit nullness annotation, the annotation
-   * fixes the nullness of that use without constraining the underlying inference variable. Any
-   * incompatibility involving that fixed annotation is handled by the normal type compatibility
-   * checks.
+   * <p>Only an inference variable takes a constraint, meaning a type-variable use with no explicit
+   * nullness annotation. Every other type already has a fixed nullness, including a class type and
+   * an explicitly annotated type-variable use. For those cases, this method does not introduce any
+   * constraint, and the normal type compatibility checks report any incompatibility.
    *
    * @param t the type to constrain
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -1,6 +1,7 @@
 package com.uber.nullaway.jspecify;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneJavaCompiler;
@@ -14,12 +15,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
-/** Tests the locations and counts of generic inference failure diagnostics. */
+/**
+ * Tests the diagnostics NullAway reports for generic inference: which ones, how many, and where.
+ */
 public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
 
   /**
@@ -189,6 +193,127 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
               }
             }
             """);
+    assertThat(
+            compileAndReportDiagnostics(List.of(unrelatedSource, callerSource)).stream()
+                .filter(diagnostic -> diagnostic.contains("inference failure: type variable T"))
+                .toList())
+        .containsExactly(
+            "File2.java:7: [NullAway] inference failure: type variable T constrained to be both"
+                + " @NonNull and @Nullable");
+  }
+
+  /**
+   * Fails when an explicit {@code @Nullable} annotation on a type-variable use constrains the
+   * underlying inference variable, which makes NullAway report one mismatch twice: as an inference
+   * failure and again as the ordinary compatibility diagnostic. NullAway must report the
+   * compatibility diagnostic alone; see https://github.com/uber/NullAway/issues/1730.
+   *
+   * <p>This has to assert the whole set of diagnostics, so it cannot live in {@link
+   * GenericMethodTests}: {@code CompilationTestHelper} accepts a line whose {@code // BUG:
+   * Diagnostic contains:} comment matches one diagnostic even when the line carries another. The
+   * source below therefore carries every shape from that issue whose line still expects a
+   * diagnostic. Both annotation checks in {@code
+   * ConstraintSolverImpl.treatAsTypeVariableForInference} are reached, by an explicit
+   * {@code @Nullable} on a use and an explicit {@code @NonNull} on a parameter. The call with an
+   * explicit type witness reaches neither, because a witness skips inference; it is here as one of
+   * the issue's shapes, and it guards against such a call acquiring an inference failure of its
+   * own. A shape whose line expects nothing needs no help, since {@code CompilationTestHelper}
+   * rejects any diagnostic there.
+   */
+  @Test
+  public void annotatedTypeVariableUseIsNotAnInferenceFailure() {
+    JavaFileObject callerSource =
+        FileObjects.forSourceLines(
+            "Caller.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Caller {
+              static <T extends @Nullable Object> @Nullable T id(T value) {
+                return value;
+              }
+              static <T extends @Nullable Object> T nonNullParamId(@NonNull T value) {
+                return value;
+              }
+              static String nonNullTarget() {
+                return id("");
+              }
+              static String witness() {
+                return Caller.<String>id("");
+              }
+              static String nullableArgument(@Nullable String value) {
+                return id(value);
+              }
+              static void nonNullParameter(@Nullable String value) {
+                nonNullParamId(value);
+              }
+            }
+            """);
+
+    assertThat(compileAndReportDiagnostics(List.of(callerSource)))
+        .containsExactly(
+            "Caller.java:14: [NullAway] returning @Nullable expression from method with @NonNull"
+                + " return type",
+            "Caller.java:17: [NullAway] returning @Nullable expression from method with @NonNull"
+                + " return type",
+            "Caller.java:20: [NullAway] returning @Nullable expression from method with @NonNull"
+                + " return type",
+            "Caller.java:23: [NullAway] passing @Nullable parameter 'value' where @NonNull is"
+                + " required");
+  }
+
+  /**
+   * Fails when {@link #compileAndReportDiagnostics} reports a diagnostic that names no line in the
+   * compiled source. javac emits a summary note against a file rather than against no file at all,
+   * so a filter that only asks for a source lets the note through, and the expected set of any test
+   * whose source triggers one has to carry it. The source below compiles without a NullAway
+   * diagnostic and produces two such notes.
+   */
+  @Test
+  public void summaryNotesAreNotReported() {
+    JavaFileObject uncheckedSource =
+        FileObjects.forSourceLines(
+            "Unchecked.java",
+            """
+            package com.uber;
+            import java.util.ArrayList;
+            import java.util.List;
+            @org.jspecify.annotations.NullMarked
+            class Unchecked {
+              @SuppressWarnings("rawtypes")
+              static List raw() {
+                return new ArrayList();
+              }
+              static void use() {
+                List<String> typed = raw();
+              }
+            }
+            """);
+
+    assertThat(compileAndReportDiagnostics(List.of(uncheckedSource))).isEmpty();
+  }
+
+  /**
+   * Compiles {@code sources} with NullAway in JSpecify mode and reports every diagnostic that names
+   * a position in them, as {@code <file>:<line>: <message>}. A caller asserts the returned list,
+   * whole or narrowed to the diagnostics its own name covers, so one that appears, disappears,
+   * moves to another line, or changes its wording fails the test. Severity is not part of the
+   * filter, since a check reported below warning level is still a diagnostic about the source.
+   *
+   * <p>A diagnostic is reported only when it names both a file and a line, which is what a reader
+   * of the source can locate. That leaves out javac's {@code [options]} warnings, which name no
+   * file, and its summary notes such as "uses unchecked or unsafe operations", which name a file at
+   * {@link Diagnostic#NOPOS}. Dropping those loses no error, because compilation has to succeed
+   * anyway: NullAway reports at warning severity here, so a compile error means the test source
+   * itself is broken.
+   *
+   * @param sources the compilation units to compile
+   * @return the rendered diagnostics, in the order javac emitted them
+   */
+  private List<String> compileAndReportDiagnostics(List<JavaFileObject> sources) {
     DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
     List<String> args =
         new ArrayList<>(
@@ -203,28 +328,39 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
 
     boolean compilationSucceeded =
         compiler
-            .getTask(
-                null,
-                FileManagers.testFileManager(),
-                diagnosticCollector,
-                args,
-                null,
-                List.of(unrelatedSource, callerSource))
+            .getTask(null, FileManagers.testFileManager(), diagnosticCollector, args, null, sources)
             .call();
 
-    assertThat(compilationSucceeded).isTrue();
-    List<Diagnostic<? extends JavaFileObject>> inferenceFailureDiagnostics =
-        diagnosticCollector.getDiagnostics().stream()
-            .filter(
-                diagnostic ->
-                    diagnostic
-                        .getMessage(Locale.ROOT)
-                        .contains("inference failure: type variable T"))
-            .toList();
-    assertThat(inferenceFailureDiagnostics).hasSize(1);
-    Diagnostic<? extends JavaFileObject> inferenceFailure = inferenceFailureDiagnostics.get(0);
-    assertThat(inferenceFailure.getSource().getName()).endsWith("File2.java");
-    assertThat(inferenceFailure.getLineNumber()).isEqualTo(7L);
+    assertWithMessage("compilation failed: %s", diagnosticCollector.getDiagnostics())
+        .that(compilationSucceeded)
+        .isTrue();
+    return diagnosticCollector.getDiagnostics().stream()
+        .filter(
+            diagnostic ->
+                diagnostic.getSource() != null && diagnostic.getLineNumber() != Diagnostic.NOPOS)
+        .map(GenericInferenceErrorReportingTests::render)
+        .toList();
+  }
+
+  /**
+   * Renders {@code diagnostic} as {@code <file>:<line>: <message>}, on one line. The directory the
+   * test file manager invented is dropped, as is the "see" line Error Prone appends to every
+   * NullAway diagnostic, so the result holds what a reader of the source would recognize. Both
+   * separators end a directory here: {@link javax.tools.FileObject#getName()} promises only a
+   * user-friendly name, and a file manager is free to hand back a platform path.
+   *
+   * @param diagnostic the diagnostic to render
+   * @return the rendered diagnostic
+   */
+  private static String render(Diagnostic<? extends JavaFileObject> diagnostic) {
+    String path = diagnostic.getSource().getName();
+    String fileName = path.substring(Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\')) + 1);
+    String message =
+        Arrays.stream(diagnostic.getMessage(Locale.ROOT).split("\\R"))
+            .map(String::trim)
+            .filter(line -> !line.startsWith("(see "))
+            .collect(Collectors.joining(" "));
+    return fileName + ":" + diagnostic.getLineNumber() + ": " + message;
   }
 
   private CompilationTestHelper makeHelper() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -953,7 +953,14 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  /** Regression test for https://github.com/uber/NullAway/issues/1730. */
+  /**
+   * Pins the diagnostics NullAway reports for a call involving an explicitly annotated
+   * type-variable use (https://github.com/uber/NullAway/issues/1730). A line that expects no
+   * diagnostic is checked in full here. For a line carrying a {@code // BUG: Diagnostic contains:}
+   * comment, {@link
+   * GenericInferenceErrorReportingTests#annotatedTypeVariableUseIsNotAnInferenceFailure()} is what
+   * guards the absence of the redundant inference failure.
+   */
   @Test
   public void nullableTypeVariableReturnDoesNotCauseInferenceFailure() {
     makeHelper()


### PR DESCRIPTION
### Why

`GenericMethodTests#nullableTypeVariableReturnDoesNotCauseInferenceFailure`, added in #1759, passes against the pre-fix solver, so it does not guard the change it is named for. On that solver `return id("")` reported the redundant `inference failure: type variable T constrained to be both @NonNull and @Nullable` *and* `returning @Nullable expression from method with @NonNull return type` on the same line, and `CompilationTestHelper` accepts a line whose `// BUG: Diagnostic contains:` comment matches one diagnostic even when the line carries another. A line that expects no diagnostic is checked strictly, so the gap is exactly the four lines that carry such a comment. Restoring `ConstraintSolverImpl` from 94003d27 leaves only `nestedGenericMethodRepairPreservesTopLevelNullability` and the `@Contract` sibling failing.

The Javadoc that #1759 added to `constrainAsNullable` and `constrainAsNonNull` describes one no-op case, the explicitly annotated type-variable use. The guard `treatAsTypeVariableForInference` also returns false for every type that is not a type-variable use at all, and that path is live: `directlyConstrainTypePair` calls `constrainAsNonNull(s)` where `s` may be a plain `ClassType`.

### What

`GenericInferenceErrorReportingTests#annotatedTypeVariableUseIsNotAnInferenceFailure` pins the complete reported set for those four lines: three `@Nullable T` uses and one `@NonNull T` parameter, which is both branches of `treatAsTypeVariableForInference`.

The comparison is over every reported diagnostic rather than over counts of a substring. `compileAndReportDiagnostics` renders each one as `<file>:<line>: <message>` and the test hands the list to `containsExactly`, so a diagnostic that appears, disappears, moves to another line, or changes its wording fails. Counting occurrences of a substring would stay right when one message is swapped for another. The rendering keeps file, line and message; it drops the temporary directory the test file manager invents, the severity, and the "see" line Error Prone appends.

A diagnostic is reported only when it names both a file and a line. javac emits its summary notes against a file at `NOPOS`, so a filter on the source alone would put "uses unchecked or unsafe operations" into the expected set of any test whose source triggers one; `summaryNotesAreNotReported` pins that. Severity is not part of the filter, so a finding reported below warning level is still asserted on.

`inferenceFailureReportedOnceInCorrectFile` shares the new helper but keeps its own contract, asserting on the inference-failure diagnostics alone. A change to the compatibility diagnostic on that same line does not reach a test whose name promises nothing about it.

The two solver comments now state the rule they enforce: a constraint is recorded only for an inference variable, and every other type, class type included, keeps the nullness it already has.

`nullableTypeVariableReturnDoesNotCauseInferenceFailure` keeps its cases and says which of its lines it pins by itself and which the new test covers.

### How to verify

```
./gradlew :nullaway:test --tests "com.uber.nullaway.jspecify.GenericInferenceErrorReportingTests" --tests "com.uber.nullaway.jspecify.GenericMethodTests"
```

Restore `nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java` from 94003d27 and `annotatedTypeVariableUseIsNotAnInferenceFailure` fails with an extra `inference failure` entry on three of its four lines. The fourth is the explicit type witness, which never produced one, so it is defense-in-depth rather than a shape the fix changed.

Weaken the filter in `compileAndReportDiagnostics` to `getSource() != null` and `summaryNotesAreNotReported` fails with the two unchecked notes.

Follow-up to #1759; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how generic nullness constraints and inference behavior are interpreted.
  * Expanded documentation for expected diagnostics involving nullable and non-null generic return types.

* **Tests**
  * Improved validation of generic inference failure diagnostics.
  * Added coverage confirming explicitly annotated type-variable uses avoid redundant inference errors.
  * Ensured summary compiler notes are excluded from reported diagnostics.
  * Documented related diagnostic expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->