### PR TITLE
Improve diagnostics for non-null type variable bounds

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
@@ -22,12 +22,25 @@ public interface ConstraintSolver {
     /** Type variable on which the contradiction was detected */
     private final Element typeVariable;
 
+    /** Whether a {@code @Nullable} constraint conflicts with the type variable's upper bound. */
+    private final boolean causedByNonNullUpperBound;
+
     public UnsatisfiableConstraintsException(Element typeVariable) {
+      this(typeVariable, false);
+    }
+
+    public UnsatisfiableConstraintsException(
+        Element typeVariable, boolean causedByNonNullUpperBound) {
       this.typeVariable = typeVariable;
+      this.causedByNonNullUpperBound = causedByNonNullUpperBound;
     }
 
     public Element getTypeVariable() {
       return typeVariable;
+    }
+
+    public boolean isCausedByNonNullUpperBound() {
+      return causedByNonNullUpperBound;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -348,10 +348,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
     if (st.nullness == n) {
       return false;
     }
-    if (st.nullness != NullnessState.UNKNOWN) {
-      throw new UnsatisfiableConstraintsException(typeVarElement);
-    }
     if (n == NullnessState.NULLABLE && !st.nullableAllowed) {
+      throw new UnsatisfiableConstraintsException(typeVarElement, true);
+    }
+    if (st.nullness != NullnessState.UNKNOWN) {
       throw new UnsatisfiableConstraintsException(typeVarElement);
     }
     st.nullness = n;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1387,6 +1387,11 @@ public final class GenericsChecks {
   }
 
   private String inferenceFailureMessage(UnsatisfiableConstraintsException e) {
+    if (e.isCausedByNonNullUpperBound()) {
+      return String.format(
+          "inference failure: type variable %s is constrained to be @Nullable, but its upper bound requires it to be @NonNull",
+          e.getTypeVariable());
+    }
     return String.format(
         "inference failure: type variable %s constrained to be both @NonNull and @Nullable",
         e.getTypeVariable());

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -79,7 +79,7 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
               }
               void f() {
                 call(() -> { return ""; });
-                // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                // BUG: Diagnostic contains: inference failure: type variable T is constrained to be @Nullable, but its upper bound requires it to be @NonNull
                 call(() -> { return null; });
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -198,8 +198,8 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
                 .filter(diagnostic -> diagnostic.contains("inference failure: type variable T"))
                 .toList())
         .containsExactly(
-            "File2.java:7: [NullAway] inference failure: type variable T constrained to be both"
-                + " @NonNull and @Nullable");
+            "File2.java:7: [NullAway] inference failure: type variable T is constrained to be @Nullable, "
+                + "but its upper bound requires it to be @NonNull");
   }
 
   /**

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -222,7 +222,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
             final class Test {
                 static void reproduce() {
                     var future = future();
-                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                    // BUG: Diagnostic contains: inference failure: type variable T is constrained to be @Nullable, but its upper bound requires it to be @NonNull
                     run(() -> future.join());
                 }
                 private static CompletableFuture<?> future() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1344,7 +1344,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
                     return Optional.ofNullable(value);
                 }
                 public static <U extends @Nullable Object> Optional<U> optionalResultPositive1(@Nullable U value) {
-                    // BUG: Diagnostic contains: inference failure: type variable T constrained to be both @NonNull and @Nullable
+                    // BUG: Diagnostic contains: inference failure: type variable T is constrained to be @Nullable, but its upper bound requires it to be @NonNull
                     return Optional.of(value);
                 }
                 // identical to above, testing the other error message


### PR DESCRIPTION
Record when generic nullability inference fails because a nullable constraint conflicts with a type variable's non-null upper bound. Use that cause to explain the bound restriction directly, while retaining the existing diagnostic for ordinary conflicting constraints.

Update generic inference, lambda, and generic method regression tests to cover the more informative message.

Fixes #1721.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generic type inference diagnostics when a nullable constraint conflicts with a non-null upper bound.
  * Error messages now clearly identify the nullable constraint and the required non-null upper bound.

* **Tests**
  * Updated inference and generic type tests to verify the revised diagnostic wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->