### PR TITLE
Document that a nullImpliesNull model applies to overriding methods

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
+++ b/nullaway/src/main/java/com/uber/nullaway/LibraryModels.java
@@ -42,16 +42,16 @@ public interface LibraryModels {
   /**
    * Get methods which fail/error out when passed null.
    *
-   * @return map from the names of null-rejecting methods to the indexes of the arguments that
-   *     aren't permitted to be null.
+   * @return map from null-rejecting methods to the indexes of the arguments that aren't permitted
+   *     to be null.
    */
   ImmutableSetMultimap<MethodRef, Integer> failIfNullParameters();
 
   /**
    * Get (method, parameter) pairs that must be modeled as if explicitly annotated with @Nullable.
    *
-   * @return map from the names of methods with @Nullable parameters to the indexes of the arguments
-   *     that are @Nullable.
+   * @return map from methods with @Nullable parameters to the indexes of the arguments that
+   *     are @Nullable.
    *     <p>This is taken into account for override checks, requiring methods that override the
    *     methods listed here to take @Nullable parameters on the same indexes. The main use for this
    *     is to document which API callbacks can be passed null values.
@@ -61,8 +61,8 @@ public interface LibraryModels {
   /**
    * Get (method, parameter) pairs that must be modeled as @NonNull.
    *
-   * @return map from the names of methods with @NonNull parameters to the indexes of the arguments
-   *     that are @NonNull.
+   * @return map from methods with @NonNull parameters to the indexes of the arguments that
+   *     are @NonNull.
    *     <p>Note that these methods are different from the {@link #failIfNullParameters()} methods,
    *     in that we expect the null checker to ensure that the parameters passed to these methods
    *     are @NonNull. In contrast, the null checker does no such enforcement for methods in {@link
@@ -74,16 +74,16 @@ public interface LibraryModels {
   /**
    * Get (method, parameter) pairs that cause the method to return <code>true</code> when null.
    *
-   * @return map from the names of null-querying methods to the indexes of the arguments that are
-   *     compared against null.
+   * @return map from null-querying methods to the indexes of the arguments that are compared
+   *     against null.
    */
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesTrueParameters();
 
   /**
    * Get (method, parameter) pairs that cause the method to return <code>false</code> when null.
    *
-   * @return map from the names of non-null-querying methods to the indexes of the arguments that
-   *     are compared against null.
+   * @return map from non-null-querying methods to the indexes of the arguments that are compared
+   *     against null.
    */
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesFalseParameters();
 
@@ -108,8 +108,11 @@ public interface LibraryModels {
    *
    * <pre><code>@Contract("!null -&gt; !null") @Nullable</code></pre>
    *
-   * @return map from the names of null-in-implies-null out methods to the indexes of the arguments
-   *     that determine nullness of the return.
+   * <p>The model applies to any method that overrides the listed method. NullAway does not check
+   * that such an override obeys the contract (issue #803).
+   *
+   * @return map from null-in-implies-null-out methods to the indexes of the arguments that
+   *     determine nullness of the return.
    */
   ImmutableSetMultimap<MethodRef, Integer> nullImpliesNullParameters();
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -226,11 +226,11 @@ public class LibraryModelsHandler implements Handler {
       return exprMayBeNull;
     }
     OptimizedLibraryModels optLibraryModels = getOptLibraryModels(state.context);
-    // When looking up library models of annotated code, we match the exact method signature only;
-    // overriding methods in subclasses must be explicitly given their own library model.
-    // When dealing with unannotated code, we default to generality: a model applies to a method
-    // and any of its overriding implementations.
-    // see https://github.com/uber/NullAway/issues/445 for why this is needed.
+    // A model of a method's return nullness matches the exact signature when the method is
+    // annotated: the overriding method carries its own annotations, and an inherited model must
+    // not override them (issue #445). Unannotated code has no annotations to defer to, so there a
+    // model covers every overriding implementation. A nullImpliesNull model is a conditional
+    // contract, and applies to an overriding implementation in annotated code too.
     boolean isMethodUnannotated =
         getCodeAnnotationInfo(state.context)
             .isSymbolUnannotated(methodSymbol, this.config, mainHandler);


### PR DESCRIPTION
### Why

#1758 routed `nullImpliesNullParameters` through the override-aware lookup, so a `nullImpliesNull` model now reaches an overriding method whether or not that method is declared in annotated code. Two comments still state the older exact-signature rule: the lookup-policy comment in `LibraryModelsHandler`, twelve lines above the call that no longer follows it, and the `LibraryModels#nullImpliesNullParameters` javadoc, which says nothing about overriders at all. Both cost me an investigation in #1769.

### What

The handler comment gives the rule for each kind of model separately, so it no longer reads as a claim about both. It also names the reason #445 carried, instead of sending the reader to the URL for it: covering the issue number in the old comment left `for why this is needed`, which states nothing.

The `LibraryModels` javadoc states the inheritance rule, and records that NullAway does not check an override against the contract (#803). `LibraryModels` is a published SPI, so an implementer reading the generated page cannot look at the lookup code to discover either fact.

Six `@return` lines described a `MethodRef` key as a method name, which is its own trap in a file where `MethodRef.methodName` is a separate field. This file already spells the same thing correctly for `ensuresNonNullIfTrueMethodCalls` and `methodTypeVariablesWithNullableUpperBounds`, so the six now match those. This was not part of the drift, and it is easy to drop from the branch if you would rather keep the two changes apart.

### How to verify

```bash
./gradlew :nullaway:javadoc :nullaway:test
```

971 tests, 0 failures. Every changed line is a comment line, so no behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified library model documentation for nullness contracts and parameter behavior.
  * Documented how models apply to overriding methods and annotated implementations.
  * Improved explanations of conditional nullness contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->