### PR TITLE
Remove outdated Spark test

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,8 @@ rxjava2 = "2.1.2"
 reactor = "3.8.6"
 commons-lang3 = "3.8.1"
 commons-lang = "2.6"
+commons-collections = "3.2.2"
+commons-collections4 = "4.4"
 jsr305 = "3.0.2"
 lombok = "1.18.38"
 spring-beans = "5.3.7"
@@ -104,6 +106,8 @@ rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 commons-lang = { module = "commons-lang:commons-lang", version.ref = "commons-lang" }
+commons-collections = { module = "commons-collections:commons-collections", version.ref = "commons-collections" }
+commons-collections4 = { module = "org.apache.commons:commons-collections4", version.ref = "commons-collections4" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 spring-beans = { module = "org.springframework:spring-beans", version.ref = "spring-beans" }

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -90,6 +90,8 @@ dependencies {
     testImplementation libs.reactor.core
     testImplementation libs.commons.lang
     testImplementation libs.commons.lang3
+    testImplementation libs.commons.collections
+    testImplementation libs.commons.collections4
     testImplementation project(":test-library-models")
     testImplementation libs.lombok
     testImplementation libs.spring.beans
@@ -102,10 +104,6 @@ dependencies {
     testImplementation libs.assertj
     testImplementation libs.amazon.utils
     testImplementation libs.jakarta.annotations
-    // This is for a test exposing a CFG construction failure in the Checker Framework.  We can probably remove it once
-    // the issue is fixed upstream and we update. See https://github.com/typetools/checker-framework/issues/6396.
-    testImplementation 'org.apache.spark:spark-sql_2.12:3.3.2'
-
     errorProneOldest "com.google.errorprone:error_prone_check_api:${oldestErrorProneVersion}"
     errorProneOldest "com.google.errorprone:error_prone_core:${oldestErrorProneVersion}"
     errorProneOldest("com.google.errorprone:error_prone_test_helpers:${oldestErrorProneVersion}") {

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -1177,33 +1177,6 @@ public class CoreTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  /**
-   * This test exposes a failure in CFG construction in Checker Framework 3.41.0 and above. Once a
-   * fix for this issue makes it to a Checker Framework release, we can probably remove this test.
-   * See https://github.com/typetools/checker-framework/issues/6396.
-   */
-  @Test
-  public void cfgConstructionSymbolCompletionFailure() {
-    defaultCompilationHelper
-        .addSourceLines(
-            "Test.java",
-            """
-            package com.uber;
-            import org.apache.spark.sql.SparkSession;
-            class Test {
-              static class X {
-                X(SparkSession session) {}
-              }
-              X run() {
-                try (SparkSession session = SparkSession.builder().getOrCreate()) {
-                  return new X(session);
-                }
-              }
-            }
-            """)
-        .doTest();
-  }
-
   @Test
   public void testDefaultEqualsInInterfaceTakesNullable() {
     defaultCompilationHelper


### PR DESCRIPTION
The Checker Framework bug was fixed long ago.  This change trims the classpath for tests dramatically, which may give some test speedup.  We add some Commons collections dependencies explicitly, as some tests depend on them and were getting them implicitly as transitive deps before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to validate compatibility with common collection utilities.
  * Removed an obsolete test for a previously identified analysis edge case.

* **Chores**
  * Refined the project’s testing setup to support current compatibility checks and reduce outdated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->