### PR TITLE
Disable Jacoco by default

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,12 +45,20 @@ jobs:
         run: ./gradlew javaToolchains
       - name: Build and test
         run: ./gradlew build
+        env:
+          # The Linux build produces the execution data consumed by the Codecov aggregation step.
+          # Keep ordinary macOS and Windows test runs free of JaCoCo instrumentation overhead.
+          ORG_GRADLE_PROJECT_enableJacoco: ${{ matrix.os == 'ubuntu-latest' && 'true' || 'false' }}
       - name: Run shellcheck
         run: ./gradlew shellcheck
         if: runner.os == 'Linux'
       - name: Aggregate jacoco coverage
         id: jacoco_report
         run: ./gradlew codeCoverageReport
+        env:
+          # Use the same test-task configuration as the preceding Linux build so its JaCoCo
+          # execution data remains up-to-date and is included in the aggregate XML report.
+          ORG_GRADLE_PROJECT_enableJacoco: 'true'
         continue-on-error: true
         if: runner.os == 'Linux' && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -39,6 +39,18 @@ jacoco {
     toolVersion = "0.8.16-SNAPSHOT"
 }
 
+// Instrument test processes only when coverage is explicitly requested.  JaCoCo adds measurable
+// overhead to compilation-heavy tests, so ordinary local and CI test runs should not pay that cost.
+def enableJacoco = providers.gradleProperty("enableJacoco")
+        .map { it.toBoolean() }
+        .orElse(false)
+
+tasks.withType(Test).configureEach {
+    extensions.configure(JacocoTaskExtension) { jacocoExtension ->
+        jacocoExtension.enabled = enableJacoco.get()
+    }
+}
+
 // Do not generate reports for individual projects
 tasks.named("jacocoTestReport") {
     enabled = false


### PR DESCRIPTION
Jacoco adds a significant cost to test execution times.  With this change, we disable it by default and enable via a Gradle property.  Update CI so Jacoco still runs where we collect coverage reports for codecov.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Quality**
  * Improved test coverage collection in continuous integration.
  * Reduced overhead during standard test runs by enabling coverage instrumentation only when explicitly requested.
  * Ensured coverage aggregation uses the appropriate instrumentation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->