### PR TITLE
fix override checks for method type variables bounded by a class type variable

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2667,6 +2667,9 @@ public final class GenericsChecks {
     if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
       return true;
     }
+    if (Nullness.hasNonNullAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+      return false;
+    }
     // Member-type substitution (asMemberOf) can strip type-use @Nullable from a concrete method
     // type-variable bound while leaving the bound type itself (e.g. Object). Example that needs
     // this fallback:
@@ -2680,6 +2683,9 @@ public final class GenericsChecks {
         (Type) ((TypeVariable) originalTypeParams.get(typeVarIndex).asType()).getUpperBound();
     if (Nullness.hasNullableAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
       return true;
+    }
+    if (Nullness.hasNonNullAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
+      return false;
     }
     // Bound may still be a free type variable (e.g. subclass keeps the enclosing type parameter).
     // In that case, use the declaration-site nullability of that type variable's upper bound.

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2667,11 +2667,6 @@ public final class GenericsChecks {
     if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
       return true;
     }
-    // Bound may still be a free type variable (e.g. subclass keeps the enclosing type parameter).
-    // In that case, use the declaration-site nullability of that type variable's upper bound.
-    if (upperBound.getKind() == TypeKind.TYPEVAR) {
-      return GenericsUtils.upperBoundIsNullable(upperBound.asElement(), config, handler, state);
-    }
     // Member-type substitution (asMemberOf) can strip type-use @Nullable from a concrete method
     // type-variable bound while leaving the bound type itself (e.g. Object). Example that needs
     // this fallback:
@@ -2679,14 +2674,17 @@ public final class GenericsChecks {
     //   class Baz implements Foo { public <T extends @Nullable Object> void bar(T arg) {} }
     // After substitution the bound may look like plain Object with no annotation mirrors; without
     // consulting the original declaration we would treat the overridden bound as non-null and
-    // false-positive on a matching @Nullable override. Skip original bounds that are still type
-    // variables — those must be resolved via substitution (or the free type-var path above).
+    // false-positive on a matching @Nullable override.
     List<Symbol.TypeVariableSymbol> originalTypeParams = overriddenMethod.getTypeParameters();
     Type originalBound =
         (Type) ((TypeVariable) originalTypeParams.get(typeVarIndex).asType()).getUpperBound();
-    if (originalBound.getKind() != TypeKind.TYPEVAR
-        && Nullness.hasNullableAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
+    if (Nullness.hasNullableAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
       return true;
+    }
+    // Bound may still be a free type variable (e.g. subclass keeps the enclosing type parameter).
+    // In that case, use the declaration-site nullability of that type variable's upper bound.
+    if (upperBound.getKind() == TypeKind.TYPEVAR) {
+      return GenericsUtils.upperBoundIsNullable(upperBound.asElement(), config, handler, state);
     }
     return false;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -144,7 +144,13 @@ public class GenericsUtils {
       }
     }
     Type upperBound = (Type) ((TypeVariable) typeVarElement.asType()).getUpperBound();
-    return Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config);
+    if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+      return true;
+    }
+    if (upperBound.getKind() == TypeKind.TYPEVAR) {
+      return upperBoundIsNullable(upperBound.asElement(), config, handler, state);
+    }
+    return false;
   }
 
   private static boolean fromUnannotatedMethodOrClass(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -116,7 +116,9 @@ public class GenericsUtils {
    *
    * <p>A bound is nullable when the enclosing method or class comes from unannotated code, when a
    * library model overrides the bound nullability for the type variable, or when the declared upper
-   * bound has an explicit {@code @Nullable} annotation.
+   * bound has an explicit {@code @Nullable} annotation. An explicit {@code @NonNull} annotation on
+   * a type-variable bound takes precedence over nullability inherited from that type variable's
+   * upper bound.
    */
   static boolean upperBoundIsNullable(
       Element typeVarElement, Config config, Handler handler, VisitorState state) {
@@ -146,6 +148,9 @@ public class GenericsUtils {
     Type upperBound = (Type) ((TypeVariable) typeVarElement.asType()).getUpperBound();
     if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
       return true;
+    }
+    if (Nullness.hasNonNullAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+      return false;
     }
     if (upperBound.getKind() == TypeKind.TYPEVAR) {
       return upperBoundIsNullable(upperBound.asElement(), config, handler, state);

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -2166,6 +2166,80 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void overridePreservesExplicitNonNullFreeTypeVariableMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X extends @Nullable Object> {
+                <T extends @NonNull X> void bar(T arg);
+              }
+              static class Baz<X extends @Nullable Object> implements Foo<X> {
+                @Override
+                public <T extends @NonNull X> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideWidensExplicitNonNullFreeTypeVariableMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X extends @Nullable Object> {
+                <T extends @NonNull X> void bar(T arg);
+              }
+              static class Baz<X extends @Nullable Object> implements Foo<X> {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a @Nullable upper bound
+                public <T extends X> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideNarrowsNullableFreeTypeVariableMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X extends @Nullable Object> {
+                <T extends X> void bar(T arg);
+              }
+              static class Baz<X extends @Nullable Object> implements Foo<X> {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a non-null upper bound
+                public <T extends @NonNull X> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void overridePreservesChainedMethodTypeVariableBound() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -2139,6 +2139,59 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void overridePreservesFreeTypeVariableMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X extends @Nullable Object> {
+                <T extends X> void bar(T arg);
+              }
+              interface Bar<X extends @Nullable Object> extends Foo<X> {
+                @Override
+                <T extends X> void bar(T arg);
+              }
+              static class Baz<X extends @Nullable Object> implements Foo<X> {
+                @Override
+                public <T extends X> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideNarrowsFreeTypeVariableMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X> {
+                <T extends @Nullable X> void bar(T arg);
+              }
+              static class Baz<X> implements Foo<X> {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a non-null upper bound
+                public <T extends X> void bar(T arg) {
+                  arg.hashCode();
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void overrideOfNullUnmarkedMethodTypeVariableBoundSkipped() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -2139,6 +2139,31 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void overrideWidensSubstitutedExplicitNonNullMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo<X extends @Nullable Object> {
+                <T extends X> void bar(T arg);
+              }
+              static class Baz<Y extends @Nullable Object> implements Foo<@NonNull Y> {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a @Nullable upper bound
+                public <T extends Y> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void overridePreservesFreeTypeVariableMethodTypeVariableBound() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -2166,6 +2166,29 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void overridePreservesChainedMethodTypeVariableBound() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo {
+                <X extends @Nullable Object, T extends X> void bar(T arg);
+              }
+              static class Baz implements Foo {
+                @Override
+                public <X extends @Nullable Object, T extends X> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void overrideNarrowsFreeTypeVariableMethodTypeVariableBound() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
fixes a bug introduced in 0.14.0 where checks on overriding and overridden methods were computed differently, which resulted in a mismatch

```
interface Foo<X extends @Nullable Object> { 
  <T extends X> void bar(T arg); 
}       
                                                 
class Baz<X extends @Nullable Object> implements Foo<X> {                                                                           
  @Override 
  public <T extends X> void bar(T arg) {} // error: T has a non-null upper bound                                          
}
```

encountered this in vavr:
- https://github.com/vavr-io/vavr/pull/3338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for generic method overrides, including type-variable upper bounds and chained bounds.
  * Correctly honors explicit `@Nullable` and `@NonNull` annotations when evaluating substituted bounds.
  * Detects when an overriding method narrows or widens a nullable upper bound and reports the appropriate diagnostic.

* **Tests**
  * Added coverage for preserved, chained, narrowed, and widened generic type-variable bounds in method overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->