### PR TITLE
Fix builds from a linked git worktree by skipping installGitHooks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,11 +188,23 @@ shellcheck {
 //  Google Java Format pre-commit hook installation
 //
 
+// The hook goes into `.git/hooks`, which exists only where `.git` is a directory.  A linked worktree
+// has a `.git` file naming that worktree's git directory instead, and a source archive has no
+// `.git` at all; a `Copy` task pointed at either one fails validation.  A worktree loses no hook by
+// being skipped, since git runs the hooks of the shared repository that the main checkout installs
+// into.
+def dotGitDir = file('.git')
+def gitHooksDir = dotGitDir.isDirectory() ? new File(dotGitDir, 'hooks') : null
+
 tasks.register('installGitHooks', Copy) {
     from(file('config/hooks/pre-commit-stub')) {
         rename 'pre-commit-stub', 'pre-commit'
     }
-    into file('.git/hooks')
+    if (gitHooksDir == null) {
+        enabled = false
+    } else {
+        into gitHooksDir
+    }
     filePermissions {
         unix(0777)
     }


### PR DESCRIPTION
### Why

In a linked worktree created by `git worktree add`, `.git` is a file naming that worktree's git directory rather than a directory. `installGitHooks` copies into `<project>/.git/hooks`, so the task fails validation, and with it every task that compiles Java:

```text
A problem was found with the configuration of task ':installGitHooks' (type 'Copy').
Property is not writable
  Type 'org.gradle.api.tasks.Copy' property 'destinationDir' is not writable because '.../.git/hooks' ancestor '.../.git' is not a directory
```

Building from a worktree therefore needs `-x installGitHooks` on every invocation.

### What

The task installs the hook only where `.git` is a directory, and disables itself otherwise. A linked worktree loses no hook by being skipped: git runs the hooks of the shared repository, which a build in the main checkout installs into. A source tree with no git metadata, such as a source archive, no longer grows a stray `.git/hooks/pre-commit`.

An earlier revision resolved the shared hooks directory through the `gitdir:` pointer and the worktree's `commondir` entry. @msridhar asked for the simpler rule instead, and this is it.

### How to verify

```bash
git worktree add ../nullaway-worktree && cd ../nullaway-worktree && ./gradlew :nullaway:compileJava
```

The build succeeds without `-x installGitHooks`, and `installGitHooks` reports `SKIPPED`.

In a plain checkout the task still writes `.git/hooks/pre-commit` with mode 777. Renaming `.git` away, which is what a source archive looks like, makes the task report `SKIPPED` and leaves no `.git` behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git hook installation now correctly detects the repository’s hooks directory.
  - Hook setup works more reliably in standard repositories and avoids attempting installation when hooks are unavailable, such as linked worktrees or source archives.
  - This prevents setup failures caused by assuming every project uses a local `.git/hooks` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->