### PR TITLE
Cover anonymous class type arguments and modeled call-site returns

### DIFF
--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -359,6 +359,9 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
                   Map<String, String> map,
                   BiFunction<String, @Nullable String, @Nullable String> remappingFunction) {
                 map.compute("key", remappingFunction);
+                String value = map.compute("key", remappingFunction);
+                // BUG: Diagnostic contains: dereferenced expression 'value' is @Nullable
+                value.length();
               }
               @Override
               public @Nullable String compute(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1908,6 +1908,84 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * Fails when a diamond anonymous class loses the {@code @Nullable} on its supertype's type
+   * argument. See https://github.com/uber/NullAway/issues/1746
+   */
+  @Test
+  public void overrideDiamondAnonymousClassWithNestedGenericTypes() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              interface Foo<T extends @Nullable Object> {
+                List<T> get();
+                void accept(List<T> values);
+              }
+              static void test() {
+                Foo<@Nullable String> foo = new Foo<>() {
+                  @Override
+                  public List<@Nullable String> get() { throw new AssertionError(); }
+                  @Override
+                  public void accept(List<@Nullable String> values) {}
+                };
+                Foo<@Nullable String> badFoo = new Foo<>() {
+                  @Override
+                  // BUG: Diagnostic contains: mismatched type parameter nullability
+                  public List<String> get() { throw new AssertionError(); }
+                  @Override
+                  // BUG: Diagnostic contains: mismatched type parameter nullability
+                  public void accept(List<String> values) {}
+                };
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * Fails when an anonymous class loses the {@code @Nullable} on its supertype's type argument and
+   * the override wraps the type variable in an array. See
+   * https://github.com/uber/NullAway/issues/1746
+   */
+  @Test
+  public void overrideAnonymousClassWithArrayOfTypeVariable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              interface Foo<T extends @Nullable Object> {
+                T[] get();
+                void accept(T[] values);
+              }
+              static void test() {
+                Foo<@Nullable String> explicit = new Foo<@Nullable String>() {
+                  @Override
+                  public @Nullable String[] get() { throw new AssertionError(); }
+                  @Override
+                  // BUG: Diagnostic contains: Parameter has type String [], but overridden method has parameter type @Nullable String []
+                  public void accept(String[] values) {}
+                };
+                Foo<@Nullable String> diamond = new Foo<>() {
+                  @Override
+                  public @Nullable String[] get() { throw new AssertionError(); }
+                  @Override
+                  // BUG: Diagnostic contains: Parameter has type String [], but overridden method has parameter type @Nullable String []
+                  public void accept(String[] values) {}
+                };
+              }
+            }
+            """)
+        .doTest();
+  }
+
   @Test
   public void nullableGenericTypeVariableReturnType() {
     makeHelper()


### PR DESCRIPTION
Follow-up tests for #1746, which #1722 fixed. Offered per https://github.com/uber/NullAway/issues/1746#issuecomment-5463822003

## Why

`overrideExplicitlyTypedAnonymousClassWithNestedGenericTypes`, added by #1722, covers an anonymous class that implements an interface at `@Nullable String` and overrides `List<T>`. The diamond form and an array element take paths that test does not reach, and #1746 reported both as false positives.

#1722 also stopped `nullableReturns()` from stripping whitespace out of astubx signatures, which lets 36 entries of `jspecify-jdk.astubx` match for the first time — every one of them differing only by a space inside a wildcard bound such as `? super K`. Those entries feed `hasNullableReturn` at every call site, not only at override checks, and `mapComputeOverrideUsesJSpecifyModel` discarded the result of `map.compute(...)`, so nothing pinned the call-site direction.

## What

Two new tests in `GenericsTests`: a diamond anonymous class whose overrides wrap the type variable in `List<T>`, and an anonymous class in both the explicit and the diamond form whose overrides wrap it in an array.

`mapComputeOverrideUsesJSpecifyModel` now also dereferences the result of `map.compute(...)`. The bare call stays: an unmarked line asserts that no diagnostic fires there, which is how the existing test pins that a `BiFunction<String, @Nullable String, @Nullable String>` argument is accepted. A `// BUG:` marker on that line would have consumed any other diagnostic it produced.

`Optional.orElseGet` is the other way to pin the call-site direction, and this change leaves it alone. `JSpecifyLibraryModelsTests.optionalOrElseGet` passes today, but `LibraryModelsHandler` still carries the hand-written model for that method commented out under #1616, so removing the `@Ignore` is a call for a maintainer rather than for this pull request.

## How to verify

```
./gradlew :nullaway:test --tests "com.uber.nullaway.jspecify.GenericsTests" --tests "com.uber.nullaway.JSpecifyJDKModelsTest"
```

Every assertion here fails at 70da029a, the commit before #1722. The two array blocks needed checking one marker at a time, because the harness stops at the first unmarked line that carries an error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for `Map.compute` results, correctly identifying values that may be null.
  * Preserved `@Nullable` annotations when analyzing anonymous classes with nested generic types, diamond syntax, and arrays of type variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->