### PR TITLE
Document MethodRef overload signatures in the sample library model #1016

### DIFF
--- a/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
+++ b/sample-library-model/src/main/java/com/uber/modelexample/ExampleLibraryModels.java
@@ -40,10 +40,18 @@ public class ExampleLibraryModels implements LibraryModels {
     return ImmutableSetMultimap.of();
   }
 
+  /**
+   * MethodRef signatures are the method name plus argument types with no spaces after commas.
+   * Overloads need a separate entry each; {@code isEmptyOrNull(java.lang.CharSequence, boolean)}
+   * (space after the comma) would not match the two-argument method.
+   */
   @Override
   public ImmutableSetMultimap<MethodRef, Integer> nullImpliesTrueParameters() {
     return ImmutableSetMultimap.<MethodRef, Integer>builder()
         .put(methodRef("org.utilities.StringUtils", "isEmptyOrNull(java.lang.CharSequence)"), 0)
+        .put(
+            methodRef("org.utilities.StringUtils", "isEmptyOrNull(java.lang.CharSequence,boolean)"),
+            0)
         .build();
   }
 

--- a/sample/src/main/java/com/uber/mylib/MyClass.java
+++ b/sample/src/main/java/com/uber/mylib/MyClass.java
@@ -20,6 +20,13 @@ public class MyClass {
     return 0;
   }
 
+  static int checkModelTrim(@Nullable String s) {
+    if (!StringUtils.isEmptyOrNull(s, true)) {
+      return s.hashCode();
+    }
+    return 0;
+  }
+
   static void foo() {
     log(null);
   }

--- a/sample/src/main/java/org/utilities/StringUtils.java
+++ b/sample/src/main/java/org/utilities/StringUtils.java
@@ -7,4 +7,11 @@ public class StringUtils {
   public static boolean isEmptyOrNull(@Nullable CharSequence value) {
     return value == null || value.length() == 0;
   }
+
+  public static boolean isEmptyOrNull(@Nullable CharSequence value, boolean trim) {
+    if (value == null) {
+      return true;
+    }
+    return trim ? value.toString().trim().isEmpty() : value.length() == 0;
+  }
 }


### PR DESCRIPTION
The sample library model only showed one MethodRef. Overloads need a separate entry each, and the signature has no spaces after commas. A space after the comma is why only one overload matched in #1016.

I added a two-argument isEmptyOrNull overload to the sample and a matching MethodRef so that shows up next to the existing one.

Fixes #1016


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enhanced empty-or-null check that can optionally trim surrounding whitespace before evaluating a value.
  * Existing behavior remains unchanged when trimming is not requested.
  * Added support for checking strings with the new trimming option in sample usage.
* **Bug Fixes**
  * Improved handling and recognition of the overloaded empty-or-null check so both supported forms are evaluated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->