### PR TITLE
ci: generate the build matrix instead of fixing it to three operating systems

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,22 +4,61 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      matrix_rng_seed:
+        description: Seed of an earlier run, to draw the same matrix again
+        required: false
 concurrency:
-  group: ${{ github.ref }}
+  # A master run draws a sample no later run will draw again, so let it finish. Pull request
+  # runs still cancel, since the next push redraws the same rows from the same seed.
+  group: ${{ github.ref == 'refs/heads/master' && format('ci-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 permissions:
   contents: read
 jobs:
+  matrix_prep:
+    name: "Prepare the build matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      MATRIX_JOBS: 8
+      # The seed. Without GITHUB_PR_NUMBER every push to a pull request draws a different
+      # matrix, so a failure that lands on an exotic row cannot be told apart from one that
+      # was simply not drawn again. RNG_SEED replays the rows of an earlier run.
+      GITHUB_PR_NUMBER: ${{ github.event.number }}
+      RNG_SEED: ${{ github.event.inputs.matrix_rng_seed }}
+    steps:
+      - name: Check out NullAway sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/workflows/package-lock.json
+      - name: Install the matrix generator
+        run: npm ci
+        working-directory: .github/workflows
+      - name: Generate the matrix
+        id: set-matrix
+        run: node matrix.mjs
+        working-directory: .github/workflows
   build:
-    name: "Build and test on ${{ matrix.os }}"
+    needs: matrix_prep
+    name: "Build and test on ${{ matrix.name }}"
     strategy:
-      matrix:
-        include:
-          - os: macos-latest
-          - os: windows-latest
-          - os: ubuntu-latest
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      # Flags for the test JVMs only; Gradle itself keeps the runner's default locale.
+      ORG_GRADLE_PROJECT_testExtraJvmArgs: ${{ matrix.testExtraJvmArgs }}
+      # Reverses the compilation units of each multi-file test; see nullaway/build.gradle.
+      ORG_GRADLE_PROJECT_permuteSources: ${{ matrix.permuteSources }}
     steps:
       - name: Check out NullAway sources
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -30,17 +69,39 @@ jobs:
         with:
           website: jdk.java.net
           release: 28
-      - name: 'Set up JDKs'
+      - name: 'Set up the toolchains the build needs'
+        # These are the JDKs testJdk17, testJdk21 and the compile toolchain run on, so the
+        # row's distribution has to reach them: installing them all from one vendor is what
+        # makes java_distribution an axis over the code under test rather than over JAVA_HOME.
+        # testJdk26 has no setup-java step and comes from the foojay resolver.
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: |
             17
             21
             25
-          distribution: 'temurin'
+          distribution: ${{ matrix.java_distribution }}
+          # Explicit, to work around https://github.com/actions/setup-java/issues/559
+          architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
+          check-latest: 'true'
+      - name: 'Set up the JDK that runs Gradle'
+        # setup-java points JAVA_HOME at the last JDK it installs, so this decides which JDK
+        # Gradle and the default test task run on. The toolchains above stay discoverable.
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: ${{ matrix.java_version }}
+          distribution: ${{ matrix.java_distribution }}
+          architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
           check-latest: 'true'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # setup-gradle hashes the matrix into its cache key, so a randomized matrix would
+          # write an entry per job per run that no later run can match, filling the
+          # repository's cache budget and evicting what is still useful. Only the pinned row
+          # writes, and only on master: its axis values are the same every run, so its key is
+          # the same every run. Every other job reads.
+          cache-read-only: ${{ !(github.ref == 'refs/heads/master' && matrix.collectCoverage) }}
       - name: List toolchains
         run: ./gradlew javaToolchains
       - name: Build and test
@@ -52,7 +113,7 @@ jobs:
         id: jacoco_report
         run: ./gradlew codeCoverageReport
         continue-on-error: true
-        if: runner.os == 'Linux' && github.repository == 'uber/NullAway'
+        if: matrix.collectCoverage && github.repository == 'uber/NullAway'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -71,6 +132,15 @@ jobs:
         run: ./gradlew publishToMavenLocal
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
+      - name: Upload the test reports of a failing job
+        # The rows are drawn per run, so a failure on an exotic combination is a one-shot
+        # event. The job name would need sanitizing to be an artifact name, so index instead.
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-reports-${{ strategy.job-index }}
+          path: '**/build/reports/tests/**'
+          if-no-files-found: ignore
   test-with-error-prone-snapshot:
     name: "Test with Error Prone snapshot"
     runs-on: ubuntu-latest

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -1,0 +1,178 @@
+// Builds the job matrix for continuous-integration.yml.
+//
+// The fixed matrix this replaces ran three jobs: one per operating system, all on the same JDK,
+// in the same locale, with the same JVM defaults. The axes below are the ones NullAway has
+// already been bitten by or is plausibly sensitive to; pairwise selection keeps the job count
+// near where it was while covering their product rather than their sum.
+//
+// Preview the rows, and the coverage a budget buys:
+//     cd .github/workflows && npm ci && RNG_SEED=1 node matrix.mjs
+//     cd .github/workflows && RNG_SEED=1 node matrix.mjs --coverage
+import { createGitHubMatrixBuilder, setGitHubOutput } from '@vlsi/github-actions-random-matrix/github';
+
+// The seed comes from RNG_SEED, then from the pull request number, and is written to the job
+// summary. continuous-integration.yml passes both, so every push to a pull request draws the
+// same rows, and a failing row can be replayed from the Actions UI or on a laptop.
+const { matrix } = createGitHubMatrixBuilder();
+
+matrix.failOnUnsatisfiableFilters(true);
+
+matrix.addAxis({
+  name: 'os',
+  title: x => x.value.replace('-latest', ''),
+  values: [
+    // Every operating system runs at least once, because the require list below says so.
+    // These weights decide how many of the remaining rows land on each: GitHub bills Windows
+    // minutes at twice the Linux rate and macOS at ten times, and both are slower per job.
+    { value: 'ubuntu-latest', weight: 4 },
+    { value: 'windows-latest', weight: 1 },
+    { value: 'macos-latest', weight: 1 },
+  ],
+});
+
+// The JDK that runs Gradle and the default `test` task. build.gradle refuses to run on
+// anything below 21, so the axis starts there. Nothing is lost by leaving 17 out: `check`
+// depends on testJdk17, testJdk21, testJdk26 and testJdk28, so every row runs the suite on
+// all four through toolchains whatever this value is.
+matrix.addAxis({
+  name: 'java_version',
+  title: x => 'Java ' + x,
+  values: [
+    '21',
+    '25',
+  ],
+});
+
+// The vendor of every JDK the job installs, toolchains included, so the axis reaches the
+// process that runs the tests rather than only the one that launches it. Distributions of the
+// same release differ in their build and their backport level, and NullAway reads javac
+// through its internal API, where that difference is visible.
+matrix.addAxis({
+  name: 'java_distribution',
+  values: [
+    'temurin',
+    'zulu',
+    'corretto',
+    'liberica',
+  ],
+});
+
+// Identity hash codes decide the iteration order of every HashMap and HashSet keyed on a javac
+// Symbol, and NullAway keys several on one. -XX:hashCode=2 makes every identity hash the constant
+// 1, so those maps degenerate to insertion order; a result that changes under it does not depend
+// on the program being checked. See https://github.com/uber/NullAway/issues/1780.
+matrix.addAxis({
+  name: 'hash',
+  values: [
+    { value: 'regular', title: '', weight: 4 },
+    { value: 'same', title: 'same hashcode', weight: 1 },
+  ],
+});
+
+// -ea turns on the assertions in javac, in the Checker Framework dataflow library NullAway
+// builds on, and in NullAway itself. It costs only the jobs that carry it.
+matrix.addAxis({
+  name: 'assertions',
+  title: x => x.value === 'yes' ? 'assertions' : '',
+  values: [
+    { value: 'yes', weight: 2 },
+    { value: 'no', weight: 4 },
+  ],
+});
+
+// Reverses the compilation units of each multi-file test and requires the same diagnostics.
+// The order a build system hands source files to javac is not part of the program, and NullAway
+// has depended on it before: https://github.com/uber/NullAway/issues/1725 and
+// https://github.com/uber/NullAway/issues/1733. Costs one extra compilation per multi-file test
+// in the rows that carry it.
+matrix.addAxis({
+  name: 'permute_sources',
+  values: [
+    { value: 'no', title: '', weight: 3 },
+    { value: 'yes', title: 'permuted sources', weight: 1 },
+  ],
+});
+
+// NullAway lowercases and formats type names, option values and messages.
+matrix.addAxis({
+  name: 'locale',
+  title: x => x.language + '_' + x.country,
+  values: [
+    { language: 'en', country: 'US' },
+    // Turkish lowercases I to a dotless i, which breaks a case-insensitive comparison written
+    // against the default locale.
+    { language: 'tr', country: 'TR' },
+    { language: 'de', country: 'DE' },
+    { language: 'ru', country: 'RU' },
+  ],
+});
+
+matrix.setNamePattern([
+  'java_version', 'java_distribution', 'os', 'hash', 'assertions', 'permute_sources', 'locale',
+]);
+
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 8), {
+  require: [
+    // The configuration the fixed matrix ran. It is the one job that uploads coverage and the
+    // one that writes the Gradle cache, so everything that moves either is pinned: the number
+    // stays comparable between runs, and the cache key stays the same one from run to run.
+    {
+      filter: {
+        os: { value: 'ubuntu-latest' },
+        java_version: '25',
+        java_distribution: 'temurin',
+        hash: { value: 'regular' },
+        assertions: { value: 'no' },
+        permute_sources: { value: 'no' },
+        locale: { language: 'en' },
+      },
+      tag: row => { row.collectCoverage = true; },
+    },
+    // Every operating system, as before.
+    ...matrix.allAxisValues('os'),
+    // Both JDKs the build runs on.
+    ...matrix.allAxisValues('java_version'),
+    // At least one job with degenerate identity hash codes.
+    { hash: { value: 'same' } },
+    // At least one job with assertions on.
+    { assertions: { value: 'yes' } },
+    // At least one job that reverses the compilation units.
+    { permute_sources: { value: 'yes' } },
+  ],
+});
+
+if (include.length === 0) {
+  throw new Error('Matrix list is empty');
+}
+
+include.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+
+include.forEach(row => {
+  const jvmArgs = [];
+  if (row.hash.value === 'same') {
+    jvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
+  }
+  if (row.assertions.value === 'yes') {
+    jvmArgs.push('-ea');
+  }
+  // Gradle itself does not run in the tr_TR locale (https://github.com/gradle/gradle/issues/17361),
+  // so the locale reaches the test JVM only.
+  jvmArgs.push(`-Duser.language=${row.locale.language}`, `-Duser.country=${row.locale.country}`);
+  row.testExtraJvmArgs = jvmArgs.join(' ');
+  row.permuteSources = row.permute_sources.value === 'yes';
+  // runs-on takes the plain string, and the axis objects have served their purpose.
+  row.os = row.os.value;
+  delete row.hash;
+  delete row.assertions;
+  delete row.locale;
+  delete row.permute_sources;
+});
+
+if (process.argv.includes('--coverage')) {
+  const coverage = matrix.pairCoverageReport();
+  console.log(
+    `Pair coverage: ${coverage.covered}/${coverage.total} (${coverage.percentage}%), weighted ${coverage.weightPercentage}%`);
+} else {
+  console.log(include);
+  setGitHubOutput('matrix', { include });
+}

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "nullaway-ci-matrix",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nullaway-ci-matrix",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vlsi/github-actions-random-matrix": "^2.4.0"
+      }
+    },
+    "node_modules/@vlsi/github-actions-random-matrix": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.4.0.tgz",
+      "integrity": "sha512-OO79/PYYm3zXol0KhI6T6U1rJXJbV/q2JOelz0jsir50Iqw5GvMdhlvq8Qbgw9PL3w2v/KETt0AzlFxC+tc0rQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nullaway-ci-matrix",
+  "private": true,
+  "description": "Generates the randomized job matrix for continuous-integration.yml",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@vlsi/github-actions-random-matrix": "^2.4.0"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ tmp/
 
 # TeXlipse plugin
 .texlipse
+
+# npm dependencies of the CI matrix generator
+.github/workflows/node_modules

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,13 @@ subprojects { project ->
 
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        // CI passes JVM flags that belong to the test JVM rather than to Gradle: the locale, which
+        // Gradle itself does not run in (https://github.com/gradle/gradle/issues/17361), and the
+        // identity-hash mode.  See .github/workflows/matrix.mjs.
+        def extraJvmArgs = providers.gradleProperty("testExtraJvmArgs").getOrElse("").trim()
+        if (!extraJvmArgs.isEmpty()) {
+            jvmArgs(extraJvmArgs.split(" +").toList())
+        }
     }
 
     repositories {


### PR DESCRIPTION
### Why

The `build` job runs one row per operating system, all on Temurin 25, in the runner's locale, with the JVM's default identity-hash mode and assertions off. Several axes NullAway has been bitten by, or is plausibly sensitive to, are held constant across all three rows.

The identity-hash axis has a confirmed defect behind it. NullAway keys several `HashMap`s and `HashSet`s on javac `Symbol` objects, which inherit `Object.hashCode`, so their iteration order depends on identity hash codes. #1780 shows the consequence: for the same source, the same flags and the same build, an inference-failure diagnostic names `type variable T` in one run and `type variable U` in the next. Nothing in CI can see that today.

### What

`.github/workflows/matrix.mjs` builds the rows with [@vlsi/github-actions-random-matrix](https://github.com/vlsi/github-actions-random-matrix), which picks a pairwise-covering sample of a fixed size. Eight rows cover the product of seven axes rather than the sum of one:

| Axis | Values |
| --- | --- |
| `os` | ubuntu, windows, macos — ubuntu weighted 4x, since GitHub bills Windows at 2x and macOS at 10x |
| `java_version` | 21, 25 — the JDK that runs Gradle and the default `test` task |
| `java_distribution` | temurin, zulu, corretto, liberica — for every JDK the job installs, toolchains included |
| `hash` | regular, `-XX:hashCode=2` |
| `assertions` | off, `-ea` |
| `permute_sources` | no, yes — reverses the compilation units of each multi-file test |
| `locale` | en_US, tr_TR, de_DE, ru_RU |

`require` pins the row the fixed matrix already ran and tags it `collectCoverage`, so exactly one job uploads to Codecov. It also pins every operating system, both JDKs, one job with degenerate identity hash codes, one with assertions on, and one with reversed compilation units. Eight rows reach 85% of the feasible pairs; seven reach 76%.

**The seed comes from the pull request number.** Every push to the same pull request draws the same rows, so a failure that lands on an exotic combination does not vanish on the next commit — which is the difference between a signal and a rumor. `workflow_dispatch` takes a `matrix_rng_seed` input, so any run can be drawn again, and the generator writes the seed it used to the job summary.

**The JDK axis starts at 21**, because `build.gradle` throws `NullAway only builds on JDK 21 or higher now` before it configures anything. Nothing is lost by leaving 17 out: `check` depends on `testJdk17`, `testJdk21`, `testJdk26` and `testJdk28`, so every row runs the suite on all four through toolchains whatever the axis says. What the axis does change is the JDK Gradle and the default `test` task run on.

**The distribution reaches the toolchains**, not only `JAVA_HOME`. The `testJdkNN` tasks take their JVM from a toolchain, so installing the toolchains from one vendor per row is what makes this an axis over the code under test rather than over the process that launches it. `testJdk26` has no `setup-java` step and still comes from the foojay resolver.

`-XX:hashCode=2` makes every identity hash the constant 1, so a `HashMap` keyed on a `Symbol` degenerates to insertion order. A result that changes between that mode and the default does not depend on the program being checked.

`-ea` turns on the assertions in javac, in the Checker Framework dataflow library NullAway builds on, and in NullAway itself. javac runs inside the test JVM here, so the flag reaches it.

Turkish lowercases `I` to a dotless `ı`, which is the standard way to find a case-insensitive comparison written against the default locale.

`permuteSources` reaches `nullaway/build.gradle` as a project property and turns on the compilation-unit-order check that #1782 adds. The property is inert until that lands, so the two changes can merge in either order.

`build.gradle` passes the row's JVM flags to every `Test` task through the `testExtraJvmArgs` project property. They do not reach the Gradle daemon, because Gradle does not run in tr_TR (gradle/gradle#17361).

**Caching.** `setup-gradle` hashes the matrix into its cache key, so under a randomized matrix every job would write an entry no later run can match, filling the repository's 10 GB cache budget and evicting what is still useful. Only the pinned row writes, and only on `master`: its axis values are identical on every seed, so its key is stable. Every other job reads.

**Diagnosis.** A failing job uploads its test reports, and a `master` run is no longer cancelled by the next push — the rows it drew are a sample nothing else will draw again.

### How to verify

Preview the rows and the pair coverage without GitHub Actions:

```bash
cd .github/workflows && npm ci && RNG_SEED=1 node matrix.mjs
```

```bash
cd .github/workflows && RNG_SEED=1 node matrix.mjs --coverage
```

Run the suite in the configurations the matrix adds, the second being the nastiest row it can draw:

```bash
./gradlew :nullaway:test -PtestExtraJvmArgs="-ea"
```

```bash
./gradlew :nullaway:test -PtestExtraJvmArgs="-XX:+UnlockExperimentalVMOptions -XX:hashCode=2 -ea -Duser.language=tr -Duser.country=TR"
```

Both pass on this branch, so the change adds coverage without a red build.

### Risks

`-XX:hashCode` is an experimental HotSpot flag. It is accepted on 11 through 26; I could not check a JDK 28 EA build, and `testJdk28` runs as part of `check`, so a removal there would show up as a JVM that refuses to start.

A JDK version that a distribution does not publish for a given runner would fail in `setup-java`. `matrix.exclude(...)` takes such a combination out; none is excluded yet, because I could not verify the publication matrix for all four vendors across the three runners.

The job count rises from 3 to 8. `MATRIX_JOBS` in the workflow sets it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - CI now dynamically tests varied operating systems, JDK versions, distributions, locales, JVM configurations, and source variations.
  - Builds use the appropriate JDK configuration and preserve master-branch runs.
  - Previous test matrices can be replayed manually when needed.
  - Failed jobs now upload test reports for easier diagnosis.

- **Build & Testing**
  - CI-provided JVM options are forwarded to test processes.
  - Coverage is assigned to the appropriate build configuration.
  - Test coverage is distributed across varied environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->