### PR TITLE
Check wildcard generics handling flag for enhanced for loops

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1133,13 +1133,26 @@ public final class GenericsChecks {
   public Nullness getEnhancedForLoopElementNullness(ExpressionTree expression, VisitorState state) {
     Type elementType =
         getEnhancedForLoopElementType(expression, state, /* calledFromDataflow= */ true);
+    if (!config.handleWildcardGenerics()
+        && elementType != null
+        && GenericsUtils.asWildcard(elementType) != null) {
+      // if we're not handling wildcards, always treat as non-null
+      return Nullness.NONNULL;
+    }
     return elementType == null
         ? Nullness.NONNULL
-        : getReturnTypeNullness(elementType, state, /* followTypeVarUpperBound= */ true);
+        : getTypeNullnessForRead(
+            elementType, state, /* followUnsubstitutedTypeVarUpperBound= */ true);
   }
 
   /**
    * Gets the element type of an enhanced-for expression, preserving nested nullability annotations.
+   *
+   * @param expression the expression being iterated over
+   * @param state the visitor state
+   * @param calledFromDataflow whether this function was called from dataflow analysis
+   * @return the element type for the loop variable of the enhanced-for, or {@code null} if it can't
+   *     be found
    */
   private @Nullable Type getEnhancedForLoopElementType(
       ExpressionTree expression, VisitorState state, boolean calledFromDataflow) {
@@ -1162,7 +1175,9 @@ public final class GenericsChecks {
       return null;
     }
     com.sun.tools.javac.util.List<Type> typeArguments = iterableType.getTypeArguments();
-    return GenericsUtils.effectiveWildcardUpperBound(typeArguments.head, state, config, handler);
+    return config.handleWildcardGenerics()
+        ? GenericsUtils.effectiveWildcardUpperBound(typeArguments.head, state, config, handler)
+        : typeArguments.head;
   }
 
   private @Nullable Type getInferredTypeForVarLocalDeclaration(
@@ -2822,7 +2837,7 @@ public final class GenericsChecks {
         overriddenMethodType instanceof ExecutableType,
         "expected ExecutableType but instead got %s",
         overriddenMethodType.getClass());
-    return getReturnTypeNullness(overriddenMethodType.getReturnType(), state);
+    return getTypeNullnessForRead(overriddenMethodType.getReturnType(), state);
   }
 
   /**
@@ -3502,28 +3517,45 @@ public final class GenericsChecks {
   }
 
   /**
-   * Returns the nullness of a return type. For wildcard and javac captured wildcard types, use the
-   * effective upper bound: a read from {@code Foo<? extends @Nullable Object>} or {@code Foo<?
-   * super String>} can produce any value permitted by the capture's upper bound.
+   * Returns the nullness of a value read from {@code type}. For wildcard and javac captured
+   * wildcard types, uses the effective upper bound: a read from {@code Foo<? extends @Nullable
+   * Object>} or {@code Foo<? super String>} can produce any value permitted by the capture's upper
+   * bound.
+   *
+   * @param type type from which a value is read
+   * @param state visitor state
+   * @return nullness of a value read from {@code type}
    */
-  private Nullness getReturnTypeNullness(Type type, VisitorState state) {
-    return getReturnTypeNullness(type, state, false);
+  private Nullness getTypeNullnessForRead(Type type, VisitorState state) {
+    return getTypeNullnessForRead(type, state, /* followUnsubstitutedTypeVarUpperBound= */ false);
   }
 
-  private Nullness getReturnTypeNullness(
-      Type type, VisitorState state, boolean followTypeVarUpperBound) {
+  /**
+   * Returns the nullness of a value read from {@code type}, optionally following the upper bound of
+   * an unsubstituted type variable.
+   *
+   * @param type type from which a value is read
+   * @param state visitor state
+   * @param followUnsubstitutedTypeVarUpperBound whether to use the upper bound when {@code type} is
+   *     an unsubstituted type variable
+   * @return nullness of a value read from {@code type}
+   */
+  private Nullness getTypeNullnessForRead(
+      Type type, VisitorState state, boolean followUnsubstitutedTypeVarUpperBound) {
     if (getTypeNullness(type).equals(Nullness.NULLABLE)) {
       return Nullness.NULLABLE;
     }
     if (config.handleWildcardGenerics() && GenericsUtils.asWildcard(type) != null) {
       Type effectiveUpperBound =
           GenericsUtils.effectiveWildcardUpperBound(type, state, config, handler);
-      return getReturnTypeNullness(effectiveUpperBound, state, true);
+      return getTypeNullnessForRead(
+          effectiveUpperBound, state, /* followUnsubstitutedTypeVarUpperBound= */ true);
     }
-    if (followTypeVarUpperBound && type instanceof Type.TypeVar typeVar) {
+    if (followUnsubstitutedTypeVarUpperBound && type instanceof Type.TypeVar typeVar) {
       Type upperBound = typeVar.getUpperBound();
       if (upperBound != null) {
-        return getReturnTypeNullness(upperBound, state, true);
+        return getTypeNullnessForRead(
+            upperBound, state, /* followUnsubstitutedTypeVarUpperBound= */ true);
       }
     }
     return Nullness.NONNULL;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullnessOperatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullnessOperatorTests.java
@@ -444,6 +444,37 @@ public class NullnessOperatorTests extends NullAwayTestsBase {
 
   @Ignore("https://github.com/uber/NullAway/issues/1727")
   @Test
+  public void issue1727EnhancedForLoopFalsePositive() {
+    makeHelper()
+        .addSourceLines(
+            "Repro.java",
+            """
+            import java.util.Collection;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Repro<E extends @Nullable Object> {
+              boolean add(E element) {
+                return false;
+              }
+
+              boolean addAll(Collection<? extends E> elements) {
+                boolean changed = false;
+                for (E element : elements) {
+                  if (add(element)) {
+                    changed = true;
+                  }
+                }
+                return changed;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Ignore("https://github.com/uber/NullAway/issues/1727")
+  @Test
   public void issue1727WildcardDirectArgumentFalsePositive() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1407,6 +1407,41 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void nullableTypeParameterEnhancedForLoopWithWildcardHandlingDisabled() {
+    makeTestHelperWithArgs(
+            List.of(
+                "-XepOpt:NullAway:OnlyNullMarked=true",
+                JSpecifyJavacConfig.JSPECIFY_MODE_FLAG,
+                JSpecifyJavacConfig.ADD_TYPE_ANNOTATIONS_FLAG))
+        .addSourceLines(
+            "Repro.java",
+            """
+            import java.util.Collection;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Repro<E extends @Nullable Object> {
+
+              boolean add(E element) {
+                return false;
+              }
+
+              boolean addAll(Collection<? extends E> elements) {
+                boolean changed = false;
+                for (E element : elements) {
+                  if (add(element)) {
+                    changed = true;
+                  }
+                }
+                return changed;
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
When improving handling of enhanced for loops, we neglected to gate wildcard handling behind the relevant flag.  Also, rename `getReturnTypeNullness` as its being used for more than return types now.

The test comes from Spring and exposes another scenario where we need to handle the `NO_CHANGE` operator.