### PR TITLE
Add a check for nullness annotations in locations JSpecify does not recognize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Add `JSpecifyUnrecognizedAnnotationLocation`, an opt-in check that reports nullness annotations in locations JSpecify does not recognize (#1787)
+
 Version 0.14.1
 --------------
 

--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -245,7 +245,8 @@ tasks.named('check').configure {
 
 // Create a task to build NullAway with NullAway checking enabled
 tasks.register('buildWithNullAway', JavaCompile) {
-    // Configure compilation to run with Error Prone and NullAway
+    // Configure compilation to run with Error Prone, NullAway, and the JSpecify
+    // annotation-location check
     source = sourceSets.main.java
     classpath = sourceSets.main.compileClasspath
     destinationDirectory.set(layout.buildDirectory.dir('ignoredClasses'))
@@ -259,6 +260,7 @@ tasks.register('buildWithNullAway', JavaCompile) {
     options.errorprone {
         disableAllChecks = true
         error("NullAway")
+        error("JSpecifyUnrecognizedAnnotationLocation")
         option("NullAway:AnnotatedPackages", "com.uber,org.checkerframework.nullaway,com.google.common")
         option("NullAway:CastToNonNullMethod", "com.uber.nullaway.NullabilityUtil.castToNonNull")
         option("NullAway:CheckOptionalEmptiness")

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -75,6 +75,13 @@ import org.jspecify.annotations.Nullable;
  * source; see <a href="https://jspecify.dev/docs/spec/#recognized-type-use">Recognized locations
  * for type-use annotations</a>.
  *
+ * <p>The diagnostics use JSpecify's own terms. The <em>root type</em> is the whole type a construct
+ * names: {@code String[]} in {@code String[] names}, {@code List<String>} in {@code (List<String>)
+ * o}. The type components inside it, such as a type argument, a wildcard bound or an array
+ * component type, are type usages in their own right, so {@code (@Nullable String) o} is reported
+ * where {@code (List<@Nullable String>) o} is not. A few locations are unrecognized throughout, the
+ * operand of an {@code instanceof} among them, and there a type argument is reported too.
+ *
  * <p>The check reports an annotation only where it can name the unrecognized location, so a
  * construct it cannot name yields a missed diagnostic rather than a wrong one. Most of the
  * locations it names are ones the specification lists; two come from its rule that everything not
@@ -133,6 +140,11 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
     INSTANCEOF("on the type after an instanceof operator", true),
     CAST("on the root type of a cast"),
     OBJECT_CREATION("on the root type of an object creation expression"),
+    /**
+     * The array an array creation expression creates, as in {@code new String @Nullable [5]}. An
+     * annotation written before the element type annotates that element type instead, so {@code
+     * new @Nullable String[5]} is recognized.
+     */
     ARRAY_CREATION("on the array type of an array creation expression"),
     METHOD_REFERENCE("on the root type of a method reference"),
     /**
@@ -146,6 +158,11 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
     CONSTRUCTOR_RESULT("on the result type of a constructor"),
     TYPE_PARAMETER("directly on a type parameter declaration"),
     WILDCARD("directly on a wildcard"),
+    /**
+     * The enclosing class an inner class is named through, which takes an annotation written before
+     * the whole name: {@code @Nullable Outer.Inner} annotates {@code Outer} where the author meant
+     * {@code Outer.@Nullable Inner}.
+     */
     OUTER_TYPE("on the outer type qualifying an inner type"),
     ANNOTATION_MEMBER("on the return type of an annotation interface member", true);
 
@@ -155,11 +172,9 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
      * Whether the location covers the type usages written inside it, so that a nullness annotation
      * anywhere within the location is unrecognized too.
      *
-     * <p>A location that does not cover them reaches its own root type and stops, which leaves the
-     * type argument in {@code (List<@Nullable String>) o} recognized. Compare {@code
-     * (List<@Nullable ?>) o}, reported as a wildcard because a cast stops short of it, with {@code
-     * o instanceof List<@Nullable ?>}, reported as the {@code instanceof} operand because JSpecify
-     * recognizes no type usage there at all.
+     * <p>Most locations reach their own root type and stop, so {@code (List<@Nullable ?>) o} is
+     * reported as a wildcard rather than as a cast. The locations marked here are the exception:
+     * {@code o instanceof List<@Nullable ?>} is reported as the {@code instanceof} operand.
      */
     private final boolean coversNestedTypes;
 
@@ -178,7 +193,7 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
    * against.
    *
    * @param anchor the type usage the annotation lands on, or the qualified name as a whole where
-   *     the annotation lands on one of its qualifiers
+   *     the annotation lands on one of its qualifiers, as it does in {@code @Nullable Outer.Inner}
    */
   private record TypeUsage(UnrecognizedLocation location, Tree anchor) {}
 
@@ -378,8 +393,8 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
    * <p>Neither answer can be read off {@code tree}, so the method walks {@link
    * VisitorState#getPath} outwards to the declaration or expression the type usage belongs to. The
    * walk settles two questions: whether the annotation stands on that construct's root type or
-   * below it, and, where the type usage and the construct around it are both unrecognized, which
-   * of the two names the annotation's position better and so gives the fix its target.
+   * below it, and, where the type usage and the construct around it are both unrecognized, which of
+   * the two names the annotation's position better and so gives the fix its target.
    *
    * <p>Returns {@code null} in two cases. The location is recognized, as the type argument in
    * {@code (List<@Nullable String>) o} is. Or javac has put one subtree under two parents, which
@@ -430,7 +445,8 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
           && classTree.getSimpleName().isEmpty()
           && isSupertype(classTree, child)) {
         // An anonymous class body's supertype tree is the tree the enclosing `new` expression
-        // names, so this path is a second view of an annotation the NewClassTree path reports.
+        // names, so this is the second of the two TreePaths that reach the annotation.  The walk
+        // from the NewClassTree reports it as an object creation.
         return null;
       } else if (parent instanceof MemberSelectTree memberSelect
           && Objects.equals(memberSelect.getExpression(), child)) {
@@ -444,8 +460,9 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
       } else if (parent instanceof VariableTree
           && path.getParentPath() != null
           && isCompactConstructorParameter(path.getParentPath().getLeaf(), parent)) {
-        // The compact constructor's parameters are javac's copies of the record components, so
-        // this path is a second view of an annotation the component itself reports.
+        // A compact constructor's parameters are javac's copies of the record components and
+        // share their annotation trees, so this is the second of the two TreePaths that reach the
+        // annotation.  The walk from the component reports it.
         return null;
       } else {
         // The construct takes the annotation, unless the annotation stands below its root type
@@ -523,10 +540,10 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
    * components into its compact constructor.
    *
    * <p>The copies keep the components' source positions and share their annotation trees, so each
-   * is a second view of a declaration already reported. The parameter list they sit in tells them
-   * apart from an ordinary declaration, not their own symbol kind: a lambda parameter written in
-   * the constructor's body is an {@link ElementKind#PARAMETER} owned by that same constructor, and
-   * its annotations are the author's own.
+   * reaches an annotation the component itself already reports. The parameter list they sit in
+   * tells them apart from an ordinary declaration, not their own symbol kind: a lambda parameter
+   * written in the constructor's body is an {@link ElementKind#PARAMETER} owned by that same
+   * constructor, and its annotations are the author's own.
    *
    * @param parent the tree {@code variable} is declared under
    */
@@ -680,7 +697,7 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
    * that only removes it when no such location can be named unambiguously.
    *
    * @param annotationCount how many nullness annotations share {@code anchor}; a move is ambiguous
-   *     once there is more than one
+   *     once there is more than one, as in {@code List<@Nullable @NonNull ?>}, and both are removed
    */
   private static SuggestedFix buildFix(
       AnnotationTree annotation,
@@ -786,12 +803,14 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
    * <p>A move writes on the last name of a qualified type name, or on the type name itself where
    * there is no qualifier. Every nullness annotation on a qualifier is relocated to that one
    * position, so the one written closest to it is the one that arrives and every other is deleted.
-   * Only an annotation that the move would pass is therefore an obstacle, and {@code moving} is
-   * where the walk stops.
+   * Only an annotation that the move would pass therefore occupies the destination, and {@code
+   * moving} is where the walk stops. The fix for {@code @Nullable Outer.@Nullable Inner} removes
+   * the annotation in front and leaves {@code Outer.@Nullable Inner}.
    *
    * <p>{@code moving} is outside {@code typeTree} altogether where it was written in a
    * declaration's modifiers, or on the wildcard or type parameter that {@code typeTree} bounds. The
-   * walk then reaches no stopping point, and every annotation in the chain is an obstacle.
+   * walk then reaches no stopping point, and every annotation in the chain occupies the
+   * destination.
    */
   private static boolean destinationIsOccupied(Tree typeTree, AnnotationTree moving) {
     Tree type = typeTree;
@@ -801,7 +820,7 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
           return false;
         }
         // An AnnotatedTypeTree wrapping an array annotates the array rather than the name written
-        // inside it, as in `Outer.Inner @NonNull []`, so it is not an obstacle.
+        // inside it, as in `Outer.Inner @NonNull []`, so it does not occupy the destination.
         if (!(annotatedType.getUnderlyingType() instanceof ArrayTypeTree)
             && !nullnessAnnotationsIn(annotatedType.getAnnotations()).isEmpty()) {
           return true;

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -172,9 +172,9 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
      * Whether the location covers the type usages written inside it, so that a nullness annotation
      * anywhere within the location is unrecognized too.
      *
-     * <p>Most locations reach their own root type and stop, so {@code (List<@Nullable ?>) o} is
-     * reported as a wildcard rather than as a cast. The locations marked here are the exception:
-     * {@code o instanceof List<@Nullable ?>} is reported as the {@code instanceof} operand.
+     * <p>Most locations reach their own root type and stop, so the type argument in {@code
+     * (List<@Nullable String>) o} is recognized. The locations marked here are the exception:
+     * {@code o instanceof List<@Nullable String>} is reported as the {@code instanceof} operand.
      */
     private final boolean coversNestedTypes;
 

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -1,0 +1,914 @@
+/*
+ * Copyright (c) 2026 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.ErrorProneToken;
+import com.google.errorprone.util.ErrorProneTokens;
+import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ArrayTypeTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.InstanceOfTree;
+import com.sun.source.tree.IntersectionTypeTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.PrimitiveTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.tree.TypeParameterTree;
+import com.sun.source.tree.UnionTypeTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.tree.WildcardTree;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.util.Position;
+import java.util.List;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.lang.model.element.ElementKind;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reports a JSpecify nullness annotation written in a location the specification does not
+ * recognize.
+ *
+ * <p>JSpecify defines the locations in which {@code @Nullable} and {@code @NonNull} carry meaning,
+ * and states that an annotation anywhere else has none, as in {@code @Nullable int count} or {@code
+ * List<@Nullable ?> values}. The specification recommends this diagnostic to tools that analyze
+ * source; see <a href="https://jspecify.dev/docs/spec/#recognized-type-use">Recognized locations
+ * for type-use annotations</a>.
+ *
+ * <p>The check reports an annotation only where it can name the unrecognized location, so a
+ * construct it cannot name yields a missed diagnostic rather than a wrong one. Most of the
+ * locations it names are ones the specification lists; two come from its rule that everything not
+ * listed as recognized is unrecognized, namely the result type of a constructor and the root type
+ * of a method reference.
+ *
+ * <p>The check reads {@code org.jspecify.annotations.Nullable} and {@code
+ * org.jspecify.annotations.NonNull}, and no other nullness annotation, because the rule is
+ * JSpecify's and JSpecify states it about its own annotations. Other tools give their own
+ * {@code @Nullable} a meaning in some of these locations: the Checker Framework reads
+ * {@code @Nullable} on the root type of a local variable and of a cast, and IntelliJ reads the
+ * JetBrains {@code @Nullable} on a local variable.
+ *
+ * <p>At its default {@link SeverityLevel#SUGGESTION} severity the check reports nothing at all, so
+ * a user who has not asked for it sees no diagnostics and no notes. Raise it with {@code
+ * -Xep:JSpecifyUnrecognizedAnnotationLocation:WARN} or {@code :ERROR} to turn it on.
+ *
+ * <p>The root type of a local variable is the only location with an option of its own, and it is
+ * reported by default, so that turning the check on reports every location the specification lists.
+ * A codebase migrating from an annotation that does carry meaning there, such as JetBrains', may
+ * want to keep those annotations in the meantime; {@code
+ * -XepOpt:JSpecifyUnrecognizedAnnotationLocation:CheckLocalVariableRootType=false} leaves them
+ * alone.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+    severity = SeverityLevel.SUGGESTION,
+    summary =
+        "[JSpecifyUnrecognizedAnnotationLocation] JSpecify gives no meaning to a nullness"
+            + " annotation in a location it does not recognize.")
+public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
+    implements BugChecker.AnnotatedTypeTreeMatcher,
+        BugChecker.ClassTreeMatcher,
+        BugChecker.MethodTreeMatcher,
+        BugChecker.NewArrayTreeMatcher,
+        BugChecker.TypeParameterTreeMatcher,
+        BugChecker.VariableTreeMatcher {
+
+  /**
+   * A location in which JSpecify does not recognize a nullness annotation.
+   *
+   * <p>Each constant carries the phrase that names the location in the diagnostic, which reads
+   * {@code A nullness annotation <phrase> has no meaning under JSpecify.}
+   */
+  private enum UnrecognizedLocation {
+    PRIMITIVE_TYPE("on a primitive type"),
+    LOCAL_VARIABLE_ROOT_TYPE("on the root type of a local variable"),
+    ENUM_CONSTANT("on the type of an enum constant"),
+    EXCEPTION_PARAMETER("on the type of an exception parameter"),
+    RECEIVER_PARAMETER("on the type of a receiver parameter", true),
+    PATTERN("on a type in a pattern", true),
+    /**
+     * The type an {@code instanceof} operator tests against, as in {@code o instanceof @Nullable
+     * String}. A type pattern that binds a variable is {@link #PATTERN} instead.
+     */
+    INSTANCEOF("on the type after an instanceof operator", true),
+    CAST("on the root type of a cast"),
+    OBJECT_CREATION("on the root type of an object creation expression"),
+    ARRAY_CREATION("on the array type of an array creation expression"),
+    METHOD_REFERENCE("on the root type of a method reference"),
+    /**
+     * A type an {@code extends} or {@code implements} clause names, as in {@code class C
+     * extends @Nullable ArrayList<String>}. An anonymous class's supertype is reported as {@link
+     * #OBJECT_CREATION} instead.
+     */
+    SUPERTYPE("on a supertype in a class declaration"),
+    THROWN_TYPE("on a thrown exception type"),
+    CLASS_DECLARATION("on a class declaration"),
+    CONSTRUCTOR_RESULT("on the result type of a constructor"),
+    TYPE_PARAMETER("directly on a type parameter declaration"),
+    WILDCARD("directly on a wildcard"),
+    OUTER_TYPE("on the outer type qualifying an inner type"),
+    ANNOTATION_MEMBER("on the return type of an annotation interface member", true);
+
+    private final String phrase;
+
+    /**
+     * Whether the location covers the type usages nested inside it, so that a nullness annotation
+     * anywhere within the location is unrecognized too.
+     */
+    private final boolean coversNestedTypes;
+
+    UnrecognizedLocation(String phrase) {
+      this(phrase, false);
+    }
+
+    UnrecognizedLocation(String phrase, boolean coversNestedTypes) {
+      this.phrase = phrase;
+      this.coversNestedTypes = coversNestedTypes;
+    }
+  }
+
+  /**
+   * An unrecognized location that a nullness annotation was written in, and the tree a fix is built
+   * against.
+   *
+   * @param anchor the type usage the annotation lands on, or the qualified name as a whole where
+   *     the annotation lands on one of its qualifiers
+   */
+  private record TypeUsage(UnrecognizedLocation location, Tree anchor) {}
+
+  /** The nullness annotations JSpecify defines, which are the only ones this check reads. */
+  private static final ImmutableSet<String> JSPECIFY_NULLNESS_ANNOTATIONS =
+      ImmutableSet.of("org.jspecify.annotations.Nullable", "org.jspecify.annotations.NonNull");
+
+  /**
+   * Name of the Error Prone flag that turns off reporting for {@link
+   * UnrecognizedLocation#LOCAL_VARIABLE_ROOT_TYPE}. It carries the check's own name rather than
+   * NullAway's, since the check reads no NullAway configuration.
+   */
+  private static final String FL_CHECK_LOCAL_VARIABLE_ROOT_TYPE =
+      "JSpecifyUnrecognizedAnnotationLocation:CheckLocalVariableRootType";
+
+  /** Whether an annotation on the root type of a local variable is reported. True by default. */
+  private final boolean checkLocalVariableRootType;
+
+  /**
+   * Creates a check with default options. Error Prone requires this constructor in addition to the
+   * one taking an {@link ErrorProneFlags} object.
+   */
+  public JSpecifyUnrecognizedAnnotationLocation() {
+    checkLocalVariableRootType = true;
+  }
+
+  @Inject // For future Error Prone versions in which checkers are loaded using Guice
+  public JSpecifyUnrecognizedAnnotationLocation(ErrorProneFlags flags) {
+    checkLocalVariableRootType = flags.getBoolean(FL_CHECK_LOCAL_VARIABLE_ROOT_TYPE).orElse(true);
+  }
+
+  @Override
+  public Description matchAnnotatedType(AnnotatedTypeTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    ImmutableList<AnnotationTree> annotations = nullnessAnnotationsIn(tree.getAnnotations());
+    if (annotations.isEmpty()) {
+      return Description.NO_MATCH;
+    }
+    TypeUsage usage = classifyTypeUsage(tree, state);
+    if (usage != null) {
+      report(annotations, usage.location(), usage.anchor(), state);
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    TreePath parent = state.getPath().getParentPath();
+    if (parent != null && isCompactConstructorParameter(parent.getLeaf(), tree)) {
+      return Description.NO_MATCH;
+    }
+    checkAnnotationsOnDeclaration(
+        tree.getModifiers().getAnnotations(), tree.getType(), variableLocation(tree), state);
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    // Only a constructor has no return type tree.  JSpecify recognizes a method's return type but
+    // lists no result type for a constructor.
+    Tree returnType = tree.getReturnType();
+    UnrecognizedLocation declarationLocation;
+    if (returnType == null) {
+      declarationLocation = UnrecognizedLocation.CONSTRUCTOR_RESULT;
+    } else {
+      declarationLocation =
+          isAnnotationInterfaceMember(tree) ? UnrecognizedLocation.ANNOTATION_MEMBER : null;
+    }
+    checkAnnotationsOnDeclaration(
+        tree.getModifiers().getAnnotations(), returnType, declarationLocation, state);
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    checkAnnotationsOnDeclaration(
+        tree.getModifiers().getAnnotations(), null, UnrecognizedLocation.CLASS_DECLARATION, state);
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchTypeParameter(TypeParameterTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    report(
+        nullnessAnnotationsIn(tree.getAnnotations()),
+        UnrecognizedLocation.TYPE_PARAMETER,
+        tree,
+        state);
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchNewArray(NewArrayTree tree, VisitorState state) {
+    if (!isEnabled(state)) {
+      return Description.NO_MATCH;
+    }
+    // javac records the annotations of an array creation in one of two places.  Given dimension
+    // expressions, as in `new String @Nullable [5] @NonNull [3]`, it splits them by dimension from
+    // the created array outwards, and only the first list annotates the array itself.  Given an
+    // initializer, as in `new String @Nullable [] {"x"}`, there are no dimensions to split by: the
+    // created array's annotations are the tree's own, and any inner dimension's annotations have
+    // moved into the element type.  Either way, the rest annotate component types, and JSpecify
+    // recognizes those.
+    List<? extends List<? extends AnnotationTree>> dimensionAnnotations = tree.getDimAnnotations();
+    List<? extends AnnotationTree> arrayAnnotations =
+        dimensionAnnotations.isEmpty() ? tree.getAnnotations() : dimensionAnnotations.get(0);
+    report(
+        nullnessAnnotationsIn(arrayAnnotations), UnrecognizedLocation.ARRAY_CREATION, tree, state);
+    return Description.NO_MATCH;
+  }
+
+  /**
+   * Reports each nullness annotation in a declaration's modifiers that lands in an unrecognized
+   * location. Such an annotation lands on the declared type, with two exceptions that {@link
+   * #modifierAnnotationLocation} reads off that type: array dimensions are stripped, so an
+   * annotation before {@code String[] names} annotates {@code String}; and the outermost type in a
+   * qualified name takes the annotation, so one before {@code Outer.Inner} annotates {@code Outer}.
+   *
+   * @param annotations every annotation in the declaration's modifiers, not only the nullness ones
+   * @param typeTree the declared type, or {@code null} for a declaration that has none
+   * @param declarationLocation the location to report if the declared root type is unrecognized, or
+   *     {@code null} if the declaration is a recognized location
+   */
+  private void checkAnnotationsOnDeclaration(
+      List<? extends AnnotationTree> annotations,
+      @Nullable Tree typeTree,
+      @Nullable UnrecognizedLocation declarationLocation,
+      VisitorState state) {
+    ImmutableList<AnnotationTree> nullnessAnnotations = nullnessAnnotationsIn(annotations);
+    if (nullnessAnnotations.isEmpty()) {
+      return;
+    }
+    UnrecognizedLocation location = modifierAnnotationLocation(typeTree, declarationLocation);
+    if (location != null) {
+      report(nullnessAnnotations, location, typeTree, state);
+    }
+  }
+
+  /**
+   * Returns the location of an annotation written in the modifiers of a declaration whose declared
+   * type is {@code typeTree}, or {@code null} if that location is recognized.
+   */
+  private static @Nullable UnrecognizedLocation modifierAnnotationLocation(
+      @Nullable Tree typeTree, @Nullable UnrecognizedLocation declarationLocation) {
+    if (typeTree == null) {
+      return declarationLocation;
+    }
+    // In `@Nullable String[] names` the annotation applies to the component type rather than to the
+    // array, so strip the array dimensions to find the type usage it lands on.
+    Tree rootType = typeTree;
+    boolean onArrayComponent = false;
+    while (true) {
+      if (rootType instanceof AnnotatedTypeTree annotatedType) {
+        rootType = annotatedType.getUnderlyingType();
+      } else if (rootType instanceof ArrayTypeTree arrayType) {
+        rootType = arrayType.getType();
+        onArrayComponent = true;
+      } else {
+        break;
+      }
+    }
+    if (rootType instanceof PrimitiveTypeTree) {
+      return UnrecognizedLocation.PRIMITIVE_TYPE;
+    }
+    if (onArrayComponent
+        && (declarationLocation == null || !declarationLocation.coversNestedTypes)) {
+      // The annotation lands on the array component type, a recognized location even where the
+      // declaration's own root type is not.  Only a qualified inner type is left to report: in
+      // `@Nullable Outer.Inner[] x` it lands on `Outer`, and the author meant
+      // `Outer.@Nullable Inner[] x`.
+      return qualifiedInnerType(rootType) != null ? UnrecognizedLocation.OUTER_TYPE : null;
+    }
+    if (declarationLocation != null) {
+      return declarationLocation;
+    }
+    return qualifiedInnerType(rootType) != null ? UnrecognizedLocation.OUTER_TYPE : null;
+  }
+
+  /**
+   * Returns the location of a nullness annotation written directly on the type usage {@code tree},
+   * together with the tree a fix is built against.
+   *
+   * <p>Returns {@code null} where the annotation is not reported here: either the location is
+   * recognized, or a second {@link TreePath} reaches the same annotation and reports it.
+   */
+  private static @Nullable TypeUsage classifyTypeUsage(AnnotatedTypeTree tree, VisitorState state) {
+    Tree underlyingType = tree.getUnderlyingType();
+    // A primitive or a wildcard is unrecognized on its own, but neither classification is returned
+    // until the walk out to the enclosing construct has finished.  A construct on the way out may
+    // suppress the classification altogether, because an annotation reachable through two
+    // TreePaths is classified on one of them.  The two differ in whether an unrecognized enclosing
+    // location replaces them.  A primitive names the most specific location there is, so nothing
+    // outside it improves on the phrase.  A wildcard's fix moves the annotation to a bound, and a
+    // location that covers what is nested inside it leaves the annotation just as meaningless
+    // there.
+    UnrecognizedLocation onTypeItself =
+        underlyingType instanceof PrimitiveTypeTree
+            ? UnrecognizedLocation.PRIMITIVE_TYPE
+            : underlyingType instanceof WildcardTree ? UnrecognizedLocation.WILDCARD : null;
+    // Walk out to the declaration or expression the type usage belongs to.  Along the way, nested
+    // records whether a recognized nesting step (a type argument, an array component, or a bound)
+    // was crossed, and qualifierAnchor records the name whose qualifier the annotation landed on.
+    Tree qualifierAnchor = null;
+    boolean nested = false;
+    Tree child = tree;
+    for (TreePath path = state.getPath().getParentPath();
+        path != null;
+        path = path.getParentPath()) {
+      Tree parent = path.getLeaf();
+      if (parent instanceof ParameterizedTypeTree parameterizedType) {
+        nested |= parameterizedType.getTypeArguments().contains(child);
+      } else if (parent instanceof ArrayTypeTree
+          || parent instanceof WildcardTree
+          || parent instanceof TypeParameterTree) {
+        nested = true;
+      } else if (parent instanceof AnnotatedTypeTree) {
+        // The enclosing annotated type reports its own annotations.  Where it wraps the qualified
+        // name that the fix writes into, it carries the annotations already on that name, so the
+        // anchor moves out to it and destinationIsOccupied can see them.
+        if (Objects.equals(child, qualifierAnchor)) {
+          qualifierAnchor = parent;
+        }
+      } else if (parent instanceof UnionTypeTree || parent instanceof IntersectionTypeTree) {
+        // An alternative of a union type and a member of an intersection type are in the same
+        // location as the type that contains them, so crossing one is not a nesting step.
+      } else if (parent instanceof ClassTree classTree
+          && classTree.getSimpleName().isEmpty()
+          && isSupertype(classTree, child)) {
+        // An anonymous class body's supertype tree is the tree the enclosing `new` expression
+        // names, so this path is a second view of an annotation the NewClassTree path reports.
+        return null;
+      } else if (parent instanceof MemberSelectTree memberSelect
+          && Objects.equals(memberSelect.getExpression(), child)) {
+        if (!nested) {
+          // The outermost qualified name is the anchor, so `@Nullable P.Inner.Innermost` moves the
+          // annotation to `Innermost` rather than to `Inner`, which qualifies it in turn.  Within a
+          // type argument the annotation lands on that argument rather than on a qualifier, as in
+          // `P.Generic<@Nullable String>.Deep`, so nothing is recorded.
+          qualifierAnchor = memberSelect;
+        }
+      } else if (parent instanceof VariableTree
+          && path.getParentPath() != null
+          && isCompactConstructorParameter(path.getParentPath().getLeaf(), parent)) {
+        // The compact constructor's parameters are javac's copies of the record components, so
+        // this path is a second view of an annotation the component itself reports.
+        return null;
+      } else {
+        UnrecognizedLocation enclosing = anchorLocation(parent, child);
+        if (onTypeItself != UnrecognizedLocation.PRIMITIVE_TYPE
+            && enclosing != null
+            && (enclosing.coversNestedTypes || !nested)) {
+          return new TypeUsage(enclosing, underlyingType);
+        }
+        break;
+      }
+      child = parent;
+    }
+    if (qualifierAnchor != null) {
+      return new TypeUsage(UnrecognizedLocation.OUTER_TYPE, qualifierAnchor);
+    }
+    return onTypeItself == null ? null : new TypeUsage(onTypeItself, underlyingType);
+  }
+
+  /**
+   * Returns the location of the root type {@code child} names. Returns {@code null} where that
+   * location is recognized, and where {@code anchor} is a kind the check does not classify.
+   *
+   * @param anchor the declaration or expression that holds the type usage
+   * @param child the child of {@code anchor} the type usage was reached through
+   */
+  private static @Nullable UnrecognizedLocation anchorLocation(Tree anchor, Tree child) {
+    if (anchor instanceof VariableTree variable) {
+      return variableLocation(variable);
+    }
+    if (anchor instanceof MethodTree method) {
+      if (Objects.equals(child, method.getReturnType())) {
+        return isAnnotationInterfaceMember(method) ? UnrecognizedLocation.ANNOTATION_MEMBER : null;
+      }
+      return method.getThrows().contains(child) ? UnrecognizedLocation.THROWN_TYPE : null;
+    }
+    if (anchor instanceof ClassTree classTree) {
+      return isSupertype(classTree, child) ? UnrecognizedLocation.SUPERTYPE : null;
+    }
+    if (anchor instanceof TypeCastTree) {
+      return UnrecognizedLocation.CAST;
+    }
+    if (anchor instanceof InstanceOfTree) {
+      return UnrecognizedLocation.INSTANCEOF;
+    }
+    if (anchor instanceof NewClassTree newClass) {
+      return Objects.equals(child, newClass.getIdentifier())
+          ? UnrecognizedLocation.OBJECT_CREATION
+          : null;
+    }
+    if (anchor instanceof MemberReferenceTree reference) {
+      // A method reference's qualifier expression is its root type, as in `@Nullable String::new`.
+      // The location does not cover what is nested inside it, so `ArrayList<@Nullable String>::new`
+      // stays recognized.
+      return Objects.equals(child, reference.getQualifierExpression())
+          ? UnrecognizedLocation.METHOD_REFERENCE
+          : null;
+    }
+    // A component type of an array creation expression is recognized, and every other anchor is
+    // left to a future revision of this check.
+    return null;
+  }
+
+  /**
+   * Returns whether {@code variable} is one of the parameters javac copies from a record's
+   * components into its compact constructor.
+   *
+   * <p>The copies keep the components' source positions and share their annotation trees, so each
+   * is a second view of a declaration already reported. The parameter list they sit in tells them
+   * apart from an ordinary declaration, not their own symbol kind: a lambda parameter written in
+   * the constructor's body is an {@link ElementKind#PARAMETER} owned by that same constructor, and
+   * its annotations are the author's own.
+   *
+   * @param parent the tree {@code variable} is declared under
+   */
+  private static boolean isCompactConstructorParameter(@Nullable Tree parent, Tree variable) {
+    if (!(parent instanceof MethodTree method) || !method.getParameters().contains(variable)) {
+      return false;
+    }
+    Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(method);
+    return symbol != null && (symbol.flags() & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0;
+  }
+
+  /** Returns whether {@code child} is a type {@code classTree} extends or implements. */
+  private static boolean isSupertype(ClassTree classTree, Tree child) {
+    return Objects.equals(child, classTree.getExtendsClause())
+        || classTree.getImplementsClause().contains(child);
+  }
+
+  /**
+   * Returns the location of {@code variable}'s root type, or {@code null} for a declaration whose
+   * root type JSpecify recognizes.
+   */
+  private static @Nullable UnrecognizedLocation variableLocation(VariableTree variable) {
+    if (variable.getNameExpression() != null) {
+      // Only a receiver parameter has a name expression, as in `void m(Foo this)`.
+      return UnrecognizedLocation.RECEIVER_PARAMETER;
+    }
+    Symbol symbol = ASTHelpers.getSymbol(variable);
+    if (symbol == null) {
+      return null;
+    }
+    return switch (symbol.getKind()) {
+      case LOCAL_VARIABLE, RESOURCE_VARIABLE -> UnrecognizedLocation.LOCAL_VARIABLE_ROOT_TYPE;
+      case EXCEPTION_PARAMETER -> UnrecognizedLocation.EXCEPTION_PARAMETER;
+      case BINDING_VARIABLE -> UnrecognizedLocation.PATTERN;
+      case ENUM_CONSTANT -> UnrecognizedLocation.ENUM_CONSTANT;
+      // Every other kind is a recognized location: a field, a parameter, or a record component.
+      default -> null;
+    };
+  }
+
+  /** Returns whether {@code method} is declared in an annotation interface. */
+  private static boolean isAnnotationInterfaceMember(MethodTree method) {
+    Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(method);
+    return symbol != null && symbol.enclClass().getKind() == ElementKind.ANNOTATION_TYPE;
+  }
+
+  /**
+   * Returns the member select through which {@code typeTree} names a qualified type, as in {@code
+   * Outer.Inner}, {@code Map.Entry} or {@code java.util.List}; or {@code null} if {@code typeTree}
+   * names a type without a qualifier.
+   *
+   * <p>Array dimensions, type arguments and annotations are stripped first, and repeatedly: {@code
+   * Outer.Inner[][]} names the same type as {@code Outer.Inner}.
+   *
+   * <p>An annotation on the type has to be <em>written</em> before the member select's last part.
+   * Before its first part the annotation either annotates a different type, as {@code @Nullable
+   * Outer.Inner} annotates {@code Outer}, or javac rejects it outright, as it does {@code @Nullable
+   * java.util.List}. {@link #qualifiedInnerType} decides the narrower question of where an
+   * annotation already written lands.
+   */
+  private static @Nullable MemberSelectTree selectedTypeName(Tree typeTree) {
+    Tree type = typeTree;
+    while (true) {
+      if (type instanceof AnnotatedTypeTree annotatedType) {
+        type = annotatedType.getUnderlyingType();
+      } else if (type instanceof ArrayTypeTree arrayType) {
+        type = arrayType.getType();
+      } else if (type instanceof ParameterizedTypeTree parameterizedType) {
+        type = parameterizedType.getType();
+      } else {
+        break;
+      }
+    }
+    return type instanceof MemberSelectTree memberSelect
+            && ASTHelpers.getSymbol(type) instanceof Symbol.ClassSymbol
+        ? memberSelect
+        : null;
+  }
+
+  /**
+   * Returns the member select through which {@code typeTree} names an inner class from its
+   * enclosing class, or {@code null} where {@code typeTree} names no such class.
+   *
+   * <p>An annotation written before the whole name lands on that enclosing class.
+   */
+  private static @Nullable MemberSelectTree qualifiedInnerType(Tree typeTree) {
+    MemberSelectTree memberSelect = selectedTypeName(typeTree);
+    if (memberSelect == null) {
+      return null;
+    }
+    // Only an inner type has an enclosing type for an annotation to land on.  A package or a
+    // static member type merely scopes the name, so this method returns null for both
+    // `@Nullable Map.Entry` and `@Nullable java.util.List`.  Whether javac accepts either
+    // spelling varies by position, and this method does not decide that.
+    Symbol qualifier = ASTHelpers.getSymbol(memberSelect.getExpression());
+    return qualifier instanceof Symbol.ClassSymbol
+            && !ASTHelpers.isStatic(ASTHelpers.getSymbol(memberSelect))
+        ? memberSelect
+        : null;
+  }
+
+  /** Returns the JSpecify nullness annotations among {@code annotations}. */
+  private static ImmutableList<AnnotationTree> nullnessAnnotationsIn(
+      List<? extends AnnotationTree> annotations) {
+    return annotations.stream()
+        .filter(JSpecifyUnrecognizedAnnotationLocation::isNullnessAnnotation)
+        .collect(toImmutableList());
+  }
+
+  /** Returns whether {@code annotation} is one of the nullness annotations JSpecify defines. */
+  private static boolean isNullnessAnnotation(AnnotationTree annotation) {
+    Symbol symbol = ASTHelpers.getSymbol(annotation.getAnnotationType());
+    return symbol instanceof Symbol.ClassSymbol
+        && JSPECIFY_NULLNESS_ANNOTATIONS.contains(symbol.getQualifiedName().toString());
+  }
+
+  /**
+   * Reports each annotation at {@code location}, with a fix that puts the annotation where the
+   * author meant it or removes it when no such place exists.
+   *
+   * <p>Reports nothing at {@link UnrecognizedLocation#LOCAL_VARIABLE_ROOT_TYPE} when {@link
+   * #checkLocalVariableRootType} is false.
+   *
+   * @param anchor the tree a fix is built against, or {@code null} where only removal is offered
+   */
+  private void report(
+      ImmutableList<AnnotationTree> annotations,
+      UnrecognizedLocation location,
+      @Nullable Tree anchor,
+      VisitorState state) {
+    if (annotations.isEmpty()
+        || (location == UnrecognizedLocation.LOCAL_VARIABLE_ROOT_TYPE
+            && !checkLocalVariableRootType)) {
+      return;
+    }
+    for (AnnotationTree annotation : annotations) {
+      Description.Builder description =
+          buildDescription(annotation)
+              .setMessage(
+                  "A nullness annotation " + location.phrase + " has no meaning under JSpecify.");
+      SuggestedFix fix = buildFix(annotation, location, anchor, annotations.size(), state);
+      if (!fix.isEmpty()) {
+        description.addFix(fix);
+      }
+      state.reportMatch(description.build());
+    }
+  }
+
+  /**
+   * Returns a fix that moves {@code annotation} to the recognized location the author meant, or one
+   * that only removes it when no such location can be named unambiguously.
+   *
+   * @param annotationCount how many nullness annotations share {@code anchor}; a move is ambiguous
+   *     once there is more than one
+   */
+  private static SuggestedFix buildFix(
+      AnnotationTree annotation,
+      UnrecognizedLocation location,
+      @Nullable Tree anchor,
+      int annotationCount,
+      VisitorState state) {
+    String source = state.getSourceForNode(annotation);
+    SuggestedFix.Builder fix = deleteAnnotation(annotation, state);
+    if (source == null || anchor == null || annotationCount > 1) {
+      return fix.build();
+    }
+    return switch (location) {
+      case WILDCARD -> moveToWildcardBound(fix, (WildcardTree) anchor, annotation, source, state);
+      case TYPE_PARAMETER ->
+          moveToTypeParameterBound(fix, (TypeParameterTree) anchor, annotation, source, state);
+      case OUTER_TYPE -> moveToSelectedName(fix, anchor, annotation, source, state);
+      default -> fix.build();
+    };
+  }
+
+  /**
+   * Returns a fix that removes {@code annotation} together with the spaces and tabs separating it
+   * from whatever follows it on the line.
+   *
+   * <p>Those blanks belong to the annotation: leaving them turns {@code (@Nullable T) o} into
+   * {@code ( T) o}, and gives a line that began with the annotation a column of indentation. A
+   * newline is left alone, so an annotation written on a line of its own leaves that line empty
+   * rather than joining it to the next.
+   */
+  private static SuggestedFix.Builder deleteAnnotation(
+      AnnotationTree annotation, VisitorState state) {
+    int start = ASTHelpers.getStartPosition(annotation);
+    int end = state.getEndPosition(annotation);
+    CharSequence source = state.getSourceCode();
+    if (start == Position.NOPOS || end == Position.NOPOS || source == null) {
+      return SuggestedFix.builder().delete(annotation);
+    }
+    while (end < source.length() && (source.charAt(end) == ' ' || source.charAt(end) == '\t')) {
+      end++;
+    }
+    return SuggestedFix.builder().replace(start, end, "");
+  }
+
+  /**
+   * Returns {@code fix} with {@code annotationSource} written on the type {@code bound} names. That
+   * position is not always the start of {@code bound}'s source text: {@code @Nullable String[]}
+   * annotates the component rather than the array, and {@code @Nullable Outer.Inner} annotates the
+   * qualifier rather than the inner type. {@code fix} comes back unchanged where a nullness
+   * annotation already stands at that position; see {@link #destinationIsOccupied}.
+   */
+  private static SuggestedFix.Builder annotateBound(
+      SuggestedFix.Builder fix,
+      Tree bound,
+      AnnotationTree moving,
+      String annotationSource,
+      VisitorState state) {
+    Tree component = bound;
+    boolean onArray = false;
+    boolean arrayIsAnnotated = false;
+    while (true) {
+      if (component instanceof AnnotatedTypeTree annotatedType) {
+        // An AnnotatedTypeTree that the walk reaches before it descends into an array annotates
+        // the array itself, as in `String @NonNull []`. One that it reaches afterwards annotates a
+        // component type, which is a type usage of its own.
+        arrayIsAnnotated |=
+            !onArray && !nullnessAnnotationsIn(annotatedType.getAnnotations()).isEmpty();
+        component = annotatedType.getUnderlyingType();
+      } else if (component instanceof ArrayTypeTree arrayType) {
+        component = arrayType.getType();
+        onArray = true;
+      } else {
+        break;
+      }
+    }
+    if (onArray) {
+      if (arrayIsAnnotated) {
+        return fix;
+      }
+      // The outermost array is annotated after the element type, as in `String @Nullable [][]`.
+      // Every ArrayTypeTree in `String[][]` reports the range of the whole type, so the element
+      // type supplies the offset.
+      int afterComponent = state.getEndPosition(component);
+      return fix.replace(afterComponent, afterComponent, " " + annotationSource);
+    }
+    if (destinationIsOccupied(bound, moving)) {
+      return fix;
+    }
+    MemberSelectTree memberSelect = selectedTypeName(bound);
+    if (memberSelect == null) {
+      return fix.prefixWith(bound, annotationSource + " ");
+    }
+    int nameStart = selectedNameStart(memberSelect, state);
+    if (nameStart == Position.NOPOS) {
+      return fix;
+    }
+    return fix.replace(nameStart, nameStart, annotationSource + " ");
+  }
+
+  /**
+   * Returns whether a nullness annotation already stands where a move would write {@code moving}.
+   *
+   * <p>A move writes on the last name of a qualified type name, or on the type name itself where
+   * there is no qualifier. Every nullness annotation on a qualifier is relocated to that one
+   * position, so the one written closest to it is the one that arrives and every other is deleted.
+   * Only an annotation that the move would pass is therefore an obstacle, and {@code moving} is
+   * where the walk stops.
+   *
+   * <p>{@code moving} is outside {@code typeTree} altogether where it was written in a
+   * declaration's modifiers, or on the wildcard or type parameter that {@code typeTree} bounds. The
+   * walk then reaches no stopping point, and every annotation in the chain is an obstacle.
+   */
+  private static boolean destinationIsOccupied(Tree typeTree, AnnotationTree moving) {
+    Tree type = typeTree;
+    while (true) {
+      if (type instanceof AnnotatedTypeTree annotatedType) {
+        if (annotatedType.getAnnotations().contains(moving)) {
+          return false;
+        }
+        // An AnnotatedTypeTree wrapping an array annotates the array rather than the name written
+        // inside it, as in `Outer.Inner @NonNull []`, so it is not an obstacle.
+        if (!(annotatedType.getUnderlyingType() instanceof ArrayTypeTree)
+            && !nullnessAnnotationsIn(annotatedType.getAnnotations()).isEmpty()) {
+          return true;
+        }
+        type = annotatedType.getUnderlyingType();
+      } else if (type instanceof ArrayTypeTree arrayType) {
+        type = arrayType.getType();
+      } else if (type instanceof ParameterizedTypeTree parameterizedType) {
+        type = parameterizedType.getType();
+      } else if (type instanceof MemberSelectTree memberSelect) {
+        type = memberSelect.getExpression();
+      } else {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Returns the offset {@code memberSelect}'s last name starts at, which is where an annotation on
+   * the type it names goes; or {@link Position#NOPOS} if the source does not yield one.
+   *
+   * <p>The offset is read off the tokens rather than computed from the name's length, because a
+   * name may be written with Unicode escapes, which javac decodes before it lexes: {@code Inner}
+   * spelled with an escape for its {@code e} is ten characters of source for a five-character name,
+   * so subtracting the name's length from the end position lands inside the escape.
+   *
+   * <p>A member select's source ends at its own name, so the last token carrying a name is that
+   * name whatever precedes it. What precedes it can be a comment or an annotation written between
+   * the dot and the name, an annotation argument that is itself an identifier, or a keyword javac
+   * tags as named, such as the {@code int} of {@code @Marker(type = int.class)}; a later token
+   * overwrites each of them.
+   *
+   * <p>The tokens come from {@link ErrorProneTokens} rather than from {@link
+   * VisitorState#getOffsetTokensForNode}, whose return type changed from {@code List} to {@code
+   * ImmutableList} after the oldest Error Prone release NullAway supports. NullAway compiles
+   * against the newest, so a call to it would throw {@link NoSuchMethodError} on the oldest.
+   */
+  private static int selectedNameStart(MemberSelectTree memberSelect, VisitorState state) {
+    int offset = ASTHelpers.getStartPosition(memberSelect);
+    String source = state.getSourceForNode(memberSelect);
+    if (offset == Position.NOPOS || source == null) {
+      return Position.NOPOS;
+    }
+    int start = Position.NOPOS;
+    for (ErrorProneToken token : ErrorProneTokens.getTokens(source, offset, state.context)) {
+      if (token.hasName()) {
+        start = token.pos();
+      }
+    }
+    return start;
+  }
+
+  /**
+   * Rewrites a wildcard so that the annotation lands on its upper bound.
+   *
+   * <p>{@code Foo<@Nullable ?>} becomes {@code Foo<? extends @Nullable Object>}, and {@code
+   * Foo<@Nullable ? extends Bar>} becomes {@code Foo<? extends @Nullable Bar>}.
+   */
+  private static SuggestedFix moveToWildcardBound(
+      SuggestedFix.Builder fix,
+      WildcardTree wildcard,
+      AnnotationTree moving,
+      String annotationSource,
+      VisitorState state) {
+    return switch (wildcard.getKind()) {
+      case EXTENDS_WILDCARD ->
+          annotateBound(fix, wildcard.getBound(), moving, annotationSource, state).build();
+      case UNBOUNDED_WILDCARD ->
+          fix.postfixWith(wildcard, " extends " + annotationSource + " Object").build();
+      // A lower-bounded wildcard has no upper bound to write the annotation on.
+      default -> fix.build();
+    };
+  }
+
+  /**
+   * Rewrites a type parameter so that the annotation lands on its bound.
+   *
+   * <p>{@code <@Nullable T>} becomes {@code <T extends @Nullable Object>}, and {@code <@Nullable T
+   * extends Bar>} becomes {@code <T extends @Nullable Bar>}.
+   */
+  private static SuggestedFix moveToTypeParameterBound(
+      SuggestedFix.Builder fix,
+      TypeParameterTree typeParameter,
+      AnnotationTree moving,
+      String annotationSource,
+      VisitorState state) {
+    List<? extends Tree> bounds = typeParameter.getBounds();
+    if (bounds.isEmpty()) {
+      return fix.postfixWith(typeParameter, " extends " + annotationSource + " Object").build();
+    }
+    if (bounds.size() > 1) {
+      // An intersection bound has no single member that the annotation belongs on, and a fix that
+      // annotated every member would add annotations the author did not write.
+      return fix.build();
+    }
+    return annotateBound(fix, bounds.get(0), moving, annotationSource, state).build();
+  }
+
+  /** Rewrites {@code @Nullable Outer.Inner} as {@code Outer.@Nullable Inner}. */
+  private static SuggestedFix moveToSelectedName(
+      SuggestedFix.Builder fix,
+      Tree typeTree,
+      AnnotationTree moving,
+      String annotationSource,
+      VisitorState state) {
+    MemberSelectTree memberSelect = selectedTypeName(typeTree);
+    if (memberSelect == null || destinationIsOccupied(typeTree, moving)) {
+      return fix.build();
+    }
+    int nameStart = selectedNameStart(memberSelect, state);
+    if (nameStart == Position.NOPOS) {
+      return fix.build();
+    }
+    // Rewriting the whole member select would drop any other annotation written on it, and would
+    // overlap this fix's own deletion where the annotation being moved sits inside the qualifier.
+    return fix.replace(nameStart, nameStart, annotationSource + " ").build();
+  }
+
+  /**
+   * Returns whether the check reports at the severity it is running under.
+   *
+   * <p>The check reports nothing at {@link SeverityLevel#SUGGESTION}, its default, and reports at
+   * every other severity. JSpecify recommends that tools offer this diagnostic as an option, and
+   * Error Prone cannot ship a plugin check turned off, so this default is as close to off as the
+   * check can get.
+   */
+  private boolean isEnabled(VisitorState state) {
+    return !SeverityLevel.SUGGESTION.equals(state.severityMap().get(canonicalName()));
+  }
+
+  @Override
+  public String linkUrl() {
+    return "https://jspecify.dev/docs/spec/#recognized-type-use";
+  }
+}

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -491,12 +491,11 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
   }
 
   /**
-   * Returns the location of the root type {@code child} names within {@code construct}. Returns
-   * {@code null} where that location is recognized, and where {@code construct} is a kind the check
-   * does not classify.
+   * Returns the unrecognized location of the root type tree {@code child}, whose parent is {@code
+   * construct}. Returns {@code null} where that location is recognized, and where {@code construct}
+   * is a kind the check does not classify.
    *
    * @param construct the declaration or expression that holds the type usage
-   * @param child the child of {@code construct} the type usage was reached through
    */
   private static @Nullable UnrecognizedLocation enclosingLocation(Tree construct, Tree child) {
     if (construct instanceof VariableTree variable) {

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -152,8 +152,14 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
     private final String phrase;
 
     /**
-     * Whether the location covers the type usages nested inside it, so that a nullness annotation
+     * Whether the location covers the type usages written inside it, so that a nullness annotation
      * anywhere within the location is unrecognized too.
+     *
+     * <p>A location that does not cover them reaches its own root type and stops, which leaves the
+     * type argument in {@code (List<@Nullable String>) o} recognized. Compare {@code
+     * (List<@Nullable ?>) o}, reported as a wildcard because a cast stops short of it, with {@code
+     * o instanceof List<@Nullable ?>}, reported as the {@code instanceof} operand because JSpecify
+     * recognizes no type usage there at all.
      */
     private final boolean coversNestedTypes;
 
@@ -366,51 +372,60 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
 
   /**
    * Returns the location of a nullness annotation written directly on the type usage {@code tree},
-   * together with the tree a fix is built against.
+   * together with the tree a fix is built against. Call it only where {@code tree} carries such an
+   * annotation.
    *
-   * <p>Returns {@code null} where the annotation is not reported here: either the location is
-   * recognized, or a second {@link TreePath} reaches the same annotation and reports it.
+   * <p>Neither answer can be read off {@code tree}, so the method walks {@link
+   * VisitorState#getPath} outwards to the declaration or expression the type usage belongs to. The
+   * walk settles two questions: whether the annotation stands on that construct's root type or
+   * below it, and, where the type usage and the construct around it are both unrecognized, which
+   * of the two names the annotation's position better and so gives the fix its target.
+   *
+   * <p>Returns {@code null} in two cases. The location is recognized, as the type argument in
+   * {@code (List<@Nullable String>) o} is. Or javac has put one subtree under two parents, which
+   * Error Prone scans once per parent, so the same annotation arrives here through two {@link
+   * TreePath}s and the walk from the other parent reports it. An anonymous class body's supertype
+   * tree is the tree the enclosing {@code new} expression names, and a compact constructor's
+   * parameters are javac's copies of the record components, sharing their annotation trees.
    */
   private static @Nullable TypeUsage classifyTypeUsage(AnnotatedTypeTree tree, VisitorState state) {
     Tree underlyingType = tree.getUnderlyingType();
-    // A primitive or a wildcard is unrecognized on its own, but neither classification is returned
-    // until the walk out to the enclosing construct has finished.  A construct on the way out may
-    // suppress the classification altogether, because an annotation reachable through two
-    // TreePaths is classified on one of them.  The two differ in whether an unrecognized enclosing
-    // location replaces them.  A primitive names the most specific location there is, so nothing
-    // outside it improves on the phrase.  A wildcard's fix moves the annotation to a bound, and a
-    // location that covers what is nested inside it leaves the annotation just as meaningless
-    // there.
+    // A primitive and a wildcard are unrecognized wherever they are written, but the walk still
+    // runs before either is returned.  The walk recognizes a subtree javac reached through two
+    // parents, and that case returns null so the other walk reports the annotation.
     UnrecognizedLocation onTypeItself =
         underlyingType instanceof PrimitiveTypeTree
             ? UnrecognizedLocation.PRIMITIVE_TYPE
             : underlyingType instanceof WildcardTree ? UnrecognizedLocation.WILDCARD : null;
-    // Walk out to the declaration or expression the type usage belongs to.  Along the way, nested
-    // records whether a recognized nesting step (a type argument, an array component, or a bound)
-    // was crossed, and qualifierAnchor records the name whose qualifier the annotation landed on.
+    // Walk out to the declaration or expression the type usage belongs to.  Crossing a type
+    // argument, an array component, or a bound puts the annotation below the root type of whatever
+    // construct is reached next, on a type usage JSpecify recognizes in its own right, and
+    // belowRootType records that.  qualifierAnchor records the qualified name the annotation stands
+    // in front of, which is where a fix moves it.
     Tree qualifierAnchor = null;
-    boolean nested = false;
+    boolean belowRootType = false;
     Tree child = tree;
     for (TreePath path = state.getPath().getParentPath();
         path != null;
         path = path.getParentPath()) {
       Tree parent = path.getLeaf();
       if (parent instanceof ParameterizedTypeTree parameterizedType) {
-        nested |= parameterizedType.getTypeArguments().contains(child);
+        belowRootType |= parameterizedType.getTypeArguments().contains(child);
       } else if (parent instanceof ArrayTypeTree
           || parent instanceof WildcardTree
           || parent instanceof TypeParameterTree) {
-        nested = true;
+        belowRootType = true;
       } else if (parent instanceof AnnotatedTypeTree) {
         // The enclosing annotated type reports its own annotations.  Where it wraps the qualified
         // name that the fix writes into, it carries the annotations already on that name, so the
-        // anchor moves out to it and destinationIsOccupied can see them.
+        // anchor moves out to it and destinationIsOccupied() can see them.
         if (Objects.equals(child, qualifierAnchor)) {
           qualifierAnchor = parent;
         }
       } else if (parent instanceof UnionTypeTree || parent instanceof IntersectionTypeTree) {
-        // An alternative of a union type and a member of an intersection type are in the same
-        // location as the type that contains them, so crossing one is not a nesting step.
+        // Crossing into a union or an intersection stays on a root type: each alternative of
+        // `catch (@Nullable A | B e)` is a root type of the exception parameter, and each member of
+        // `(@Nullable A & B) o` is a root type of the cast.  Both are reported as that construct.
       } else if (parent instanceof ClassTree classTree
           && classTree.getSimpleName().isEmpty()
           && isSupertype(classTree, child)) {
@@ -419,7 +434,7 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
         return null;
       } else if (parent instanceof MemberSelectTree memberSelect
           && Objects.equals(memberSelect.getExpression(), child)) {
-        if (!nested) {
+        if (!belowRootType) {
           // The outermost qualified name is the anchor, so `@Nullable P.Inner.Innermost` moves the
           // annotation to `Innermost` rather than to `Inner`, which qualifies it in turn.  Within a
           // type argument the annotation lands on that argument rather than on a qualifier, as in
@@ -433,10 +448,16 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
         // this path is a second view of an annotation the component itself reports.
         return null;
       } else {
-        UnrecognizedLocation enclosing = anchorLocation(parent, child);
+        // The construct takes the annotation, unless the annotation stands below its root type
+        // and the construct stops there.  A primitive is the exception that always keeps its own
+        // phrase: `(@Nullable int) x` reads as a primitive rather than as a cast, and no fix moves
+        // the annotation either way.  The construct replaces a wildcard, because the wildcard's own
+        // fix moves the annotation to a bound: `(List<@Nullable ?>) o` reports the wildcard and
+        // gets that fix, while `o instanceof List<@Nullable ?>` reports the operand and removes it.
+        UnrecognizedLocation enclosing = enclosingLocation(parent, child);
         if (onTypeItself != UnrecognizedLocation.PRIMITIVE_TYPE
             && enclosing != null
-            && (enclosing.coversNestedTypes || !nested)) {
+            && (enclosing.coversNestedTypes || !belowRootType)) {
           return new TypeUsage(enclosing, underlyingType);
         }
         break;
@@ -444,43 +465,47 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
       child = parent;
     }
     if (qualifierAnchor != null) {
+      // The outer type is reported only where no construct took the annotation first.  So
+      // `(@Nullable Outer.Inner) o` is reported as a cast, and the field
+      // `List<@Nullable Outer.Inner> f`, whose construct takes nothing, as an outer type.
       return new TypeUsage(UnrecognizedLocation.OUTER_TYPE, qualifierAnchor);
     }
     return onTypeItself == null ? null : new TypeUsage(onTypeItself, underlyingType);
   }
 
   /**
-   * Returns the location of the root type {@code child} names. Returns {@code null} where that
-   * location is recognized, and where {@code anchor} is a kind the check does not classify.
+   * Returns the location of the root type {@code child} names within {@code construct}. Returns
+   * {@code null} where that location is recognized, and where {@code construct} is a kind the check
+   * does not classify.
    *
-   * @param anchor the declaration or expression that holds the type usage
-   * @param child the child of {@code anchor} the type usage was reached through
+   * @param construct the declaration or expression that holds the type usage
+   * @param child the child of {@code construct} the type usage was reached through
    */
-  private static @Nullable UnrecognizedLocation anchorLocation(Tree anchor, Tree child) {
-    if (anchor instanceof VariableTree variable) {
+  private static @Nullable UnrecognizedLocation enclosingLocation(Tree construct, Tree child) {
+    if (construct instanceof VariableTree variable) {
       return variableLocation(variable);
     }
-    if (anchor instanceof MethodTree method) {
+    if (construct instanceof MethodTree method) {
       if (Objects.equals(child, method.getReturnType())) {
         return isAnnotationInterfaceMember(method) ? UnrecognizedLocation.ANNOTATION_MEMBER : null;
       }
       return method.getThrows().contains(child) ? UnrecognizedLocation.THROWN_TYPE : null;
     }
-    if (anchor instanceof ClassTree classTree) {
+    if (construct instanceof ClassTree classTree) {
       return isSupertype(classTree, child) ? UnrecognizedLocation.SUPERTYPE : null;
     }
-    if (anchor instanceof TypeCastTree) {
+    if (construct instanceof TypeCastTree) {
       return UnrecognizedLocation.CAST;
     }
-    if (anchor instanceof InstanceOfTree) {
+    if (construct instanceof InstanceOfTree) {
       return UnrecognizedLocation.INSTANCEOF;
     }
-    if (anchor instanceof NewClassTree newClass) {
+    if (construct instanceof NewClassTree newClass) {
       return Objects.equals(child, newClass.getIdentifier())
           ? UnrecognizedLocation.OBJECT_CREATION
           : null;
     }
-    if (anchor instanceof MemberReferenceTree reference) {
+    if (construct instanceof MemberReferenceTree reference) {
       // A method reference's qualifier expression is its root type, as in `@Nullable String::new`.
       // The location does not cover what is nested inside it, so `ArrayList<@Nullable String>::new`
       // stays recognized.
@@ -488,7 +513,7 @@ public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
           ? UnrecognizedLocation.METHOD_REFERENCE
           : null;
     }
-    // A component type of an array creation expression is recognized, and every other anchor is
+    // A component type of an array creation expression is recognized, and every other construct is
     // left to a future revision of this check.
     return null;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
@@ -20,12 +20,13 @@ public class AndroidTest {
   @SuppressWarnings("CheckReturnValue")
   @Before
   public void setup() {
-    compilationHelper = CompilationTestHelper.newInstance(NullAway.class, getClass());
-    compilationHelper.setArgs(
-        Arrays.asList(
-            "-d",
-            temporaryFolder.getRoot().getAbsolutePath(),
-            "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex"));
+    compilationHelper =
+        NullAwayTestsBase.makeTestHelperWithArgs(
+            getClass(),
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex"));
   }
 
   // Core Fragment tests
@@ -174,7 +175,7 @@ public class AndroidTest {
         .doTest();
   }
 
-  /** Initialises the default android classes that are commonly used. */
+  /** Adds the Android stub sources that all the tests in this class share. */
   @SuppressWarnings("CheckReturnValue")
   private void initialiseAndroidCoreClasses() {
     compilationHelper

--- a/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AndroidTest.java
@@ -33,7 +33,7 @@ public class AndroidTest {
 
   @Test
   public void coreFragmentSuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Fragment.java")
         .addSourceFile("testdata/android-success/CoreFragment.java")
@@ -42,7 +42,7 @@ public class AndroidTest {
 
   @Test
   public void coreFragmentMissingOnAttachError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Fragment.java")
         .addSourceFile("testdata/android-error/CoreFragmentWithoutOnAttach.java")
@@ -51,7 +51,7 @@ public class AndroidTest {
 
   @Test
   public void coreFragmentMissingOnCreateError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Fragment.java")
         .addSourceFile("testdata/android-error/CoreFragmentWithoutOnCreate.java")
@@ -60,7 +60,7 @@ public class AndroidTest {
 
   @Test
   public void coreFragmentMissingOnCreateViewError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Fragment.java")
         .addSourceFile("testdata/android-error/CoreFragmentWithoutOnCreateView.java")
@@ -70,7 +70,7 @@ public class AndroidTest {
   // AndroidX Library Fragment
   @Test
   public void androidxFragmentSuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
         .addSourceFile("testdata/android-success/AndroidxFragment.java")
@@ -79,7 +79,7 @@ public class AndroidTest {
 
   @Test
   public void androidxFragmentMissingOnAttachError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
         .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnAttach.java")
@@ -88,7 +88,7 @@ public class AndroidTest {
 
   @Test
   public void androidxFragmentMissingOnCreateError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
         .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnCreate.java")
@@ -97,7 +97,7 @@ public class AndroidTest {
 
   @Test
   public void androidxFragmentMissingOnCreateViewError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/androidx/Fragment.java")
         .addSourceFile("testdata/android-error/AndroidxFragmentWithoutOnCreateView.java")
@@ -108,7 +108,7 @@ public class AndroidTest {
 
   @Test
   public void supportLibFragmentSuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
         .addSourceFile("testdata/android-success/SupportLibraryFragment.java")
@@ -117,7 +117,7 @@ public class AndroidTest {
 
   @Test
   public void supportLibFragmentMissingOnAttachError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
         .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnAttach.java")
@@ -126,7 +126,7 @@ public class AndroidTest {
 
   @Test
   public void supportLibFragmentMissingOnCreateError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
         .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnCreate.java")
@@ -135,7 +135,7 @@ public class AndroidTest {
 
   @Test
   public void supportLibFragmentMissingOnCreateViewError() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/supportlib/Fragment.java")
         .addSourceFile("testdata/android-error/SupportLibraryFragmentWithoutOnCreateView.java")
@@ -146,7 +146,7 @@ public class AndroidTest {
 
   @Test
   public void coreActivitySuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Activity.java")
         .addSourceFile("testdata/android-success/CoreActivity.java")
@@ -157,7 +157,7 @@ public class AndroidTest {
 
   @Test
   public void supportLibActivitySuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/supportlib/ActivityCompat.java")
         .addSourceFile("testdata/android-success/SupportLibActivityCompat.java")
@@ -168,7 +168,7 @@ public class AndroidTest {
 
   @Test
   public void androidxActivitySuccess() {
-    initialiseAndroidCoreClasses();
+    initializeAndroidCoreClasses();
     compilationHelper
         .addSourceFile("testdata/androidstubs/androidx/ActivityCompat.java")
         .addSourceFile("testdata/android-success/AndroidxActivityCompat.java")
@@ -177,7 +177,7 @@ public class AndroidTest {
 
   /** Adds the Android stub sources that all the tests in this class share. */
   @SuppressWarnings("CheckReturnValue")
-  private void initialiseAndroidCoreClasses() {
+  private void initializeAndroidCoreClasses() {
     compilationHelper
         .addSourceFile("testdata/androidstubs/core/Context.java")
         .addSourceFile("testdata/androidstubs/core/Bundle.java")

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
@@ -760,37 +760,37 @@ public class JSpecifyUnrecognizedAnnotationLocationTest {
   }
 
   @Test
-  public void outerTypeIsReportedUnderEveryAnchorThatDoesNotCoverNestedTypes() {
+  public void outerTypeIsReportedUnderEveryConstructThatDoesNotCoverNestedTypes() {
     compilationHelper
         .addSourceLines(
-            "test/Anchors.java",
+            "test/Constructs.java",
             """
             package test;
             import java.util.ArrayList;
             import java.util.List;
             import org.jspecify.annotations.Nullable;
-            class Anchors {
+            class Constructs {
               class Inner {}
               // BUG: Diagnostic contains: on the outer type qualifying an inner type
-              List<@Nullable Anchors.Inner> field;
+              List<@Nullable Constructs.Inner> field;
               // BUG: Diagnostic contains: on the outer type qualifying an inner type
-              static class Sub extends ArrayList<@Nullable Anchors.Inner> {}
+              static class Sub extends ArrayList<@Nullable Constructs.Inner> {}
               void method(Object o) {
                 // BUG: Diagnostic contains: on the outer type qualifying an inner type
-                List<@Nullable Anchors.Inner> local = null;
+                List<@Nullable Constructs.Inner> local = null;
                 // BUG: Diagnostic contains: on the outer type qualifying an inner type
-                Object cast = (List<@Nullable Anchors.Inner>) o;
+                Object cast = (List<@Nullable Constructs.Inner>) o;
                 // BUG: Diagnostic contains: on the outer type qualifying an inner type
-                Object created = new ArrayList<@Nullable Anchors.Inner>();
+                Object created = new ArrayList<@Nullable Constructs.Inner>();
                 // A location that covers nested types takes the annotation instead, so the fix
                 // removes it rather than moving it somewhere still unrecognized.
                 // BUG: Diagnostic contains: on the type after an instanceof operator
-                if (o instanceof @Nullable Anchors.Inner) {}
+                if (o instanceof @Nullable Constructs.Inner) {}
                 // BUG: Diagnostic contains: on a type in a pattern
-                if (o instanceof @Nullable Anchors.Inner i) {}
-                // The cast's own root type is not nested, so the cast wins there.
+                if (o instanceof @Nullable Constructs.Inner i) {}
+                // The annotation is on the cast's own root type, so the cast wins there.
                 // BUG: Diagnostic contains: on the root type of a cast
-                Object rootCast = (@Nullable Anchors.Inner) o;
+                Object rootCast = (@Nullable Constructs.Inner) o;
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
@@ -1,0 +1,2013 @@
+package com.uber.nullaway;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BaseErrorProneJavaCompiler;
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.DiagnosticTestHelper;
+import com.google.errorprone.FileManagers;
+import com.google.errorprone.FileObjects;
+import com.google.errorprone.scanner.ScannerSupplier;
+import java.io.StringWriter;
+import java.util.Locale;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JSpecifyUnrecognizedAnnotationLocationTest {
+
+  /** Raises the check to warning level, since it reports nothing at its default severity. */
+  private static final String WARN = "-Xep:JSpecifyUnrecognizedAnnotationLocation:WARN";
+
+  /** Turns off reporting on the root type of a local variable, the one location with an option. */
+  private static final String NO_LOCAL_ROOT_TYPE =
+      "-XepOpt:JSpecifyUnrecognizedAnnotationLocation:CheckLocalVariableRootType=false";
+
+  private CompilationTestHelper compilationHelper;
+  private CompilationTestHelper compilationHelperDefaultLevel;
+  private BugCheckerRefactoringTestHelper refactoringHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper =
+        CompilationTestHelper.newInstance(JSpecifyUnrecognizedAnnotationLocation.class, getClass())
+            .setArgs(WARN);
+    compilationHelperDefaultLevel =
+        CompilationTestHelper.newInstance(JSpecifyUnrecognizedAnnotationLocation.class, getClass());
+    refactoringHelper =
+        BugCheckerRefactoringTestHelper.newInstance(
+                JSpecifyUnrecognizedAnnotationLocation.class, getClass())
+            .setArgs(WARN);
+  }
+
+  @Test
+  public void noReportAtDefaultLevel() {
+    // The source covers one construct per matcher, so any of the six that lost its isEnabled check
+    // would report here.  At its SUGGESTION default the check emits neither a warning nor a note.
+    compilationHelperDefaultLevel
+        .addSourceLines(
+            "test/Quiet.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            @Nullable
+            class Quiet {
+              @Nullable int count = 0;
+              List<@Nullable ?> wildcard;
+              @Nullable int method() {
+                return 0;
+              }
+              <@Nullable T> void typeParameter() {}
+              void arrayCreation() {
+                Object array = new String @Nullable [5];
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void localVariableRootTypeIsSilencedWhenAskedFor() {
+    // NO_LOCAL_ROOT_TYPE silences the root type only.  The rest of a local declaration is
+    // classified as usual: a primitive is still reported for being a primitive, and a type
+    // argument stays recognized.
+    CompilationTestHelper.newInstance(JSpecifyUnrecognizedAnnotationLocation.class, getClass())
+        .setArgs(WARN, NO_LOCAL_ROOT_TYPE)
+        .addSourceLines(
+            "test/Locals.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Locals {
+              void method() {
+                @Nullable List<String> rootType = null;
+                String @Nullable [] array = null;
+                try (@Nullable AutoCloseable resource = null) {
+                } catch (Exception e) {
+                }
+                List<@Nullable String> typeArgument = null;
+                // BUG: Diagnostic contains: on a primitive type
+                @Nullable int primitive = 0;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void localVariableRootTypeIsReportedUnlessSilenced() {
+    compilationHelper
+        .addSourceLines(
+            "test/Locals.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Locals {
+              void method() {
+                // BUG: Diagnostic contains: on the root type of a local variable
+                @Nullable List<String> rootType = null;
+                // BUG: Diagnostic contains: on the root type of a local variable
+                String @Nullable [] array = null;
+                try (
+                    // BUG: Diagnostic contains: on the root type of a local variable
+                    @Nullable AutoCloseable resource = null) {
+                } catch (Exception e) {
+                }
+                List<@Nullable String> typeArgument = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void suppressionUsesTheCanonicalName() {
+    compilationHelper
+        .addSourceLines(
+            "test/Suppressed.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Suppressed {
+              @SuppressWarnings("JSpecifyUnrecognizedAnnotationLocation")
+              @Nullable int count = 0;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nonJSpecifyNullnessAnnotationsAreIgnored() {
+    // The check matches JSpecify's own two annotations by fully qualified name, because the rule
+    // is JSpecify's and JSpecify states it about its own annotations.  Another tool's annotation
+    // keeps the meaning that tool defines, in these locations as it does anywhere else.
+    compilationHelper
+        .addSourceLines(
+            "test/Nullable.java",
+            """
+            package test;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            @Target(ElementType.TYPE_USE)
+            public @interface Nullable {}
+            """)
+        .addSourceLines(
+            "test/Families.java",
+            """
+            package test;
+            class Families {
+              @org.jetbrains.annotations.Nullable int jetbrains = 0;
+              @org.jetbrains.annotations.NotNull int notNull = 0;
+              @org.checkerframework.checker.nullness.qual.Nullable int checker = 0;
+              @javax.annotation.Nullable int declarationOnly = 0;
+              @Nullable int declaredHere = 0;
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @org.jspecify.annotations.Nullable int jspecifyNullable = 0;
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @org.jspecify.annotations.NonNull int jspecifyNonNull = 0;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nullAwayStillReportsTheInnerClassLocation() {
+    // Both checks report this annotation, each under its own canonical name, so suppressing one
+    // leaves the other reported.
+    bothChecksOn(
+        """
+        package test;
+        import org.jspecify.annotations.Nullable;
+        class Both {
+          class Inner {}
+          // BUG: Diagnostic contains: Type-use nullability annotations should be applied on inner class
+          @Nullable Both.Inner field;
+        }
+        """);
+  }
+
+  @Test
+  public void outerTypeStillReportedAlongsideNullAway() {
+    bothChecksOn(
+        """
+        package test;
+        import org.jspecify.annotations.Nullable;
+        class Both {
+          class Inner {}
+          // BUG: Diagnostic contains: on the outer type qualifying an inner type
+          @Nullable Both.Inner field;
+        }
+        """);
+  }
+
+  @Test
+  public void annotationsInRecognizedLocationsAreNotReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Recognized.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import java.util.List;
+            import java.util.Map;
+            import java.util.function.Function;
+            import org.jspecify.annotations.Nullable;
+            class Recognized<T extends @Nullable Object> {
+              @Nullable String field;
+              String @Nullable [] nullableArray;
+              @Nullable String[] arrayOfNullable;
+              List<@Nullable String> typeArgument;
+              List<? extends @Nullable String> wildcardBound;
+              Map.@Nullable Entry<String, String> innerType;
+              @Nullable String method(@Nullable String parameter) {
+                return parameter;
+              }
+              void nested() {
+                Function<@Nullable String, String> lambda = (@Nullable String s) -> "";
+                Object cast = (List<@Nullable String>) typeArgument;
+                Object created = new ArrayList<@Nullable String>();
+                Object array = new @Nullable String[5];
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aRecognizedLocationNestedInAnUnrecognizedOneIsNotReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Nested.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Nested extends ArrayList<@Nullable String> {
+              record Component(@Nullable String value) {}
+              void varargs(@Nullable String... values) {}
+              void method(Object o) {
+                Object cast = (List<@Nullable String>) o;
+                Object created = new ArrayList<@Nullable String>();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotationInsideAQualifierChainIsRecognized() {
+    // The annotation is on the type argument of a qualifier, a recognized location, so the check
+    // reports nothing.  It is not on the outer type that qualifies Deep.
+    compilationHelper
+        .addSourceLines(
+            "test/Chain.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Chain {
+              class Generic<X> { class Deep {} }
+              Chain.Generic<@Nullable String>.Deep insideChain;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNullnessAnnotationOnAPrimitiveIsReported() {
+    // An annotation before an array applies to the component type, so the check reports a
+    // primitive array as a primitive.  An annotation on the array itself is recognized.
+    compilationHelper
+        .addSourceLines(
+            "test/Primitives.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Primitives {
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @Nullable int field = 0;
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @Nullable int[] primitiveArray = {};
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @Nullable int[][] twoDimensions = {};
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @Nullable int method() {
+                return 0;
+              }
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              void parameter(@Nullable long value) {}
+              void local() {
+                // BUG: Diagnostic contains: A nullness annotation on a primitive type
+                @Nullable int[] array = null;
+              }
+              int @Nullable [] annotatedArray = null;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void eachConstructInsideAMethodBodyIsReportedAsItsOwnLocation() {
+    compilationHelper
+        .addSourceLines(
+            "test/Locals.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Locals {
+              void method(Object o) {
+                // BUG: Diagnostic contains: on the root type of a local variable
+                @Nullable List<String> local = null;
+                // BUG: Diagnostic contains: on the root type of a local variable
+                String @Nullable [] array = null;
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object cast = (@Nullable String) o;
+                // BUG: Diagnostic contains: on the root type of an object creation expression
+                Object created = new @Nullable ArrayList<String>();
+                // BUG: Diagnostic contains: on the array type of an array creation expression
+                Object newArray = new String @Nullable [5];
+                // BUG: Diagnostic contains: on the type after an instanceof operator
+                if (o instanceof @Nullable String) {}
+                // BUG: Diagnostic contains: on a type in a pattern
+                if (o instanceof @Nullable String s) {}
+                try {
+                  method(o);
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (@Nullable RuntimeException e) {
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void declarationsAndSupertypes() {
+    compilationHelper
+        .addSourceLines(
+            "test/Declarations.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import org.jspecify.annotations.Nullable;
+            // BUG: Diagnostic contains: A nullness annotation on a class declaration
+            @Nullable
+            // BUG: Diagnostic contains: on a supertype in a class declaration
+            class Declarations extends @Nullable ArrayList<String> {
+              // BUG: Diagnostic contains: directly on a type parameter declaration
+              <@Nullable T> void typeParameter() {}
+              // BUG: Diagnostic contains: on the type of a receiver parameter
+              void receiver(@Nullable Declarations this) {}
+              // BUG: Diagnostic contains: on a thrown exception type
+              void thrown() throws @Nullable RuntimeException {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotationInterfaceMemberReturnTypeIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Marker.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            @interface Marker {
+              // BUG: Diagnostic contains: on the return type of an annotation interface member
+              @Nullable String value();
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNullnessAnnotationDirectlyOnAWildcardIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Wildcards.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Wildcards {
+              // BUG: Diagnostic contains: A nullness annotation directly on a wildcard
+              List<@Nullable ?> unbounded;
+              // BUG: Diagnostic contains: A nullness annotation directly on a wildcard
+              List<@Nullable ? extends String> upperBounded;
+              // BUG: Diagnostic contains: A nullness annotation directly on a wildcard
+              List<@Nullable ? super String> lowerBounded;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void outerTypeQualifyingAnInnerTypeIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Outer.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Outer {
+              class Inner {}
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              @Nullable Outer.Inner field;
+              Outer.@Nullable Inner recognized;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void anAnnotatedEnumConstantIsReportedAsItsType() {
+    compilationHelper
+        .addSourceLines(
+            "test/Constants.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            enum Constants {
+              // BUG: Diagnostic contains: on the type of an enum constant
+              @Nullable BARE,
+              // BUG: Diagnostic contains: on the type of an enum constant
+              @Nullable WITH_ARGUMENT("x"),
+              // BUG: Diagnostic contains: on the type of an enum constant
+              @Nullable WITH_BODY {
+                @Override
+                String describe() {
+                  return "body";
+                }
+              };
+              Constants() {}
+              Constants(String unused) {}
+              String describe() {
+                return "constant";
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aConstructorIsReportedAsItsResultType() {
+    compilationHelper
+        .addSourceLines(
+            "test/Constructors.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Constructors {
+              // BUG: Diagnostic contains: on the result type of a constructor
+              @Nullable Constructors() {}
+              static class Nested {
+                // BUG: Diagnostic contains: on the result type of a constructor
+                @Nullable Nested() {}
+              }
+              record Rec(String value) {
+                // BUG: Diagnostic contains: on the result type of a constructor
+                @Nullable Rec {
+                }
+              }
+              static class WithDeclarationAnnotation {
+                // BUG: Diagnostic contains: on the result type of a constructor
+                @Deprecated @Nullable WithDeclarationAnnotation() {}
+              }
+              @Nullable String method() {
+                return null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotationInterfaceDeclarationIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Marked.java",
+            """
+            package test;
+            // BUG: Diagnostic contains: on a class declaration
+            @org.jspecify.annotations.Nullable
+            @interface Marked {}
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void anyMultiCatchAlternativeIsReportedAsAnExceptionParameter() {
+    compilationHelper
+        .addSourceLines(
+            "test/MultiCatch.java",
+            """
+            package test;
+            import java.io.IOException;
+            import org.jspecify.annotations.Nullable;
+            class MultiCatch {
+              void first() {
+                try {
+                  throw new IOException();
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (@Nullable IOException | RuntimeException e) {
+                }
+              }
+              void second() {
+                try {
+                  throw new IOException();
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (IOException | @Nullable RuntimeException e) {
+                }
+              }
+              void third() {
+                try {
+                  throw new IOException();
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (IOException | IllegalArgumentException | @Nullable IllegalStateException e) {
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void intersectionCastRootTypeIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Intersection.java",
+            """
+            package test;
+            import java.io.Serializable;
+            import java.util.RandomAccess;
+            import org.jspecify.annotations.Nullable;
+            class Intersection {
+              void first(Object o) {
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object x = (@Nullable Runnable & Serializable) o;
+              }
+              void later(Object o) {
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object x = (Runnable & @Nullable Serializable) o;
+              }
+              void three(Object o) {
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object x = (Runnable & Serializable & @Nullable RandomAccess) o;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void typeArgumentOfReceiverParameterTypeIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Receiver.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Receiver<T> {
+              class Inner {
+                // BUG: Diagnostic contains: on the type of a receiver parameter
+                void method(Receiver<@Nullable T>.Inner this) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void methodReferenceRootTypeIsReported() {
+    // JSpecify lists no location that a method reference's root type falls under, so its
+    // catch-all rule classifies the root type: everything not listed as recognized is
+    // unrecognized.
+    //
+    // Two spellings that javac has not treated alike across releases sit in
+    // methodReferenceQualifiedRootTypeIsReported and methodReferenceArrayRootTypeBeforeJdk26
+    // instead, so this fixture holds only rows that produce the same diagnostic on every
+    // supported release.
+    compilationHelper
+        .addSourceLines(
+            "test/References.java",
+            """
+            package test;
+            import java.util.function.Function;
+            import java.util.function.Supplier;
+            import org.jspecify.annotations.Nullable;
+            class References {
+              static class Nested {}
+              // BUG: Diagnostic contains: on the root type of a method reference
+              Supplier<String> simpleName = @Nullable String::new;
+              // BUG: Diagnostic contains: on the root type of a method reference
+              Function<String, Integer> instanceMethod = @Nullable String::length;
+              // A type argument of the root type is nested inside it, and stays recognized.
+              java.util.function.Supplier<java.util.List<String>> typeArgument =
+                  java.util.ArrayList<@Nullable String>::new;
+              <X> void g() {}
+              void explicitTypeArgument() {
+                // Written as a type argument, the same name reports its qualifier instead.  The
+                // phrase is the specification's and names the common case; `Nested` is static
+                // here, so `References` scopes the name rather than enclosing an instance.
+                // BUG: Diagnostic contains: on the outer type qualifying an inner type
+                this.<@Nullable References.Nested>g();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void methodReferenceQualifiedRootTypeIsReported() {
+    // A qualified name crashes javac while it parses, in TreeInfo.isStaticSym on a symbol the
+    // parser has not set yet, where 25 and earlier accept it.  The regression arrived in 26 b23
+    // and is open as https://bugs.openjdk.org/browse/JDK-8391567.
+    //
+    // The upper bound is a reminder, not a claim about 29: the test runs again on 29, and passes
+    // there once javac is fixed.  A failure on 29 says the fix has not landed, so raise the bound
+    // to the next release; once it passes, drop the guard and fold this fixture back into
+    // methodReferenceRootTypeIsReported.
+    int feature = Runtime.version().feature();
+    Assume.assumeTrue(feature < 26 || feature >= 29);
+    compilationHelper
+        .addSourceLines(
+            "test/References.java",
+            """
+            package test;
+            import java.util.function.Supplier;
+            import org.jspecify.annotations.Nullable;
+            class References {
+              static class Nested {}
+              // BUG: Diagnostic contains: on the root type of a method reference
+              Supplier<Nested> qualifiedName = @Nullable References.Nested::new;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void methodReferenceArrayRootTypeBeforeJdk26() {
+    // Before 26 javac lands the annotation on the array; from 26 on it lands on the component,
+    // which JSpecify recognizes.  So the diagnostic below is the right one only before 26.  That
+    // move is deliberate: JDK-8369489 replaced the wrapping with insertAnnotationsToMostInner.
+    // This guard therefore stays, unlike the one in methodReferenceQualifiedRootTypeIsReported.
+    // The test pins the check to the type usage javac produces, not to which of the two readings
+    // the language specifies.
+    Assume.assumeTrue(Runtime.version().feature() < 26);
+    compilationHelper
+        .addSourceLines(
+            "test/References.java",
+            """
+            package test;
+            import java.util.function.Function;
+            import org.jspecify.annotations.Nullable;
+            class References {
+              // BUG: Diagnostic contains: on the root type of a method reference
+              Function<Integer, String[]> arrayConstructor = @Nullable String[]::new;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void arrayTypeOfAnArrayCreationIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/ArrayCreation.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class ArrayCreation {
+              void method() {
+                // BUG: Diagnostic contains: on the array type of an array creation expression
+                Object initializer = new String @Nullable [] {"a"};
+                // BUG: Diagnostic contains: on the array type of an array creation expression
+                Object dimension = new String @Nullable [5];
+                // BUG: Diagnostic contains: on the array type of an array creation expression
+                Object nested = new String @Nullable [][] {{"a"}};
+                Object component = new @Nullable String[] {"a"};
+                Object componentDimension = new @Nullable String[5];
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void arrayCreationReportsTheCreatedArrayOnlyOnce() {
+    // javac records the created array's annotation in getAnnotations() for the initializer
+    // spelling and in getDimAnnotations() for the dimension spelling; matchNewArray reads
+    // whichever holds it, so it reports each spelling's array once.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Once.java",
+            "package test;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Once {",
+            "  Object initializer = new String @Nullable [] {\"x\"};",
+            "  Object dimension = new String @Nullable [1];",
+            "}");
+    assertThat(messages).hasSize(2);
+    for (String message : messages) {
+      assertThat(message).contains("on the array type of an array creation expression");
+    }
+  }
+
+  @Test
+  public void unionAndIntersectionMembersAreReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Members.java",
+            """
+            package test;
+            import java.io.IOException;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Members {
+              void method(Object o) {
+                try {
+                  throw new IOException();
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (@Nullable IOException | RuntimeException e) {
+                }
+                try {
+                  throw new IOException();
+                // BUG: Diagnostic contains: on the type of an exception parameter
+                } catch (IOException | @Nullable RuntimeException e) {
+                }
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object intersection = (@Nullable Runnable & Serializable) o;
+              }
+              // A type parameter bound is recognized, intersection or not.
+              <T extends @Nullable Number & Serializable> void bound() {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void outerTypeIsReportedUnderEveryAnchorThatDoesNotCoverNestedTypes() {
+    compilationHelper
+        .addSourceLines(
+            "test/Anchors.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Anchors {
+              class Inner {}
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              List<@Nullable Anchors.Inner> field;
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              static class Sub extends ArrayList<@Nullable Anchors.Inner> {}
+              void method(Object o) {
+                // BUG: Diagnostic contains: on the outer type qualifying an inner type
+                List<@Nullable Anchors.Inner> local = null;
+                // BUG: Diagnostic contains: on the outer type qualifying an inner type
+                Object cast = (List<@Nullable Anchors.Inner>) o;
+                // BUG: Diagnostic contains: on the outer type qualifying an inner type
+                Object created = new ArrayList<@Nullable Anchors.Inner>();
+                // A location that covers nested types takes the annotation instead, so the fix
+                // removes it rather than moving it somewhere still unrecognized.
+                // BUG: Diagnostic contains: on the type after an instanceof operator
+                if (o instanceof @Nullable Anchors.Inner) {}
+                // BUG: Diagnostic contains: on a type in a pattern
+                if (o instanceof @Nullable Anchors.Inner i) {}
+                // The cast's own root type is not nested, so the cast wins there.
+                // BUG: Diagnostic contains: on the root type of a cast
+                Object rootCast = (@Nullable Anchors.Inner) o;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void outerTypeInsideAnUnrecognizedRootIsReportedAsThatRoot() {
+    // Moving the annotation inward would only relocate it to another unrecognized location, so the
+    // diagnostic names the enclosing root and the fix only deletes the annotation.
+    compilationHelper
+        .addSourceLines(
+            "test/Roots.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Roots {
+              class Inner extends RuntimeException { class Deeper {} }
+              // BUG: Diagnostic contains: on the root type of a cast
+              Object cast(Object o) { return (@Nullable Roots.Inner) o; }
+              // BUG: Diagnostic contains: on the type after an instanceof operator
+              boolean test(Object o) { return o instanceof @Nullable Roots.Inner; }
+              // BUG: Diagnostic contains: on a thrown exception type
+              void thrown() throws @Nullable Roots.Inner {}
+              // BUG: Diagnostic contains: on the root type of an object creation expression
+              Object created = new @Nullable Roots.Inner();
+              // BUG: Diagnostic contains: on the root type of a cast
+              Object chainInCast(Object o) { return (@Nullable Roots.Inner.Deeper) o; }
+              // A type argument is a recognized nesting step, so this one still moves.
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              List<@Nullable Roots.Inner> typeArgument;
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              @Nullable Roots.Inner field;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void qualifiedInnerTypeInArrayIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Arrays.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Arrays {
+              class Inner {}
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              @Nullable Arrays.Inner field;
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              @Nullable Arrays.Inner[] oneDimension;
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              @Nullable Arrays.Inner[][] twoDimensions;
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              void parameter(@Nullable Arrays.Inner[] values) {}
+              // A plain array component is a recognized location and stays unreported.
+              @Nullable String[] plainArray;
+              void locals() {
+                // BUG: Diagnostic contains: on the root type of a local variable
+                @Nullable Arrays.Inner local = null;
+                // The array component is a recognized location even in a local, so the annotation
+                // is named by what it lands on rather than by the declaration.
+                // BUG: Diagnostic contains: on the outer type qualifying an inner type
+                @Nullable Arrays.Inner[] arrayLocal = null;
+                @Nullable String[] plainLocal = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void wildcardTakesAnEnclosingLocationThatCoversNestedTypes() {
+    compilationHelper
+        .addSourceLines(
+            "test/CoveredByEnclosing.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class CoveredByEnclosing {
+              void method(Object o) {
+                // BUG: Diagnostic contains: on the type after an instanceof operator
+                if (o instanceof List<@Nullable ?>) {}
+                // BUG: Diagnostic contains: on a type in a pattern
+                if (o instanceof List<@Nullable ?> l) {}
+                // BUG: Diagnostic contains: A nullness annotation directly on a wildcard
+                List<@Nullable ?> local = null;
+                // BUG: Diagnostic contains: A nullness annotation directly on a wildcard
+                Object cast = (List<@Nullable ?>) o;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotatedPrimitiveInAnonymousSupertypeIsReportedOnce() {
+    // The primitive classification is held until the walk ends, so the anonymous-class guard
+    // still runs and keeps the supertype path from reporting a second time.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Primitive.java",
+            "package test;",
+            "import java.util.ArrayList;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Primitive {",
+            "  Object anonymous = new ArrayList<@Nullable int[]>() {};",
+            "  Object plain = new ArrayList<@Nullable int[]>();",
+            "  Object cast(long x) { return (@Nullable int) x; }",
+            "  @Nullable int field = 0;",
+            "  boolean test(java.util.List<int[]> l) { return l instanceof ArrayList<@Nullable int[]>; }",
+            "  void pattern(java.util.List<int[]> l) {",
+            "    if (l instanceof ArrayList<@Nullable int[]> a) {}",
+            "  }",
+            "}");
+    // `instanceof` and its pattern cover the types nested inside them, so an enclosing location
+    // competes with the primitive on those two rows alone.  Both need a checked operand: with
+    // an `Object` the cast is unchecked and javac rejects the source.
+    assertThat(messages).hasSize(6);
+    for (String message : messages) {
+      // A primitive names the most specific location, so an enclosing one never wins.
+      assertThat(message).contains("on a primitive type");
+    }
+  }
+
+  @Test
+  public void typeArgumentOfGenericOuterTypeIsRecognized() {
+    compilationHelper
+        .addSourceLines(
+            "test/Generic.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Generic<T> {
+              class Inner {}
+              Generic<@Nullable String>.Inner field;
+              void parameter(Generic<@Nullable T>.Inner unused) {}
+              void method() {
+                Generic<@Nullable String>.Inner local = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void anonymousClassSupertypeIsReportedOnce() {
+    // The anonymous class body's supertype tree is the same tree the `new` expression names, so
+    // the annotation is reachable through two TreePaths and the check reports it on only one.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Anonymous.java",
+            "package test;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Anonymous {",
+            "  class Inner {}",
+            "  class Generic<X> {}",
+            "  Object fromInterface = new @Nullable Runnable() { public void run() {} };",
+            "  Object fromClass = new @Nullable Thread() {};",
+            "  Object qualified = new @Nullable Anonymous.Inner() {};",
+            "  Object parameterized = new @Nullable Anonymous.Generic<String>() {};",
+            "  Object plain = new @Nullable Thread();",
+            "}");
+    assertThat(messages).hasSize(5);
+    for (String message : messages) {
+      assertThat(message).contains("on the root type of an object creation expression");
+    }
+  }
+
+  @Test
+  public void namedClassInsideAnonymousClassStillReportsItsSupertype() {
+    // The anonymous-class guard covers only the supertype the `new` expression names, so
+    // declarations inside the body keep their own locations.
+    compilationHelper
+        .addSourceLines(
+            "test/Inside.java",
+            """
+            package test;
+            import java.util.ArrayList;
+            import org.jspecify.annotations.Nullable;
+            class Inside {
+              Object o = new Runnable() {
+                // BUG: Diagnostic contains: on a supertype in a class declaration
+                class Local extends @Nullable ArrayList<String> {}
+                // BUG: Diagnostic contains: on the root type of a local variable
+                public void run() { @Nullable String s = null; }
+              };
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotatedEnumConstantIsReportedOnce() {
+    // An enum constant with a body declares an anonymous class as well, so one annotation could be
+    // reported twice.  A per-line diagnostic match sees the text of a report and not how many
+    // arrive, so this test asserts the number of messages instead.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Constants.java",
+            "package test;",
+            "import org.jspecify.annotations.Nullable;",
+            "enum Constants {",
+            "  UNANNOTATED,",
+            "  @Nullable ANNOTATED,",
+            "  @Nullable WITH_BODY { void run() {} };",
+            "  void run() {}",
+            "  @Nullable String field;",
+            "}");
+    assertThat(messages).hasSize(2);
+    for (String message : messages) {
+      assertThat(message).contains("on the type of an enum constant");
+    }
+  }
+
+  @Test
+  public void annotationsInsideEnumConstantArgumentsKeepTheirOwnLocations() {
+    // An enum constant declares no type, so the only annotation it can carry is in its modifiers.
+    // An annotation written inside its arguments takes the location of the construct that holds it.
+    compilationHelper
+        .addSourceLines(
+            "test/Arguments.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            enum Arguments {
+              // BUG: Diagnostic contains: on the root type of a cast
+              CAST((@Nullable Object) null),
+              // The component type of an array creation is a recognized location.
+              ARRAY(new @Nullable String[1]),
+              // BUG: Diagnostic contains: on the root type of an object creation expression
+              CREATION(new @Nullable Object());
+              Arguments(Object o) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void recordComponentIsReportedOnce() {
+    // javac copies each record component into the compact constructor's parameter list, keeping
+    // the component's source positions and sharing its annotation trees, so one annotation is
+    // reachable through two declarations.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Records.java",
+            "package test;",
+            "import java.util.List;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Records {",
+            "  class Inner {}",
+            "  record Compact(@Nullable int x) { Compact { } }",
+            "  record CompactWildcard(List<@Nullable ?> w) { CompactWildcard { } }",
+            "  record CompactQualifier(@Nullable Records.Inner q) { CompactQualifier { } }",
+            "  record CompactGeneric<T>(List<@Nullable ?> g) { CompactGeneric { } }",
+            "  record Bare(@Nullable int z) {}",
+            "}");
+    assertThat(messages).hasSize(5);
+  }
+
+  @Test
+  public void compactConstructorBodyIsStillReported() {
+    // javac's copies of the record components are told apart from the author's own declarations by
+    // the parameter list they sit in, not by their symbol kind: a lambda parameter written in the
+    // compact constructor's body is an ElementKind.PARAMETER owned by that same constructor.
+    compilationHelper
+        .addSourceLines(
+            "test/Body.java",
+            """
+            package test;
+            import java.util.function.IntFunction;
+            import org.jspecify.annotations.Nullable;
+            class Body {
+              record R(int a) {
+                R {
+                  // BUG: Diagnostic contains: on a primitive type
+                  IntFunction<String> lambda = (@Nullable int s) -> "";
+                  // BUG: Diagnostic contains: on the root type of a local variable
+                  @Nullable String local = null;
+                  try {
+                    throw new RuntimeException();
+                  // BUG: Diagnostic contains: on the type of an exception parameter
+                  } catch (@Nullable RuntimeException caught) {
+                  }
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void explicitCanonicalConstructorReportsBothAnnotations() {
+    // An explicit canonical constructor's parameters are the author's own, not javac's copies, so
+    // an annotation on the component and one on the parameter are two reports, not one.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Explicit.java",
+            "package test;",
+            "class Explicit {",
+            "  record R(@org.jspecify.annotations.Nullable int y) {",
+            "    R(@org.jspecify.annotations.Nullable int y) { this.y = y; }",
+            "  }",
+            "}");
+    assertThat(messages).hasSize(2);
+  }
+
+  @Test
+  public void recordComponentAnnotationIsReportedWhateverTheConstructorForm() {
+    // A compact constructor's parameters are javac's copies of the record components, and the
+    // check reports the component rather than the copy.
+    compilationHelper
+        .addSourceLines(
+            "test/Constructors.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Constructors {
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              record Implicit(@Nullable int a) {}
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              record Compact(@Nullable int a) {
+                Compact {
+                  a = Math.abs(a);
+                }
+              }
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              record Explicit(@Nullable int a) {
+                Explicit(int a) {
+                  this.a = a;
+                }
+              }
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              record Generic<T>(@Nullable int a, T b) {
+                Generic {}
+              }
+              // An annotation the author writes on an explicit canonical constructor's own
+              // parameter is on that parameter, so it is still classified.
+              record WrittenParameter(int a) {
+                // BUG: Diagnostic contains: A nullness annotation on a primitive type
+                WrittenParameter(@Nullable int a) {
+                  this.a = a;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unrecognizedRecordComponentTypeIsReported() {
+    compilationHelper
+        .addSourceLines(
+            "test/Components.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Components {
+              class Inner {}
+              // BUG: Diagnostic contains: on the outer type qualifying an inner type
+              record OuterType(@Nullable Components.Inner outerType) {}
+              record Primitive(
+                  // BUG: Diagnostic contains: on a primitive type
+                  @Nullable int count) {}
+              // BUG: Diagnostic contains: on a primitive type
+              @Nullable int notARecordComponent = 0;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixRemovesAnnotationOnPrimitive() {
+    refactoringHelper
+        .addInputLines(
+            "test/Primitives.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Primitives {
+              @Nullable int count = 0;
+              @Nullable int[] counts = {};
+              @Nullable int[][] grid = {};
+            }
+            """)
+        .addOutputLines(
+            "test/Primitives.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Primitives {
+              int count = 0;
+              int[] counts = {};
+              int[][] grid = {};
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesWildcardAnnotationToBound() {
+    refactoringHelper
+        .addInputLines(
+            "test/Wildcards.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Wildcards {
+              List<@Nullable ?> unbounded;
+              List<@Nullable ? extends String> upperBounded;
+            }
+            """)
+        .addOutputLines(
+            "test/Wildcards.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Wildcards {
+              List<? extends @Nullable Object> unbounded;
+              List<? extends @Nullable String> upperBounded;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesTypeParameterAnnotationToBound() {
+    refactoringHelper
+        .addInputLines(
+            "test/Parameters.java",
+            """
+            package test;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Parameters {
+              <@Nullable T> void unbounded() {}
+              <@Nullable T extends Number> void bounded() {}
+              <@Nullable T extends Number & Serializable> void intersection() {}
+            }
+            """)
+        .addOutputLines(
+            "test/Parameters.java",
+            """
+            package test;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Parameters {
+              <T extends @Nullable Object> void unbounded() {}
+              <T extends @Nullable Number> void bounded() {}
+              <T extends Number & Serializable> void intersection() {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesBoundAnnotationOntoTheBoundItself() {
+    refactoringHelper
+        .addInputLines(
+            "test/Bounds.java",
+            """
+            package test;
+            import java.util.List;
+            import java.util.Map;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Bounds {
+              class Inner {}
+              <@Nullable T extends Bounds.Inner> void innerType() {}
+              <@Nullable T extends Map.Entry<String, String>> void staticNested() {}
+              <@Nullable T extends java.util.Locale> void packageQualified() {}
+              <@Nullable T extends Number> void plainClass() {}
+              List<@Nullable ? extends Bounds.Inner> innerTypeWildcard;
+              List<@Nullable ? extends Map.Entry<String, String>> staticNestedWildcard;
+              List<@Nullable ? extends String[]> arrayWildcard;
+              List<@Nullable ? extends String[][]> twoDimensionArrayWildcard;
+              List<@Nullable ? extends String @NonNull []> alreadyAnnotatedArrayWildcard;
+            }
+            """)
+        .addOutputLines(
+            "test/Bounds.java",
+            """
+            package test;
+            import java.util.List;
+            import java.util.Map;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Bounds {
+              class Inner {}
+              <T extends Bounds.@Nullable Inner> void innerType() {}
+              <T extends Map.@Nullable Entry<String, String>> void staticNested() {}
+              <T extends java.util.@Nullable Locale> void packageQualified() {}
+              <T extends @Nullable Number> void plainClass() {}
+              List<? extends Bounds.@Nullable Inner> innerTypeWildcard;
+              List<? extends Map.@Nullable Entry<String, String>> staticNestedWildcard;
+              List<? extends String @Nullable []> arrayWildcard;
+              List<? extends String @Nullable [][]> twoDimensionArrayWildcard;
+              List<? extends String @NonNull []> alreadyAnnotatedArrayWildcard;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixAnnotatesAnArrayBoundAtItsOutermostDimension() {
+    refactoringHelper
+        .addInputLines(
+            "test/ArrayBounds.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class ArrayBounds {
+              List<@Nullable ? extends String[][]> twoDimensional;
+              List<@Nullable ? extends int[]> primitiveComponent;
+            }
+            """)
+        .addOutputLines(
+            "test/ArrayBounds.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class ArrayBounds {
+              List<? extends String @Nullable [][]> twoDimensional;
+              List<? extends int @Nullable []> primitiveComponent;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixAnnotatesAnArrayBoundWithAGenericOrQualifiedComponent() {
+    refactoringHelper
+        .addInputLines(
+            "test/Components.java",
+            """
+            package test;
+            import java.util.List;
+            import java.util.Map;
+            import org.jspecify.annotations.Nullable;
+            class Components {
+              class Inner {}
+              List<@Nullable ? extends List<String>[]> generic;
+              List<@Nullable ? extends Map.Entry<String, String>[]> qualified;
+              List<@Nullable ? extends Components.Inner[]> innerClass;
+            }
+            """)
+        .addOutputLines(
+            "test/Components.java",
+            """
+            package test;
+            import java.util.List;
+            import java.util.Map;
+            import org.jspecify.annotations.Nullable;
+            class Components {
+              class Inner {}
+              List<? extends List<String> @Nullable []> generic;
+              List<? extends Map.Entry<String, String> @Nullable []> qualified;
+              List<? extends Components.Inner @Nullable []> innerClass;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOntoAnArrayWhoseComponentIsAlreadyAnnotated() {
+    refactoringHelper
+        .addInputLines(
+            "test/AnnotatedComponent.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class AnnotatedComponent {
+              List<@Nullable ? extends @NonNull String[]> field;
+            }
+            """)
+        .addOutputLines(
+            "test/AnnotatedComponent.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class AnnotatedComponent {
+              List<? extends @NonNull String @Nullable []> field;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixAnnotatesAnArrayBoundWhoseOutermostDimensionIsAnnotated() {
+    refactoringHelper
+        .addInputLines(
+            "test/Td.java",
+            """
+            package test;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            @Target(ElementType.TYPE_USE)
+            @interface Td {}
+            """)
+        .expectUnchanged()
+        .addInputLines(
+            "test/Dimensions.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Dimensions {
+              List<@Nullable ? extends String @Td []> outermost;
+              List<@Nullable ? extends String @Td [] @Td []> bothDimensions;
+              List<@Nullable ? extends String @NonNull []> occupied;
+            }
+            """)
+        .addOutputLines(
+            "test/Dimensions.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Dimensions {
+              List<? extends String @Nullable @Td []> outermost;
+              List<? extends String @Nullable @Td [] @Td []> bothDimensions;
+              List<? extends String @NonNull []> occupied;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixRemovesAnnotationOnLowerBoundedWildcard() {
+    refactoringHelper
+        .addInputLines(
+            "test/Wildcards.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Wildcards {
+              List<@Nullable ? super String> lowerBounded;
+            }
+            """)
+        .addOutputLines(
+            "test/Wildcards.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Wildcards {
+              List<? super String> lowerBounded;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixRemovesTypeParameterAnnotationWhenTheBoundIsAnIntersection() {
+    refactoringHelper
+        .addInputLines(
+            "test/Intersection.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Intersection {
+              interface A {}
+              interface B {}
+              <@Nullable T extends A & B> void method() {}
+            }
+            """)
+        .addOutputLines(
+            "test/Intersection.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Intersection {
+              interface A {}
+              interface B {}
+              <T extends A & B> void method() {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationToInnerType() {
+    refactoringHelper
+        .addInputLines(
+            "test/Outer.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Outer {
+              class Inner {}
+              @Nullable Outer.Inner field;
+            }
+            """)
+        .addOutputLines(
+            "test/Outer.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class Outer {
+              class Inner {}
+              Outer.@Nullable Inner field;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationPastEveryQualifier() {
+    refactoringHelper
+        .addInputLines(
+            "test/Chain.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Chain {
+              class B {
+                class C {}
+              }
+              List<@Nullable Chain.B.C> insideATypeArgument;
+              @Nullable Chain.B.C inModifiers;
+            }
+            """)
+        .addOutputLines(
+            "test/Chain.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Chain {
+              class B {
+                class C {}
+              }
+              List<Chain.B.@Nullable C> insideATypeArgument;
+              Chain.B.@Nullable C inModifiers;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationInsideATypeArgument() {
+    refactoringHelper
+        .addInputLines(
+            "test/Outer.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Outer {
+              class Inner {}
+              List<@Nullable Outer.Inner> field;
+            }
+            """)
+        .addOutputLines(
+            "test/Outer.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Outer {
+              class Inner {}
+              List<Outer.@Nullable Inner> field;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationInAnArrayDeclaration() {
+    refactoringHelper
+        .addInputLines(
+            "test/ArrayFix.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class ArrayFix {
+              class Inner {}
+              @Nullable ArrayFix.Inner[] oneDimension;
+              @Nullable ArrayFix.Inner[][] twoDimensions;
+            }
+            """)
+        .addOutputLines(
+            "test/ArrayFix.java",
+            """
+            package test;
+            import org.jspecify.annotations.Nullable;
+            class ArrayFix {
+              class Inner {}
+              ArrayFix.@Nullable Inner[] oneDimension;
+              ArrayFix.@Nullable Inner[][] twoDimensions;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationWithAGenericQualifier() {
+    refactoringHelper
+        .addInputLines(
+            "test/Generic.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Generic<X> {
+              class Inner {
+                class Deeper {}
+              }
+              List<@Nullable Generic<String>.Inner> typeArgument;
+              List<? extends @Nullable Generic<String>.Inner> wildcardBound;
+              List<@Nullable Generic<String>.Inner[]> arrayComponent;
+              List<@Nullable Generic<String>.Inner.Deeper> twoLevels;
+              @Nullable Generic<String>.Inner declaration;
+            }
+            """)
+        .addOutputLines(
+            "test/Generic.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Generic<X> {
+              class Inner {
+                class Deeper {}
+              }
+              List<Generic<String>.@Nullable Inner> typeArgument;
+              List<? extends Generic<String>.@Nullable Inner> wildcardBound;
+              List<Generic<String>.@Nullable Inner[]> arrayComponent;
+              List<Generic<String>.Inner.@Nullable Deeper> twoLevels;
+              Generic<String>.@Nullable Inner declaration;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixKeepsOtherTypeUseAnnotationsOnTheQualifiedType() {
+    refactoringHelper
+        .addInputLines(
+            "test/Nested.java",
+            """
+            package test;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Nested {
+              @Target(ElementType.TYPE_USE)
+              @interface Interned {}
+              class Inner {}
+              List<@Nullable @Interned Nested.Inner> insideATypeArgument;
+              @Nullable Nested.@Interned Inner inModifiers;
+            }
+            """)
+        .addOutputLines(
+            "test/Nested.java",
+            """
+            package test;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Nested {
+              @Target(ElementType.TYPE_USE)
+              @interface Interned {}
+              class Inner {}
+              List<@Interned Nested.@Nullable Inner> insideATypeArgument;
+              Nested.@Interned @Nullable Inner inModifiers;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixLocatesTheSelectedNameInSource() {
+    // A name may be written with Unicode escapes, which javac decodes before it lexes, so the
+    // source tokens have to supply the offset rather than the decoded name's length.  The fixture
+    // spells `Inner` with an escape for its `e`: `\\u0065` is not itself a Unicode escape, because
+    // only an odd number of backslashes starts one, so the six characters reach the fixture intact.
+    // The assertions read the fix out of the diagnostic rather than through
+    // BugCheckerRefactoringTestHelper, which formats both sides with google-java-format and cannot
+    // parse an escaped name.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Escapes.java",
+            "package test;",
+            "import java.util.List;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Escapes {",
+            "  class Inner {}",
+            "  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)",
+            "  @interface Marker { String name(); Class<?> type() default void.class; }",
+            "  @Nullable Escapes.Inn\\u0065r escapedName;",
+            "  @Nullable Escap\\u0065s.Inner escapedQualifier;",
+            "  @Nullable Escapes. /* between */ Inner comment;",
+            "  @Nullable Escapes.@Marker(name = \"x\") Inner annotationArgument;",
+            "  List<@Nullable ? extends Escapes.Inn\\u0065r> escapedBound;",
+            "  List<@Nullable ? extends Escapes.@Marker(name = \"x\") Inner> annotatedBound;",
+            "  @Nullable Escapes.@Marker(name = \"x\", type = int.class) Inner keywordArgument;",
+            "}");
+    assertThat(messages).hasSize(7);
+    assertThat(messages.get(0)).contains("Escapes.@Nullable Inn\\u0065r escapedName");
+    assertThat(messages.get(1)).contains("Escap\\u0065s.@Nullable Inner escapedQualifier");
+    assertThat(messages.get(2)).contains("Escapes. /* between */ @Nullable Inner comment");
+    assertThat(messages.get(3))
+        .contains("Escapes.@Marker(name = \"x\") @Nullable Inner annotationArgument");
+    assertThat(messages.get(4)).contains("? extends Escapes.@Nullable Inn\\u0065r");
+    assertThat(messages.get(5)).contains("? extends Escapes.@Marker(name = \"x\") @Nullable Inner");
+    assertThat(messages.get(6))
+        .contains(
+            "Escapes.@Marker(name = \"x\", type = int.class) @Nullable Inner keywordArgument");
+  }
+
+  @Test
+  public void fixMovesOuterTypeAnnotationPastAnAnnotatedQualifier() {
+    refactoringHelper
+        .addInputLines(
+            "test/Tq.java",
+            """
+            package test;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            @Target(ElementType.TYPE_USE)
+            @interface Tq {}
+            """)
+        .expectUnchanged()
+        .addInputLines(
+            "test/Chain.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Chain {
+              class B {
+                class C {}
+              }
+              List<@Nullable Chain.@Tq B.C> nested;
+              @Nullable Chain.@Tq B.C declaration;
+              List<@Nullable Chain.@Nullable B.C> nullnessOnTheQualifier;
+              List<@Nullable Chain.@NonNull B.C> differentNullnessOnTheQualifier;
+              @Nullable Chain.@Nullable B.C nullnessOnTheQualifierInADeclaration;
+              List<@Nullable Chain.@Tq B.@Nullable C> bothArms;
+            }
+            """)
+        .addOutputLines(
+            "test/Chain.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Chain {
+              class B {
+                class C {}
+              }
+              List<Chain.@Tq B.@Nullable C> nested;
+              Chain.@Tq B.@Nullable C declaration;
+              List<Chain.B.@Nullable C> nullnessOnTheQualifier;
+              List<Chain.B.@NonNull C> differentNullnessOnTheQualifier;
+              Chain.B.@Nullable C nullnessOnTheQualifierInADeclaration;
+              List<Chain.@Tq B.@Nullable C> bothArms;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixRemovesTheAnnotationWhereTheDestinationCarriesOneAlready() {
+    refactoringHelper
+        .addInputLines(
+            "test/Occupied.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Occupied {
+              class Inner {}
+              List<@Nullable ? extends @Nullable String> annotatedBound;
+              List<@Nullable ? extends @NonNull String> differentAnnotationOnBound;
+              List<@Nullable ? extends String @NonNull []> occupiedArrayBound;
+              List<@Nullable ? extends @Nullable Occupied.Inner> annotatedInnerBound;
+              List<@Nullable ? extends @NonNull Occupied.Inner> annotatedInnerQualifier;
+              <@Nullable T extends @Nullable String> void typeParameter() {}
+              @Nullable Occupied.@Nullable Inner innerType;
+              List<@Nullable Occupied.@Nullable Inner> nestedInnerType;
+            }
+            """)
+        .addOutputLines(
+            "test/Occupied.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Occupied {
+              class Inner {}
+              List<? extends @Nullable String> annotatedBound;
+              List<? extends @NonNull String> differentAnnotationOnBound;
+              List<? extends String @NonNull []> occupiedArrayBound;
+              List<? extends Occupied.@Nullable Inner> annotatedInnerBound;
+              List<? extends Occupied.@NonNull Inner> annotatedInnerQualifier;
+              <T extends @Nullable String> void typeParameter() {}
+              Occupied.@Nullable Inner innerType;
+              List<Occupied.@Nullable Inner> nestedInnerType;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixStillMovesWhereTheExistingAnnotationSitsElsewhere() {
+    refactoringHelper
+        .addInputLines(
+            "test/Elsewhere.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Elsewhere {
+              class Inner {}
+              List<@Nullable ? extends List<@Nullable String>> annotatedTypeArgument;
+              @Nullable Elsewhere.Inner @NonNull [] annotatedArrayOfInner;
+            }
+            """)
+        .addOutputLines(
+            "test/Elsewhere.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Elsewhere {
+              class Inner {}
+              List<? extends @Nullable List<@Nullable String>> annotatedTypeArgument;
+              Elsewhere.@Nullable Inner @NonNull [] annotatedArrayOfInner;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixDeletesWhereNoRecognizedLocationExists() {
+    // A lower-bounded wildcard has no upper bound to write the annotation on, and two annotations
+    // on one anchor make the move ambiguous.  In both, the fix only deletes the annotation.
+    refactoringHelper
+        .addInputLines(
+            "test/Ambiguous.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Ambiguous {
+              List<@Nullable ? super String> lowerBounded;
+              List<@Nullable @NonNull ?> twoAnnotations;
+            }
+            """)
+        .addOutputLines(
+            "test/Ambiguous.java",
+            """
+            package test;
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Ambiguous {
+              List<? super String> lowerBounded;
+              List<?> twoAnnotations;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void fixLeavesNoBlankBehindTheAnnotation() {
+    // A blank left where the annotation stood survives -XepPatchChecks into the working tree, where
+    // a style checker rejects `( T)` and rejects the column of indentation a line gains when it
+    // began with the annotation.  Neither refactoring mode shows the blank: TEXT_MATCH formats
+    // both sides with google-java-format, and AST_MATCH compares parsed trees.  The fix text is
+    // read out of the diagnostic instead, and the diagnostic renderer trims the line it quotes, so
+    // it cannot show a blank in front of the annotation; each assertion below is the same
+    // deletion, seen where the blank falls inside the line instead.
+    ImmutableList<String> messages =
+        diagnostics(
+            "test/Blanks.java",
+            "package test;",
+            "import java.util.List;",
+            "import org.jspecify.annotations.Nullable;",
+            "class Blanks {",
+            "  void parameter(@Nullable int value) {}",
+            "  List<@Nullable ?> wildcard;",
+            "  void body(Object o) {",
+            "    Object cast = (@Nullable String) o;",
+            "  }",
+            "}");
+    assertThat(messages.get(0)).contains("void parameter(int value) {}");
+    assertThat(messages.get(1)).contains("List<? extends @Nullable Object> wildcard;");
+    assertThat(messages.get(2)).contains("Object cast = (String) o;");
+  }
+
+  @Test
+  public void fixOutputIsNotReportedAgain() {
+    // A move fix must yield source the check does not report, so every move fix's output belongs in
+    // this fixture.  A fix that relocates an annotation into another unrecognized location fails
+    // here.
+    compilationHelper
+        .addSourceLines(
+            "test/Outputs.java",
+            """
+            package test;
+            import java.io.Serializable;
+            import java.util.List;
+            import java.util.Map;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            class Outputs {
+              class Inner { class Innermost {} }
+              class Generic<X> { class Deep {} }
+              Outputs.@Nullable Inner field;
+              Outputs.@Nullable Inner[] array;
+              Outputs.@Nullable Inner[][] twoDimensions;
+              List<Outputs.@Nullable Inner> typeArgument;
+              List<Outputs.Inner.@Nullable Innermost> chain;
+              List<Outputs.Generic<String>.@Nullable Deep> parameterizedChain;
+              List<? extends @Nullable Object> unboundedWildcard;
+              List<? extends @Nullable String> boundedWildcard;
+              List<? extends Outputs.@Nullable Inner> innerTypeWildcard;
+              List<? extends Map.@Nullable Entry<String, String>> staticNestedWildcard;
+              List<? extends String @Nullable []> arrayWildcard;
+              List<? extends String @Nullable [][]> twoDimensionArrayWildcard;
+              List<? extends String @NonNull []> alreadyAnnotatedArrayWildcard;
+              <T extends @Nullable Object> void unbounded() {}
+              <T extends @Nullable Number> void bounded() {}
+              <T extends Number & Serializable> void intersection() {}
+              <T extends Outputs.@Nullable Inner> void innerTypeBound() {}
+              <T extends Map.@Nullable Entry<String, String>> void staticNestedBound() {}
+              <T extends java.util.@Nullable Locale> void packageQualifiedBound() {}
+              void locals() {
+                Outputs.@Nullable Inner[] arrayLocal = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * Returns the check's diagnostics for {@code lines}, one string each.
+   *
+   * <p>Each string is one diagnostic's line number, a colon, then its message. The strings arrive
+   * in the order javac reported the diagnostics. Fails the test when {@code lines} does not
+   * compile.
+   *
+   * <p>{@link CompilationTestHelper} matches each {@code // BUG:} pattern against the diagnostics
+   * on its line with a {@code hasItem} matcher, so a construct reported twice looks exactly like
+   * one reported once. To test that a construct is reported exactly once, count the diagnostics.
+   */
+  private static ImmutableList<String> diagnostics(String path, String... lines) {
+    DiagnosticTestHelper diagnosticHelper = new DiagnosticTestHelper();
+    boolean compiled =
+        new BaseErrorProneJavaCompiler(
+                ScannerSupplier.fromBugCheckerClasses(JSpecifyUnrecognizedAnnotationLocation.class))
+            .getTask(
+                new StringWriter(),
+                FileManagers.testFileManager(),
+                diagnosticHelper.collector,
+                ImmutableList.of(
+                    "-encoding",
+                    "UTF-8",
+                    "-XDcompilePolicy=simple",
+                    "-XDaddTypeAnnotationsToSymbol=true",
+                    "-proc:none",
+                    WARN),
+                ImmutableList.of(),
+                ImmutableList.of(FileObjects.forSourceLines(path, lines)))
+            .call();
+    ImmutableList.Builder<String> messages = ImmutableList.builder();
+    for (Diagnostic<? extends JavaFileObject> diagnostic : diagnosticHelper.getDiagnostics()) {
+      messages.add(diagnostic.getLineNumber() + ": " + diagnostic.getMessage(Locale.ENGLISH));
+    }
+    ImmutableList<String> built = messages.build();
+    // getDiagnostics() returns errors as well as warnings, so the returned list holds only the
+    // check's reports when the snippet compiled.
+    assertWithMessage("%s did not compile: %s", path, built).that(compiled).isTrue();
+    return built;
+  }
+
+  /**
+   * Runs NullAway and this check together over {@code source}, both at warning level, as a user who
+   * has turned both on would.
+   *
+   * <p>NullAway checks package {@code test} only, so declare {@code package test;} in {@code
+   * source}.
+   */
+  private void bothChecksOn(String source) {
+    CompilationTestHelper.newInstance(
+            ScannerSupplier.fromBugCheckerClasses(
+                NullAway.class, JSpecifyUnrecognizedAnnotationLocation.class),
+            getClass())
+        .setArgs("-Xep:NullAway:WARN", WARN, "-XepOpt:NullAway:AnnotatedPackages=test")
+        .addSourceLines("test/Both.java", source)
+        .doTest();
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocationTest.java
@@ -325,9 +325,14 @@ public class JSpecifyUnrecognizedAnnotationLocationTest {
             """
             package test;
             import java.util.ArrayList;
+            import java.util.Collection;
             import java.util.List;
             import org.jspecify.annotations.Nullable;
             class Locals {
+              void typeArgument(Collection<String> o) {
+                // BUG: Diagnostic contains: on the type after an instanceof operator
+                if (o instanceof List<@Nullable String>) {}
+              }
               void method(Object o) {
                 // BUG: Diagnostic contains: on the root type of a local variable
                 @Nullable List<String> local = null;

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
@@ -1,12 +1,15 @@
 package com.uber.nullaway;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.scanner.ScannerSupplier;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class NullAwayTestsBase {
+
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   protected CompilationTestHelper defaultCompilationHelper;
@@ -14,26 +17,29 @@ public abstract class NullAwayTestsBase {
   @SuppressWarnings("CheckReturnValue")
   @Before
   public void setup() {
-    defaultCompilationHelper =
-        makeTestHelperWithArgs(
-            List.of(
-                "-d",
-                temporaryFolder.getRoot().getAbsolutePath(),
-                "-XepOpt:NullAway:KnownInitializers="
-                    + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases.Super.doInit,"
-                    + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"
-                    + ".SuperInterface.doInit2",
-                "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
-                // We give the following in Regexp format to test that support
-                "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
-                "-XepOpt:NullAway:ExcludedClasses="
-                    + "com.uber.nullaway.testdata.Shape_Stuff,"
-                    + "com.uber.nullaway.testdata.excluded",
-                "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.nullaway.testdata.TestAnnot",
-                "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
-                "-XepOpt:NullAway:ExternalInitAnnotations=com.uber.ExternalInit",
-                "-XepOpt:NullAway:ExcludedFieldAnnotations=com.uber.ExternalFieldInit",
-                "-XDaddTypeAnnotationsToSymbol=true"));
+    defaultCompilationHelper = makeTestHelperWithArgs(defaultArgs());
+  }
+
+  /** Returns the javac arguments {@link #setup} builds {@link #defaultCompilationHelper} from. */
+  protected List<String> defaultArgs() {
+    return List.of(
+        "-d",
+        temporaryFolder.getRoot().getAbsolutePath(),
+        "-XepOpt:NullAway:KnownInitializers="
+            + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases.Super.doInit,"
+            + "com.uber.nullaway.testdata.CheckFieldInitNegativeCases"
+            + ".SuperInterface.doInit2",
+        "-XepOpt:NullAway:AnnotatedPackages=com.uber,com.ubercab,io.reactivex",
+        // A regexp value for UnannotatedSubPackages, so the tests cover regexp support
+        "-XepOpt:NullAway:UnannotatedSubPackages=com.uber.nullaway.[a-zA-Z0-9.]+.unannotated",
+        "-XepOpt:NullAway:ExcludedClasses="
+            + "com.uber.nullaway.testdata.Shape_Stuff,"
+            + "com.uber.nullaway.testdata.excluded",
+        "-XepOpt:NullAway:ExcludedClassAnnotations=com.uber.nullaway.testdata.TestAnnot",
+        "-XepOpt:NullAway:CastToNonNullMethod=com.uber.nullaway.testdata.Util.castToNonNull",
+        "-XepOpt:NullAway:ExternalInitAnnotations=com.uber.ExternalInit",
+        "-XepOpt:NullAway:ExcludedFieldAnnotations=com.uber.ExternalFieldInit",
+        "-XDaddTypeAnnotationsToSymbol=true");
   }
 
   /**
@@ -42,10 +48,45 @@ public abstract class NullAwayTestsBase {
    * this method must be used to create a test helper when a different set of javac arguments is
    * required than those used for {@link #defaultCompilationHelper}.
    *
+   * <p>The helper runs {@link JSpecifyUnrecognizedAnnotationLocation} alongside NullAway, so a test
+   * whose source annotates a location JSpecify does not recognize fails. A source that does so on
+   * purpose carries {@code @SuppressWarnings("JSpecifyUnrecognizedAnnotationLocation")} on the
+   * annotated declaration or on one enclosing it.
+   *
+   * <p>The helper is built from a {@link ScannerSupplier} rather than from NullAway alone, so Error
+   * Prone does not require a diagnostic naming NullAway on a line marked {@code // BUG: Diagnostic
+   * contains:}. Any diagnostic on that line containing the marker text satisfies the marker.
+   *
    * @param args the javac arguments
    * @return the test helper
    */
   protected CompilationTestHelper makeTestHelperWithArgs(List<String> args) {
-    return CompilationTestHelper.newInstance(NullAway.class, getClass()).setArgs(args);
+    return makeTestHelperWithArgs(getClass(), args);
+  }
+
+  /**
+   * Creates a {@link CompilationTestHelper} that runs NullAway and {@link
+   * JSpecifyUnrecognizedAnnotationLocation} together over the sources a test compiles. The location
+   * check runs at {@code WARN}, since it reports nothing at its default severity.
+   *
+   * <p>A test class that builds its own NullAway helper calls this rather than {@link
+   * CompilationTestHelper#newInstance}, so that its sources are checked too. {@link
+   * UnrecognizedAnnotationLocationInTestSourcesTest} covers only {@link #defaultCompilationHelper},
+   * not a helper built some other way.
+   *
+   * @param testClass the test class, used to resolve source paths
+   * @param args the javac arguments
+   */
+  public static CompilationTestHelper makeTestHelperWithArgs(
+      Class<?> testClass, List<String> args) {
+    return CompilationTestHelper.newInstance(
+            ScannerSupplier.fromBugCheckerClasses(
+                NullAway.class, JSpecifyUnrecognizedAnnotationLocation.class),
+            testClass)
+        .setArgs(
+            ImmutableList.<String>builder()
+                .addAll(args)
+                .add("-Xep:JSpecifyUnrecognizedAnnotationLocation:WARN")
+                .build());
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/UnrecognizedAnnotationLocationInTestSourcesTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnrecognizedAnnotationLocationInTestSourcesTest.java
@@ -1,0 +1,54 @@
+package com.uber.nullaway;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Fails when the test harness stops running {@link JSpecifyUnrecognizedAnnotationLocation} over the
+ * sources a test compiles.
+ *
+ * <p>{@link NullAwayTestsBase#makeTestHelperWithArgs} runs that check alongside NullAway and raises
+ * it to {@code WARN}, since it reports nothing at its default severity. A test source therefore
+ * cannot quietly annotate a location JSpecify gives no meaning to. Nothing else asserts that
+ * wiring, and a test whose sources lost the check would still pass.
+ *
+ * <p>If this fails, the helper no longer supplies both checks, no longer raises the check, or
+ * {@code @SuppressWarnings} no longer silences it. A test source that annotates such a location on
+ * purpose carries that suppression.
+ */
+@RunWith(JUnit4.class)
+public class UnrecognizedAnnotationLocationInTestSourcesTest extends NullAwayTestsBase {
+
+  @Test
+  public void checkRunsOverTestSources() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              // BUG: Diagnostic contains: A nullness annotation on a primitive type
+              @Nullable int count = 0;
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void suppressingSilencesTheCheck() {
+    defaultCompilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import org.jspecify.annotations.Nullable;
+            @SuppressWarnings("JSpecifyUnrecognizedAnnotationLocation")
+            class Test {
+              @Nullable int count = 0;
+            }
+            """)
+        .doTest();
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/UnsoundnessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnsoundnessTests.java
@@ -1,6 +1,5 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,12 +11,11 @@ public class UnsoundnessTests extends NullAwayTestsBase {
   @Override
   public void setup() {
     defaultCompilationHelper =
-        CompilationTestHelper.newInstance(NullAway.class, getClass())
-            .setArgs(
-                Arrays.asList(
-                    "-d",
-                    temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+        makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -226,7 +226,7 @@ public class GenericsTests extends NullAwayTestsBase {
                   abstract R apply(P p);
                 }
               }
-              static void param(@Nullable Wrapper<String>.Fn<String> p) {}
+              static void param(Wrapper<String>.@Nullable Fn<String> p) {}
               static void positiveParam() {
                 Wrapper<@Nullable String>.Fn<String> x = null;
                 // BUG: Diagnostic contains: incompatible types: Test.Wrapper<@Nullable String>.Fn<String>
@@ -237,7 +237,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 // BUG: Diagnostic contains: incompatible types: Test.Wrapper<@Nullable String>.Fn<String> cannot be converted to Test.Wrapper<String>.Fn<String>
                 Wrapper<String>.Fn<String> p2 = p1;
               }
-              static @Nullable Wrapper<String>.Fn<String> positiveReturn() {
+              static Wrapper<String>.@Nullable Fn<String> positiveReturn() {
                 Wrapper<@Nullable String>.Fn<String> p1 = null;
                 // BUG: Diagnostic contains: incompatible types: Test.Wrapper<@Nullable String>.Fn<String>
                 return p1;
@@ -250,7 +250,7 @@ public class GenericsTests extends NullAwayTestsBase {
                 Wrapper<@Nullable String>.Fn<String> p1 = null;
                 Wrapper<@Nullable String>.Fn<String> p2 = p1;
               }
-              static @Nullable Wrapper<@Nullable String>.Fn<String> negativeReturn() {
+              static Wrapper<@Nullable String>.@Nullable Fn<String> negativeReturn() {
                 Wrapper<@Nullable String>.Fn<String> p1 = null;
                 return p1;
               }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -850,6 +850,8 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
             import org.jspecify.annotations.Nullable;
 
             @NullMarked
+            // The annotation on the created array is what this test is about
+            @SuppressWarnings("JSpecifyUnrecognizedAnnotationLocation")
             public class Test {
               private char @Nullable [] @Nullable [] foo = null;
 

--- a/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
@@ -23,7 +23,7 @@
 package com.uber.nullaway.thirdpartylibs;
 
 import com.google.errorprone.CompilationTestHelper;
-import com.uber.nullaway.NullAway;
+import com.uber.nullaway.NullAwayTestsBase;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,20 +45,17 @@ public class GrpcTest {
   @Before
   public void setup() {
     ioGrpcCompilationTestHelper =
-        CompilationTestHelper.newInstance(NullAway.class, getClass())
-            .setArgs(
-                Arrays.asList(
-                    "-d",
-                    temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                    // IMPORTANT:
-                    // These tests use the fact that io.grpc.Metadata.get(...) is annotated
-                    // @Nullable. Without the flag above (or a corresponding library model),
-                    // the gRPC libraries themseves would need to be part of  AnnotatedPackages
-                    // for the true positives in the tests below to manifest. Using the
-                    // default optimistic-nullness assumptions for third-party code, results
-                    // in assuming that all calls to Metadata.get(...) return non-null.
-                    "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"));
+        NullAwayTestsBase.makeTestHelperWithArgs(
+            getClass(),
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                // The errors these tests expect depend on the @Nullable that
+                // io.grpc.Metadata.get(...) declares, and NullAway acknowledges an annotation
+                // in unannotated code only under AcknowledgeRestrictiveAnnotations. Without it,
+                // NullAway optimistically reads every Metadata.get(...) call as non-null.
+                "-XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true"));
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/thirdpartylibs/GrpcTest.java
@@ -88,7 +88,7 @@ public class GrpcTest {
   }
 
   @Test
-  public void ioGrpcMetadataAsMapPossitiveTest() {
+  public void ioGrpcMetadataAsMapPositiveTest() {
     ioGrpcCompilationTestHelper
         .addSourceLines(
             "Keys.java",

--- a/nullaway/src/test/java/com/uber/nullaway/tools/SerializationTestHelper.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/SerializationTestHelper.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.fail;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import com.uber.nullaway.NullAway;
+import com.uber.nullaway.NullAwayTestsBase;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -69,9 +69,15 @@ public class SerializationTestHelper<T extends Display> {
     return this;
   }
 
+  /**
+   * Creates the {@link CompilationTestHelper} that compiles the test sources with {@code args} on
+   * the javac command line.
+   *
+   * <p>Call this before {@link #addSourceLines}, which adds to the helper created here. A second
+   * call starts over with a fresh helper and loses the sources added so far.
+   */
   public SerializationTestHelper<T> setArgs(List<String> args) {
-    compilationTestHelper =
-        CompilationTestHelper.newInstance(NullAway.class, getClass()).setArgs(args);
+    compilationTestHelper = NullAwayTestsBase.makeTestHelperWithArgs(getClass(), args);
     return this;
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,6 +33,7 @@ tasks.withType(JavaCompile) {
         options.errorprone {
             check("NullAway", CheckSeverity.ERROR)
             option("NullAway:AnnotatedPackages", "com.uber")
+            check("JSpecifyUnrecognizedAnnotationLocation", CheckSeverity.WARN)
         }
     }
 }


### PR DESCRIPTION
## Why

JSpecify defines the locations where `@Nullable` and `@NonNull` carry meaning and states that an annotation anywhere else has none. `@Nullable int count` and `List<@Nullable ?> values` read as claims about nullness and are not, so an author who writes one holds a false sense of safety and nothing says otherwise. The specification asks source-analysis tools to offer exactly this diagnostic.

Error Prone's existing checks reach 4 of the 17 locations the specification lists. Compiling one file that holds an example of each through the default checks reports `NullablePrimitive` on the primitive type, `NullableWildcard` on the wildcard, `NullableTypeParameter` on the type parameter, and `NullableOnContainingClass` on the outer type qualifying an inner type. The 13 they do not reach are the local variable root type, cast root type, `instanceof` type, pattern type, object creation, array creation, supertype, thrown type, exception parameter, receiver parameter, class declaration, enum constant, and annotation interface member return.

Measured on a real migration: the Apache Calcite branch that replaces the Checker Framework with NullAway and JSpecify ([apache/calcite#5213](https://github.com/apache/calcite/pull/5213)) carries 161 annotations in unrecognized locations, all of them local variable root types (141) and cast root types (20). The four existing checks reach none of the 161. **40 of the 161 were introduced by the migration branch itself**, established both by `git blame` against the branch's commit range and by comparing each line against the merge base. So the check catches the mistake while it is being made, not only the backlog a project inherits. Every one carries a suggested fix: `-XepPatchChecks:JSpecifyUnrecognizedAnnotationLocation` makes 161 replacements across 74 files and the rebuild reports zero.

## What

`JSpecifyUnrecognizedAnnotationLocation` reports the 17 unrecognized locations the specification lists, and two more its catch-all reaches: the result type of a constructor, which `NullableConstructor` already reports, and the root type of a method reference, which nothing else reaches.

It reads `org.jspecify.annotations.Nullable` and `org.jspecify.annotations.NonNull` by their qualified names and no other annotation. Reading any annotation named `Nullable` was rejected: the tools that define the others read them in some of these very locations. The Checker Framework reads its `@Nullable` on the root type of a local variable and of a cast; IntelliJ reads JetBrains' on a local variable. Telling those users the annotation has no meaning where their own tool does read it would be wrong. Supporting another annotation is left to a flag on this check.

It is one check rather than a documented set of per-construct checks because JSpecify's rule is about position, not about constructs: everything not listed as recognized is unrecognized. That is what separates `(List<@Nullable String>) o`, which is clean, from `(@Nullable String) o`, which is not, and `new ArrayList<@Nullable String>()` from `new @Nullable ArrayList<String>()`. Each per-construct check has to re-derive that a type argument inside an unrecognized root is still recognized. One check is also one severity and one `@SuppressWarnings("JSpecifyUnrecognizedAnnotationLocation")`, where a documented set costs N flags and N suppression names and grows silently as locations are covered.

The check ships at `SUGGESTION` and reports nothing there, not even a note, so a user who upgrades NullAway without asking for it sees no change. `-Xep:JSpecifyUnrecognizedAnnotationLocation:WARN` or `:ERROR` turns it on. Error Prone cannot ship a plugin check turned off outright ([google/error-prone#5387](https://github.com/google/error-prone/issues/5387)), and this is how close to off a default can get.

`-XepOpt:JSpecifyUnrecognizedAnnotationLocation:CheckLocalVariableRootType=false` silences the root type of a local variable, the one location a codebase arriving from JetBrains' annotations carries in bulk; IntelliJ added the same switch in [IDEA-374631](https://youtrack.jetbrains.com/issue/IDEA-374631). It reports by default, so that switching the check on reports every location the specification lists.

Fixes move the annotation to the bound of a wildcard or type parameter, onto the last name of a qualified type, and after the element type of an array, so `@Nullable Bounds.Inner` and `@Nullable String[]` become `Bounds.@Nullable Inner` and `String @Nullable []` rather than losing the annotation. They remove it where no single recognized form expresses the intent, such as a lower-bounded wildcard or an intersection bound, and where a nullness annotation already stands at the destination.

Running the check over NullAway's own sources found one real defect, fixed here: `GenericsTests.nestedGenericTypes` wrote `@Nullable Wrapper<String>.Fn<String>`, which annotates the outer `Wrapper` rather than the `Fn` the test means to make nullable. The JSpecify-correct `Wrapper<String>.@Nullable Fn<String>` passes every assertion that test already made. One test source in `JSpecifyArrayTests` annotates an unrecognized location on purpose and now says so with `@SuppressWarnings`.

## Verification

66 tests in `JSpecifyUnrecognizedAnnotationLocationTest` establish one diagnostic per location, that the recognized locations nested inside unrecognized ones stay unreported, a fix per fix shape, and exact report counts for the annotations two tree paths reach, which a `// BUG:` marker cannot tell apart from one reported once; `UnrecognizedAnnotationLocationInTestSourcesTest` (new) fails if the harness stops running the check over the sources every other test compiles.

## Scope

A construct the check cannot name is left alone rather than reported under the specification's catch-all, so the failure mode is a missed diagnostic rather than a wrong one.

A codebase still on the Checker Framework's or JetBrains' annotations gets no diagnostic until it has switched. That is the narrowing working as intended; the follow-up is a flag on this check that maps another annotation onto JSpecify's.

The severity is per check rather than per location, so a build cannot take `@Nullable Outer.Inner`, which contradicts a property the specification calls intrinsic, as an error while leaving another location a warning. `Description.Builder.overrideSeverity` would express that and is `@RestrictedApi`: "Overriding the severity for individual Descriptions causes any command line options to be ignored, which is potentially very confusing." Measured: with it, a user who writes `-Xep:JSpecifyUnrecognizedAnnotationLocation:WARN` gets errors anyway. A build that wants the strict reading of the outer type has it from `NullableOnContainingClass`, which reports it as an error today.

`CheckLocalVariableRootType` is the only location switch, and it is one key per location rather than one list of locations because `ErrorProneFlags` holds one value per key: two convention plugins each appending to a shared list would leave whichever ran last, silently.

`Build caffeine with snapshot` is red on two `@Nullable` on local variable root types in `LocalAsyncCache`. @ben-manes has said caffeine can switch those to `var`, so this branch needs no change for that job.
