### PR TITLE
Run every snippet test against bytecode as well as source

### DIFF
--- a/nullaway/build.gradle
+++ b/nullaway/build.gradle
@@ -238,7 +238,7 @@ tasks.named('check').configure {
         filter {
             // On Error Prone 2.46.0 and above, this test will not pass, since CompilationTestHelper passes the
             // -XDaddTypeAnnotationsToSymbol flag by default.  The test is still run on JDK 17.
-            excludeTestsMatching "com.uber.nullaway.ErrorProneCLIFlagsConfigTest.missingTypeAnnotationSymbolFlagForJSpecifyModeOnOlderJDK"
+            excludeTestsMatching "com.uber.nullaway.ErrorProneCLIFlagsConfigTest.missingTypeAnnotationSymbolFlagForJSpecifyModeOnOlderJDK*"
         }
     }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/AcknowledgeRestrictiveAnnotationsTests.java
@@ -1,10 +1,14 @@
 package com.uber.nullaway;
 
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
 import java.util.Arrays;
 import org.junit.Test;
 
 public class AcknowledgeRestrictiveAnnotationsTests extends NullAwayTestsBase {
 
+  @SkipBytecodeTestMode(
+      "TreatGeneratedAsUnannotated has no effect on class files, since the generated-code"
+          + " markers have SOURCE retention")
   @Test
   public void generatedAsUnannotatedPlusRestrictive() {
     makeTestHelperWithArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/ArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ArrayTests.java
@@ -23,10 +23,7 @@
 package com.uber.nullaway;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
 public class ArrayTests extends NullAwayTestsBase {
   @Test
   public void arrayDeclarationAnnotation() {

--- a/nullaway/src/test/java/com/uber/nullaway/ContractsBooleanTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ContractsBooleanTests.java
@@ -1,6 +1,6 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -635,7 +635,7 @@ public class ContractsBooleanTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper helper() {
+  private DualModeCompilationTestHelper helper() {
     return makeTestHelperWithArgs(
             Arrays.asList(
                 "-d",

--- a/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/CoreTests.java
@@ -24,11 +24,8 @@ package com.uber.nullaway;
 
 import java.util.Arrays;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link com.uber.nullaway.NullAway}. */
-@RunWith(JUnit4.class)
 public class CoreTests extends NullAwayTestsBase {
 
   @SuppressWarnings("deprecation")

--- a/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
@@ -4,21 +4,20 @@ import static com.uber.nullaway.ErrorProneCLIFlagsConfig.ANNOTATED_PACKAGES_ONLY
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneFlags;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assume;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
+@SkipBytecodeTestMode("the tests assert on the error a misconfigured compilation throws")
 public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
 
   @Test
   public void noFlagsFails() {
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(List.of())
             .addSourceLines("Stub.java", "package com.uber; class Stub {}");
     AssertionError e = assertThrows(AssertionError.class, () -> compilationTestHelper.doTest());
@@ -44,7 +43,7 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
 
   @Test
   public void onlyNullMarkedFalseFails() {
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=false"))
             .addSourceLines("Stub.java", "package com.uber; class Stub {}");
     AssertionError e = assertThrows(AssertionError.class, () -> compilationTestHelper.doTest());
@@ -53,7 +52,7 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
 
   @Test
   public void bothAnnotatedPackagesAndOnlyNullMarkedFails() {
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(
                 List.of(
                     "-XepOpt:NullAway:OnlyNullMarked",
@@ -66,7 +65,7 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
   @Test
   public void missingTypeAnnotationSymbolFlagForJSpecifyModeOnOlderJDK() {
     Assume.assumeTrue(Runtime.version().feature() < 22);
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(
                 List.of("-XepOpt:NullAway:OnlyNullMarked", "-XepOpt:NullAway:JSpecifyMode=true"))
             .addSourceLines("Stub.java", "package com.uber; class Stub {}");
@@ -77,7 +76,7 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
 
   @Test
   public void jspecifyJDKOutsideJSpecifyMode() {
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(
                 List.of(
                     "-XepOpt:NullAway:OnlyNullMarked", "-XepOpt:NullAway:JSpecifyJDKModels=true"))

--- a/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/FrameworkTests.java
@@ -1,6 +1,6 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -1895,7 +1895,8 @@ public class FrameworkTests extends NullAwayTestsBase {
    * @param helper the test helper to add the stubs to
    * @return the test helper, for chaining
    */
-  private static CompilationTestHelper addSpringMockAnnotationStubs(CompilationTestHelper helper) {
+  private static DualModeCompilationTestHelper addSpringMockAnnotationStubs(
+      DualModeCompilationTestHelper helper) {
     String bootPackage = "package org.springframework.boot.test.mock.mockito;";
     String overridePackage = "package org.springframework.test.context.bean.override.mockito;";
     return helper
@@ -1982,7 +1983,8 @@ public class FrameworkTests extends NullAwayTestsBase {
    * @param helper the test helper to add the stubs to
    * @return the test helper, for chaining
    */
-  private static CompilationTestHelper addMockitoAnnotationStubs(CompilationTestHelper helper) {
+  private static DualModeCompilationTestHelper addMockitoAnnotationStubs(
+      DualModeCompilationTestHelper helper) {
     String mockitoPackage = "package org.mockito;";
     return helper
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/InitializationTests.java
@@ -1,6 +1,6 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -11,7 +11,8 @@ public class InitializationTests extends NullAwayTestsBase {
    * @param helper compilation helper to configure
    * @return the same helper, with the shared utility source added
    */
-  private CompilationTestHelper addReadBeforeInitUtil(CompilationTestHelper helper) {
+  private DualModeCompilationTestHelper addReadBeforeInitUtil(
+      DualModeCompilationTestHelper helper) {
     String utilSource =
         """
         package com.uber.nullaway.testdata;

--- a/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JSpecifyJDKModelsTest.java
@@ -1,19 +1,16 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
 public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
 
   @Test
   public void modelsDisabledDoesNotLoadAstubxModel() {
-    CompilationTestHelper compilationTestHelper =
+    DualModeCompilationTestHelper compilationTestHelper =
         makeTestHelperWithArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=foo"))
             .addSourceLines(
                 "Test.java",
@@ -530,7 +527,7 @@ public class JSpecifyJDKModelsTest extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=true")));
   }

--- a/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/JakartaPersistenceTests.java
@@ -1,12 +1,13 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import org.junit.Test;
 
 @SuppressWarnings("deprecation")
 public class JakartaPersistenceTests extends NullAwayTestsBase {
 
-  private CompilationTestHelper addJpaAnnotationStubs(CompilationTestHelper helper) {
+  private DualModeCompilationTestHelper addJpaAnnotationStubs(
+      DualModeCompilationTestHelper helper) {
     return helper
         .addSourceLines(
             "jakarta/persistence/Access.java",

--- a/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/MonotonicNonNullTests.java
@@ -1,10 +1,7 @@
 package com.uber.nullaway;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
 public class MonotonicNonNullTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
+++ b/nullaway/src/test/java/com/uber/nullaway/NullAwayTestsBase.java
@@ -1,15 +1,45 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
+import com.uber.nullaway.tools.TestMode;
 import java.util.List;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.Statement;
 
+/**
+ * Base class for the test suites that check NullAway on source snippets.
+ *
+ * <p>Every test method runs once per {@link TestMode}. The source run is what the method would have
+ * done on its own; the bytecode run happens only for a snippet that splits into files NullAway
+ * analyzes and files it reads from the classpath, and is skipped through a JUnit assumption
+ * otherwise, which covers most of the suite. See {@link DualModeCompilationTestHelper} for the
+ * split.
+ */
+@RunWith(Parameterized.class)
 public abstract class NullAwayTestsBase {
+
+  /** The modes every test method of every subclass runs in. */
+  @Parameterized.Parameters(name = "{0}")
+  public static List<TestMode> testModes() {
+    return List.of(TestMode.values());
+  }
+
+  @Parameterized.Parameter public TestMode testMode;
+
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  protected CompilationTestHelper defaultCompilationHelper;
+  /** Honors {@link SkipBytecodeTestMode} on the test method and on the test class. */
+  @Rule public final TestRule skipBytecodeTestMode = this::applySkipBytecodeTestMode;
+
+  protected DualModeCompilationTestHelper defaultCompilationHelper;
 
   @SuppressWarnings("CheckReturnValue")
   @Before
@@ -37,15 +67,52 @@ public abstract class NullAwayTestsBase {
   }
 
   /**
-   * Creates a new {@link CompilationTestHelper} with a list of javac arguments. As of Error Prone
-   * 2.5.1, {@link CompilationTestHelper#setArgs(List)} can only be invoked once per object. So,
-   * this method must be used to create a test helper when a different set of javac arguments is
-   * required than those used for {@link #defaultCompilationHelper}.
+   * Creates a new {@link DualModeCompilationTestHelper} with a list of javac arguments. As of Error
+   * Prone 2.5.1, the arguments of a compilation can only be set once per object. So, this method
+   * must be used to create a test helper when a different set of javac arguments is required than
+   * those used for {@link #defaultCompilationHelper}.
    *
    * @param args the javac arguments
    * @return the test helper
    */
-  protected CompilationTestHelper makeTestHelperWithArgs(List<String> args) {
-    return CompilationTestHelper.newInstance(NullAway.class, getClass()).setArgs(args);
+  protected DualModeCompilationTestHelper makeTestHelperWithArgs(List<String> args) {
+    return DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), testMode)
+        .setArgs(args);
+  }
+
+  /**
+   * Wraps a test method in the assumption that skips it in {@link TestMode#BYTECODE}.
+   *
+   * @param base the statement that runs the test method
+   * @param description the test method
+   * @return the wrapped statement
+   */
+  private Statement applySkipBytecodeTestMode(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        SkipBytecodeTestMode skip = skipAnnotation(description);
+        if (testMode == TestMode.BYTECODE && skip != null) {
+          throw new AssumptionViolatedException(skip.value());
+        }
+        base.evaluate();
+      }
+    };
+  }
+
+  /**
+   * Returns the {@link SkipBytecodeTestMode} annotation of a test method, falling back to the one
+   * of its class.
+   *
+   * @param description the test method
+   * @return the annotation, or null when neither the method nor its class carries one
+   */
+  private static SkipBytecodeTestMode skipAnnotation(Description description) {
+    SkipBytecodeTestMode onMethod = description.getAnnotation(SkipBytecodeTestMode.class);
+    if (onMethod != null) {
+      return onMethod;
+    }
+    Class<?> testClass = description.getTestClass();
+    return testClass == null ? null : testClass.getAnnotation(SkipBytecodeTestMode.class);
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -38,6 +38,7 @@ import com.uber.nullaway.tools.DisplayFactory;
 import com.uber.nullaway.tools.ErrorDisplay;
 import com.uber.nullaway.tools.FieldInitDisplay;
 import com.uber.nullaway.tools.SerializationTestHelper;
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
 import com.uber.nullaway.tools.version1.ErrorDisplayV1;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -48,14 +49,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 /** Unit tests for {@link com.uber.nullaway.NullAway}. */
-@RunWith(JUnit4.class)
+@SkipBytecodeTestMode(
+    "the tests assert on the fix-serialization output files, which one compilation writes once")
 public class SerializationTest extends NullAwayTestsBase {
   private String configPath;
   private Path root;

--- a/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ThriftTests.java
@@ -1,5 +1,6 @@
 package com.uber.nullaway;
 
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -161,6 +162,9 @@ public class ThriftTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SkipBytecodeTestMode(
+      "TreatGeneratedAsUnannotated has no effect on class files, since the generated-code"
+          + " markers have SOURCE retention")
   @Test
   public void testThriftAndCastToNonNull() {
     makeTestHelperWithArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/TypeUseAnnotationsTests.java
@@ -23,10 +23,7 @@
 package com.uber.nullaway;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
 public class TypeUseAnnotationsTests extends NullAwayTestsBase {
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnannotatedTests.java
@@ -1,5 +1,6 @@
 package com.uber.nullaway;
 
+import com.uber.nullaway.tools.SkipBytecodeTestMode;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -170,6 +171,9 @@ public class UnannotatedTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SkipBytecodeTestMode(
+      "TreatGeneratedAsUnannotated has no effect on class files, since the generated-code"
+          + " markers have SOURCE retention")
   @Test
   public void generatedAsUnannotated() {
     makeTestHelperWithArgs(
@@ -196,6 +200,9 @@ public class UnannotatedTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @SkipBytecodeTestMode(
+      "TreatGeneratedAsUnannotated has no effect on class files, since the generated-code"
+          + " markers have SOURCE retention")
   @Test
   public void generatedAsUnannotatedCustomAnnotation() {
     makeTestHelperWithArgs(

--- a/nullaway/src/test/java/com/uber/nullaway/UnsoundnessTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/UnsoundnessTests.java
@@ -1,7 +1,6 @@
 package com.uber.nullaway;
 
-import com.google.errorprone.CompilationTestHelper;
-import java.util.Arrays;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,12 +11,11 @@ public class UnsoundnessTests extends NullAwayTestsBase {
   @Override
   public void setup() {
     defaultCompilationHelper =
-        CompilationTestHelper.newInstance(NullAway.class, getClass())
-            .setArgs(
-                Arrays.asList(
-                    "-d",
-                    temporaryFolder.getRoot().getAbsolutePath(),
-                    "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+        makeTestHelperWithArgs(
+            List.of(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber"));
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/BytecodeGenericsTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.List;
 import org.junit.Test;
 
@@ -255,7 +255,7 @@ public class BytecodeGenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/ConditionalExprTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.List;
 import org.junit.Test;
 
@@ -422,7 +422,7 @@ public class ConditionalExprTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(List.of("-XepOpt:NullAway:OnlyNullMarked=true")));
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericDiamondTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -588,7 +588,7 @@ public class GenericDiamondTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -3,7 +3,6 @@ package com.uber.nullaway.jspecify;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneJavaCompiler;
 import com.google.errorprone.FileManagers;
 import com.google.errorprone.FileObjects;
@@ -11,6 +10,7 @@ import com.google.errorprone.scanner.ScannerSupplier;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -209,7 +209,7 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
    * compatibility diagnostic alone; see https://github.com/uber/NullAway/issues/1730.
    *
    * <p>This has to assert the whole set of diagnostics, so it cannot live in {@link
-   * GenericMethodTests}: {@code CompilationTestHelper} accepts a line whose {@code // BUG:
+   * GenericMethodTests}: {@code DualModeCompilationTestHelper} accepts a line whose {@code // BUG:
    * Diagnostic contains:} comment matches one diagnostic even when the line carries another. The
    * source below therefore carries every shape from that issue whose line still expects a
    * diagnostic. Both annotation checks in {@code
@@ -217,8 +217,8 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
    * {@code @Nullable} on a use and an explicit {@code @NonNull} on a parameter. The call with an
    * explicit type witness reaches neither, because a witness skips inference; it is here as one of
    * the issue's shapes, and it guards against such a call acquiring an inference failure of its
-   * own. A shape whose line expects nothing needs no help, since {@code CompilationTestHelper}
-   * rejects any diagnostic there.
+   * own. A shape whose line expects nothing needs no help, since {@code
+   * DualModeCompilationTestHelper} rejects any diagnostic there.
    */
   @Test
   public void annotatedTypeVariableUseIsNotAnInferenceFailure() {
@@ -363,7 +363,7 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
     return fileName + ":" + diagnostic.getLineNumber() + ": " + message;
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInheritanceTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -383,7 +383,7 @@ public class GenericInheritanceTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericLambdaTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -263,7 +263,7 @@ public class GenericLambdaTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1296,7 +1296,7 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1,9 +1,11 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
+import com.uber.nullaway.tools.TestMode;
 import java.util.Arrays;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -1775,6 +1777,10 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void issue1453() {
+    // The JDK pins the observable condition rather than the cause.
+    Assume.assumeTrue(
+        "the bytecode run fails on JDK 17, and no task pairs JDK 17 with the current Error Prone",
+        testMode == TestMode.SOURCE || Runtime.version().feature() > 17);
     makeHelper()
         .addSourceLines(
             "NullUtil.java",
@@ -2344,7 +2350,7 @@ public class GenericMethodTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1777,9 +1777,10 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void issue1453() {
-    // The JDK pins the observable condition rather than the cause.
+    // The JDK decides this, not the Error Prone version: JDK 21 passes with the same Error Prone
+    // that JDK 17 fails with.
     Assume.assumeTrue(
-        "the bytecode run fails on JDK 17, and no task pairs JDK 17 with the current Error Prone",
+        "the bytecode run fails on JDK 17; see https://github.com/uber/NullAway/issues/1791",
         testMode == TestMode.SOURCE || Runtime.version().feature() > 17);
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -1777,11 +1777,10 @@ public class GenericMethodTests extends NullAwayTestsBase {
 
   @Test
   public void issue1453() {
-    // The JDK decides this, not the Error Prone version: JDK 21 passes with the same Error Prone
-    // that JDK 17 fails with.
     Assume.assumeTrue(
-        "the bytecode run fails on JDK 17; see https://github.com/uber/NullAway/issues/1791",
-        testMode == TestMode.SOURCE || Runtime.version().feature() > 17);
+        "the bytecode run needs a JDK that carries -XDaddTypeAnnotationsToSymbol;"
+            + " see https://github.com/uber/NullAway/issues/1791",
+        testMode == TestMode.SOURCE || jdkCarriesTypeAnnotationsFromBytecode());
     makeHelper()
         .addSourceLines(
             "NullUtil.java",
@@ -2349,6 +2348,25 @@ public class GenericMethodTests extends NullAwayTestsBase {
             }
             """)
         .doTest();
+  }
+
+  /**
+   * Says whether this JDK reads type annotations from a class file onto the symbol, which JSpecify
+   * mode needs and which {@code -XDaddTypeAnnotationsToSymbol} turns on. JDK 22 does it
+   * unconditionally, and the flag was backported to 17.0.19 and 21.0.8; an older JDK ignores the
+   * flag, and NullAway then reports an inference failure against a class file that it does not
+   * report against the same code as source. See the JSpecify support matrix at
+   * https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions
+   *
+   * @return true when the running JDK carries the annotations
+   */
+  private static boolean jdkCarriesTypeAnnotationsFromBytecode() {
+    Runtime.Version version = Runtime.version();
+    return switch (version.feature()) {
+      case 17 -> version.compareToIgnoreOptional(Runtime.Version.parse("17.0.19")) >= 0;
+      case 21 -> version.compareToIgnoreOptional(Runtime.Version.parse("21.0.8")) >= 0;
+      default -> version.feature() >= 22;
+    };
   }
 
   private DualModeCompilationTestHelper makeHelper() {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericsTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Assume;
@@ -3226,13 +3226,13 @@ public class GenericsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
   }
 
-  private CompilationTestHelper makeHelperWithoutJSpecifyMode() {
+  private DualModeCompilationTestHelper makeHelperWithoutJSpecifyMode() {
     return makeTestHelperWithArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"));
   }
 }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -22,9 +22,9 @@
 
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -898,7 +898,7 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyLibraryModelsTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -158,7 +158,7 @@ public class JSpecifyLibraryModelsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyVarargsTests.java
@@ -1,9 +1,9 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.VarargsTests;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -799,7 +799,7 @@ public class JSpecifyVarargsTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/NullnessOperatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/NullnessOperatorTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -617,7 +617,7 @@ public class NullnessOperatorTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/StreamNullabilityPropagatorTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -180,7 +180,7 @@ public class StreamNullabilityPropagatorTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -395,7 +395,7 @@ public class VarDeclaredLocalTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:AnnotatedPackages=com.uber")));

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1,8 +1,8 @@
 package com.uber.nullaway.jspecify;
 
-import com.google.errorprone.CompilationTestHelper;
 import com.uber.nullaway.NullAwayTestsBase;
 import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import com.uber.nullaway.tools.DualModeCompilationTestHelper;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -1407,7 +1407,7 @@ public class WildcardTests extends NullAwayTestsBase {
         .doTest();
   }
 
-  private CompilationTestHelper makeHelper() {
+  private DualModeCompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));

--- a/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelper.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelper.java
@@ -80,6 +80,11 @@ public final class DualModeCompilationTestHelper {
   private static final List<String> BUG_MARKERS =
       List.of("// BUG: Diagnostic contains:", "// BUG: Diagnostic matches:");
 
+  private static final List<String> CLASSPATH_OPTIONS =
+      List.of("-classpath", "-cp", "--class-path");
+
+  private static final String CLASS_PATH_PREFIX = "--class-path=";
+
   private final Class<? extends BugChecker> checker;
   private final Class<?> resourceClass;
   private final TestMode testMode;
@@ -395,12 +400,13 @@ public final class DualModeCompilationTestHelper {
 
   /**
    * Returns the javac arguments for the sources that become class files. Error Prone arguments are
-   * dropped, since no check runs on those sources.
+   * dropped, since no check runs on those sources, and the classpath is stated once so that these
+   * sources see what the test declared rather than what javac happened to read last.
    *
    * @param classes the directory the class files are written to
    * @return the javac arguments
    */
-  private List<String> javacOptions(Path classes) {
+  List<String> javacOptions(Path classes) {
     List<String> options =
         new ArrayList<>(
             List.of(
@@ -410,7 +416,7 @@ public final class DualModeCompilationTestHelper {
                 "-d",
                 classes.toString(),
                 "-classpath",
-                runtimeClasspath()));
+                declaredClasspath()));
     List<String> declared = javacArgs();
     options.addAll(declared);
     if (declared.stream().noneMatch(arg -> arg.startsWith("-proc") || arg.equals("-processor"))) {
@@ -422,12 +428,13 @@ public final class DualModeCompilationTestHelper {
   /** Returns the arguments the test declared, without the Error Prone and output-directory ones. */
   private List<String> javacArgs() {
     List<String> result = new ArrayList<>();
-    for (int i = 0; i < args.size(); i++) {
-      String arg = args.get(i);
+    List<String> withoutClasspath = argsWithoutClasspath();
+    for (int i = 0; i < withoutClasspath.size(); i++) {
+      String arg = withoutClasspath.get(i);
       if (arg.startsWith("-Xep")) {
         continue;
       }
-      if (arg.equals("-d") || arg.equals("-classpath") || arg.equals("-cp")) {
+      if (arg.equals("-d")) {
         i++;
         continue;
       }
@@ -442,10 +449,51 @@ public final class DualModeCompilationTestHelper {
    * @param classes the directory holding the class files
    * @return the javac arguments
    */
-  private List<String> argsWithClasspath(Path classes) {
-    List<String> result = new ArrayList<>(args);
+  List<String> argsWithClasspath(Path classes) {
+    List<String> result = argsWithoutClasspath();
     result.add("-classpath");
-    result.add(classes + File.pathSeparator + runtimeClasspath());
+    result.add(classes + File.pathSeparator + declaredClasspath());
+    return result;
+  }
+
+  /**
+   * Returns the classpath the test declared, or the runtime classpath when it declared none.
+   *
+   * <p>javac takes the last classpath option it is given, so this does too. A test that names a
+   * classpath means it for both compilations of bytecode mode: the sources that become class files
+   * are compiled against it, and the analyzed sources see it behind the class files.
+   *
+   * @return the classpath
+   */
+  private String declaredClasspath() {
+    String classpath = runtimeClasspath();
+    for (int i = 0; i < args.size(); i++) {
+      String arg = args.get(i);
+      if (arg.startsWith(CLASS_PATH_PREFIX)) {
+        classpath = arg.substring(CLASS_PATH_PREFIX.length());
+      } else if (CLASSPATH_OPTIONS.contains(arg) && i + 1 < args.size()) {
+        classpath = args.get(++i);
+      }
+    }
+    return classpath;
+  }
+
+  /**
+   * Returns the arguments the test declared, with every spelling of the classpath option removed.
+   */
+  private List<String> argsWithoutClasspath() {
+    List<String> result = new ArrayList<>();
+    for (int i = 0; i < args.size(); i++) {
+      String arg = args.get(i);
+      if (arg.startsWith(CLASS_PATH_PREFIX)) {
+        continue;
+      }
+      if (CLASSPATH_OPTIONS.contains(arg)) {
+        i++;
+        continue;
+      }
+      result.add(arg);
+    }
     return result;
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelper.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelper.java
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) 2026 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.tools;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.bugpatterns.BugChecker;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.AssumptionViolatedException;
+
+/**
+ * Runs a NullAway test snippet either as plain source code or with part of it moved to the
+ * classpath, depending on the {@link TestMode} it is created with.
+ *
+ * <p>The helper records the sources and the javac arguments a test declares and replays them
+ * through Error Prone's {@link CompilationTestHelper} when {@link #doTest()} runs. In {@link
+ * TestMode#SOURCE} the replay is exactly what the test would have done on its own. In {@link
+ * TestMode#BYTECODE} some of the source files are compiled to class files first and handed to
+ * NullAway on the classpath, which exercises the class-file reading path against a snippet written
+ * for the source path.
+ *
+ * <p>Every file carrying an {@code // BUG: Diagnostic contains:} marker stays source, since only a
+ * file NullAway analyzes can produce the diagnostics the test expects, and the files that carry no
+ * marker move to the classpath. Bytecode mode therefore needs at least one file with no marker and
+ * at least one file left to analyze, which a single-file snippet — the commonest shape in the suite
+ * — never has, and neither has a snippet whose every file is marked. The helper compiles as many of
+ * the eligible files as javac accepts, dropping the ones it reports errors on and retrying with the
+ * rest, and keeps the largest set that compiles. With nothing marked it weighs all but the last
+ * file against all but the first, since either end of the snippet may be the file under test.
+ * {@link #doTest()} skips the test through a JUnit assumption whenever no split compiles, so use
+ * {@link SkipBytecodeTestMode} only for a test that must not run in bytecode mode at all.
+ */
+public final class DualModeCompilationTestHelper {
+
+  private static final List<String> BUG_MARKERS =
+      List.of("// BUG: Diagnostic contains:", "// BUG: Diagnostic matches:");
+
+  private final Class<? extends BugChecker> checker;
+  private final Class<?> resourceClass;
+  private final TestMode testMode;
+  private final List<TestSource> sources = new ArrayList<>();
+  private List<String> args = List.of();
+
+  private DualModeCompilationTestHelper(
+      Class<? extends BugChecker> checker, Class<?> resourceClass, TestMode testMode) {
+    this.checker = checker;
+    this.resourceClass = resourceClass;
+    this.testMode = testMode;
+  }
+
+  /**
+   * Returns a helper for the given check.
+   *
+   * @param checker the {@link BugChecker} to test
+   * @param resourceClass the class used to locate the resources of {@link #addSourceFile}
+   * @param testMode whether the snippet runs as source or partly as class files
+   * @return the test helper
+   */
+  public static DualModeCompilationTestHelper newInstance(
+      Class<? extends BugChecker> checker, Class<?> resourceClass, TestMode testMode) {
+    return new DualModeCompilationTestHelper(checker, resourceClass, testMode);
+  }
+
+  /**
+   * Adds a source file to the test compilation, from the string content of the file.
+   *
+   * @param path a path for the source file
+   * @param lines the content of the source file
+   * @return this helper
+   */
+  public DualModeCompilationTestHelper addSourceLines(String path, String... lines) {
+    sources.add(new SourceLines(path, lines));
+    return this;
+  }
+
+  /**
+   * Adds a source file to the test compilation, from an existing resource file.
+   *
+   * @param path the resource path of the source file
+   * @return this helper
+   */
+  public DualModeCompilationTestHelper addSourceFile(String path) {
+    sources.add(new ResourceFile(resourceClass, path));
+    return this;
+  }
+
+  /**
+   * Sets the javac arguments for the compilation, which may be given only once.
+   *
+   * @param args the javac arguments
+   * @return this helper
+   */
+  public DualModeCompilationTestHelper setArgs(List<String> args) {
+    Preconditions.checkState(this.args.isEmpty(), "Args already set: %s", this.args);
+    this.args = List.copyOf(args);
+    return this;
+  }
+
+  /** Compiles the snippet and checks that the diagnostics match the expectations. */
+  public void doTest() {
+    if (testMode == TestMode.SOURCE) {
+      errorProneHelper(sources, args).doTest();
+      return;
+    }
+    List<List<TestSource>> candidates = candidateDependencies();
+    assumeTrue(
+        "bytecode mode needs a source file that carries no expected diagnostics",
+        !candidates.isEmpty());
+    Path workingDir = createWorkingDirectory();
+    try {
+      List<String> errors = List.of();
+      List<TestSource> best = List.of();
+      Path bestClasses = workingDir;
+      for (int i = 0; i < candidates.size(); i++) {
+        List<TestSource> candidate = candidates.get(i);
+        Attempt attempt = shrinkUntilItCompiles(candidate, workingDir, i);
+        if (errors.isEmpty()) {
+          errors = attempt.errors;
+        }
+        if (attempt.dependencies.isEmpty()) {
+          continue;
+        }
+        if (attempt.dependencies.size() == candidate.size()) {
+          // A candidate that compiled unshrunk is a whole starting set, and no result is larger
+          // than a starting set, so no later candidate can beat it.
+          errorProneHelper(analyzed(attempt.dependencies), argsWithClasspath(attempt.classes))
+              .doTest();
+          return;
+        }
+        // What one result has over another is subset inclusion: everything the smaller reads from a
+        // class file the larger reads from one too. Size linearizes that order, and declaration
+        // order breaks a tie between results the order cannot compare.
+        if (attempt.dependencies.size() > best.size()) {
+          best = attempt.dependencies;
+          bestClasses = attempt.classes;
+        }
+      }
+      if (!best.isEmpty()) {
+        errorProneHelper(analyzed(best), argsWithClasspath(bestClasses)).doTest();
+        return;
+      }
+      throw new AssumptionViolatedException(
+          "the sources moved to the classpath do not compile on their own: " + errors);
+    } finally {
+      deleteRecursively(workingDir);
+    }
+  }
+
+  /**
+   * Compiles a candidate dependency set, dropping the sources javac reported errors on and retrying
+   * until what is left compiles or nothing is left.
+   *
+   * <p>Removing a source can only remove symbols, so a source that fails in one set fails in every
+   * subset containing it. The loop therefore settles on the largest subset of the candidate that
+   * compiles, rather than on an arbitrary one — except where javac reports an error it names no
+   * source for, which leaves nothing to drop and gives up on a candidate a smaller subset of which
+   * might have compiled.
+   *
+   * @param candidate the sources to start from
+   * @param workingDir the directory holding this run's sources and class files
+   * @param index which candidate this is, used to keep the attempts in separate directories
+   * @return what compiled, with an empty dependency list when nothing did
+   */
+  private Attempt shrinkUntilItCompiles(List<TestSource> candidate, Path workingDir, int index) {
+    List<TestSource> dependencies = candidate;
+    List<String> errors = List.of();
+    Path classes = workingDir;
+    for (int step = 0; !dependencies.isEmpty(); step++) {
+      classes = workingDir.resolve("classes" + index + "-" + step);
+      CompileResult result =
+          compileToClassFiles(
+              dependencies, workingDir.resolve("src" + index + "-" + step), classes);
+      if (result.errors.isEmpty()) {
+        return new Attempt(dependencies, classes, errors);
+      }
+      if (errors.isEmpty()) {
+        errors = result.errors;
+      }
+      // Everything failed, so by the same monotonicity no subset compiles; or javac named no
+      // source, which leaves nothing to drop and is where this gives up early.
+      if (result.failed.isEmpty() || result.failed.size() == dependencies.size()) {
+        break;
+      }
+      List<TestSource> failed = result.failed;
+      dependencies =
+          dependencies.stream()
+              .filter(source -> !failed.contains(source))
+              .collect(Collectors.toList());
+    }
+    return new Attempt(List.of(), classes, errors);
+  }
+
+  /** What one candidate dependency set settled on. */
+  private static final class Attempt {
+    private final List<TestSource> dependencies;
+    private final Path classes;
+    private final List<String> errors;
+
+    Attempt(List<TestSource> dependencies, Path classes, List<String> errors) {
+      this.dependencies = dependencies;
+      this.classes = classes;
+      this.errors = errors;
+    }
+  }
+
+  /**
+   * Returns the dependency sets bytecode mode may start from, most thorough first. The list is
+   * empty for a snippet that cannot be split at all, such as a single-file one.
+   *
+   * @return the candidate dependency sets
+   */
+  private List<List<TestSource>> candidateDependencies() {
+    List<TestSource> unmarked =
+        sources.stream().filter(source -> !hasBugMarker(source)).collect(Collectors.toList());
+    if (unmarked.size() < sources.size()) {
+      // Some file is marked, so every unmarked file may become a class file.
+      return unmarked.isEmpty() ? List.of() : List.of(unmarked);
+    }
+    if (sources.size() < 2) {
+      return List.of();
+    }
+    // With nothing marked, either end of the snippet may be the file under test. Shrinking cannot
+    // reach the second candidate from the first, since it moves a different file into the analyzed
+    // half.
+    return List.of(sources.subList(0, sources.size() - 1), sources.subList(1, sources.size()));
+  }
+
+  /**
+   * Returns the sources NullAway analyzes, which are the ones that did not become class files.
+   *
+   * @param dependencies the sources compiled to class files
+   * @return the sources to analyze, in declaration order
+   */
+  private List<TestSource> analyzed(List<TestSource> dependencies) {
+    return sources.stream()
+        .filter(source -> !dependencies.contains(source))
+        .collect(Collectors.toList());
+  }
+
+  private static boolean hasBugMarker(TestSource source) {
+    String content = source.content();
+    return BUG_MARKERS.stream().anyMatch(content::contains);
+  }
+
+  /**
+   * Builds an Error Prone test helper for the given sources and arguments.
+   *
+   * @param sources the sources NullAway analyzes
+   * @param args the javac arguments
+   * @return the test helper
+   */
+  @SuppressWarnings("CheckReturnValue")
+  private CompilationTestHelper errorProneHelper(List<TestSource> sources, List<String> args) {
+    CompilationTestHelper helper = CompilationTestHelper.newInstance(checker, resourceClass);
+    if (!args.isEmpty()) {
+      helper = helper.setArgs(args);
+    }
+    for (TestSource source : sources) {
+      helper = source.addTo(helper);
+    }
+    return helper;
+  }
+
+  /**
+   * Compiles the given sources to class files with plain javac.
+   *
+   * @param dependencies the sources to compile
+   * @param sourceDir the directory the sources are written to
+   * @param classes the directory the class files are written to
+   * @return the compilation errors and the sources they were reported on
+   */
+  private CompileResult compileToClassFiles(
+      List<TestSource> dependencies, Path sourceDir, Path classes) {
+    List<Path> files = new ArrayList<>();
+    try {
+      Files.createDirectories(classes);
+      for (TestSource source : dependencies) {
+        Path file = sourceDir.resolve(source.path());
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, source.content(), UTF_8);
+        files.add(file);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    JavaCompiler javac =
+        Preconditions.checkNotNull(
+            ToolProvider.getSystemJavaCompiler(),
+            "no system Java compiler; tests must run on a JDK");
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+    boolean compiled;
+    // The file objects are paired with the sources that produced them, so a diagnostic names a
+    // TestSource without any matching on file names.
+    IdentityHashMap<JavaFileObject, TestSource> sourceOf = new IdentityHashMap<>();
+    Map<URI, TestSource> sourceOfUri = new LinkedHashMap<>();
+    try (StandardJavaFileManager fileManager =
+        javac.getStandardFileManager(diagnostics, null, UTF_8)) {
+      List<JavaFileObject> fileObjects = new ArrayList<>();
+      fileManager.getJavaFileObjectsFromPaths(files).forEach(fileObjects::add);
+      for (int i = 0; i < fileObjects.size(); i++) {
+        sourceOf.put(fileObjects.get(i), dependencies.get(i));
+        sourceOfUri.put(fileObjects.get(i).toUri(), dependencies.get(i));
+      }
+      compiled =
+          javac
+              .getTask(null, fileManager, diagnostics, javacOptions(classes), null, fileObjects)
+              .call();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    List<Diagnostic<? extends JavaFileObject>> errorDiagnostics =
+        diagnostics.getDiagnostics().stream()
+            .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+            .collect(Collectors.toList());
+    List<String> errors =
+        errorDiagnostics.stream().map(d -> d.getMessage(Locale.ROOT)).collect(Collectors.toList());
+    if (!compiled && errors.isEmpty()) {
+      // Reporting this as an error would send it down the retry-then-skip path, where a broken
+      // compiler reads as a snippet that cannot be split.
+      throw new AssertionError(
+          "javac failed without reporting an error; options=" + javacOptions(classes));
+    }
+    List<TestSource> failed = new ArrayList<>();
+    for (Diagnostic<? extends JavaFileObject> diagnostic : errorDiagnostics) {
+      JavaFileObject file = diagnostic.getSource();
+      if (file == null) {
+        continue;
+      }
+      TestSource source = sourceOf.get(file);
+      if (source == null) {
+        source = sourceOfUri.get(file.toUri());
+      }
+      if (source != null && !failed.contains(source)) {
+        failed.add(source);
+      }
+    }
+    return new CompileResult(errors, failed);
+  }
+
+  /** What one javac run over a candidate dependency set reported. */
+  private static final class CompileResult {
+    private final List<String> errors;
+    private final List<TestSource> failed;
+
+    CompileResult(List<String> errors, List<TestSource> failed) {
+      this.errors = errors;
+      this.failed = failed;
+    }
+  }
+
+  /**
+   * Returns the javac arguments for the sources that become class files. Error Prone arguments are
+   * dropped, since no check runs on those sources.
+   *
+   * @param classes the directory the class files are written to
+   * @return the javac arguments
+   */
+  private List<String> javacOptions(Path classes) {
+    List<String> options =
+        new ArrayList<>(
+            List.of(
+                "-encoding",
+                "UTF-8",
+                "-parameters",
+                "-d",
+                classes.toString(),
+                "-classpath",
+                runtimeClasspath()));
+    List<String> declared = javacArgs();
+    options.addAll(declared);
+    if (declared.stream().noneMatch(arg -> arg.startsWith("-proc") || arg.equals("-processor"))) {
+      options.add("-proc:none");
+    }
+    return options;
+  }
+
+  /** Returns the arguments the test declared, without the Error Prone and output-directory ones. */
+  private List<String> javacArgs() {
+    List<String> result = new ArrayList<>();
+    for (int i = 0; i < args.size(); i++) {
+      String arg = args.get(i);
+      if (arg.startsWith("-Xep")) {
+        continue;
+      }
+      if (arg.equals("-d") || arg.equals("-classpath") || arg.equals("-cp")) {
+        i++;
+        continue;
+      }
+      result.add(arg);
+    }
+    return result;
+  }
+
+  /**
+   * Returns the arguments the test declared, with the compiled sources prepended to the classpath.
+   *
+   * @param classes the directory holding the class files
+   * @return the javac arguments
+   */
+  private List<String> argsWithClasspath(Path classes) {
+    List<String> result = new ArrayList<>(args);
+    result.add("-classpath");
+    result.add(classes + File.pathSeparator + runtimeClasspath());
+    return result;
+  }
+
+  private static String runtimeClasspath() {
+    return System.getProperty("java.class.path");
+  }
+
+  private static Path createWorkingDirectory() {
+    try {
+      return Files.createTempDirectory("nullaway-bytecode-mode");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Deletes a directory and everything under it, best-effort. This runs in a {@code finally} block,
+   * where an exception would replace the failure the test is already reporting, and the directory
+   * lives under the system temp directory, so a failed delete leaks rather than corrupts.
+   *
+   * @param dir the directory to delete
+   */
+  private static void deleteRecursively(Path dir) {
+    try (Stream<Path> paths = Files.walk(dir)) {
+      for (Path path : paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
+        try {
+          Files.delete(path);
+        } catch (IOException e) {
+          // best-effort
+        }
+      }
+    } catch (IOException | UncheckedIOException e) {
+      // best-effort; Files.walk reports a failure during traversal as UncheckedIOException
+    }
+  }
+
+  /** A source file of a snippet, replayable into an Error Prone {@link CompilationTestHelper}. */
+  private abstract static class TestSource {
+    /** Returns the path the source file is written to when it becomes a class file. */
+    abstract String path();
+
+    /** Returns the content of the source file. */
+    abstract String content();
+
+    /**
+     * Adds this source to an Error Prone test helper the same way the test declared it.
+     *
+     * @param helper the test helper
+     * @return the test helper
+     */
+    abstract CompilationTestHelper addTo(CompilationTestHelper helper);
+  }
+
+  /** A source file given as literal lines. */
+  private static final class SourceLines extends TestSource {
+    private final String path;
+    private final String[] lines;
+
+    SourceLines(String path, String[] lines) {
+      this.path = path;
+      this.lines = lines;
+    }
+
+    @Override
+    String path() {
+      return path;
+    }
+
+    @Override
+    String content() {
+      return String.join("\n", lines) + "\n";
+    }
+
+    @Override
+    CompilationTestHelper addTo(CompilationTestHelper helper) {
+      return helper.addSourceLines(path, lines);
+    }
+  }
+
+  /** A source file read from a test resource. */
+  private static final class ResourceFile extends TestSource {
+    private final Class<?> resourceClass;
+    private final String path;
+    private String content;
+
+    ResourceFile(Class<?> resourceClass, String path) {
+      this.resourceClass = resourceClass;
+      this.path = path;
+    }
+
+    @Override
+    String path() {
+      return path;
+    }
+
+    @Override
+    String content() {
+      if (content == null) {
+        try (InputStream stream = resourceClass.getResourceAsStream(path)) {
+          if (stream == null) {
+            throw new AssertionError("could not find resource: " + path + " for: " + resourceClass);
+          }
+          content = new String(ByteStreams.toByteArray(stream), UTF_8);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      }
+      return content;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    CompilationTestHelper addTo(CompilationTestHelper helper) {
+      return helper.addSourceFile(path);
+    }
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
@@ -275,7 +275,8 @@ public class DualModeCompilationTestHelperTest {
         values.add(options.get(++i));
       }
     }
-    assertEquals("javac takes the last classpath option, so exactly one may be passed", 1, values.size());
+    assertEquals(
+        "javac takes the last classpath option, so exactly one may be passed", 1, values.size());
     return values.get(0);
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.tools;
+
+import static org.junit.Assert.assertThrows;
+
+import com.uber.nullaway.NullAway;
+import java.util.List;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Checks that {@link TestMode#BYTECODE} does what the suites relying on it assume.
+ *
+ * <p>Every other test reaches bytecode mode through {@link com.uber.nullaway.NullAwayTestsBase},
+ * where a snippet the mode cannot handle is skipped through a JUnit assumption. That is right for a
+ * snippet, and wrong as the only outcome the suite can produce: were the class-file path to break
+ * for a reason no snippet controls, the suite would report skips and stay green. These tests fail
+ * instead, so a break in the mode itself is a red build.
+ *
+ * <p>Each snippet below gives one file a NullAway error with no marker. That file is the
+ * discriminator: it must end up compiled to a class file, since analyzing it reports a diagnostic
+ * on a line carrying no marker and fails the run.
+ */
+@RunWith(JUnit4.class)
+public class DualModeCompilationTestHelperTest {
+
+  /**
+   * Returns a helper over a two-file snippet whose dependency holds a NullAway error with no
+   * marker, and whose analyzed file holds one with a marker.
+   *
+   * <p>The snippet passes in bytecode mode only if all three of these hold: {@code Dep.java} was
+   * compiled by plain javac and so was never analyzed, since its unmarked error would otherwise
+   * fail the run; the class file reached NullAway on the classpath, since {@code Dep} would
+   * otherwise be an unresolved symbol; and {@code @Nullable} survived into the class file, since
+   * the marked diagnostic would otherwise not be reported. It fails in source mode, on the unmarked
+   * error.
+   *
+   * @param testMode the mode to run the snippet in
+   * @return the test helper
+   */
+  private DualModeCompilationTestHelper snippetSplitByItsMarkers(TestMode testMode) {
+    return DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), testMode)
+        .setArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(
+            "Dep.java",
+            """
+            package com.uber;
+            import javax.annotation.Nullable;
+            public class Dep {
+              @Nullable public Object get() { return null; }
+              public void unmarkedError(@Nullable Object o) { o.toString(); }
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            class Test {
+              void f(Dep d) {
+                // BUG: Diagnostic contains: dereferenced expression
+                d.get().toString();
+              }
+            }
+            """);
+  }
+
+  /**
+   * Runs a snippet, turning the assumption that skips an unsplittable snippet into a failure.
+   *
+   * @param helper the test helper
+   */
+  private static void runExpectingNoSkip(DualModeCompilationTestHelper helper) {
+    try {
+      helper.doTest();
+    } catch (AssumptionViolatedException e) {
+      throw new AssertionError("bytecode mode skipped a snippet that must split", e);
+    }
+  }
+
+  @Test
+  public void bytecodeModeAnalyzesOnlyTheMarkedFile() {
+    runExpectingNoSkip(snippetSplitByItsMarkers(TestMode.BYTECODE));
+  }
+
+  @Test
+  public void sourceModeAnalyzesEveryFile() {
+    DualModeCompilationTestHelper helper = snippetSplitByItsMarkers(TestMode.SOURCE);
+    assertThrows(AssertionError.class, helper::doTest);
+  }
+
+  /**
+   * Returns a helper carrying the annotated-packages flag and the first source file of a snippet,
+   * to which the caller adds the rest.
+   *
+   * @param testMode the mode to run the snippet in
+   * @param path the path of the source file
+   * @param lines the content of the source file
+   * @return the test helper
+   */
+  private DualModeCompilationTestHelper snippetStartingWith(
+      TestMode testMode, String path, String... lines) {
+    return DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), testMode)
+        .setArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+        .addSourceLines(path, lines);
+  }
+
+  @Test
+  public void bytecodeModeSplitsASnippetWithNoMarkerAtItsLastFile() {
+    runExpectingNoSkip(
+        snippetStartingWith(
+                TestMode.BYTECODE,
+                "Dep.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                public class Dep {
+                  public void unmarkedError(@Nullable Object o) { o.toString(); }
+                }
+                """)
+            .addSourceLines(
+                "Test.java",
+                """
+                package com.uber;
+                class Test {
+                  void f(Dep d) { d.unmarkedError(new Object()); }
+                }
+                """));
+  }
+
+  @Test
+  public void bytecodeModeFallsBackToAnalyzingTheFirstFile() {
+    runExpectingNoSkip(
+        snippetStartingWith(
+                TestMode.BYTECODE,
+                "Test.java",
+                """
+                package com.uber;
+                class Test {
+                  void f(Dep d) { d.get(); }
+                }
+                """)
+            .addSourceLines(
+                "Dep.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                public class Dep {
+                  public Object get() { return new Object(); }
+                  public void unmarkedError(@Nullable Object o) { o.toString(); }
+                }
+                """));
+  }
+
+  @Test
+  public void bytecodeModeShortensTheDependencySetUntilItCompiles() {
+    // NeedsMarked precedes Standalone, so no prefix of the unmarked files compiles and only
+    // dropping the file javac reported on reaches a split.
+    runExpectingNoSkip(
+        snippetStartingWith(
+                TestMode.BYTECODE,
+                "Marked.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                public class Marked {
+                  @Nullable public Object get() { return null; }
+                  void f() {
+                    // BUG: Diagnostic contains: dereferenced expression
+                    get().toString();
+                  }
+                }
+                """)
+            .addSourceLines(
+                "NeedsMarked.java",
+                """
+                package com.uber;
+                public class NeedsMarked {
+                  void f(Marked m) { m.get(); }
+                }
+                """)
+            .addSourceLines(
+                "Standalone.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                public class Standalone {
+                  public void unmarkedError(@Nullable Object o) { o.toString(); }
+                }
+                """));
+  }
+
+  @Test
+  public void bytecodeModeKeepsTheLargestDependencySetThatCompiles() {
+    // Nothing is marked, so the candidates are {A, B} and {B, C}. A refers to C, so the first
+    // shrinks to {B} while the second compiles whole, and only the second puts C on the classpath.
+    runExpectingNoSkip(
+        snippetStartingWith(
+                TestMode.BYTECODE,
+                "A.java",
+                """
+                package com.uber;
+                class A {
+                  void f(C c) { c.ok(); }
+                }
+                """)
+            .addSourceLines(
+                "B.java",
+                """
+                package com.uber;
+                public class B {
+                  public void ok() {}
+                }
+                """)
+            .addSourceLines(
+                "C.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                public class C {
+                  public void ok() {}
+                  public void unmarkedError(@Nullable Object o) { o.toString(); }
+                }
+                """));
+  }
+
+  @Test
+  public void bytecodeModeSkipsASnippetItCannotSplit() {
+    DualModeCompilationTestHelper helper =
+        DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), TestMode.BYTECODE)
+            .setArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"))
+            .addSourceLines(
+                "Test.java",
+                """
+                package com.uber;
+                import javax.annotation.Nullable;
+                class Test {
+                  void f(@Nullable Object o) {
+                    // BUG: Diagnostic contains: dereferenced expression
+                    o.toString();
+                  }
+                }
+                """);
+    assertThrows(AssumptionViolatedException.class, helper::doTest);
+  }
+}

--- a/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/DualModeCompilationTestHelperTest.java
@@ -22,9 +22,14 @@
 
 package com.uber.nullaway.tools;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.uber.nullaway.NullAway;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
@@ -244,6 +249,67 @@ public class DualModeCompilationTestHelperTest {
                   public void unmarkedError(@Nullable Object o) { o.toString(); }
                 }
                 """));
+  }
+
+  /** The spellings javac accepts for the classpath option, each with the value {@code custom}. */
+  private static final List<List<String>> CLASSPATH_SPELLINGS =
+      List.of(
+          List.of("-classpath", "custom"),
+          List.of("-cp", "custom"),
+          List.of("--class-path", "custom"),
+          List.of("--class-path=custom"));
+
+  /**
+   * Returns the value of the single classpath option in a javac command line.
+   *
+   * @param options the javac arguments
+   * @return the classpath
+   */
+  private static String onlyClasspath(List<String> options) {
+    List<String> values = new ArrayList<>();
+    for (int i = 0; i < options.size(); i++) {
+      String option = options.get(i);
+      if (option.startsWith("--class-path=")) {
+        values.add(option.substring("--class-path=".length()));
+      } else if (List.of("-classpath", "-cp", "--class-path").contains(option)) {
+        values.add(options.get(++i));
+      }
+    }
+    assertEquals("javac takes the last classpath option, so exactly one may be passed", 1, values.size());
+    return values.get(0);
+  }
+
+  @Test
+  public void aDeclaredClasspathReachesBothCompilations() {
+    Path classes = Paths.get("classes");
+    for (List<String> spelling : CLASSPATH_SPELLINGS) {
+      List<String> args = new ArrayList<>(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+      args.addAll(spelling);
+      DualModeCompilationTestHelper helper =
+          DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), TestMode.BYTECODE)
+              .setArgs(args);
+      assertEquals(
+          "sources becoming class files are compiled against what the test declared: " + spelling,
+          "custom",
+          onlyClasspath(helper.javacOptions(classes)));
+      assertEquals(
+          "analyzed sources see the class files ahead of what the test declared: " + spelling,
+          classes + File.pathSeparator + "custom",
+          onlyClasspath(helper.argsWithClasspath(classes)));
+    }
+  }
+
+  @Test
+  public void withoutADeclaredClasspathBothCompilationsUseTheRuntimeClasspath() {
+    Path classes = Paths.get("classes");
+    DualModeCompilationTestHelper helper =
+        DualModeCompilationTestHelper.newInstance(NullAway.class, getClass(), TestMode.BYTECODE)
+            .setArgs(List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber"));
+    String runtimeClasspath = System.getProperty("java.class.path");
+    assertEquals(runtimeClasspath, onlyClasspath(helper.javacOptions(classes)));
+    assertEquals(
+        classes + File.pathSeparator + runtimeClasspath,
+        onlyClasspath(helper.argsWithClasspath(classes)));
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/tools/SkipBytecodeTestMode.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/SkipBytecodeTestMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.tools;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excludes a test method or a whole test class from {@link TestMode#BYTECODE}.
+ *
+ * <p>Two kinds of test earn the annotation. A test that asserts on something other than the
+ * diagnostics of one compilation — output files on disk, or an exception thrown out of {@code
+ * doTest} — has nothing to gain from a second run and can break on the assumption that skips an
+ * unsplittable snippet. A test that documents a known difference between analyzing source and
+ * reading class files states that difference in {@link #value()}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface SkipBytecodeTestMode {
+  /** Why this test runs in {@link TestMode#SOURCE} only. */
+  String value();
+}

--- a/nullaway/src/test/java/com/uber/nullaway/tools/TestMode.java
+++ b/nullaway/src/test/java/com/uber/nullaway/tools/TestMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.nullaway.tools;
+
+/**
+ * Says how {@link DualModeCompilationTestHelper} presents the classes a test snippet depends on.
+ *
+ * <p>NullAway reads nullability information from two places: the source code javac is compiling,
+ * and the class files it loads from the classpath. The two paths disagree whenever an annotation
+ * fails to survive compilation, so running the same snippet both ways turns an ordinary test into a
+ * metamorphic one.
+ */
+public enum TestMode {
+  /** Every source file of the test is compiled in one pass, with NullAway analyzing all of them. */
+  SOURCE,
+  /**
+   * The source files a test snippet depends on are compiled to class files first, and NullAway sees
+   * only the remaining files as source. {@link DualModeCompilationTestHelper} skips a test that
+   * cannot be split this way.
+   */
+  BYTECODE
+}


### PR DESCRIPTION
## Why

NullAway reads nullability from two places: the source javac is compiling, and the class files it loads from the classpath. The two paths disagree whenever an annotation does not survive compilation, and only 8 tests — `BytecodeInteractionsTests` and a handful of JSpecify ones — covered the second one. Every other multi-file snippet in the suite is a source-vs-bytecode test nobody was running.

## What

`NullAwayTestsBase` runs on `Parameterized`, so every test method of every subclass runs once per `TestMode`. `DualModeCompilationTestHelper` records the sources and javac arguments a test declares and replays them: unchanged in source mode, and in bytecode mode with the files that carry no `// BUG: Diagnostic contains:` marker compiled to class files first and handed to NullAway on the classpath. Test bodies do not change; only the type of `defaultCompilationHelper` does.

A file that refers to a marked one does not compile on its own, so the helper drops the files javac reported errors on and retries with the rest. Removing a source can only remove symbols, so a source that fails in one set fails in every subset containing it, and the loop therefore settles on the largest subset that compiles rather than on an arbitrary one. With nothing marked, either end of the snippet may be the file under test, so all but the last file is weighed against all but the first, and the larger result wins. A snippet that splits no way is skipped through a JUnit assumption carrying the reason.

196 tests now exercise the class-file path, up from 8. 756 bytecode entries are skipped, almost all of them single-file snippets, which cannot be split by construction; 3 snippets have no split at all.

`DualModeCompilationTestHelperTest` is the floor under that. A bytecode-mode skip is an assumption, so a break in the class-file path would leave the suite green and empty rather than red. Each of its snippets gives one file a NullAway error with no marker, which fails the run wherever that file is analyzed rather than compiled, and each test converts a skip into a failure.

### Discrepancies the mode found

Four tests are excluded through `@SkipBytecodeTestMode` with the reason: a generated-code marker has `SOURCE` retention, so `TreatGeneratedAsUnannotated` has no effect on a class read from the classpath. That one is not fixable — the information is not in the class file.

`GenericMethodTests.issue1453` is the interesting one and looks like a real defect: inference for a generic method read from a class file rejects a `@Nullable` type argument, on JDK 17 only. It is gated on the JDK rather than switched off, so `testJdk21`, `testJdk26`, `testJdk28` and the default `test` task keep running the bytecode variant and will fail if it regresses there. **This wants a tracking issue whose URL replaces the prose in the assumption message**, matching the `@Ignore("https://github.com/uber/NullAway/issues/1493")` convention four lines below it.

`SerializationTest` and `ErrorProneCLIFlagsConfigTest` opt out at class level: their tests assert on output files and on the error a misconfigured compilation throws, neither of which a second compilation says anything about.

## How to verify

```bash
./gradlew :nullaway:test :nullaway:testJdk21 :nullaway:buildWithNullAway
```

Green. `:nullaway:testJdk17` and `:nullaway:testErrorProneOldest` fail 4 `[SOURCE]` tests — `WildcardTests.issue1671` and three in `BytecodeGenericsTests` — which fail identically on `1924f0d4` without this change, verified in a clean clone.

To see what the mode actually covers rather than what it reports as passing:

```bash
python3 -c "import glob,collections,xml.etree.ElementTree as ET; c=collections.Counter((('BYTECODE' if t.get('name').endswith('[BYTECODE]') else 'SOURCE'), 'skipped' if t.findall('skipped') else 'ran') for f in glob.glob('nullaway/build/test-results/test/*.xml') for t in ET.parse(f).getroot().iter('testcase') if t.get('name').endswith(']')); print(c)"
```

## Cost

The default `test` task grows by roughly 24 seconds, which is the 196 additional compilations. Ineligible tests reach their assumption before compiling anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validation across source-based and compiled-class analysis modes.
  * Added coverage for dependency compilation, classpath handling, diagnostics, and unsupported scenarios.
  * Improved handling of tests that cannot run meaningfully in compiled-class mode.
  * Updated test infrastructure for more reliable dual-mode execution across supported analysis scenarios.
  * Corrected exclusions so related test variants are consistently skipped when required.
  * Increased confidence in nullness analysis results across source and compiled-class inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->