### PR TITLE
Detect support for the addTypeAnnotationsToSymbol flag on JDK 17 / 21

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1905,13 +1905,12 @@ public class NullAway extends BugChecker
     }
     if (!checkedJDKVersionForJSpecifyMode) {
       checkedJDKVersionForJSpecifyMode = true;
-      if (config.isJSpecifyMode()
-          && !JSpecifyJavacConfig.isValidJavacConfigForJSpecifyMode(state)) {
-        String msg =
-            "Running NullAway in JSpecify mode requires either JDK 22+"
-                + " or passing the flag -XDaddTypeAnnotationsToSymbol=true to an older JDK that supports it;"
-                + " see https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions for details.";
-        throw new IllegalStateException(msg);
+      if (config.isJSpecifyMode()) {
+        JSpecifyJavacConfig.JavacConfigValidityResult validity =
+            JSpecifyJavacConfig.isValidJavacConfigForJSpecifyMode(state);
+        if (validity != JSpecifyJavacConfig.JavacConfigValidityResult.VALID) {
+          throw new IllegalStateException(invalidJSpecifyJavacConfigErrorMessage(validity));
+        }
       }
     }
     // Check if the class is excluded according to the filter
@@ -1962,6 +1961,13 @@ public class NullAway extends BugChecker
       checkFieldInitialization(tree, state);
     }
     return Description.NO_MATCH;
+  }
+
+  private String invalidJSpecifyJavacConfigErrorMessage(
+      JSpecifyJavacConfig.JavacConfigValidityResult validity) {
+    return "Running NullAway in JSpecify mode requires either JDK 22+"
+        + " or passing the flag -XDaddTypeAnnotationsToSymbol=true to an older JDK that supports it;"
+        + " see https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions for details.";
   }
 
   // UNBOXING CHECKS

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1980,7 +1980,8 @@ public class NullAway extends BugChecker
               + " The flag -XDaddTypeAnnotationsToSymbol=true was passed, but it is not supported"
               + " by the running JDK (version "
               + Runtime.version()
-              + "). Typically, JDK 17.0.19+ or 21.0.8+ is required for flag support.";
+              + "). Typically, JDK 17.0.19+ or 21.0.8+ is required for flag support (may vary by distribution),"
+              + " and Oracle JDK 17/21 may not support the flag.";
       case VALID ->
           throw new IllegalArgumentException("Cannot create an error message for a valid config");
     };

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1963,11 +1963,27 @@ public class NullAway extends BugChecker
     return Description.NO_MATCH;
   }
 
-  private String invalidJSpecifyJavacConfigErrorMessage(
+  /**
+   * Returns an error message describing why the javac configuration is invalid for JSpecify mode.
+   */
+  static String invalidJSpecifyJavacConfigErrorMessage(
       JSpecifyJavacConfig.JavacConfigValidityResult validity) {
-    return "Running NullAway in JSpecify mode requires either JDK 22+"
-        + " or passing the flag -XDaddTypeAnnotationsToSymbol=true to an older JDK that supports it;"
-        + " see https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions for details.";
+    String requirement =
+        "Running NullAway in JSpecify mode requires either JDK 22+"
+            + " or passing the flag -XDaddTypeAnnotationsToSymbol=true to an older JDK that supports it;"
+            + " see https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions for details.";
+    return switch (validity) {
+      case FLAG_NOT_SET_TO_TRUE ->
+          requirement + " The flag -XDaddTypeAnnotationsToSymbol=true was not passed.";
+      case FLAG_NOT_SUPPORTED_BY_JAVAC ->
+          requirement
+              + " The flag -XDaddTypeAnnotationsToSymbol=true was passed, but it is not supported"
+              + " by the running JDK (version "
+              + Runtime.version()
+              + "). Typically, JDK 17.0.19+ or 21.0.8+ is required for flag support.";
+      case VALID ->
+          throw new IllegalArgumentException("Cannot create an error message for a valid config");
+    };
   }
 
   // UNBOXING CHECKS

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -44,7 +44,8 @@ public final class JSpecifyJavacConfig {
 
   /**
    * Checks that in JSpecify mode, either (1) we are running on JDK 22 or above, or (2) the user has
-   * passed {@code -XDaddTypeAnnotationsToSymbol=true} to javac
+   * passed {@code -XDaddTypeAnnotationsToSymbol=true} to javac _and_ the running javac version
+   * supports that flag
    *
    * @param state the visitor state
    * @return true if the javac configuration is valid for JSpecify mode, false otherwise

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -42,6 +42,15 @@ public final class JSpecifyJavacConfig {
     return Collections.unmodifiableList(result);
   }
 
+  public enum JavacConfigValidityResult {
+    /** valid configuration */
+    VALID,
+    /** {@code -XDaddTypeAnnotationsToSymbol=true} is missing */
+    FLAG_NOT_SET_TO_TRUE,
+    /** JDK 17 or 21 and {@code -XDaddTypeAnnotationsToSymbol} is not supported */
+    FLAG_NOT_SUPPORTED_BY_JAVAC
+  }
+
   /**
    * Checks that in JSpecify mode, either (1) we are running on JDK 22 or above, or (2) the user has
    * passed {@code -XDaddTypeAnnotationsToSymbol=true} to javac _and_ the running javac version
@@ -50,20 +59,22 @@ public final class JSpecifyJavacConfig {
    * @param state the visitor state
    * @return true if the javac configuration is valid for JSpecify mode, false otherwise
    */
-  public static boolean isValidJavacConfigForJSpecifyMode(VisitorState state) {
+  public static JavacConfigValidityResult isValidJavacConfigForJSpecifyMode(VisitorState state) {
     Runtime.Version version = Runtime.version();
     if (version.feature() < 22) {
       Options opts = Options.instance(state.context);
-      if (!opts.isSet(ADD_TYPE_ANNOTATIONS_FLAG_NAME)) {
-        return false;
+      // The flag must be set to true
+      if (!opts.isSet(ADD_TYPE_ANNOTATIONS_FLAG_NAME)
+          || !Boolean.parseBoolean(opts.get(ADD_TYPE_ANNOTATIONS_FLAG_NAME))) {
+        return JavacConfigValidityResult.FLAG_NOT_SET_TO_TRUE;
       }
-      // valid config if the flag is set to true, _and_ we are running on a JDK version that
-      // supports the flag
-      return Boolean.parseBoolean(opts.get(ADD_TYPE_ANNOTATIONS_FLAG_NAME))
-          && javacSupportsAddTypeAnnotationsToSymbol();
+      // we must also be running on a JDK version that supports the flag
+      return javacSupportsAddTypeAnnotationsToSymbol()
+          ? JavacConfigValidityResult.VALID
+          : JavacConfigValidityResult.FLAG_NOT_SUPPORTED_BY_JAVAC;
     } else {
       // JDK 22+ always has type annotations on symbols
-      return true;
+      return JavacConfigValidityResult.VALID;
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -18,7 +18,9 @@ import java.util.List;
 public final class JSpecifyJavacConfig {
 
   public static final String JSPECIFY_MODE_FLAG = "-XepOpt:NullAway:JSpecifyMode=true";
-  public static final String ADD_TYPE_ANNOTATIONS_FLAG = "-XDaddTypeAnnotationsToSymbol=true";
+  public static final String ADD_TYPE_ANNOTATIONS_FLAG_NAME = "addTypeAnnotationsToSymbol";
+  public static final String ADD_TYPE_ANNOTATIONS_FLAG =
+      "-XD" + ADD_TYPE_ANNOTATIONS_FLAG_NAME + "=true";
   public static final String HANDLE_WILDCARD_GENERICS_FLAG =
       "-XepOpt:NullAway:HandleWildcardGenerics=true";
   public static final String JSPECIFY_EXPERIMENTAL = "-XepOpt:NullAway:JSpecifyExperimental=true";
@@ -51,14 +53,31 @@ public final class JSpecifyJavacConfig {
     Runtime.Version version = Runtime.version();
     if (version.feature() < 22) {
       Options opts = Options.instance(state.context);
-      String key = "addTypeAnnotationsToSymbol";
-      if (!opts.isSet(key)) {
+      if (!opts.isSet(ADD_TYPE_ANNOTATIONS_FLAG_NAME)) {
         return false;
       }
-      return Boolean.parseBoolean(opts.get(key));
+      // valid config if the flag is set to true, _and_ we are running on a JDK version that
+      // supports the flag
+      return Boolean.parseBoolean(opts.get(ADD_TYPE_ANNOTATIONS_FLAG_NAME))
+          && javacSupportsAddTypeAnnotationsToSymbol();
     } else {
       // JDK 22+ always has type annotations on symbols
       return true;
+    }
+  }
+
+  /**
+   * Detects whether the {@code -XDaddTypeAnnotationsToSymbol} flag is supported on JDK 17 or 21, by
+   * using reflection to detect the presence of a corresponding field on {@code ClassReader}. This
+   * is fragile, but, the relevant field name in JDKs 17 / 21 is unlikely to change.
+   */
+  static boolean javacSupportsAddTypeAnnotationsToSymbol() {
+    try {
+      Class<?> classReader = Class.forName("com.sun.tools.javac.jvm.ClassReader");
+      var ignored = classReader.getDeclaredField("addTypeAnnotationsToSymbol");
+      return true;
+    } catch (ClassNotFoundException | NoSuchFieldException e) {
+      return false;
     }
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -57,7 +57,8 @@ public final class JSpecifyJavacConfig {
    * supports that flag
    *
    * @param state the visitor state
-   * @return true if the javac configuration is valid for JSpecify mode, false otherwise
+   * @return a {@link JavacConfigValidityResult} indicating whether the config is valid or why it is
+   *     invalid
    */
   public static JavacConfigValidityResult isValidJavacConfigForJSpecifyMode(VisitorState state) {
     Runtime.Version version = Runtime.version();

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -69,7 +69,7 @@ public final class JSpecifyJavacConfig {
         return JavacConfigValidityResult.FLAG_NOT_SET_TO_TRUE;
       }
       // we must also be running on a JDK version that supports the flag
-      return javacSupportsAddTypeAnnotationsToSymbol()
+      return JAVAC_SUPPORTS_TYPE_ANNOTATIONS_ON_SYMBOLS
           ? JavacConfigValidityResult.VALID
           : JavacConfigValidityResult.FLAG_NOT_SUPPORTED_BY_JAVAC;
     } else {
@@ -78,17 +78,24 @@ public final class JSpecifyJavacConfig {
     }
   }
 
+  private static final boolean JAVAC_SUPPORTS_TYPE_ANNOTATIONS_ON_SYMBOLS =
+      Runtime.version().feature() > 21 || javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol();
+
   /**
    * Detects whether the {@code -XDaddTypeAnnotationsToSymbol} flag is supported on JDK 17 or 21, by
    * using reflection to detect the presence of a corresponding field on {@code ClassReader}. This
    * is fragile, but, the relevant field name in JDKs 17 / 21 is unlikely to change.
    */
-  static boolean javacSupportsAddTypeAnnotationsToSymbol() {
+  static boolean javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol() {
     try {
-      Class<?> classReader = Class.forName("com.sun.tools.javac.jvm.ClassReader");
+      Class<?> classReader =
+          Class.forName(
+              "com.sun.tools.javac.jvm.ClassReader",
+              false,
+              JSpecifyJavacConfig.class.getClassLoader());
       var ignored = classReader.getDeclaredField("addTypeAnnotationsToSymbol");
       return true;
-    } catch (ClassNotFoundException | NoSuchFieldException e) {
+    } catch (ReflectiveOperationException | LinkageError | SecurityException e) {
       return false;
     }
   }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/JSpecifyJavacConfig.java
@@ -28,6 +28,9 @@ public final class JSpecifyJavacConfig {
   private static final List<String> JSPECIFY_MODE_ARGS =
       List.of(JSPECIFY_MODE_FLAG, ADD_TYPE_ANNOTATIONS_FLAG, JSPECIFY_EXPERIMENTAL);
 
+  private static final boolean JAVAC_SUPPORTS_TYPE_ANNOTATIONS_ON_SYMBOLS =
+      Runtime.version().feature() > 21 || javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol();
+
   private JSpecifyJavacConfig() {}
 
   /**
@@ -78,9 +81,6 @@ public final class JSpecifyJavacConfig {
       return JavacConfigValidityResult.VALID;
     }
   }
-
-  private static final boolean JAVAC_SUPPORTS_TYPE_ANNOTATIONS_ON_SYMBOLS =
-      Runtime.version().feature() > 21 || javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol();
 
   /**
    * Detects whether the {@code -XDaddTypeAnnotationsToSymbol} flag is supported on JDK 17 or 21, by

--- a/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/ErrorProneCLIFlagsConfigTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneFlags;
+import com.uber.nullaway.generics.JSpecifyJavacConfig.JavacConfigValidityResult;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assume;
@@ -72,7 +73,29 @@ public class ErrorProneCLIFlagsConfigTest extends NullAwayTestsBase {
             .addSourceLines("Stub.java", "package com.uber; class Stub {}");
     AssertionError e = assertThrows(AssertionError.class, () -> compilationTestHelper.doTest());
     assertTrue(
-        e.getMessage().contains("Running NullAway in JSpecify mode requires either JDK 22+"));
+        e.getMessage().contains("The flag -XDaddTypeAnnotationsToSymbol=true was not passed"));
+  }
+
+  @Test
+  public void missingTypeAnnotationSymbolFlagErrorMessage() {
+    String message =
+        NullAway.invalidJSpecifyJavacConfigErrorMessage(
+            JavacConfigValidityResult.FLAG_NOT_SET_TO_TRUE);
+
+    assertTrue(message.contains("The flag -XDaddTypeAnnotationsToSymbol=true was not passed"));
+  }
+
+  @Test
+  public void unsupportedTypeAnnotationSymbolFlagErrorMessage() {
+    String message =
+        NullAway.invalidJSpecifyJavacConfigErrorMessage(
+            JavacConfigValidityResult.FLAG_NOT_SUPPORTED_BY_JAVAC);
+
+    assertTrue(
+        message.contains(
+            "The flag -XDaddTypeAnnotationsToSymbol=true was passed, but it is not supported"));
+    assertTrue(message.contains("running JDK (version " + Runtime.version() + ")"));
+    assertTrue(message.contains("JDK 17.0.19+ or 21.0.8+ is required for flag support"));
   }
 
   @Test

--- a/nullaway/src/test/java/com/uber/nullaway/generics/JSpecifyJavacConfigTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/generics/JSpecifyJavacConfigTest.java
@@ -1,0 +1,156 @@
+package com.uber.nullaway.generics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.source.util.JavacTask;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JSpecifyJavacConfigTest {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /** A library class whose return type carries a type-use annotation inside a generic. */
+  private static final String LIB_SOURCE =
+      """
+      package t;
+      import java.lang.annotation.ElementType;
+      import java.lang.annotation.Retention;
+      import java.lang.annotation.RetentionPolicy;
+      import java.lang.annotation.Target;
+      import java.util.List;
+      public class Lib {
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.TYPE_USE)
+        public @interface Nullable {}
+        public static List<@Nullable String> f() { return List.of(); }
+      }
+      """;
+
+  /** A trivial compilation unit, so that the second javac invocation has something to compile. */
+  private static final String USE_SOURCE =
+      """
+      package u;
+      class Use {}
+      """;
+
+  /**
+   * Checks that NullAway's notion of "javac puts type annotations on symbols" matches what the
+   * running javac does. Vendors number their builds differently, so a version range is not a sound
+   * way to state this expectation: Oracle JDK 21.0.12, for one, lacks the support that 21.0.8
+   * introduced elsewhere.
+   */
+  @Test
+  public void detectionAgreesWithJavacBehavior() throws Exception {
+    // JDK 22+ always puts type annotations on symbols; below that, NullAway probes for the flag
+    boolean expected =
+        Runtime.version().feature() >= 22
+            || JSpecifyJavacConfig.javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol();
+    assertEquals(
+        expected,
+        typeAnnotationSurvivesBytecodeRead(),
+        "NullAway's detection disagrees with javac "
+            + Runtime.version()
+            + ". If ClassReader.addTypeAnnotationsToSymbol was renamed,"
+            + " javacOnJDK17Or21SupportsAddTypeAnnotationsToSymbol reports no support and NullAway"
+            + " rejects JSpecify mode on a JDK that in fact supports it.");
+  }
+
+  /**
+   * Compiles {@link #LIB_SOURCE}, reads the resulting class file back under {@code
+   * -XDaddTypeAnnotationsToSymbol=true}, and reports whether javac kept the type-use annotation on
+   * the symbol's type.
+   *
+   * @return true if the annotation is visible on the type read from bytecode
+   */
+  private boolean typeAnnotationSurvivesBytecodeRead() throws Exception {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    File srcDir = temporaryFolder.newFolder("src");
+    File libClasses = temporaryFolder.newFolder("libClasses");
+    File useClasses = temporaryFolder.newFolder("useClasses");
+    File libSrc = writeSource(srcDir, "Lib.java", LIB_SOURCE);
+    File useSrc = writeSource(srcDir, "Use.java", USE_SOURCE);
+
+    try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+      boolean compiled =
+          compiler
+              .getTask(
+                  null,
+                  fm,
+                  null,
+                  List.of("-d", libClasses.getAbsolutePath(), "-proc:none"),
+                  null,
+                  fm.getJavaFileObjects(libSrc))
+              .call();
+      assertTrue(compiled, "the library class must compile");
+
+      JavacTask task =
+          (JavacTask)
+              compiler.getTask(
+                  null,
+                  fm,
+                  null,
+                  List.of(
+                      "-d",
+                      useClasses.getAbsolutePath(),
+                      "-classpath",
+                      libClasses.getAbsolutePath(),
+                      "-proc:none",
+                      JSpecifyJavacConfig.ADD_TYPE_ANNOTATIONS_FLAG),
+                  null,
+                  fm.getJavaFileObjects(useSrc));
+      task.parse();
+      task.analyze();
+
+      TypeElement lib = task.getElements().getTypeElement("t.Lib");
+      assertNotNull(lib, "t.Lib must be read from bytecode");
+      TypeMirror typeArg =
+          ((DeclaredType) findMethod(lib, "f").getReturnType()).getTypeArguments().get(0);
+      return !typeArg.getAnnotationMirrors().isEmpty();
+    }
+  }
+
+  /**
+   * Writes {@code source} to a file named {@code fileName} under {@code dir}.
+   *
+   * @return the file that was written
+   */
+  private static File writeSource(File dir, String fileName, String source) throws Exception {
+    File file = new File(dir, fileName);
+    Files.write(file.toPath(), source.getBytes(StandardCharsets.UTF_8));
+    return file;
+  }
+
+  /**
+   * Returns the method named {@code name} declared by {@code type}.
+   *
+   * @throws AssertionError if {@code type} declares no such method
+   */
+  private static ExecutableElement findMethod(TypeElement type, String name) {
+    for (Element e : type.getEnclosedElements()) {
+      if (e.getKind() == ElementKind.METHOD && e.getSimpleName().contentEquals(name)) {
+        return (ExecutableElement) e;
+      }
+    }
+    throw new AssertionError("no method " + name + " on " + type);
+  }
+}


### PR DESCRIPTION
This lets us fail fast when JSpecify mode is used on a JDK 17 / 21 version that does not support it, without using point version detection (which may not accurately reflect support for certain distributions).

See #1791 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSpecify mode compatibility checks for the required compiler option on older JDK versions.
  * Prevented unsupported or incorrectly configured compiler options from being accepted.
  * Added clearer configuration errors distinguishing between a missing option and an unsupported JDK.
  * Improved handling when compiler support cannot be detected, providing more reliable behavior across JDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->