### PR TITLE
Write the full encoded byte array when serializing TSV/XML rows #1788

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ more information on `JSpecifyExperimental`.
 * Work around pre-JDK-25 limitations in reading upper bounds from wildcard arguments in bytecode (#1764)
 * Improve diagnostics for non-null type variable bounds (#1770)
 * Fix override checks for method type variables bounded by a class type variable by @pivovarit (#1775)
+* Write the full encoded byte array when serializing TSV/XML rows by @AzazelSensei (#1788)
 * Maintenance
   - Migrate FrameworkTests to `addSourceLines` by @abdeltaehass (#1712)
   - Attribute errors reported during dataflow to the right file by @vlsi (#1734)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ more information on `JSpecifyExperimental`.
 * Work around pre-JDK-25 limitations in reading upper bounds from wildcard arguments in bytecode (#1764)
 * Improve diagnostics for non-null type variable bounds (#1770)
 * Fix override checks for method type variables bounded by a class type variable by @pivovarit (#1775)
-* Write the full encoded byte array when serializing TSV/XML rows by @AzazelSensei (#1788)
 * Maintenance
   - Migrate FrameworkTests to `addSourceLines` by @abdeltaehass (#1712)
   - Attribute errors reported during dataflow to the right file by @vlsi (#1734)

--- a/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
+++ b/nullaway/src/main/java/com/uber/nullaway/fixserialization/Serializer.java
@@ -126,7 +126,7 @@ public class Serializer {
     }
     try (OutputStream os = new FileOutputStream(path.toFile())) {
       header += "\n";
-      os.write(header.getBytes(Charset.defaultCharset()), 0, header.length());
+      os.write(header.getBytes(Charset.defaultCharset()));
       os.flush();
     } catch (IOException e) {
       throw new RuntimeException("Could not finish resetting File at Path: " + path, e);
@@ -184,7 +184,7 @@ public class Serializer {
     }
     row = row + "\n";
     try (OutputStream os = new FileOutputStream(path.toFile(), true)) {
-      os.write(row.getBytes(Charset.defaultCharset()), 0, row.length());
+      os.write(row.getBytes(Charset.defaultCharset()));
       os.flush();
     } catch (IOException e) {
       throw new RuntimeException("Error happened for writing at file: " + path, e);

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -41,11 +41,13 @@ import com.uber.nullaway.tools.SerializationTestHelper;
 import com.uber.nullaway.tools.version1.ErrorDisplayV1;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -2746,6 +2748,43 @@ public class SerializationTest extends NullAwayTestsBase {
         "<nonnull_target>",
         "<target_kind>FIELD</target_kind>",
         "<target_class>com.uber.Foo</target_class>");
+  }
+
+  /**
+   * Serializer writes {@code string.getBytes(charset)} with {@code string.length()} as the byte
+   * count. That drops the trailing newline whenever a record contains a multi-byte character, so
+   * the next record is appended onto the same line.
+   */
+  @Test
+  public void tsvRowsWithMultibyteCharactersKeepTheirTrailingNewline() throws IOException {
+    Assume.assumeTrue("Café".getBytes(Charset.defaultCharset()).length > "Café".length());
+    makeTestHelperWithArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                "-XepOpt:NullAway:SerializeFixMetadata=true",
+                "-XepOpt:NullAway:SerializeFixMetadataVersion=3",
+                "-XepOpt:NullAway:FixSerializationConfigPath=" + configPath))
+        .addSourceLines(
+            "com/uber/Cafe.java",
+            """
+            package com.uber;
+            public class Cafe {
+               Object café() {
+                   // BUG: Diagnostic contains: returning @Nullable
+                   return null;
+               }
+               Object other() {
+                   // BUG: Diagnostic contains: returning @Nullable
+                   return null;
+               }
+            }
+            """)
+        .doTest();
+    List<String> lines =
+        Files.readAllLines(root.resolve(ERROR_FILE_NAME), Charset.defaultCharset());
+    assertEquals(3, lines.size(), "header plus two error rows; a dropped newline merges the rows");
   }
 
   private void assertXmlContains(Path outputDir, String... fragments) {

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -2753,7 +2753,8 @@ public class SerializationTest extends NullAwayTestsBase {
   /**
    * The serializer used to write {@code string.getBytes(charset)} with {@code string.length()} as
    * the byte count. That dropped the trailing newline whenever a record contained a multi-byte
-   * character, so the next record was appended onto the same line.
+   * character, so the next record was appended onto the same line. This test ensures we don't
+   * regress on that behavior.
    */
   @Test
   public void tsvRowsWithMultibyteCharactersKeepTheirTrailingNewline() throws IOException {

--- a/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/SerializationTest.java
@@ -2751,9 +2751,9 @@ public class SerializationTest extends NullAwayTestsBase {
   }
 
   /**
-   * Serializer writes {@code string.getBytes(charset)} with {@code string.length()} as the byte
-   * count. That drops the trailing newline whenever a record contains a multi-byte character, so
-   * the next record is appended onto the same line.
+   * The serializer used to write {@code string.getBytes(charset)} with {@code string.length()} as
+   * the byte count. That dropped the trailing newline whenever a record contained a multi-byte
+   * character, so the next record was appended onto the same line.
    */
   @Test
   public void tsvRowsWithMultibyteCharactersKeepTheirTrailingNewline() throws IOException {


### PR DESCRIPTION
Serializer was passing `String.length()` as the byte count to `OutputStream.write`. That only matches when every character encodes to one byte, so a multi-byte character dropped the trailing newline and the next TSV/XML record landed on the same line.

I switched both write sites to `write(byte[])` so the encoder owns the length. Left the charset as `defaultCharset()` — pinning UTF-8 would be a format change for the Annotator.

Fixes #1788

- [x] A description about what and why you are contributing, even if it's trivial.

- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

- [x] If applicable, unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed TSV error serialization so records containing multi-byte characters are written completely.
  - Preserved trailing newlines and prevented data from being truncated during file output.

- **Tests**
  - Added coverage to verify that serialized TSV records retain their full contents, including trailing newlines, when multi-byte characters are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->