### PR TITLE
Script to remove unnecessary NullAway suppressions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.13'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: scripts/nullaway-suppression-remover/pyproject.toml
       - name: Install suppression remover test dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,26 @@ jobs:
         run: ./gradlew publishToMavenLocal
       - name: Check that Git tree is clean after build and test
         run: ./.buildscript/check_git_clean.sh
+  suppression-remover-regression-tests:
+    name: "Suppression remover regression tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out NullAway sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: scripts/nullaway-suppression-remover/pyproject.toml
+      - name: Install suppression remover test dependencies
+        working-directory: scripts/nullaway-suppression-remover
+        run: python -m pip install --editable '.[test]'
+      - name: Run suppression remover regression tests
+        working-directory: scripts/nullaway-suppression-remover
+        run: python -m pytest
   test-with-error-prone-snapshot:
     name: "Test with Error Prone snapshot"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ tmp/
 
 # TeXlipse plugin
 .texlipse
+
+
+### NullAway suppression remover ###
+
+/scripts/nullaway-suppression-remover/.pytest_cache/
+/scripts/nullaway-suppression-remover/.venv/
+/scripts/nullaway-suppression-remover/**/__pycache__/
+/scripts/nullaway-suppression-remover/src/*.egg-info/

--- a/scripts/nullaway-suppression-remover/README.md
+++ b/scripts/nullaway-suppression-remover/README.md
@@ -13,7 +13,7 @@ not been tested).
 
 ## Prerequisites
 
-- Python 3.9 or newer
+- Python 3.10 or newer
 - A working build for the project being processed
 - For the default build behavior, a Gradle project with either `gradlew` at its
   root or `gradle` on `PATH`

--- a/scripts/nullaway-suppression-remover/README.md
+++ b/scripts/nullaway-suppression-remover/README.md
@@ -1,0 +1,176 @@
+# NullAway suppression remover
+
+`suppression-remover` removes unnecessary checker entries from Java
+`@SuppressWarnings` annotations. It temporarily removes every matching suppression,
+compiles the target module, and restores the suppressions required to make the build
+pass. The remaining source changes are the suppressions that the tool determined were
+unnecessary.  The technique is a heuristic, and is not guaranteed to remove all
+unnecessary suppressions.
+
+Although it was written for NullAway, the tool could be used with another Error
+Prone checker whose diagnostics use the standard `[CheckerName]` format (this has
+not been tested).
+
+## Prerequisites
+
+- Python 3.9 or newer
+- A working build for the project being processed
+- For the default build behavior, a Gradle project with either `gradlew` at its
+  root or `gradle` on `PATH`
+
+Install the command from this directory. Using a virtual environment keeps its
+Python dependencies isolated:
+
+```bash
+cd scripts/nullaway-suppression-remover
+python3 -m venv /tmp/nullaway-suppression-remover-venv
+source /tmp/nullaway-suppression-remover-venv/bin/activate
+python -m pip install -e .
+```
+
+The `suppression-remover` command is then available whenever that virtual
+environment is active.
+
+## Before running it
+
+The tool edits Java source files in place and does not have a dry-run mode. Run it
+from a clean Git worktree so that you can inspect or discard its changes. Also run
+the relevant build once before using the tool; pre-existing build failures can
+prevent it from determining which suppressions are needed.
+
+Avoid interrupting the process while a build is running. The tool normally restores
+files when it cannot produce a passing build, but an external interruption may leave
+the temporary edits in place.
+
+## Usage
+
+From anywhere inside the project to process, run:
+
+```text
+suppression-remover MODULE CHECKER [OPTIONS]
+```
+
+`MODULE` is the module directory relative to the project root, and `CHECKER` is
+the name printed in compiler diagnostics. For example, from the root of this
+repository:
+
+```bash
+suppression-remover nullaway NullAway --alt-suppression NullAway.Init
+```
+
+This scans every `.java` file below `nullaway/src`, treats both `NullAway` and
+`NullAway.Init` as NullAway suppressions, and updates unnecessary annotations.
+
+To process a whole project, including all of its submodules, use `.` for the module
+and provide a build command that compiles everything:
+
+```bash
+suppression-remover . NullAway --build-cmd "./gradlew build --continue"
+```
+
+In this mode, the tool scans for Java files beneath every directory named `src`
+under the project root. It trusts that the supplied build command compiles all of
+those sources and reports checker errors for them. This mode also works for a
+single-module project. A custom build command is required when the module is `.`.
+
+After the command succeeds, inspect the resulting changes and run the project's
+normal test or verification command before committing them.
+
+### Options
+
+`--alt-suppression ALT`
+: Treat `ALT` as another suppression name for the same checker. The option can be
+  repeated, for example:
+
+  ```bash
+  suppression-remover app NullAway \
+    --alt-suppression NullAway.Init \
+    --alt-suppression NullAway.Optional
+  ```
+
+`--project-root DIR`
+: Use `DIR` as the project root. Without this option, the tool walks upward from
+  the current directory and selects the first directory containing one of
+  `settings.gradle`, `settings.gradle.kts`, `build.gradle`, `build.gradle.kts`, or
+  `pom.xml`.
+
+  ```bash
+  suppression-remover subprojects/service NullAway --project-root /path/to/project
+  ```
+
+`--build-cmd CMD`
+: Run `CMD` instead of the generated Gradle command. The command must compile all
+  source sets that should be checked, emit standard Java/Error Prone diagnostics,
+  and exit nonzero when checker errors occur.
+
+  This option is required for Maven and other non-Gradle builds, for processing a
+  whole project with `MODULE` set to `.`, and for unusual Gradle layouts:
+
+  ```bash
+  suppression-remover service NullAway \
+    --build-cmd "mvn -pl service test-compile"
+  ```
+
+  The value is split into arguments using shell-like quoting, but it is not run
+  through a shell. Shell operators such as `&&`, pipes, redirections, and environment
+  assignments are therefore not supported; put complex build logic in a script and
+  pass that script as the command instead.
+
+`--max-iterations N`
+: Set the maximum number of restore-and-verify iterations after the initial build.
+  The default is `5`, and the value must be a positive integer. Increase it for
+  codebases where nested or interacting suppressions require more refinement passes,
+  or when removing suppressions across many modules:
+
+  ```bash
+  suppression-remover . NullAway \
+    --build-cmd "./gradlew build --continue" \
+    --max-iterations 10
+  ```
+
+Use `suppression-remover --help` to display the command-line help.
+
+## Default Gradle build
+
+For a specific non-root module, when `--build-cmd` is omitted, the tool discovers
+source sets containing Java files under `MODULE/src` and runs their compile tasks
+with `--continue`. For a module named `service` with `main` and `test` source sets,
+the generated command is equivalent to:
+
+```bash
+./gradlew :service:compileJava :service:compileTestJava --continue
+```
+
+A custom source set such as `testFixtures` is mapped to
+`compileTestFixturesJava`.
+
+## What gets changed
+
+Only `@SuppressWarnings` annotations containing an exact matching string are
+considered. If the target checker is the only entry, the entire annotation is
+removed. If an annotation also suppresses other checkers, it is rewritten with
+those entries retained. For example:
+
+```java
+@SuppressWarnings({"NullAway", "deprecation"})
+```
+
+becomes:
+
+```java
+@SuppressWarnings("deprecation")
+```
+
+The tool parses Java syntax, so text in comments and string literals is ignored.
+When it removes one value from a multiline annotation, it preserves the annotation's
+multiline layout and indentation. It may normalize a single-line multi-checker
+annotation that it updates.  Trailing comments are removed.
+
+## Running the tool's tests
+
+Install the test dependency and run `pytest` from this directory:
+
+```bash
+python -m pip install -e '.[test]'
+python -m pytest
+```

--- a/scripts/nullaway-suppression-remover/pyproject.toml
+++ b/scripts/nullaway-suppression-remover/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "nullaway-suppression-remover"
 version = "0.1.0"
 description = "Remove unnecessary @SuppressWarnings annotations by iteratively building and restoring."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "tree-sitter>=0.23,<1",
     "tree-sitter-java>=0.23,<1",

--- a/scripts/nullaway-suppression-remover/pyproject.toml
+++ b/scripts/nullaway-suppression-remover/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nullaway-suppression-remover"
+version = "0.1.0"
+description = "Remove unnecessary @SuppressWarnings annotations by iteratively building and restoring."
+requires-python = ">=3.9"
+dependencies = [
+    "tree-sitter>=0.23,<1",
+    "tree-sitter-java>=0.23,<1",
+]
+
+[project.scripts]
+suppression-remover = "suppression_remover.cli:main"
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/scripts/nullaway-suppression-remover/src/suppression_remover/__init__.py
+++ b/scripts/nullaway-suppression-remover/src/suppression_remover/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/scripts/nullaway-suppression-remover/src/suppression_remover/cli.py
+++ b/scripts/nullaway-suppression-remover/src/suppression_remover/cli.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Command-line interface for the suppression remover."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import core
+
+
+def positive_int(value: str) -> int:
+    """Parse a command-line value that must be a positive integer."""
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def parse_args(input_args=None):
+    parser = argparse.ArgumentParser(
+        description="Remove unnecessary @SuppressWarnings annotations for a checker.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Gradle project, targeting the 'caffeine' submodule\n"
+            "  suppression-remover caffeine NullAway --alt-suppression NullAway.Init\n"
+            "\n"
+            "  # Explicit module path and project root\n"
+            "  suppression-remover ./submodule NullAway --project-root /path/to/repo\n"
+            "\n"
+            "  # Custom build command\n"
+            '  suppression-remover . MyChecker --build-cmd "./gradlew build --continue"'
+        ),
+    )
+    parser.add_argument(
+        "module",
+        help=(
+            "Module directory to process (relative to project root). "
+            "Use '.' to process every src tree under the project root; "
+            "this requires --build-cmd."
+        ),
+    )
+    parser.add_argument(
+        "checker",
+        help="Checker name as it appears in build errors (e.g. NullAway)",
+    )
+    parser.add_argument(
+        "--alt-suppression",
+        action="append",
+        default=[],
+        dest="alt_suppressions",
+        metavar="ALT",
+        help=(
+            "Alternate suppression string for the same checker (may be repeated). "
+            "Annotations containing this string are also treated as suppressing "
+            "the checker and will be removed if unnecessary."
+        ),
+    )
+    parser.add_argument(
+        "--project-root",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Project root directory. Auto-detected if not provided "
+            "(walks up from cwd looking for build files)."
+        ),
+    )
+    parser.add_argument(
+        "--build-cmd",
+        default=None,
+        metavar="CMD",
+        help=(
+            "Custom build command. Overrides the default Gradle invocation. "
+            "Must compile the target module (or all modules when MODULE is '.') "
+            "and exit non-zero on errors."
+        ),
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=positive_int,
+        default=core.MAX_ITERATIONS,
+        metavar="N",
+        help=(
+            "Maximum number of restore-and-verify iterations after the initial "
+            f"build (default: {core.MAX_ITERATIONS})."
+        ),
+    )
+    return parser.parse_args(input_args)
+
+
+def main(input_args=None):
+    args = parse_args(input_args)
+
+    if args.project_root:
+        project_root = Path(args.project_root).resolve()
+    else:
+        project_root = core.find_project_root()
+
+    module_dir = (project_root / args.module).resolve()
+    if not module_dir.is_dir():
+        sys.exit(f"Module directory does not exist: {module_dir}")
+
+    build_cmd = None
+    if args.build_cmd:
+        import shlex
+
+        build_cmd = shlex.split(args.build_cmd)
+
+    if module_dir == project_root and build_cmd is None:
+        sys.exit("Processing the project root requires --build-cmd.")
+
+    core.run(
+        module_dir,
+        args.checker,
+        args.alt_suppressions,
+        project_root,
+        build_cmd=build_cmd,
+        max_iterations=args.max_iterations,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nullaway-suppression-remover/src/suppression_remover/cli.py
+++ b/scripts/nullaway-suppression-remover/src/suppression_remover/cli.py
@@ -121,6 +121,8 @@ def main(input_args=None):
     module_dir = (project_root / args.module).resolve()
     if not module_dir.is_dir():
         sys.exit(f"Module directory does not exist: {module_dir}")
+    if module_dir != project_root and project_root not in module_dir.parents:
+        sys.exit(f"Module directory is outside the project root: {module_dir}")
 
     build_cmd = None
     if args.build_cmd:

--- a/scripts/nullaway-suppression-remover/src/suppression_remover/core.py
+++ b/scripts/nullaway-suppression-remover/src/suppression_remover/core.py
@@ -1,0 +1,847 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Core logic for removing unnecessary @SuppressWarnings annotations.
+
+Algorithm
+---------
+1. Discover all Java source files in the target module directory.
+2. Parse every @SuppressWarnings annotation that contains the target checker
+   (or any alternate suppression string). Tree-sitter is used for parsing so
+   occurrences inside string literals, block comments, and line comments are
+   correctly ignored.
+3. Strip the checker from every such annotation (or delete the whole annotation
+   line if it was the only checker). Save a backup of every original file.
+4. Run a build (e.g. ``gradle compileJava``) with ``--continue`` so all
+   previously-hidden errors surface.
+5. Map each error location back to the annotation that was suppressing it, using
+   a line-number mapping that accounts for deleted annotation lines.
+6. Iteratively restore -> remove unneeded -> verify, expanding the "needed" set
+   whenever new errors surface.
+"""
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import tree_sitter as ts
+import tree_sitter_java as tsjava
+
+JAVA_LANGUAGE = ts.Language(tsjava.language())
+
+
+@dataclass
+class Annotation:
+    """A @SuppressWarnings annotation found in a Java source file."""
+
+    start_line: int  # 1-indexed, inclusive
+    end_line: int  # 1-indexed, inclusive
+    original_lines: list  # list[str] — exact source lines (with newlines)
+    checkers: list  # list[str] — checker names in original order
+    needed: bool = field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# Project root detection
+# ---------------------------------------------------------------------------
+
+
+def find_project_root(start: Path | None = None) -> Path:
+    """Walk up from *start* (default: cwd) looking for a Gradle or Maven root."""
+    path = (start or Path.cwd()).resolve()
+    while path != path.parent:
+        if any(
+            (path / f).exists()
+            for f in (
+                "settings.gradle",
+                "settings.gradle.kts",
+                "build.gradle",
+                "build.gradle.kts",
+                "pom.xml",
+            )
+        ):
+            return path
+        path = path.parent
+    raise RuntimeError(
+        "Could not find a Gradle or Maven project root; "
+        "run from inside the project or pass --project-root."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source file discovery
+# ---------------------------------------------------------------------------
+
+
+def get_source_files(
+    module_dir: Path, include_nested_modules: bool = False
+) -> list[Path]:
+    """Return Java sources for one module, or for all modules below it.
+
+    When *include_nested_modules* is true, every directory named ``src`` below
+    *module_dir* is treated as a source root. Otherwise, only the direct
+    ``module_dir/src`` tree is searched.
+    """
+    if include_nested_modules:
+        source_dirs = sorted(
+            path for path in module_dir.rglob("src") if path.is_dir()
+        )
+        return sorted(
+            {
+                java_file
+                for source_dir in source_dirs
+                for java_file in source_dir.rglob("*.java")
+            }
+        )
+
+    src = module_dir / "src"
+    if not src.is_dir():
+        return []
+    return sorted(src.rglob("*.java"))
+
+
+# ---------------------------------------------------------------------------
+# Annotation parsing (tree-sitter based)
+# ---------------------------------------------------------------------------
+
+
+def _make_parser() -> ts.Parser:
+    parser = ts.Parser()
+    parser.language = JAVA_LANGUAGE
+    return parser
+
+
+_parser: ts.Parser | None = None
+
+
+def _get_parser() -> ts.Parser:
+    global _parser
+    if _parser is None:
+        _parser = _make_parser()
+    return _parser
+
+
+def find_suppress_warnings_nodes(root: ts.Node) -> list[ts.Node]:
+    results: list[ts.Node] = []
+    _collect(root, results)
+    return results
+
+
+def _collect(node: ts.Node, results: list[ts.Node]) -> None:
+    if node.type == "annotation":
+        name = node.child_by_field_name("name")
+        if name and name.text == b"SuppressWarnings":
+            results.append(node)
+            return
+    for child in node.children:
+        _collect(child, results)
+
+
+def annotation_checkers(node: ts.Node) -> list[str]:
+    results: list[str] = []
+    _collect_strings(node, results)
+    return results
+
+
+def _collect_strings(node: ts.Node, results: list[str]) -> None:
+    if node.type == "string_literal" and node.text:
+        text = node.text.decode()
+        if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+            results.append(text[1:-1])
+        return
+    for child in node.children:
+        _collect_strings(child, results)
+
+
+def _string_literal_nodes(node: ts.Node) -> list[ts.Node]:
+    """Return the string-literal descendants of *node* in source order."""
+    results: list[ts.Node] = []
+
+    def collect(current: ts.Node) -> None:
+        if current.type == "string_literal":
+            results.append(current)
+            return
+        for child in current.children:
+            collect(child)
+
+    collect(node)
+    return results
+
+
+def _rewrite_single_line_annotation(
+    annotation_line: str, new_value: str, suppression_names: set[str]
+) -> str:
+    """Rewrite one suppression annotation while preserving surrounding text exactly."""
+    source = annotation_line.encode("utf-8")
+    tree = _get_parser().parse(source)
+    for node in find_suppress_warnings_nodes(tree.root_node):
+        if any(checker in suppression_names for checker in annotation_checkers(node)):
+            replacement = f"@SuppressWarnings({new_value})".encode("utf-8")
+            rewritten = (
+                source[: node.start_byte] + replacement + source[node.end_byte :]
+            )
+            return rewritten.decode("utf-8")
+    raise ValueError("Could not reparse @SuppressWarnings annotation")
+
+
+def _rewrite_multiline_annotation(
+    annotation_text: str, suppression_names: set[str]
+) -> tuple[str, set[int]]:
+    """Remove selected suppression strings without flattening a multiline annotation.
+
+    A suppression occupying its own line is removed together with that line. For a
+    suppression sharing a line with another value, the smallest adjacent comma-delimited
+    region is removed. All other annotation text, including braces and indentation, is
+    retained.
+    """
+    source = annotation_text.encode("utf-8")
+    deleted_lines: set[int] = set()
+
+    def include_newly_trailing_whitespace(data: bytes, start: int, end: int) -> int:
+        """Expand an edit to remove whitespace it would newly leave at line end."""
+        if re.match(rb"[ \t]*(?:\r?\n|$)", data[end:]):
+            return len(data[:start].rstrip(b" \t"))
+        return start
+
+    def target_annotation(data: bytes) -> Optional[ts.Node]:
+        """Find the suppression annotation in *data* that still has a target value."""
+        tree = _get_parser().parse(data)
+        for node in find_suppress_warnings_nodes(tree.root_node):
+            if any(
+                literal.text
+                and literal.text.decode()[1:-1] in suppression_names
+                for literal in _string_literal_nodes(node)
+            ):
+                return node
+        return None
+
+    # First remove values that occupy a line by themselves. This produces the natural
+    # formatting for the common one-value-per-line style.
+    annotation = target_annotation(source)
+    if annotation is None:
+        raise ValueError("Could not reparse @SuppressWarnings annotation")
+    literals = _string_literal_nodes(annotation)
+    line_deletions: set[tuple[int, int]] = set()
+    for literal in literals:
+        if not literal.text or literal.text.decode()[1:-1] not in suppression_names:
+            continue
+        line_start = source.rfind(b"\n", 0, literal.start_byte) + 1
+        newline = source.find(b"\n", literal.end_byte)
+        line_end = len(source) if newline == -1 else newline + 1
+        without_literal = (
+            source[line_start : literal.start_byte]
+            + source[literal.end_byte : line_end]
+        )
+        if re.fullmatch(rb"[ \t]*,?[ \t]*(?:\r?\n)?", without_literal):
+            line_deletions.add((line_start, line_end))
+
+    for start, end in sorted(line_deletions, reverse=True):
+        deleted_lines.add(source.count(b"\n", 0, start) + 1)
+        source = source[:start] + source[end:]
+
+    # Handle values that share a line. Work one contiguous target run at a time and
+    # reparse after each edit so byte offsets remain accurate.
+    while True:
+        annotation = target_annotation(source)
+        if annotation is None:
+            break
+        literals = _string_literal_nodes(annotation)
+        is_target = [
+            bool(
+                literal.text
+                and literal.text.decode()[1:-1] in suppression_names
+            )
+            for literal in literals
+        ]
+        try:
+            run_start = is_target.index(True)
+        except ValueError:
+            break
+
+        run_end = run_start
+        while run_end + 1 < len(literals) and is_target[run_end + 1]:
+            run_end += 1
+
+        if run_end + 1 < len(literals):
+            start = literals[run_start].start_byte
+            next_literal = literals[run_end + 1]
+            if literals[run_end].end_point[0] == next_literal.start_point[0]:
+                end = next_literal.start_byte
+            else:
+                separator = source.rfind(
+                    b",", literals[run_end].end_byte, next_literal.start_byte
+                )
+                if separator == -1:
+                    raise ValueError("Missing separator between suppression values")
+                end = separator + 1
+                start = include_newly_trailing_whitespace(source, start, end)
+            source = source[:start] + source[end:]
+        else:
+            previous_literal = literals[run_start - 1]
+            if previous_literal.end_point[0] == literals[run_start].start_point[0]:
+                start = previous_literal.end_byte
+                end = literals[run_end].end_byte
+            else:
+                separator = source.find(
+                    b",", previous_literal.end_byte, literals[run_start].start_byte
+                )
+                if separator == -1:
+                    raise ValueError("Missing separator between suppression values")
+                source = source[:separator] + source[separator + 1 :]
+                start = literals[run_start].start_byte - 1
+                end = literals[run_end].end_byte - 1
+                start = include_newly_trailing_whitespace(source, start, end)
+            source = source[:start] + source[end:]
+
+    return source.decode("utf-8"), deleted_lines
+
+
+def find_annotations(
+    file_path: Path, checker: str, alt_suppressions: list[str] | None = None
+) -> list[Annotation]:
+    """Return all Annotation objects in *file_path* containing *checker* or any alt."""
+    all_suppressions = set([checker] + (alt_suppressions or []))
+    source = file_path.read_bytes()
+    lines = source.decode("utf-8").splitlines(keepends=True)
+
+    annotations: list[Annotation] = []
+    tree = _get_parser().parse(source)
+    for node in find_suppress_warnings_nodes(tree.root_node):
+        checkers = annotation_checkers(node)
+        if any(c in all_suppressions for c in checkers):
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+            annotations.append(
+                Annotation(
+                    start_line=start_line,
+                    end_line=end_line,
+                    original_lines=lines[start_line - 1 : end_line],
+                    checkers=checkers,
+                )
+            )
+    return annotations
+
+
+# ---------------------------------------------------------------------------
+# File modification
+# ---------------------------------------------------------------------------
+
+
+def build_modified_lines_and_deleted(
+    original_lines: list[str],
+    annotations_to_remove: list[Annotation],
+    checker: str,
+    alt_suppressions: list[str] | None = None,
+) -> tuple[list[str], set[int]]:
+    all_suppressions = set([checker] + (alt_suppressions or []))
+    deleted: set[int] = set()
+    new_lines = original_lines.copy()
+
+    # Work from the end of the file so replacing an annotation does not invalidate
+    # the original line indexes of annotations that precede it.
+    for ann in sorted(
+        annotations_to_remove, key=lambda item: item.start_line, reverse=True
+    ):
+        remaining = [c for c in ann.checkers if c not in all_suppressions]
+
+        if not remaining:
+            for ln in range(ann.start_line, ann.end_line + 1):
+                deleted.add(ln)
+            del new_lines[ann.start_line - 1 : ann.end_line]
+        elif ann.start_line != ann.end_line:
+            original_annotation_lines = original_lines[
+                ann.start_line - 1 : ann.end_line
+            ]
+            rewritten, deleted_relative_lines = _rewrite_multiline_annotation(
+                "".join(original_annotation_lines), all_suppressions
+            )
+            rewritten_lines = rewritten.splitlines(keepends=True)
+            removed_line_count = len(original_annotation_lines) - len(rewritten_lines)
+            deleted.update(
+                ann.start_line + relative_line - 1
+                for relative_line in deleted_relative_lines
+            )
+            unaccounted_lines = removed_line_count - len(deleted_relative_lines)
+            if unaccounted_lines > 0:
+                deleted.update(
+                    range(
+                        ann.end_line - unaccounted_lines + 1,
+                        ann.end_line + 1,
+                    )
+                )
+            new_lines[ann.start_line - 1 : ann.end_line] = rewritten_lines
+        else:
+            if len(remaining) == 1:
+                new_value = f'"{remaining[0]}"'
+            else:
+                new_value = "{" + ", ".join(f'"{c}"' for c in remaining) + "}"
+
+            new_lines[ann.start_line - 1] = _rewrite_single_line_annotation(
+                original_lines[ann.start_line - 1], new_value, all_suppressions
+            )
+
+    return new_lines, deleted
+
+
+def apply_removals(
+    file_path: Path,
+    annotations_to_remove: list[Annotation],
+    checker: str,
+    alt_suppressions: list[str] | None = None,
+) -> set[int]:
+    if not annotations_to_remove:
+        return set()
+    original_lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    new_lines, deleted = build_modified_lines_and_deleted(
+        original_lines, annotations_to_remove, checker, alt_suppressions
+    )
+    file_path.write_text("".join(new_lines), encoding="utf-8")
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Build and error parsing
+# ---------------------------------------------------------------------------
+
+
+def _source_set_compile_task(source_set: str) -> str:
+    """Map a Gradle source set directory name to its compile task name."""
+    if source_set == "main":
+        return "compileJava"
+    return f"compile{source_set[0].upper()}{source_set[1:]}Java"
+
+
+def discover_source_sets(module_dir: Path) -> list[str]:
+    """Return source set names under *module_dir*/src/ that contain Java files."""
+    src = module_dir / "src"
+    if not src.is_dir():
+        return ["main"]
+    sets = []
+    for child in sorted(src.iterdir()):
+        if child.is_dir() and any(child.rglob("*.java")):
+            sets.append(child.name)
+    return sets or ["main"]
+
+
+def default_gradle_cmd(module_dir: Path, project_root: Path) -> list[str]:
+    """Build the default Gradle command that compiles all source sets."""
+    module_name = module_dir.relative_to(project_root).as_posix().replace("/", ":")
+    gradlew = project_root / "gradlew"
+    if not gradlew.exists():
+        gradlew = Path("gradle")
+    source_sets = discover_source_sets(module_dir)
+    tasks = [f":{module_name}:{_source_set_compile_task(s)}" for s in source_sets]
+    return [str(gradlew)] + tasks + ["--continue"]
+
+
+def run_build(
+    module_dir: Path,
+    project_root: Path,
+    build_cmd: list[str] | None = None,
+) -> tuple[str, bool]:
+    """
+    Run a build for the target module.
+
+    *build_cmd* overrides the default Gradle invocation.  The default
+    compiles every source set that contains Java files::
+
+        ./gradlew :<module>:compileJava :<module>:compileTestJava ... --continue
+
+    Returns ``(combined_output, success)``.
+    """
+    cmd = build_cmd or default_gradle_cmd(module_dir, project_root)
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+    )
+    return result.stdout + result.stderr, result.returncode == 0
+
+
+def parse_checker_errors(build_output: str, checker: str) -> list[tuple[str, int]]:
+    """
+    Extract deduplicated ``(relative_path, line_number)`` pairs for *checker*.
+
+    Matches lines like::
+
+        some/path/File.java:42: error: [NullAway] ...
+        some/path/File.java:42: warning: [NullAway] ...
+    """
+    pattern = re.compile(
+        r"^(\S+\.java):(\d+):\s+(?:error|warning):\s+\["
+        + re.escape(checker)
+        + r"\]",
+        re.MULTILINE,
+    )
+    seen: set[tuple[str, int]] = set()
+    results: list[tuple[str, int]] = []
+    for m in pattern.finditer(build_output):
+        key = (m.group(1), int(m.group(2)))
+        if key not in seen:
+            seen.add(key)
+            results.append(key)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Line-number mapping
+# ---------------------------------------------------------------------------
+
+
+def build_modified_to_original(total_original_lines: int, deleted: set[int]) -> list[int]:
+    return [ln for ln in range(1, total_original_lines + 1) if ln not in deleted]
+
+
+# ---------------------------------------------------------------------------
+# Annotation lookup
+# ---------------------------------------------------------------------------
+
+
+def find_responsible_annotation(
+    error_modified_line: int,
+    annotations: list[Annotation],
+    modified_to_original: list[int],
+    lookahead: int = 5,
+) -> Optional[Annotation]:
+    if not (1 <= error_modified_line <= len(modified_to_original)):
+        return None
+    original_line = modified_to_original[error_modified_line - 1]
+
+    best: Optional[Annotation] = None
+    best_dist = float("inf")
+    best_is_preceding = False
+
+    for ann in annotations:
+        if ann.start_line <= original_line:
+            dist = original_line - ann.start_line
+            is_preceding = True
+        elif ann.start_line <= original_line + lookahead:
+            dist = ann.start_line - original_line
+            is_preceding = False
+        else:
+            continue
+
+        if dist < best_dist or (
+            dist == best_dist and is_preceding and not best_is_preceding
+        ):
+            best = ann
+            best_dist = dist
+            best_is_preceding = is_preceding
+
+    return best
+
+
+def mark_all_needed(annotations: list[Annotation]) -> int:
+    newly_marked = 0
+    for ann in annotations:
+        if not ann.needed:
+            ann.needed = True
+            newly_marked += 1
+    return newly_marked
+
+
+def find_outer_annotation(
+    inner_start: int, annotations: list[Annotation]
+) -> Optional[Annotation]:
+    outer: Optional[Annotation] = None
+    for ann in annotations:
+        if ann.start_line < inner_start:
+            if outer is None or ann.start_line > outer.start_line:
+                outer = ann
+    return outer
+
+
+# ---------------------------------------------------------------------------
+# Path resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_error_path(
+    err_rel_path: str, project_root: Path, module_dir: Path
+) -> Path | None:
+    """Try to resolve an error path from build output to an absolute path.
+
+    Gradle error paths may be absolute or relative to the project root, or
+    relative to the module directory.  We try several strategies.
+    """
+    p = Path(err_rel_path)
+    if p.is_absolute() and p.exists():
+        return p
+
+    candidate = project_root / p
+    if candidate.exists():
+        return candidate
+
+    candidate = module_dir / p
+    if candidate.exists():
+        return candidate
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+MAX_ITERATIONS = 5
+
+
+def run(
+    module_dir: Path,
+    checker: str,
+    alt_suppressions: list[str],
+    project_root: Path,
+    build_cmd: list[str] | None = None,
+    max_iterations: int | None = None,
+) -> None:
+    """
+    Discover, strip, build, and iteratively restore needed @SuppressWarnings
+    annotations for *checker*. When *module_dir* is the project root, process
+    source trees for all modules below it.
+    """
+    iteration_limit = max_iterations if max_iterations is not None else MAX_ITERATIONS
+    if iteration_limit < 1:
+        raise ValueError("max_iterations must be a positive integer")
+    print(f"Module : {module_dir.relative_to(project_root)}")
+    print(f"Checker: {checker}")
+    if alt_suppressions:
+        print(f"Alt suppressions: {', '.join(alt_suppressions)}")
+    print()
+
+    def _print_success(removed_count: int, kept_count: int) -> None:
+        print(
+            f"\nSuccess! Removed {removed_count} unnecessary "
+            f"@SuppressWarnings annotation(s) for {checker!r}"
+            + (
+                f" (including alternates: {', '.join(alt_suppressions)})"
+                if alt_suppressions
+                else ""
+            )
+            + f", kept {kept_count}."
+        )
+
+    def _do_build(label: str) -> tuple[str, bool]:
+        print(f"\nBuilding ({label}) ...")
+        return run_build(module_dir, project_root, build_cmd)
+
+    def _restore_all_and_confirm(remaining_errors: list[tuple[str, int]]) -> None:
+        for err_rel_path, _ in remaining_errors:
+            resolved = resolve_error_path(err_rel_path, project_root, module_dir)
+            if resolved is not None:
+                anns = annotations_by_file.get(resolved)
+                if anns:
+                    mark_all_needed(anns)
+
+        for path, orig_bytes in originals.items():
+            path.write_bytes(orig_bytes)
+
+        removed_count = 0
+        for path, anns in annotations_by_file.items():
+            unneeded = [a for a in anns if not a.needed]
+            if not unneeded:
+                continue
+            removed_count += len(unneeded)
+            apply_removals(path, unneeded, checker, alt_suppressions)
+
+        _final_output, final_ok = _do_build("final confirmation")
+
+        if final_ok:
+            _print_success(removed_count, total - removed_count)
+            return
+
+        print(
+            "  Build still fails after restoring all suppression(s) in the "
+            "affected file(s) — giving up."
+        )
+        for path, orig_bytes in originals.items():
+            path.write_bytes(orig_bytes)
+        sys.exit(1)
+
+    # Step 1: Discover source files.
+    print("Discovering source files ...")
+    source_files = get_source_files(
+        module_dir, include_nested_modules=module_dir == project_root
+    )
+    print(f"  {len(source_files)} Java source files")
+
+    # Step 2: Locate all @SuppressWarnings(checker) annotations.
+    all_suppression_names = [checker] + alt_suppressions
+    print(
+        f"Scanning for @SuppressWarnings containing: "
+        f"{', '.join(repr(s) for s in all_suppression_names)} ..."
+    )
+    annotations_by_file: dict[Path, list[Annotation]] = {}
+    for path in source_files:
+        anns = find_annotations(path, checker, alt_suppressions)
+        if anns:
+            annotations_by_file[path] = anns
+
+    total = sum(len(v) for v in annotations_by_file.values())
+    print(f"  Found {total} annotation(s) across {len(annotations_by_file)} file(s)")
+    if total == 0:
+        print("Nothing to do.")
+        return
+
+    # Step 3: Save originals; strip checker from ALL annotations (pass 1).
+    print(f"\nPass 1 — removing all suppression(s) for {checker!r} ...")
+    originals: dict[Path, bytes] = {p: p.read_bytes() for p in annotations_by_file}
+    original_line_counts: dict[Path, int] = {
+        p: len(p.read_text(encoding="utf-8").splitlines()) for p in annotations_by_file
+    }
+    deleted_by_file: dict[Path, set[int]] = {}
+
+    for path, anns in annotations_by_file.items():
+        deleted_by_file[path] = apply_removals(path, anns, checker, alt_suppressions)
+        print(
+            f"  {path.relative_to(project_root)}  ({len(anns)} annotation(s) removed)"
+        )
+
+    # Step 4: Build with all suppressions gone.
+    build_output, build_ok = _do_build("pass 1")
+
+    if build_ok:
+        print(f"  Build passed — all {total} annotation(s) were unnecessary!")
+        return
+
+    # Step 5: Map each error back to the responsible annotation.
+    errors = parse_checker_errors(build_output, checker)
+    print(f"  {len(errors)} unique {checker} error location(s) surfaced")
+
+    unmapped = 0
+    for err_rel_path, err_modified_line in errors:
+        err_path = resolve_error_path(err_rel_path, project_root, module_dir)
+        if err_path is None or err_path not in annotations_by_file:
+            unmapped += 1
+            continue
+
+        anns = annotations_by_file[err_path]
+        mapping = build_modified_to_original(
+            original_line_counts[err_path], deleted_by_file[err_path]
+        )
+        responsible = find_responsible_annotation(err_modified_line, anns, mapping)
+        if responsible is not None:
+            responsible.needed = True
+        else:
+            unmapped += 1
+            mark_all_needed(anns)
+            print(
+                f"  Warning: {err_path.relative_to(project_root)}:{err_modified_line} "
+                "could not be mapped to an annotation — restoring all suppression(s) "
+                "in this file"
+            )
+
+    needed = sum(1 for anns in annotations_by_file.values() for a in anns if a.needed)
+    if unmapped:
+        print(f"  Warning: {unmapped} error(s) could not be mapped to an annotation")
+    print(f"  {needed} annotation(s) needed, {total - needed} unnecessary")
+
+    # Steps 6+: Iteratively restore -> remove unneeded -> verify.
+    for iteration in range(iteration_limit):
+        label = f"Pass {iteration + 2}"
+        print(f"\n{label} — applying current needed set ...")
+
+        for path, orig_bytes in originals.items():
+            path.write_bytes(orig_bytes)
+
+        removed_count = 0
+        deleted_iter: dict[Path, set[int]] = {}
+
+        for path, anns in annotations_by_file.items():
+            unneeded = [a for a in anns if not a.needed]
+            if not unneeded:
+                continue
+            removed_count += len(unneeded)
+            deleted_iter[path] = apply_removals(
+                path, unneeded, checker, alt_suppressions
+            )
+            kept = len(anns) - len(unneeded)
+            print(
+                f"  {path.relative_to(project_root)}  "
+                f"({len(unneeded)} removed, {kept} kept)"
+            )
+
+        needed_count = total - removed_count
+        verify_output, verify_ok = _do_build(label)
+
+        if verify_ok:
+            _print_success(removed_count, needed_count)
+            return
+
+        remaining = parse_checker_errors(verify_output, checker)
+        print(
+            f"  {len(remaining)} {checker} error(s) remain — expanding needed set ..."
+        )
+
+        new_needed = 0
+        for err_rel_path, err_line in remaining:
+            err_path = resolve_error_path(err_rel_path, project_root, module_dir)
+            if err_path is None or err_path not in annotations_by_file:
+                continue
+
+            anns = annotations_by_file[err_path]
+            deleted = deleted_iter.get(err_path, set())
+            mapping = build_modified_to_original(
+                original_line_counts[err_path], deleted
+            )
+
+            responsible = find_responsible_annotation(err_line, anns, mapping)
+            if responsible is None:
+                marked = mark_all_needed(anns)
+                if marked:
+                    new_needed += marked
+                    print(
+                        f"  Warning: {err_path.relative_to(project_root)}:{err_line} "
+                        "could not be mapped to an annotation — restoring all "
+                        "suppression(s) in this file"
+                    )
+                continue
+
+            if not responsible.needed:
+                responsible.needed = True
+                new_needed += 1
+            else:
+                candidate = find_outer_annotation(responsible.start_line, anns)
+                while candidate is not None and candidate.needed:
+                    candidate = find_outer_annotation(candidate.start_line, anns)
+                if candidate is not None:
+                    candidate.needed = True
+                    new_needed += 1
+
+        if new_needed == 0:
+            print(
+                "  No new annotations identified — restoring all suppression(s) "
+                "in file(s) that still have errors ..."
+            )
+            _restore_all_and_confirm(remaining)
+            return
+
+        print(f"  Marked {new_needed} more annotation(s) as needed.")
+
+    print(
+        "Max iterations reached — restoring all suppression(s) in file(s) that "
+        "still have errors ..."
+    )
+    _restore_all_and_confirm(remaining)

--- a/scripts/nullaway-suppression-remover/src/suppression_remover/core.py
+++ b/scripts/nullaway-suppression-remover/src/suppression_remover/core.py
@@ -477,6 +477,7 @@ def run_build(
         capture_output=True,
         text=True,
         cwd=str(project_root),
+        check=False,
     )
     return result.stdout + result.stderr, result.returncode == 0
 
@@ -491,7 +492,7 @@ def parse_checker_errors(build_output: str, checker: str) -> list[tuple[str, int
         some/path/File.java:42: warning: [NullAway] ...
     """
     pattern = re.compile(
-        r"^(\S+\.java):(\d+):\s+(?:error|warning):\s+\["
+        r"^[ \t>]*(.+?\.java):(\d+):\s+(?:error|warning):\s+\["
         + re.escape(checker)
         + r"\]",
         re.MULTILINE,

--- a/scripts/nullaway-suppression-remover/tests/__init__.py
+++ b/scripts/nullaway-suppression-remover/tests/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/scripts/nullaway-suppression-remover/tests/test_annotation_parsing.py
+++ b/scripts/nullaway-suppression-remover/tests/test_annotation_parsing.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from suppression_remover.core import Annotation, find_annotations
+
+
+def _java_file(content: str) -> Path:
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".java", delete=False, encoding="utf-8"
+    )
+    f.write(content)
+    f.flush()
+    f.close()
+    return Path(f.name)
+
+
+class TestFindAnnotationsSingleChecker(TestCase):
+    def test_basic_single_checker(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(path, "NullAway")
+            self.assertEqual(len(anns), 1)
+            self.assertEqual(anns[0].checkers, ["NullAway"])
+            self.assertEqual(anns[0].start_line, 2)
+            self.assertEqual(anns[0].end_line, 2)
+            self.assertFalse(anns[0].needed)
+        finally:
+            path.unlink()
+
+    def test_multiple_annotations_in_file(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(path, "NullAway")
+            self.assertEqual(len(anns), 2)
+            self.assertEqual(anns[0].start_line, 2)
+            self.assertEqual(anns[1].start_line, 4)
+        finally:
+            path.unlink()
+
+    def test_different_checker_not_matched(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings("unchecked")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+    def test_no_annotations(self):
+        path = _java_file("class Foo {}\n")
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+
+class TestFindAnnotationsMultipleCheckers(TestCase):
+    def test_multi_checker_annotation_matched(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings({"NullAway", "unchecked"})\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(path, "NullAway")
+            self.assertEqual(len(anns), 1)
+            self.assertIn("NullAway", anns[0].checkers)
+            self.assertIn("unchecked", anns[0].checkers)
+        finally:
+            path.unlink()
+
+    def test_multi_checker_annotation_not_matched(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings({"deprecation", "unchecked"})\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+
+class TestFindAnnotationsAltSuppression(TestCase):
+    def test_alt_suppression_matched(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway.Init")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(
+                path, "NullAway", alt_suppressions=["NullAway.Init"]
+            )
+            self.assertEqual(len(anns), 1)
+            self.assertEqual(anns[0].checkers, ["NullAway.Init"])
+        finally:
+            path.unlink()
+
+    def test_alt_suppression_not_matched_without_flag(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway.Init")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+
+class TestFindAnnotationsMultiline(TestCase):
+    def test_multiline_annotation(self):
+        path = _java_file(
+            "class Foo {\n"
+            "    @SuppressWarnings({\n"
+            '        "NullAway",\n'
+            '        "unchecked"\n'
+            "    })\n"
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(path, "NullAway")
+            self.assertEqual(len(anns), 1)
+            self.assertEqual(anns[0].start_line, 2)
+            self.assertEqual(anns[0].end_line, 5)
+            self.assertIn("NullAway", anns[0].checkers)
+            self.assertIn("unchecked", anns[0].checkers)
+        finally:
+            path.unlink()
+
+
+class TestFindAnnotationsIgnoresFalsePositives(TestCase):
+    def test_ignores_string_literal(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    String msg = "@SuppressWarnings(\\"NullAway\\")";\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+    def test_ignores_line_comment(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    // @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+    def test_ignores_block_comment(self):
+        path = _java_file(
+            "class Foo {\n"
+            "    /*\n"
+            '     * @SuppressWarnings("NullAway")\n'
+            "     */\n"
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+    def test_ignores_javadoc_comment(self):
+        path = _java_file(
+            "class Foo {\n"
+            "    /**\n"
+            '     * Use {@code @SuppressWarnings("NullAway")} to suppress.\n'
+            "     */\n"
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            self.assertEqual(find_annotations(path, "NullAway"), [])
+        finally:
+            path.unlink()
+
+    def test_real_annotation_present_alongside_comment(self):
+        path = _java_file(
+            "class Foo {\n"
+            '    // @SuppressWarnings("NullAway") -- commented out\n'
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        try:
+            anns = find_annotations(path, "NullAway")
+            self.assertEqual(len(anns), 1)
+            self.assertEqual(anns[0].start_line, 3)
+        finally:
+            path.unlink()

--- a/scripts/nullaway-suppression-remover/tests/test_apply_removals.py
+++ b/scripts/nullaway-suppression-remover/tests/test_apply_removals.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from suppression_remover.core import Annotation, apply_removals
+
+
+def _java_file(content: str) -> Path:
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".java", delete=False, encoding="utf-8"
+    )
+    f.write(content)
+    f.flush()
+    f.close()
+    return Path(f.name)
+
+
+def _ann(start, end, checkers, lines_text):
+    return Annotation(
+        start_line=start,
+        end_line=end,
+        original_lines=lines_text.splitlines(keepends=True),
+        checkers=checkers,
+    )
+
+
+class TestApplyRemovals(TestCase):
+    def test_empty_annotations_returns_empty_set_and_file_unchanged(self):
+        content = '    @SuppressWarnings("NullAway")\n    public void foo() {}\n'
+        path = _java_file(content)
+        try:
+            deleted = apply_removals(path, [], "NullAway")
+            self.assertEqual(deleted, set())
+            self.assertEqual(path.read_text(encoding="utf-8"), content)
+        finally:
+            path.unlink()
+
+    def test_sole_checker_deletes_line(self):
+        content = '    @SuppressWarnings("NullAway")\n    public void foo() {}\n'
+        path = _java_file(content)
+        lines = content.splitlines(keepends=True)
+        ann = _ann(1, 1, ["NullAway"], lines[0])
+        try:
+            deleted = apply_removals(path, [ann], "NullAway")
+            self.assertEqual(deleted, {1})
+            self.assertEqual(
+                path.read_text(encoding="utf-8"), "    public void foo() {}\n"
+            )
+        finally:
+            path.unlink()
+
+    def test_multi_checker_replaces_line_strips_target(self):
+        content = '    @SuppressWarnings({"NullAway", "unchecked"})\n    public void foo() {}\n'
+        path = _java_file(content)
+        lines = content.splitlines(keepends=True)
+        ann = _ann(1, 1, ["NullAway", "unchecked"], lines[0])
+        try:
+            deleted = apply_removals(path, [ann], "NullAway")
+            self.assertEqual(deleted, set())
+            result = path.read_text(encoding="utf-8")
+            self.assertIn('@SuppressWarnings("unchecked")', result)
+            self.assertNotIn('"NullAway"', result)
+        finally:
+            path.unlink()

--- a/scripts/nullaway-suppression-remover/tests/test_build_error_parsing.py
+++ b/scripts/nullaway-suppression-remover/tests/test_build_error_parsing.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from unittest import TestCase
+
+from suppression_remover.core import parse_checker_errors
+
+
+class TestParseCheckerErrors(TestCase):
+    def _output(self, *lines):
+        return "\n".join(lines)
+
+    def test_single_error(self):
+        output = self._output(
+            "src/main/java/com/example/Foo.java:42: error: [NullAway] message here"
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [("src/main/java/com/example/Foo.java", 42)])
+
+    def test_single_warning(self):
+        output = self._output(
+            "src/main/java/com/example/Foo.java:10: warning: [NullAway] message"
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [("src/main/java/com/example/Foo.java", 10)])
+
+    def test_multiple_files(self):
+        output = self._output(
+            "com/Foo.java:1: error: [NullAway] msg",
+            "com/Bar.java:2: error: [NullAway] msg",
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(len(errors), 2)
+        self.assertIn(("com/Foo.java", 1), errors)
+        self.assertIn(("com/Bar.java", 2), errors)
+
+    def test_deduplication(self):
+        output = self._output(
+            "com/Foo.java:5: error: [NullAway] first",
+            "com/Foo.java:5: error: [NullAway] second",
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [("com/Foo.java", 5)])
+
+    def test_different_checker_not_matched(self):
+        output = self._output(
+            "com/Foo.java:1: error: [unchecked] msg",
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [])
+
+    def test_no_errors(self):
+        output = "Build successful."
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [])
+
+    def test_checker_with_special_regex_chars(self):
+        output = self._output(
+            "com/Foo.java:7: error: [NullAway.Init] msg",
+        )
+        errors = parse_checker_errors(output, "NullAway.Init")
+        self.assertEqual(errors, [("com/Foo.java", 7)])
+
+    def test_does_not_match_partial_checker_name(self):
+        output = self._output(
+            "com/Foo.java:1: error: [NullAwayExtra] msg",
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [])
+
+    def test_preserves_order(self):
+        output = self._output(
+            "com/Foo.java:30: error: [NullAway] msg",
+            "com/Foo.java:10: error: [NullAway] msg",
+            "com/Bar.java:5: error: [NullAway] msg",
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(
+            errors,
+            [("com/Foo.java", 30), ("com/Foo.java", 10), ("com/Bar.java", 5)],
+        )

--- a/scripts/nullaway-suppression-remover/tests/test_build_error_parsing.py
+++ b/scripts/nullaway-suppression-remover/tests/test_build_error_parsing.py
@@ -41,6 +41,23 @@ class TestParseCheckerErrors(TestCase):
         errors = parse_checker_errors(output, "NullAway")
         self.assertEqual(errors, [("src/main/java/com/example/Foo.java", 10)])
 
+    def test_indented_diagnostic(self):
+        output = self._output(
+            "  > src/main/java/com/example/Foo.java:10: error: [NullAway] message"
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(errors, [("src/main/java/com/example/Foo.java", 10)])
+
+    def test_path_containing_spaces(self):
+        output = self._output(
+            "module with spaces/src/main/java/Foo.java:12: error: [NullAway] message"
+        )
+        errors = parse_checker_errors(output, "NullAway")
+        self.assertEqual(
+            errors,
+            [("module with spaces/src/main/java/Foo.java", 12)],
+        )
+
     def test_multiple_files(self):
         output = self._output(
             "com/Foo.java:1: error: [NullAway] msg",

--- a/scripts/nullaway-suppression-remover/tests/test_cli.py
+++ b/scripts/nullaway-suppression-remover/tests/test_cli.py
@@ -95,6 +95,29 @@ class TestParseArgs(TestCase):
 
 
 class TestMain(TestCase):
+    def test_rejects_module_outside_project_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            parent = Path(tmpdir).resolve()
+            root = parent / "project"
+            outside = parent / "outside"
+            root.mkdir()
+            outside.mkdir()
+
+            for module in ("../outside", str(outside)):
+                with self.subTest(module=module):
+                    with (
+                        patch(
+                            "suppression_remover.cli.core.find_project_root",
+                            return_value=root,
+                        ),
+                        patch("suppression_remover.cli.core.run") as mock_run,
+                    ):
+                        with self.assertRaisesRegex(
+                            SystemExit, "outside the project root"
+                        ):
+                            main([module, "NullAway"])
+                        mock_run.assert_not_called()
+
     def test_project_root_requires_custom_build_command(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir).resolve()

--- a/scripts/nullaway-suppression-remover/tests/test_cli.py
+++ b/scripts/nullaway-suppression-remover/tests/test_cli.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from suppression_remover.cli import main, parse_args
+
+
+class TestParseArgs(TestCase):
+    def test_positional_args_parsed(self):
+        args = parse_args(["mymodule", "NullAway"])
+        self.assertEqual(args.module, "mymodule")
+        self.assertEqual(args.checker, "NullAway")
+        self.assertEqual(args.alt_suppressions, [])
+
+    def test_alt_suppression_single(self):
+        args = parse_args(
+            ["mymodule", "NullAway", "--alt-suppression", "NullAway.Init"]
+        )
+        self.assertEqual(args.alt_suppressions, ["NullAway.Init"])
+
+    def test_alt_suppression_multiple(self):
+        args = parse_args(
+            [
+                "mymodule",
+                "NullAway",
+                "--alt-suppression",
+                "NullAway.Init",
+                "--alt-suppression",
+                "NullAway.Other",
+            ]
+        )
+        self.assertEqual(args.alt_suppressions, ["NullAway.Init", "NullAway.Other"])
+
+    def test_missing_checker_raises(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["mymodule"])
+
+    def test_missing_all_args_raises(self):
+        with self.assertRaises(SystemExit):
+            parse_args([])
+
+    def test_project_root_default_is_none(self):
+        args = parse_args(["mymodule", "NullAway"])
+        self.assertIsNone(args.project_root)
+
+    def test_project_root_parsed(self):
+        args = parse_args(["mymodule", "NullAway", "--project-root", "/tmp/proj"])
+        self.assertEqual(args.project_root, "/tmp/proj")
+
+    def test_build_cmd_default_is_none(self):
+        args = parse_args(["mymodule", "NullAway"])
+        self.assertIsNone(args.build_cmd)
+
+    def test_build_cmd_parsed(self):
+        args = parse_args(["mymodule", "NullAway", "--build-cmd", "make compile"])
+        self.assertEqual(args.build_cmd, "make compile")
+
+    def test_max_iterations_defaults_to_core_default(self):
+        args = parse_args(["mymodule", "NullAway"])
+        self.assertEqual(args.max_iterations, 5)
+
+    def test_max_iterations_parsed(self):
+        args = parse_args(["mymodule", "NullAway", "--max-iterations", "12"])
+        self.assertEqual(args.max_iterations, 12)
+
+    def test_max_iterations_must_be_positive(self):
+        for value in ("0", "-1", "invalid"):
+            with self.subTest(value=value), self.assertRaises(SystemExit):
+                parse_args(["mymodule", "NullAway", "--max-iterations", value])
+
+    def test_dot_module_for_project_root(self):
+        args = parse_args([".", "NullAway"])
+        self.assertEqual(args.module, ".")
+
+
+class TestMain(TestCase):
+    def test_project_root_requires_custom_build_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir).resolve()
+            with patch(
+                "suppression_remover.cli.core.find_project_root", return_value=root
+            ):
+                with self.assertRaisesRegex(
+                    SystemExit, "project root requires --build-cmd"
+                ):
+                    main([".", "NullAway"])
+
+    def test_project_root_accepts_custom_build_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir).resolve()
+            with (
+                patch(
+                    "suppression_remover.cli.core.find_project_root", return_value=root
+                ),
+                patch("suppression_remover.cli.core.run") as mock_run,
+            ):
+                main([".", "NullAway", "--build-cmd", "./gradlew build --continue"])
+
+            mock_run.assert_called_once_with(
+                root,
+                "NullAway",
+                [],
+                root,
+                build_cmd=["./gradlew", "build", "--continue"],
+                max_iterations=5,
+            )

--- a/scripts/nullaway-suppression-remover/tests/test_file_modification.py
+++ b/scripts/nullaway-suppression-remover/tests/test_file_modification.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from unittest import TestCase
+
+from suppression_remover.core import Annotation, build_modified_lines_and_deleted
+
+
+def _lines(text):
+    return text.splitlines(keepends=True)
+
+
+def _ann(start, end, checkers, lines_text):
+    raw = lines_text.splitlines(keepends=True)
+    return Annotation(
+        start_line=start,
+        end_line=end,
+        original_lines=raw,
+        checkers=checkers,
+    )
+
+
+class TestBuildModifiedLinesAndDeleted(TestCase):
+    def test_sole_checker_deletes_line(self):
+        src = '    @SuppressWarnings("NullAway")\n    public void foo() {}\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway"], lines[0])
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, {1})
+        self.assertEqual(new_lines, ["    public void foo() {}\n"])
+
+    def test_multiple_checkers_keeps_others(self):
+        src = '    @SuppressWarnings({"NullAway", "unchecked"})\n    public void foo() {}\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway", "unchecked"], lines[0])
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, set())
+        self.assertIn('@SuppressWarnings("unchecked")', new_lines[0])
+        self.assertEqual(new_lines[1], "    public void foo() {}\n")
+
+    def test_multiple_checkers_preserves_indentation(self):
+        src = '        @SuppressWarnings({"NullAway", "unchecked"})\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway", "unchecked"], lines[0])
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertTrue(new_lines[0].startswith("        "))
+
+    def test_multiple_checkers_preserves_exact_leading_and_trailing_whitespace(self):
+        src = '\t  @SuppressWarnings({"NullAway", "removal"})  \r\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway", "removal"], lines[0])
+
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+
+        self.assertEqual(deleted, set())
+        self.assertEqual(new_lines, ['\t  @SuppressWarnings("removal")  \r\n'])
+
+    def test_three_checkers_keeps_two(self):
+        src = '    @SuppressWarnings({"NullAway", "unchecked", "deprecation"})\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway", "unchecked", "deprecation"], lines[0])
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertIn('"unchecked"', new_lines[0])
+        self.assertIn('"deprecation"', new_lines[0])
+        self.assertNotIn('"NullAway"', new_lines[0])
+
+    def test_alt_suppression_removed(self):
+        src = '    @SuppressWarnings("NullAway.Init")\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["NullAway.Init"], lines[0])
+        new_lines, deleted = build_modified_lines_and_deleted(
+            lines, [ann], "NullAway", alt_suppressions=["NullAway.Init"]
+        )
+        self.assertEqual(deleted, {1})
+        self.assertEqual(new_lines, [])
+
+    def test_multiline_annotation_deleted(self):
+        src = (
+            "    @SuppressWarnings({\n"
+            '        "NullAway"\n'
+            "    })\n"
+            "    public void foo() {}\n"
+        )
+        lines = _lines(src)
+        ann = _ann(1, 3, ["NullAway"], "".join(lines[:3]))
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, {1, 2, 3})
+        self.assertEqual(new_lines, ["    public void foo() {}\n"])
+
+    def test_multiline_annotation_preserves_layout_when_partial(self):
+        src = (
+            "    @SuppressWarnings({\n"
+            '        "NullAway",\n'
+            '        "unchecked"\n'
+            "    })\n"
+        )
+        lines = _lines(src)
+        ann = _ann(1, 4, ["NullAway", "unchecked"], "".join(lines))
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, {2})
+        self.assertEqual(
+            new_lines,
+            _lines(
+                "    @SuppressWarnings({\n"
+                '        "unchecked"\n'
+                "    })\n"
+            ),
+        )
+
+    def test_multiline_annotation_preserves_layout_when_removing_last(self):
+        src = (
+            "    @SuppressWarnings({\n"
+            '        "unchecked",\n'
+            '        "NullAway"\n'
+            "    })\n"
+        )
+        lines = _lines(src)
+        ann = _ann(1, 4, ["unchecked", "NullAway"], "".join(lines))
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, {3})
+        self.assertEqual(
+            new_lines,
+            _lines(
+                "    @SuppressWarnings({\n"
+                '        "unchecked",\n'
+                "    })\n"
+            ),
+        )
+
+    def test_multiline_annotation_preserves_layout_for_inline_values(self):
+        src = (
+            "    @SuppressWarnings({\n"
+            '        "NullAway", "unchecked", "deprecation"\n'
+            "    })\n"
+        )
+        lines = _lines(src)
+        ann = _ann(
+            1,
+            3,
+            ["NullAway", "unchecked", "deprecation"],
+            "".join(lines),
+        )
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, set())
+        self.assertEqual(
+            new_lines,
+            _lines(
+                "    @SuppressWarnings({\n"
+                '        "unchecked", "deprecation"\n'
+                "    })\n"
+            ),
+        )
+
+    def test_multiline_annotation_preserves_newline_after_removed_value(self):
+        src = (
+            '    @SuppressWarnings({  "NullAway",  \n'
+            '        "unchecked",\n'
+            '        "deprecation"})\n'
+        )
+        lines = _lines(src)
+        ann = _ann(
+            1,
+            3,
+            ["NullAway", "unchecked", "deprecation"],
+            "".join(lines),
+        )
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, set())
+        self.assertEqual(
+            new_lines,
+            _lines(
+                "    @SuppressWarnings({  \n"
+                '        "unchecked",\n'
+                '        "deprecation"})\n'
+            ),
+        )
+
+    def test_multiline_annotation_does_not_introduce_trailing_whitespace(self):
+        src = (
+            '    @SuppressWarnings({\t"NullAway",\r\n'
+            '        "unchecked"  \r\n'
+            "    })\r\n"
+        )
+        lines = _lines(src)
+        ann = _ann(1, 3, ["NullAway", "unchecked"], "".join(lines))
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(deleted, set())
+        self.assertEqual(
+            new_lines,
+            _lines(
+                "    @SuppressWarnings({\r\n"
+                '        "unchecked"  \r\n'
+                "    })\r\n"
+            ),
+        )
+
+    def test_no_annotations_to_remove(self):
+        src = "    public void foo() {}\n"
+        lines = _lines(src)
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [], "NullAway")
+        self.assertEqual(deleted, set())
+        self.assertEqual(new_lines, lines)
+
+    def test_removes_only_target_checker_from_pair(self):
+        src = '    @SuppressWarnings({"unchecked", "NullAway"})\n'
+        lines = _lines(src)
+        ann = _ann(1, 1, ["unchecked", "NullAway"], lines[0])
+        new_lines, _ = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertIn('"unchecked"', new_lines[0])
+        self.assertNotIn('"NullAway"', new_lines[0])
+
+    def test_line_numbers_outside_annotation_untouched(self):
+        src = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        lines = _lines(src)
+        ann = _ann(2, 2, ["NullAway"], lines[1])
+        new_lines, deleted = build_modified_lines_and_deleted(lines, [ann], "NullAway")
+        self.assertEqual(new_lines[0], "class Foo {\n")
+        self.assertEqual(new_lines[1], "    public void foo() {}\n")
+        self.assertEqual(new_lines[2], "}\n")

--- a/scripts/nullaway-suppression-remover/tests/test_line_mapping.py
+++ b/scripts/nullaway-suppression-remover/tests/test_line_mapping.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from unittest import TestCase
+
+from suppression_remover.core import (
+    Annotation,
+    build_modified_to_original,
+    find_outer_annotation,
+    find_responsible_annotation,
+    mark_all_needed,
+)
+
+
+def _ann(start, end=None, checkers=None):
+    if end is None:
+        end = start
+    return Annotation(
+        start_line=start,
+        end_line=end,
+        original_lines=[],
+        checkers=checkers or ["NullAway"],
+    )
+
+
+class TestBuildModifiedToOriginal(TestCase):
+    def test_no_deletions(self):
+        result = build_modified_to_original(5, set())
+        self.assertEqual(result, [1, 2, 3, 4, 5])
+
+    def test_delete_first_line(self):
+        result = build_modified_to_original(5, {1})
+        self.assertEqual(result, [2, 3, 4, 5])
+
+    def test_delete_middle_line(self):
+        result = build_modified_to_original(5, {3})
+        self.assertEqual(result, [1, 2, 4, 5])
+
+    def test_delete_multiple_lines(self):
+        result = build_modified_to_original(5, {2, 4})
+        self.assertEqual(result, [1, 3, 5])
+
+    def test_empty_file(self):
+        result = build_modified_to_original(0, set())
+        self.assertEqual(result, [])
+
+    def test_all_deleted(self):
+        result = build_modified_to_original(3, {1, 2, 3})
+        self.assertEqual(result, [])
+
+
+class TestFindResponsibleAnnotation(TestCase):
+    def _mapping(self, total, deleted=None):
+        return build_modified_to_original(total, deleted or set())
+
+    def test_annotation_immediately_above(self):
+        anns = [_ann(5)]
+        mapping = self._mapping(10)
+        result = find_responsible_annotation(6, anns, mapping)
+        self.assertIs(result, anns[0])
+
+    def test_closest_preceding_wins(self):
+        anns = [_ann(2), _ann(8)]
+        mapping = self._mapping(15)
+        result = find_responsible_annotation(10, anns, mapping)
+        self.assertIs(result, anns[1])
+
+    def test_following_annotation_within_lookahead(self):
+        anns = [_ann(10)]
+        mapping = self._mapping(20)
+        result = find_responsible_annotation(7, anns, mapping, lookahead=5)
+        self.assertIs(result, anns[0])
+
+    def test_following_annotation_outside_lookahead_ignored(self):
+        anns = [_ann(15)]
+        mapping = self._mapping(20)
+        result = find_responsible_annotation(5, anns, mapping, lookahead=5)
+        self.assertIsNone(result)
+
+    def test_preceding_beats_equidistant_following(self):
+        anns = [_ann(5), _ann(15)]
+        mapping = self._mapping(20)
+        result = find_responsible_annotation(10, anns, mapping, lookahead=10)
+        self.assertIs(result, anns[0])
+
+    def test_out_of_range_line_returns_none(self):
+        anns = [_ann(5)]
+        mapping = self._mapping(10)
+        self.assertIsNone(find_responsible_annotation(0, anns, mapping))
+        self.assertIsNone(find_responsible_annotation(11, anns, mapping))
+
+    def test_empty_annotations_returns_none(self):
+        mapping = self._mapping(10)
+        self.assertIsNone(find_responsible_annotation(5, [], mapping))
+
+    def test_accounts_for_deleted_lines(self):
+        anns = [_ann(5)]
+        mapping = self._mapping(10, deleted={1})
+        result = find_responsible_annotation(5, anns, mapping)
+        self.assertIs(result, anns[0])
+
+    def test_annotation_on_same_line_as_error(self):
+        anns = [_ann(3)]
+        mapping = self._mapping(10)
+        result = find_responsible_annotation(3, anns, mapping)
+        self.assertIs(result, anns[0])
+
+
+class TestFindOuterAnnotation(TestCase):
+    def test_basic_outer(self):
+        inner = _ann(10)
+        outer = _ann(5)
+        result = find_outer_annotation(inner.start_line, [inner, outer])
+        self.assertIs(result, outer)
+
+    def test_closest_outer_wins(self):
+        anns = [_ann(2), _ann(7), _ann(15)]
+        result = find_outer_annotation(15, anns)
+        self.assertIs(result, anns[1])
+
+    def test_no_outer_returns_none(self):
+        anns = [_ann(10)]
+        result = find_outer_annotation(10, anns)
+        self.assertIsNone(result)
+
+    def test_equal_start_line_not_counted_as_outer(self):
+        anns = [_ann(5), _ann(10)]
+        result = find_outer_annotation(5, anns)
+        self.assertIsNone(result)
+
+    def test_empty_annotations(self):
+        self.assertIsNone(find_outer_annotation(5, []))
+
+
+class TestMarkAllNeeded(TestCase):
+    def test_marks_all_unneeded_annotations(self):
+        anns = [_ann(2), _ann(5), _ann(9)]
+        marked = mark_all_needed(anns)
+        self.assertEqual(marked, 3)
+        self.assertTrue(all(a.needed for a in anns))
+
+    def test_already_needed_not_recounted(self):
+        anns = [_ann(2), _ann(5)]
+        anns[0].needed = True
+        marked = mark_all_needed(anns)
+        self.assertEqual(marked, 1)
+        self.assertTrue(all(a.needed for a in anns))
+
+    def test_all_already_needed_returns_zero(self):
+        anns = [_ann(2), _ann(5)]
+        for a in anns:
+            a.needed = True
+        marked = mark_all_needed(anns)
+        self.assertEqual(marked, 0)
+
+    def test_empty_list_returns_zero(self):
+        self.assertEqual(mark_all_needed([]), 0)

--- a/scripts/nullaway-suppression-remover/tests/test_orchestration.py
+++ b/scripts/nullaway-suppression-remover/tests/test_orchestration.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Integration tests for core.run().
+
+Each test writes real Java files to a temp directory and mocks only
+get_source_files (to avoid filesystem discovery) and run_build (to
+avoid a real build invocation).  All annotation parsing and file I/O
+run for real.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from suppression_remover.core import run
+
+CHECKER = "NullAway"
+
+
+def _write(directory: Path, filename: str, content: str) -> Path:
+    p = directory / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _patch_run(root, java_files, build_side_effects):
+    return (
+        patch("suppression_remover.core.get_source_files", return_value=java_files),
+        patch(
+            "suppression_remover.core.run_build",
+            side_effect=build_side_effects,
+        ),
+    )
+
+
+class TestOrchestrationNoAnnotations(TestCase):
+    def test_no_annotations_does_not_call_build(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", "class Foo {}\n")
+
+            get_src, mock_build = _patch_run(root, [java_file], [])
+            with get_src, mock_build as mb:
+                run(root, CHECKER, [], root)
+                mb.assert_not_called()
+
+
+class TestOrchestrationAllUnnecessary(TestCase):
+    def test_annotation_removed_when_build_passes(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+
+            get_src, mock_build = _patch_run(root, [java_file], [("", True)])
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            result = java_file.read_text(encoding="utf-8")
+            self.assertNotIn("@SuppressWarnings", result)
+            self.assertIn("public void foo()", result)
+
+    def test_project_wide_run_processes_multiple_modules(self):
+        content = (
+            "class Example {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first_source = root / "first" / "src" / "main" / "java"
+            second_source = root / "second" / "src" / "test" / "java"
+            first_source.mkdir(parents=True)
+            second_source.mkdir(parents=True)
+            first_java = _write(first_source, "First.java", content)
+            second_java = _write(second_source, "Second.java", content)
+
+            with patch(
+                "suppression_remover.core.run_build", return_value=("", True)
+            ) as mock_build:
+                run(root, CHECKER, [], root, build_cmd=["build-everything"])
+
+            self.assertNotIn(
+                "@SuppressWarnings", first_java.read_text(encoding="utf-8")
+            )
+            self.assertNotIn(
+                "@SuppressWarnings", second_java.read_text(encoding="utf-8")
+            )
+            mock_build.assert_called_once_with(root, root, ["build-everything"])
+
+
+class TestOrchestrationAllNeeded(TestCase):
+    def test_all_needed_restores_and_exits(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null not allowed\n", False),
+                (f"{rel}:2: error: [NullAway] null not allowed\n", False),
+                (f"{rel}:2: error: [NullAway] null not allowed\n", False),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                with self.assertRaises(SystemExit):
+                    run(root, CHECKER, [], root)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+
+class TestOrchestrationMixed(TestCase):
+    def test_needed_kept_unnecessary_removed(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                ("", True),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            result = java_file.read_text(encoding="utf-8")
+            ann_lines = [l for l in result.splitlines() if "@SuppressWarnings" in l]
+            self.assertEqual(len(ann_lines), 1)
+            self.assertIn("NullAway", ann_lines[0])
+            self.assertIn("public void bar()", result)
+
+
+class TestOrchestrationGiveUpRestoresAllAndConfirms(TestCase):
+    def test_final_confirmation_succeeds_after_restoring_file(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                ("", True),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+    def test_final_confirmation_still_fails_restores_originals_and_exits(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                (f"{rel}:2: error: [NullAway] null\n", False),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                with self.assertRaises(SystemExit):
+                    run(root, CHECKER, [], root)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+
+class TestOrchestrationUnmappedErrors(TestCase):
+    def test_unmapped_errors_do_not_crash(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+
+            unrelated_error = "other/Bar.java:10: error: [NullAway] null\n"
+            build_returns = [
+                (unrelated_error, False),
+                (unrelated_error, False),
+                (unrelated_error, False),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                with self.assertRaises(SystemExit):
+                    run(root, CHECKER, [], root)
+
+
+class TestOrchestrationUnmappedLineInFileRestoresAll(TestCase):
+    def test_out_of_range_line_restores_all_suppressions_in_file(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:100: error: [NullAway] null\n", False),
+                ("", True),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+
+class TestOrchestrationOuterAnnotation(TestCase):
+    def test_outer_annotation_marked_needed(self):
+        content = (
+            "class Outer {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    class Inner {\n"
+            '        @SuppressWarnings("NullAway")\n'
+            "        public void foo() {}\n"
+            "    }\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Outer.java", content)
+            rel = "Outer.java"
+
+            build_returns = [
+                (f"{rel}:3: error: [NullAway] null\n", False),
+                (f"{rel}:4: error: [NullAway] null\n", False),
+                ("", True),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            result = java_file.read_text(encoding="utf-8")
+            self.assertEqual(result.count('@SuppressWarnings("NullAway")'), 2)
+
+
+class TestOrchestrationMaxIterations(TestCase):
+    def test_max_iterations_restores_all_and_confirms(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                (f"{rel}:4: error: [NullAway] null\n", False),
+                ("", True),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                run(root, CHECKER, [], root, max_iterations=1)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+    def test_max_iterations_must_be_positive(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with self.assertRaisesRegex(ValueError, "positive integer"):
+                run(root, CHECKER, [], root, max_iterations=0)
+
+
+class TestOrchestrationMaxIterationsStillFails(TestCase):
+    def test_max_iterations_confirmation_fails_restores_and_exits(self):
+        content = (
+            "class Foo {\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void foo() {}\n"
+            '    @SuppressWarnings("NullAway")\n'
+            "    public void bar() {}\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+            rel = "Foo.java"
+
+            build_returns = [
+                (f"{rel}:2: error: [NullAway] null\n", False),
+                (f"{rel}:4: error: [NullAway] null\n", False),
+                (f"{rel}:4: error: [NullAway] null\n", False),
+            ]
+            get_src, mock_build = _patch_run(root, [java_file], build_returns)
+            with get_src, mock_build:
+                with patch("suppression_remover.core.MAX_ITERATIONS", 1):
+                    with self.assertRaises(SystemExit):
+                        run(root, CHECKER, [], root)
+
+            self.assertEqual(java_file.read_text(encoding="utf-8"), content)
+
+
+class TestOrchestrationCommentsSafe(TestCase):
+    def test_comments_and_strings_not_modified(self):
+        line_comment = '    // @SuppressWarnings("NullAway")\n'
+        block_comment = '    /* @SuppressWarnings("NullAway") */\n'
+        string_literal = '    String s = "@SuppressWarnings(\\"NullAway\\")";\n'
+        real_ann = '    @SuppressWarnings("NullAway")\n'
+        method = "    public void foo() {}\n"
+
+        content = (
+            "class Foo {\n"
+            + line_comment
+            + block_comment
+            + string_literal
+            + real_ann
+            + method
+            + "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            java_file = _write(root, "Foo.java", content)
+
+            get_src, mock_build = _patch_run(root, [java_file], [("", True)])
+            with get_src, mock_build:
+                run(root, CHECKER, [], root)
+
+            result_lines = java_file.read_text(encoding="utf-8").splitlines(
+                keepends=True
+            )
+            self.assertIn(line_comment, result_lines)
+            self.assertIn(block_comment, result_lines)
+            self.assertIn(string_literal, result_lines)
+            self.assertNotIn(real_ann, result_lines)
+            self.assertIn(method, result_lines)

--- a/scripts/nullaway-suppression-remover/tests/test_orchestration.py
+++ b/scripts/nullaway-suppression-remover/tests/test_orchestration.py
@@ -168,6 +168,14 @@ class TestOrchestrationMixed(TestCase):
             ann_lines = [l for l in result.splitlines() if "@SuppressWarnings" in l]
             self.assertEqual(len(ann_lines), 1)
             self.assertIn("NullAway", ann_lines[0])
+            self.assertIn(
+                '    @SuppressWarnings("NullAway")\n    public void foo() {}\n',
+                result,
+            )
+            self.assertNotIn(
+                '    @SuppressWarnings("NullAway")\n    public void bar() {}\n',
+                result,
+            )
             self.assertIn("public void bar()", result)
 
 

--- a/scripts/nullaway-suppression-remover/tests/test_project_and_build.py
+++ b/scripts/nullaway-suppression-remover/tests/test_project_and_build.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from suppression_remover.core import (
+    discover_source_sets,
+    find_project_root,
+    get_source_files,
+    run_build,
+)
+
+
+class TestFindProjectRoot(TestCase):
+    def _chdir(self, path):
+        old = os.getcwd()
+        os.chdir(path)
+        return old
+
+    def test_settings_gradle_kts_in_cwd(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "settings.gradle.kts").touch()
+            old = self._chdir(root)
+            try:
+                self.assertEqual(find_project_root(), root.resolve())
+            finally:
+                os.chdir(old)
+
+    def test_build_gradle_two_levels_up(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "build.gradle").touch()
+            subdir = root / "sub1" / "sub2"
+            subdir.mkdir(parents=True)
+            old = self._chdir(subdir)
+            try:
+                self.assertEqual(find_project_root(), root.resolve())
+            finally:
+                os.chdir(old)
+
+    def test_pom_xml_detected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "pom.xml").touch()
+            old = self._chdir(root)
+            try:
+                self.assertEqual(find_project_root(), root.resolve())
+            finally:
+                os.chdir(old)
+
+    def test_no_project_root_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old = self._chdir(tmpdir)
+            try:
+                with self.assertRaises(RuntimeError):
+                    find_project_root()
+            finally:
+                os.chdir(old)
+
+    def test_explicit_start_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "settings.gradle.kts").touch()
+            subdir = root / "sub"
+            subdir.mkdir()
+            self.assertEqual(find_project_root(subdir), root.resolve())
+
+
+class TestGetSourceFiles(TestCase):
+    def test_finds_java_files_under_src(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            java_file = module / "src" / "main" / "java" / "Foo.java"
+            java_file.parent.mkdir(parents=True)
+            java_file.touch()
+            paths = get_source_files(module)
+            self.assertEqual(paths, [java_file])
+
+    def test_no_src_directory_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            paths = get_source_files(module)
+            self.assertEqual(paths, [])
+
+    def test_ignores_non_java_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            src = module / "src" / "main" / "java"
+            src.mkdir(parents=True)
+            (src / "Foo.java").touch()
+            (src / "Foo.kt").touch()
+            (src / "readme.txt").touch()
+            paths = get_source_files(module)
+            self.assertEqual(len(paths), 1)
+            self.assertTrue(paths[0].name.endswith(".java"))
+
+    def test_finds_java_files_across_nested_modules(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            root_java = root / "src" / "main" / "java" / "Root.java"
+            first_module_java = (
+                root / "first" / "src" / "main" / "java" / "First.java"
+            )
+            second_module_java = (
+                root / "nested" / "second" / "src" / "test" / "java" / "Second.java"
+            )
+            outside_src = root / "third" / "Outside.java"
+            for java_file in (
+                root_java,
+                first_module_java,
+                second_module_java,
+                outside_src,
+            ):
+                java_file.parent.mkdir(parents=True, exist_ok=True)
+                java_file.touch()
+
+            paths = get_source_files(root, include_nested_modules=True)
+
+            self.assertEqual(
+                paths,
+                sorted([root_java, first_module_java, second_module_java]),
+            )
+
+    def test_module_scope_does_not_include_nested_modules(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            nested_java = module / "nested" / "src" / "main" / "java" / "Nested.java"
+            nested_java.parent.mkdir(parents=True)
+            nested_java.touch()
+
+            self.assertEqual(get_source_files(module), [])
+
+
+class TestDiscoverSourceSets(TestCase):
+    def test_discovers_main_and_test(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            (module / "src" / "main" / "java").mkdir(parents=True)
+            (module / "src" / "main" / "java" / "Foo.java").touch()
+            (module / "src" / "test" / "java").mkdir(parents=True)
+            (module / "src" / "test" / "java" / "FooTest.java").touch()
+            self.assertEqual(discover_source_sets(module), ["main", "test"])
+
+    def test_discovers_custom_source_sets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            for name in ["main", "test", "testFixtures", "jmh"]:
+                d = module / "src" / name / "java"
+                d.mkdir(parents=True)
+                (d / "A.java").touch()
+            result = discover_source_sets(module)
+            self.assertEqual(result, ["jmh", "main", "test", "testFixtures"])
+
+    def test_skips_dirs_without_java_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            (module / "src" / "main" / "java").mkdir(parents=True)
+            (module / "src" / "main" / "java" / "Foo.java").touch()
+            (module / "src" / "resources").mkdir(parents=True)
+            (module / "src" / "resources" / "app.yml").touch()
+            self.assertEqual(discover_source_sets(module), ["main"])
+
+    def test_no_src_dir_defaults_to_main(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir)
+            self.assertEqual(discover_source_sets(module), ["main"])
+
+
+class TestRunBuild(TestCase):
+    def test_default_gradle_cmd_compiles_all_source_sets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module = root / "mymodule"
+            for name in ["main", "test"]:
+                d = module / "src" / name / "java"
+                d.mkdir(parents=True)
+                (d / "A.java").touch()
+            (root / "gradlew").touch()
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "BUILD SUCCESSFUL\n"
+            mock_result.stderr = ""
+
+            with patch("suppression_remover.core.subprocess.run", return_value=mock_result) as mock_run:
+                output, ok = run_build(module, root)
+
+            self.assertTrue(ok)
+            self.assertIn("BUILD SUCCESSFUL", output)
+            cmd = mock_run.call_args[0][0]
+            self.assertIn(":mymodule:compileJava", cmd)
+            self.assertIn(":mymodule:compileTestJava", cmd)
+            self.assertIn("--continue", cmd)
+
+    def test_custom_build_cmd(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module = root / "mod"
+            module.mkdir()
+
+            mock_result = MagicMock()
+            mock_result.returncode = 1
+            mock_result.stdout = ""
+            mock_result.stderr = "error output\n"
+
+            with patch("suppression_remover.core.subprocess.run", return_value=mock_result) as mock_run:
+                output, ok = run_build(module, root, build_cmd=["make", "compile"])
+
+            self.assertFalse(ok)
+            self.assertIn("error output", output)
+            cmd = mock_run.call_args[0][0]
+            self.assertEqual(cmd, ["make", "compile"])

--- a/scripts/nullaway-suppression-remover/tests/test_project_and_build.py
+++ b/scripts/nullaway-suppression-remover/tests/test_project_and_build.py
@@ -213,6 +213,7 @@ class TestRunBuild(TestCase):
             self.assertIn(":mymodule:compileJava", cmd)
             self.assertIn(":mymodule:compileTestJava", cmd)
             self.assertIn("--continue", cmd)
+            self.assertIs(mock_run.call_args.kwargs["check"], False)
 
     def test_custom_build_cmd(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Python scripts to remove unnecessary NullAway suppressions from a project using heuristics.  The technique is basically:

1. Remove all NullAway suppressions
2. Run the build
3. If there are any build errors, restore the closest preceding suppression for each error, and then go back to step 2.

The number of iterations is bounded.  The scripts are design to minimize unnecessary perturbation of whitespace, etc.  See the README for more details.

The scripts were primarily generated by coding agents.  They won't ship with the main NullAway artifact, so they are low risk.  They include regression tests, and have been tested on multiple real projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool that identifies and removes unnecessary Java checker suppression annotations.
  * Supports Gradle and Maven projects, multi-module repositories, custom build commands, alternate suppressions, and iterative validation.
  * Preserves required suppressions and restores changes when builds reveal unresolved issues.

* **Documentation**
  * Added usage guidance, prerequisites, configuration options, safety recommendations, and testing instructions.

* **Tests**
  * Added comprehensive coverage for parsing, annotation rewriting, build error handling, project discovery, CLI behavior, and end-to-end suppression removal.
  * Added automated CI regression testing for the tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->