### PR TITLE
Less conservative handling of raw array types

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -867,7 +867,7 @@ public class NullAway extends BugChecker
         // as raw functional-interface targets and constructor references.
         jspecifyMemberReferenceMethodType =
             genericsChecks.getMemberReferenceMethodType(
-                memberReferenceTree, referencedMethod, state);
+                memberReferenceTree, referencedMethod, /* qualifierExpressionType= */ null, state);
       }
       referencedMethodParameterNullnessOverrides =
           handler.onOverrideMethodInvocationParametersNullability(

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -834,25 +834,6 @@ public class NullAway extends BugChecker
         (overridingMethod != null
                 && !codeAnnotationInfo.isSymbolUnannotated(overridingMethod, config, handler))
             || lambdaExpressionTree != null;
-    Type.MethodType jspecifyMemberReferenceMethodType = null;
-    // Keep handler-provided nullness for the referenced method separate from nullness for the
-    // functional interface method. Library models may change the referenced method's signature.
-    MethodParameterNullness referencedMethodParameterNullnessOverrides = null;
-    if (memberReferenceTree != null) {
-      Symbol.MethodSymbol referencedMethod = castToNonNull(overridingMethod);
-      jspecifyMemberReferenceMethodType =
-          genericsChecks.getMemberReferenceMethodType(memberReferenceTree, referencedMethod, state);
-      referencedMethodParameterNullnessOverrides =
-          handler.onOverrideMethodInvocationParametersNullability(
-              state.context,
-              referencedMethod,
-              isOverridingMethodAnnotated,
-              MethodParameterNullness.create(referencedMethod));
-    }
-
-    MethodParameterNullness overriddenMethodArgumentNullness =
-        MethodParameterNullness.create(overriddenMethod);
-
     // For a method reference or lambda, try to use a type inferred by GenericsChecks for the
     // tree, falling back on the type inferred by javac.  Used both to compute parameter
     // nullability below and to pretty-print the functional interface method's substituted
@@ -866,6 +847,38 @@ public class NullAway extends BugChecker
         functionalInterfaceType = ASTHelpers.getType(polyExprTree);
       }
     }
+
+    Type.MethodType jspecifyMemberReferenceMethodType = null;
+    // Keep handler-provided nullness for the referenced method separate from nullness for the
+    // functional interface method. Library models may change the referenced method's signature.
+    MethodParameterNullness referencedMethodParameterNullnessOverrides = null;
+    if (memberReferenceTree != null) {
+      Symbol.MethodSymbol referencedMethod = castToNonNull(overridingMethod);
+      if (functionalInterfaceType != null) {
+        GenericsChecks.ResolvedMethodReference resolvedMethodReference =
+            genericsChecks.resolveMemberReference(
+                memberReferenceTree, referencedMethod, functionalInterfaceType, state);
+        if (resolvedMethodReference != null) {
+          jspecifyMemberReferenceMethodType = resolvedMethodReference.methodType();
+        }
+      }
+      if (jspecifyMemberReferenceMethodType == null) {
+        // Preserve the existing behavior for cases the shared resolver intentionally skips, such
+        // as raw functional-interface targets and constructor references.
+        jspecifyMemberReferenceMethodType =
+            genericsChecks.getMemberReferenceMethodType(
+                memberReferenceTree, referencedMethod, state);
+      }
+      referencedMethodParameterNullnessOverrides =
+          handler.onOverrideMethodInvocationParametersNullability(
+              state.context,
+              referencedMethod,
+              isOverridingMethodAnnotated,
+              MethodParameterNullness.create(referencedMethod));
+    }
+
+    MethodParameterNullness overriddenMethodArgumentNullness =
+        MethodParameterNullness.create(overriddenMethod);
 
     // Collect @Nullable params of overridden method iff the overridden method is in annotated code
     // (otherwise, whether we acknowledge @Nullable in unannotated code or not depends on the

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1690,6 +1690,29 @@ public final class GenericsChecks {
       MemberReferenceTree memberReferenceTree,
       Symbol.MethodSymbol overridingMethod,
       VisitorState state) {
+    return getMemberReferenceMethodType(
+        memberReferenceTree, overridingMethod, /* qualifierExpressionType= */ null, state);
+  }
+
+  /**
+   * Gets the method type for a member reference.
+   *
+   * @param memberReferenceTree the member reference tree
+   * @param overridingMethod the method symbol for the referenced method
+   * @param qualifierExpressionType an adjusted type for the qualifier expression of the member
+   *     reference ({@code Foo} in a reference {@code Foo::bar}). For an unbound reference to a
+   *     generic instance method, javac compute the type of the qualifier expression as the generic
+   *     declaration type. Callers can provide a type instantiated from the functional interface
+   *     receiver, containing the appropriate type arguments.
+   * @param state the visitor state
+   * @return the method type for the member reference, with generics handled, or null if not in
+   *     JSpecify mode
+   */
+  Type.@Nullable MethodType getMemberReferenceMethodType(
+      MemberReferenceTree memberReferenceTree,
+      Symbol.MethodSymbol overridingMethod,
+      @Nullable Type qualifierExpressionType,
+      VisitorState state) {
     if (!config.isJSpecifyMode()) {
       return null;
     }
@@ -1698,7 +1721,10 @@ public final class GenericsChecks {
       // This handles any generic type parameters of the qualifier of the member reference, e.g. for
       // x::m, where x is of type Foo<Integer>, it handles the type parameter Integer whereever it
       // appears in the signature of m.
-      Type qualifierType = ASTHelpers.getType(memberReferenceTree.getQualifierExpression());
+      Type qualifierType =
+          qualifierExpressionType != null
+              ? qualifierExpressionType
+              : ASTHelpers.getType(memberReferenceTree.getQualifierExpression());
       if (qualifierType != null && !qualifierType.isRaw()) {
         result =
             TypeSubstitutionUtils.memberType(

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1728,20 +1728,28 @@ public final class GenericsChecks {
               qualifierExpression,
               state.withPath(new TreePath(state.getPath(), qualifierExpression)));
       boolean unbound = ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
-      if (unbound && qualifierType instanceof Type.ClassType qualifierClassType) {
-        Symbol.MethodSymbol fiMethod =
-            NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, state.getTypes());
-        Type.MethodType fiMethodTypeAsMember =
-            TypeSubstitutionUtils.memberType(state.getTypes(), groundTargetType, fiMethod, config)
-                .asMethodType();
-        com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
-        Verify.verify(
-            !fiParamTypes.isEmpty(),
-            "Expected receiver parameter for unbound method ref %s",
-            memberReferenceTree);
-        qualifierType =
-            GenericsUtils.instantiateUnboundQualifierType(
-                qualifierClassType, fiParamTypes.get(0), state.getTypes(), config);
+      if (unbound) {
+        if (qualifierType == null || qualifierType.isRaw()) {
+          // javac attributes an annotated bare qualifier such as @A Box as raw. Use the generic
+          // declaration as the substitution template; the receiver type supplies its arguments.
+          qualifierType = referencedMethod.owner.type;
+        }
+        if (qualifierType instanceof Type.ClassType qualifierClassType) {
+          Symbol.MethodSymbol fiMethod =
+              NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, state.getTypes());
+          Type.MethodType fiMethodTypeAsMember =
+              TypeSubstitutionUtils.memberType(state.getTypes(), groundTargetType, fiMethod, config)
+                  .asMethodType();
+          com.sun.tools.javac.util.List<Type> fiParamTypes =
+              fiMethodTypeAsMember.getParameterTypes();
+          Verify.verify(
+              !fiParamTypes.isEmpty(),
+              "Expected receiver parameter for unbound method ref %s",
+              memberReferenceTree);
+          qualifierType =
+              GenericsUtils.instantiateUnboundQualifierType(
+                  qualifierClassType, fiParamTypes.get(0), state.getTypes(), config);
+        }
       }
     }
     Type.MethodType methodType =

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -2320,8 +2320,9 @@ public final class GenericsChecks {
     if (condExprType == null) {
       condExprType = typeOrNullIfRawNonArray(ASTHelpers.getType(tree));
     }
-    // condExprType can be raw here: typeFromAssignmentContext does not pass through
-    // typeOrNullIfRawNonArray. This check also drops a raw array type that the helper allows.
+    // A raw type reaches this check either way: typeOrNullIfRawNonArray lets a raw array through,
+    // and a target type taken from a formal parameter or return type passes no filter at all.
+    // Both are dropped here.
     if (condExprType == null || condExprType.isRaw()) {
       return null;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -721,8 +721,9 @@ public final class GenericsChecks {
    *
    * @param tree A tree for which we need the type with preserved annotations.
    * @param state the visitor state
-   * @return Type of the tree with preserved annotations. Returns {@code null} for raw types and
-   *     other unhandled cases.
+   * @return Type of the tree with preserved annotations. Returns {@code null} for raw non-array
+   *     types and other unhandled cases. Arrays with raw component types are returned since their
+   *     structure and component annotations are still useful.
    */
   public @Nullable Type getTreeType(Tree tree, VisitorState state) {
     return getTreeType(tree, state, false);
@@ -739,8 +740,9 @@ public final class GenericsChecks {
    * @param tree A tree for which we need the type with preserved annotations.
    * @param state the visitor state
    * @param calledFromDataflow true if the type is being computed as part of dataflow analysis
-   * @return Type of the tree with preserved annotations. Returns {@code null} for raw types and
-   *     other unhandled cases.
+   * @return Type of the tree with preserved annotations. Returns {@code null} for raw non-array
+   *     types and other unhandled cases. Arrays with raw component types are returned since their
+   *     structure and component annotations are still useful.
    */
   /* package-private */ @Nullable Type getTreeType(
       Tree tree, VisitorState state, boolean calledFromDataflow) {
@@ -878,10 +880,12 @@ public final class GenericsChecks {
 
   /**
    * @param type a type to check
-   * @return the given type, or null if the type is a raw type
+   * @return the given type, or {@code null} if it is a raw non-array type. Javac reports an array
+   *     type as raw when its component type is raw, but the array structure and component
+   *     annotations are still usable for checking.
    */
   private static @Nullable Type typeOrNullIfRaw(@Nullable Type type) {
-    if (type != null && type.isRaw()) {
+    if (type != null && type.isRaw() && !(type instanceof Type.ArrayType)) {
       return null;
     }
     return type;

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -766,7 +766,7 @@ public final class GenericsChecks {
                 ? getConditionalExpressionType(conditionalExpressionTree, state, calledFromDataflow)
                 : ASTHelpers.getType(tree);
       }
-      return typeOrNullIfRaw(result);
+      return typeOrNullIfRawNonArray(result);
     }
     if (tree instanceof NewClassTree newClassTree) {
       if (isDiamondConstructorCall(newClassTree)) {
@@ -787,7 +787,7 @@ public final class GenericsChecks {
         return withEnclosingTypeFromQualifier(
             typeFromIdentifier, newClassTree, state, calledFromDataflow);
       }
-      return typeOrNullIfRaw(ASTHelpers.getType(tree));
+      return typeOrNullIfRawNonArray(ASTHelpers.getType(tree));
     } else if (tree instanceof NewArrayTree
         && ((NewArrayTree) tree).getType() instanceof AnnotatedTypeTree) {
       return typeWithPreservedAnnotations(tree);
@@ -874,7 +874,7 @@ public final class GenericsChecks {
           }
         }
       }
-      return typeOrNullIfRaw(result);
+      return typeOrNullIfRawNonArray(result);
     }
   }
 
@@ -884,7 +884,7 @@ public final class GenericsChecks {
    *     type as raw when its component type is raw, but the array structure and component
    *     annotations are still usable for checking.
    */
-  private static @Nullable Type typeOrNullIfRaw(@Nullable Type type) {
+  private static @Nullable Type typeOrNullIfRawNonArray(@Nullable Type type) {
     if (type != null && type.isRaw() && !(type instanceof Type.ArrayType)) {
       return null;
     }
@@ -1084,7 +1084,7 @@ public final class GenericsChecks {
         }
         return enhancedForElementType;
       }
-      return typeOrNullIfRaw(symbol.type);
+      return typeOrNullIfRawNonArray(symbol.type);
     }
     TreePath pathToInitializer = pathWithLeaf(state.getPath(), initializer);
     return getInferredTypeForVarLocalDeclaration(
@@ -2287,7 +2287,7 @@ public final class GenericsChecks {
       }
       return typeFromAssignmentContext;
     }
-    return typeOrNullIfRaw(ASTHelpers.getType(tree));
+    return typeOrNullIfRawNonArray(ASTHelpers.getType(tree));
   }
 
   /**
@@ -2318,8 +2318,10 @@ public final class GenericsChecks {
       hasTargetType = condExprType != null;
     }
     if (condExprType == null) {
-      condExprType = typeOrNullIfRaw(ASTHelpers.getType(tree));
+      condExprType = typeOrNullIfRawNonArray(ASTHelpers.getType(tree));
     }
+    // condExprType can be raw here: typeFromAssignmentContext does not pass through
+    // typeOrNullIfRawNonArray. This check also drops a raw array type that the helper allows.
     if (condExprType == null || condExprType.isRaw()) {
       return null;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1681,24 +1681,6 @@ public final class GenericsChecks {
   }
 
   /**
-   * Gets the method type for a member reference handling generics, in JSpecify mode
-   *
-   * @param memberReferenceTree the member reference tree
-   * @param overridingMethod the method symbol for the method referenced by {@code
-   *     memberReferenceTree}
-   * @param state the visitor state
-   * @return the method type for the member reference, with generics handled, or null if not in
-   *     JSpecify mode
-   */
-  public Type.@Nullable MethodType getMemberReferenceMethodType(
-      MemberReferenceTree memberReferenceTree,
-      Symbol.MethodSymbol overridingMethod,
-      VisitorState state) {
-    return getMemberReferenceMethodType(
-        memberReferenceTree, overridingMethod, /* qualifierExpressionType= */ null, state);
-  }
-
-  /**
    * Resolves a method reference's method and qualifier types using its functional-interface target.
    *
    * <p>For an unbound reference to an instance method in a generic class, javac leaves the
@@ -1760,7 +1742,7 @@ public final class GenericsChecks {
   }
 
   /**
-   * Gets the method type for a member reference.
+   * Gets the method type for a member reference handling generics, in JSpecify mode
    *
    * @param memberReferenceTree the member reference tree
    * @param overridingMethod the method symbol for the referenced method
@@ -1773,7 +1755,7 @@ public final class GenericsChecks {
    * @return the method type for the member reference, with generics handled, or null if not in
    *     JSpecify mode
    */
-  Type.@Nullable MethodType getMemberReferenceMethodType(
+  public Type.@Nullable MethodType getMemberReferenceMethodType(
       MemberReferenceTree memberReferenceTree,
       Symbol.MethodSymbol overridingMethod,
       @Nullable Type qualifierExpressionType,

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1585,7 +1585,8 @@ public final class GenericsChecks {
     } else { // all other cases
       Type argumentType = getTreeType(rhsExpr, state, calledFromDataflow);
       if (argumentType == null) {
-        // bail out of any checking involving raw types for now
+        // no type to constrain with; getTreeType returns null for a raw non-array type and for
+        // cases it does not handle
         return;
       }
       argumentType = refineArgumentTypeWithDataflow(argumentType, rhsExpr, state, state.getPath());
@@ -2320,9 +2321,8 @@ public final class GenericsChecks {
     if (condExprType == null) {
       condExprType = typeOrNullIfRawNonArray(ASTHelpers.getType(tree));
     }
-    // A raw type reaches this check either way: typeOrNullIfRawNonArray lets a raw array through,
-    // and a target type taken from a formal parameter or return type passes no filter at all.
-    // Both are dropped here.
+    // A raw type still arrives here: typeOrNullIfRawNonArray lets a raw array through, and not
+    // every target type reaching this point passed through it.
     if (condExprType == null || condExprType.isRaw()) {
       return null;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -80,8 +80,7 @@ import org.jspecify.annotations.Nullable;
 public final class GenericsChecks {
 
   /** Types resolved for a method reference using its ground target type. */
-  public record ResolvedMethodReference(
-      Type.MethodType methodType, @Nullable Type qualifierType, Type groundTargetType) {}
+  public record ResolvedMethodReference(Type.MethodType methodType, @Nullable Type qualifierType) {}
 
   /** Marker interface for results of attempting to infer nullability of type variables at a call */
   private interface CallInferenceResult {}
@@ -1699,6 +1698,8 @@ public final class GenericsChecks {
       Type targetType,
       VisitorState state) {
     if (!config.isJSpecifyMode() || targetType.isRaw() || referencedMethod.isConstructor()) {
+      // TODO handle constructor references like Foo::new;
+      //  https://github.com/uber/NullAway/issues/1468
       return null;
     }
     Type groundTargetType = GenericsUtils.groundTargetType(targetType, state, config, handler);
@@ -1736,9 +1737,7 @@ public final class GenericsChecks {
     }
     Type.MethodType methodType =
         getMemberReferenceMethodType(memberReferenceTree, referencedMethod, qualifierType, state);
-    return methodType == null
-        ? null
-        : new ResolvedMethodReference(methodType, qualifierType, groundTargetType);
+    return methodType == null ? null : new ResolvedMethodReference(methodType, qualifierType);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -79,6 +79,10 @@ import org.jspecify.annotations.Nullable;
 /** Methods for performing checks related to generic types and nullability. */
 public final class GenericsChecks {
 
+  /** Types resolved for a method reference using its ground target type. */
+  public record ResolvedMethodReference(
+      Type.MethodType methodType, @Nullable Type qualifierType, Type groundTargetType) {}
+
   /** Marker interface for results of attempting to infer nullability of type variables at a call */
   private interface CallInferenceResult {}
 
@@ -1692,6 +1696,59 @@ public final class GenericsChecks {
       VisitorState state) {
     return getMemberReferenceMethodType(
         memberReferenceTree, overridingMethod, /* qualifierExpressionType= */ null, state);
+  }
+
+  /**
+   * Resolves a method reference's method and qualifier types using its functional-interface target.
+   *
+   * <p>For an unbound reference to an instance method in a generic class, javac leaves the
+   * qualifier as the generic declaration type. The functional-interface receiver supplies the type
+   * arguments needed to instantiate that qualifier and, in turn, the referenced method type.
+   *
+   * @param memberReferenceTree the method reference tree
+   * @param referencedMethod the symbol for the referenced method
+   * @param targetType the functional-interface target type
+   * @param state visitor state whose current path ends at {@code memberReferenceTree}
+   * @return the resolved types, or {@code null} if the method reference cannot be resolved
+   */
+  public @Nullable ResolvedMethodReference resolveMemberReference(
+      MemberReferenceTree memberReferenceTree,
+      Symbol.MethodSymbol referencedMethod,
+      Type targetType,
+      VisitorState state) {
+    if (!config.isJSpecifyMode() || targetType.isRaw() || referencedMethod.isConstructor()) {
+      return null;
+    }
+    Type groundTargetType = GenericsUtils.groundTargetType(targetType, state, config, handler);
+    Type qualifierType = null;
+    if (!referencedMethod.isStatic()) {
+      ExpressionTree qualifierExpression = memberReferenceTree.getQualifierExpression();
+      qualifierType =
+          getTreeType(
+              qualifierExpression,
+              state.withPath(new TreePath(state.getPath(), qualifierExpression)));
+      boolean unbound = ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
+      if (unbound && qualifierType instanceof Type.ClassType qualifierClassType) {
+        Symbol.MethodSymbol fiMethod =
+            NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, state.getTypes());
+        Type.MethodType fiMethodTypeAsMember =
+            TypeSubstitutionUtils.memberType(state.getTypes(), groundTargetType, fiMethod, config)
+                .asMethodType();
+        com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
+        Verify.verify(
+            !fiParamTypes.isEmpty(),
+            "Expected receiver parameter for unbound method ref %s",
+            memberReferenceTree);
+        qualifierType =
+            GenericsUtils.instantiateUnboundQualifierType(
+                qualifierClassType, fiParamTypes.get(0), state.getTypes(), config);
+      }
+    }
+    Type.MethodType methodType =
+        getMemberReferenceMethodType(memberReferenceTree, referencedMethod, qualifierType, state);
+    return methodType == null
+        ? null
+        : new ResolvedMethodReference(methodType, qualifierType, groundTargetType);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -273,16 +273,11 @@ public class GenericsUtils {
     }
     Types types = state.getTypes();
 
-    // first, figure out the proper method type to use for the member reference
+    // First, resolve the referenced method and its qualifier type.
     Symbol.MethodSymbol referencedMethod = ASTHelpers.getSymbol(memberReferenceTree);
     if (referencedMethod == null || referencedMethod.isConstructor()) {
       // TODO handle constructor references like Foo::new;
       //  https://github.com/uber/NullAway/issues/1468
-      return;
-    }
-    Type.MethodType referencedMethodType =
-        genericsChecks.getMemberReferenceMethodType(memberReferenceTree, referencedMethod, state);
-    if (referencedMethodType == null) {
       return;
     }
     Type qualifierType = null;
@@ -294,12 +289,32 @@ public class GenericsUtils {
               state.withPath(new TreePath(state.getPath(), qualifierExpression)));
     }
 
-    // now, get the type of the corresponding functional interface method, as a member of targetType
+    // Get the type of the corresponding functional interface method as a member of targetType.
     Symbol.MethodSymbol fiMethod =
         NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, types);
     Type.MethodType fiMethodTypeAsMember =
         TypeSubstitutionUtils.memberType(types, targetType, fiMethod, genericsChecks.getConfig())
             .asMethodType();
+    com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
+    boolean unbound = ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
+    if (unbound) {
+      Verify.verify(
+          !fiParamTypes.isEmpty(),
+          "Expected receiver parameter for unbound method ref %s",
+          memberReferenceTree);
+      if (qualifierType instanceof ClassType qualifierClassType) {
+        qualifierType =
+            instantiateUnboundQualifierType(
+                qualifierClassType, fiParamTypes.get(0), types, genericsChecks.getConfig());
+      }
+    }
+
+    Type.MethodType referencedMethodType =
+        genericsChecks.getMemberReferenceMethodType(
+            memberReferenceTree, referencedMethod, unbound ? qualifierType : null, state);
+    if (referencedMethodType == null) {
+      return;
+    }
 
     // method reference return type <: functional interface return type
     Type fiReturnType = fiMethodTypeAsMember.getReturnType();
@@ -311,15 +326,10 @@ public class GenericsUtils {
 
     //  i^{th} functional interface parameter type <: i^{th} method reference parameter type,
     //  aligned appropriately in the case of unbound method references
-    com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
     com.sun.tools.javac.util.List<Type> referencedParamTypes =
         referencedMethodType.getParameterTypes();
     int fiStartIndex = 0;
-    if (((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound()) {
-      Verify.verify(
-          !fiParamTypes.isEmpty(),
-          "Expected receiver parameter for unbound method ref %s",
-          memberReferenceTree);
+    if (unbound) {
       if (qualifierType != null) {
         relationHandler.handle(
             fiParamTypes.get(0), qualifierType, MethodRefTypeRelationKind.PARAMETER);
@@ -375,5 +385,29 @@ public class GenericsUtils {
             MethodRefTypeRelationKind.PARAMETER);
       }
     }
+  }
+
+  /**
+   * Instantiates unresolved class type variables in an unbound method reference's qualifier from
+   * the functional interface receiver type.
+   *
+   * <p>For example, javac represents the qualifier in {@code Entry::getKey} as {@code Entry<K,V>}.
+   * If the functional interface receives {@code Entry<String, @Nullable String>}, this method
+   * substitutes those arguments for {@code K} and {@code V}. Explicit qualifier arguments are
+   * preserved because they do not contain the declaration's type-variable symbols.
+   */
+  private static Type instantiateUnboundQualifierType(
+      ClassType qualifierType, Type receiverType, Types types, Config config) {
+    Symbol.ClassSymbol qualifierSymbol = (Symbol.ClassSymbol) qualifierType.tsym;
+    ClassType declarationType = (ClassType) qualifierSymbol.type;
+    Type receiverAsQualifier =
+        TypeSubstitutionUtils.asSuper(types, receiverType, qualifierSymbol, config);
+    if (!(receiverAsQualifier instanceof ClassType receiverClassType)
+        || receiverAsQualifier.isRaw()
+        || declarationType.allparams().size() != receiverClassType.allparams().size()) {
+      return qualifierType;
+    }
+    return TypeSubstitutionUtils.subst(
+        types, qualifierType, declarationType.allparams(), receiverClassType.allparams(), config);
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -284,7 +284,6 @@ public class GenericsUtils {
     if (resolvedMethodReference == null) {
       return;
     }
-    targetType = resolvedMethodReference.groundTargetType();
     Type qualifierType = resolvedMethodReference.qualifierType();
     Type.MethodType referencedMethodType = resolvedMethodReference.methodType();
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -5,9 +5,7 @@ import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import com.google.common.base.Verify;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
-import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
@@ -280,14 +278,15 @@ public class GenericsUtils {
       //  https://github.com/uber/NullAway/issues/1468
       return;
     }
-    Type qualifierType = null;
-    if (!referencedMethod.isStatic()) {
-      ExpressionTree qualifierExpression = memberReferenceTree.getQualifierExpression();
-      qualifierType =
-          genericsChecks.getTreeType(
-              qualifierExpression,
-              state.withPath(new TreePath(state.getPath(), qualifierExpression)));
+    GenericsChecks.ResolvedMethodReference resolvedMethodReference =
+        genericsChecks.resolveMemberReference(
+            memberReferenceTree, referencedMethod, targetType, state);
+    if (resolvedMethodReference == null) {
+      return;
     }
+    targetType = resolvedMethodReference.groundTargetType();
+    Type qualifierType = resolvedMethodReference.qualifierType();
+    Type.MethodType referencedMethodType = resolvedMethodReference.methodType();
 
     // Get the type of the corresponding functional interface method as a member of targetType.
     Symbol.MethodSymbol fiMethod =
@@ -297,24 +296,6 @@ public class GenericsUtils {
             .asMethodType();
     com.sun.tools.javac.util.List<Type> fiParamTypes = fiMethodTypeAsMember.getParameterTypes();
     boolean unbound = ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
-    if (unbound) {
-      Verify.verify(
-          !fiParamTypes.isEmpty(),
-          "Expected receiver parameter for unbound method ref %s",
-          memberReferenceTree);
-      if (qualifierType instanceof ClassType qualifierClassType) {
-        qualifierType =
-            instantiateUnboundQualifierType(
-                qualifierClassType, fiParamTypes.get(0), types, genericsChecks.getConfig());
-      }
-    }
-
-    Type.MethodType referencedMethodType =
-        genericsChecks.getMemberReferenceMethodType(
-            memberReferenceTree, referencedMethod, unbound ? qualifierType : null, state);
-    if (referencedMethodType == null) {
-      return;
-    }
 
     // method reference return type <: functional interface return type
     Type fiReturnType = fiMethodTypeAsMember.getReturnType();
@@ -396,7 +377,7 @@ public class GenericsUtils {
    * substitutes those arguments for {@code K} and {@code V}. Explicit qualifier arguments are
    * preserved because they do not contain the declaration's type-variable symbols.
    */
-  private static Type instantiateUnboundQualifierType(
+  static Type instantiateUnboundQualifierType(
       ClassType qualifierType, Type receiverType, Types types, Config config) {
     Symbol.ClassSymbol qualifierSymbol = (Symbol.ClassSymbol) qualifierType.tsym;
     ClassType declarationType = (ClassType) qualifierSymbol.type;

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -964,6 +964,74 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1795MapEntryKeyMethodReference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.HashMap;
+            import java.util.Map;
+            import java.util.Map.Entry;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static void test() {
+                Map<String, @Nullable String> map = new HashMap<>();
+                map.put("foo", "bar");
+                map.entrySet().stream()
+                    .map(entry -> entry.getKey())
+                    .forEach(System.out::println);
+                map.entrySet().stream()
+                    .map(Entry::getKey)
+                    .forEach(System.out::println);
+                map.entrySet().stream()
+                    .map(Map.Entry::getKey)
+                    .forEach(System.out::println);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unboundGenericMethodReferenceQualifierTypeArguments() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                T get() {
+                  throw new UnsupportedOperationException();
+                }
+                Wrapper<T> getWrapped() {
+                  throw new UnsupportedOperationException();
+                }
+              }
+              static class Wrapper<T extends @Nullable Object> {}
+              static void acceptNonNull(Function<Box<String>, String> function) {}
+              static void acceptNullable(
+                  Function<Box<@Nullable String>, @Nullable String> function) {}
+              static void acceptNullableReceiverWithMismatchedNestedReturn(
+                  Function<Box<@Nullable String>, Wrapper<String>> function) {}
+              static void test() {
+                acceptNonNull(Box::get);
+                acceptNullable(Box::get);
+                // BUG: Diagnostic contains: referenced method returns Wrapper<@Nullable String>
+                acceptNullableReceiverWithMismatchedNestedReturn(Box::getWrapped);
+                // BUG: Diagnostic contains: mismatched type parameter nullability
+                acceptNullable(Box<String>::get);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void issue1528() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1032,6 +1032,32 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void unboundGenericMethodReferenceParameterTypes() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.function.BiConsumer;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                void put(T t) {}
+              }
+              static BiConsumer<Box<@Nullable String>, @Nullable String> f() {
+                return Box::put;
+              }
+              static BiConsumer<Box<String>, @Nullable String> incompatible() {
+                // BUG: Diagnostic contains: parameter t of referenced method is @NonNull
+                return Box::put;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void issue1528() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1058,6 +1058,46 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void annotatedUnboundMethodRefQualifier() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            import java.util.List;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              @Target(ElementType.TYPE_USE)
+              @interface A {}
+
+              static class Box<T extends @Nullable Object> {
+                List<T> list() {
+                  throw new RuntimeException();
+                }
+              }
+
+              static void takeNullable(Function<Box<@Nullable String>, List<@Nullable String>> f) {}
+
+              static void takeNonNull(Function<Box<String>, List<String>> f) {}
+
+              static void test() {
+                takeNullable(@A Box::list);
+                takeNullable(@A com.uber.Test.Box::list);
+                // BUG: Diagnostic contains: referenced method returns List<@Nullable String>
+                takeNonNull(@A Box<@Nullable String>::list);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void issue1528() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1059,6 +1059,10 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
   @Test
   public void annotatedUnboundMethodRefQualifier() {
+    // A qualified name crashes javac while it parses on JDK 26 through 28; see JDK-8391567.
+    int feature = Runtime.version().feature();
+    String qualifiedNameInvocation =
+        feature < 26 || feature >= 29 ? "takeNullable(@A com.uber.Test.Box::list);" : "";
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -1088,12 +1092,13 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
 
               static void test() {
                 takeNullable(@A Box::list);
-                takeNullable(@A com.uber.Test.Box::list);
+                %s
                 // BUG: Diagnostic contains: referenced method returns List<@Nullable String>
                 takeNonNull(@A Box<@Nullable String>::list);
               }
             }
-            """)
+            """
+                .formatted(qualifiedNameInvocation))
         .doTest();
   }
 

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -282,8 +282,13 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  /**
+   * An enhanced-for loop variable and a conditional expression each get their array type from a
+   * computation of their own, {@code getEnhancedForLoopElementType} and {@code
+   * getConditionalExpressionType}, which the parameter in {@link #issue1800} does not reach.
+   */
   @Test
-  public void nullableAssignmentParameterArrayWithNonGenericElementType() {
+  public void issue1800EnhancedForAndTernary() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -291,8 +296,83 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
             import org.jspecify.annotations.NullMarked;
             import org.jspecify.annotations.Nullable;
             @NullMarked
-            public class Test {
-              void foo(@Nullable Test[] array) {
+            public class Test<E> {
+              void enhancedFor(@Nullable Test[][] nullable, Test[][] nonNull) {
+                for (var row : nullable) {
+                  // OK: @Nullable binds to the innermost element, so row has @Nullable contents
+                  row[0] = null;
+                }
+                for (var row : nonNull) {
+                  // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
+                  row[0] = null;
+                }
+              }
+              void ternary(boolean b, @Nullable Test[] nullable, Test[] nonNull) {
+                // OK: since array elements are @Nullable
+                (b ? nullable : nullable)[0] = null;
+                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
+                (b ? nonNull : nonNull)[0] = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * A raw actual array and a parameterized formal are compared on the nullability of their
+   * components alone, so a missing type argument is not reported on its own.
+   */
+  @Test
+  public void rawArrayToParameterizedArray() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Test<E> {
+              static void takesParameterized(Test<String>[] array) {}
+              static void passNonNullElements(Test[] array) {
+                // OK: the components agree on nullability
+                takesParameterized(array);
+              }
+              static void passNullableElements(@Nullable Test[] array) {
+                // BUG: Diagnostic contains: incompatible types: @Nullable Test [] cannot be converted to Test<String> []
+                takesParameterized(array);
+              }
+              static Test<String>[] returnNonNullElements(Test[] array) {
+                return array;
+              }
+              static Test<String>[] returnNullableElements(@Nullable Test[] array) {
+                // BUG: Diagnostic contains: incompatible types: @Nullable Test [] cannot be converted to Test<String> []
+                return array;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * {@code Gen<String>} is not raw, so this pins the side of the rule that the allowance for raw
+   * array types must leave alone.
+   */
+  @Test
+  public void nullableAssignmentParameterArrayWithParameterizedElementType() {
+    makeHelper()
+        .addSourceLines(
+            "Gen.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Gen<E> {
+              void nullableElements(@Nullable Gen<String>[] array) {
+                // OK: since array elements are @Nullable
+                array[0] = null;
+              }
+              void nonNullElements(Gen<String>[] array) {
+                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
                 array[0] = null;
               }
             }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -257,6 +257,50 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void issue1800() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Objects;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Test<E> {
+              void nullableElements(@Nullable Test[] array) {
+                array[0] = null;
+                Objects.requireNonNull(array)[0] = null;
+              }
+              void nonNullElements(Test[] array) {
+                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
+                array[0] = null;
+                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
+                Objects.requireNonNull(array)[0] = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nullableAssignmentParameterArrayWithNonGenericElementType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Test {
+              void foo(@Nullable Test[] array) {
+                array[0] = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void arraySubtyping() {
     makeHelper()
         .addSourceLines(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/JSpecifyArrayTests.java
@@ -283,12 +283,11 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
   }
 
   /**
-   * An enhanced-for loop variable and a conditional expression each get their array type from a
-   * computation of their own, {@code getEnhancedForLoopElementType} and {@code
-   * getConditionalExpressionType}, which the parameter in {@link #issue1800} does not reach.
+   * An enhanced-for loop variable gets its array type from {@code getEnhancedForLoopElementType},
+   * which the parameter in {@link #issue1800} does not reach.
    */
   @Test
-  public void issue1800EnhancedForAndTernary() {
+  public void issue1800EnhancedForLoop() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -297,21 +296,17 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
             import org.jspecify.annotations.Nullable;
             @NullMarked
             public class Test<E> {
-              void enhancedFor(@Nullable Test[][] nullable, Test[][] nonNull) {
-                for (var row : nullable) {
+              void nullableElements(@Nullable Test[][] array) {
+                for (var row : array) {
                   // OK: @Nullable binds to the innermost element, so row has @Nullable contents
                   row[0] = null;
                 }
-                for (var row : nonNull) {
+              }
+              void nonNullElements(Test[][] array) {
+                for (var row : array) {
                   // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
                   row[0] = null;
                 }
-              }
-              void ternary(boolean b, @Nullable Test[] nullable, Test[] nonNull) {
-                // OK: since array elements are @Nullable
-                (b ? nullable : nullable)[0] = null;
-                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
-                (b ? nonNull : nonNull)[0] = null;
               }
             }
             """)
@@ -319,8 +314,35 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
   }
 
   /**
-   * A raw actual array and a parameterized formal are compared on the nullability of their
-   * components alone, so a missing type argument is not reported on its own.
+   * A conditional expression in an array store gets its type from {@code
+   * getConditionalExpressionType}, which the parameter in {@link #issue1800} does not reach.
+   */
+  @Test
+  public void issue1800Ternary() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Test<E> {
+              void nullableElements(boolean b, @Nullable Test[] array) {
+                // OK: since array elements are @Nullable
+                (b ? array : array)[0] = null;
+              }
+              void nonNullElements(boolean b, Test[] array) {
+                // BUG: Diagnostic contains: Writing @Nullable expression into array with @NonNull contents
+                (b ? array : array)[0] = null;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * A raw array and a parameterized array type are compared on the nullability of their components
+   * alone, so a missing type argument is not reported on its own.
    */
   @Test
   public void rawArrayToParameterizedArray() {
@@ -342,11 +364,28 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
                 takesParameterized(array);
               }
               static Test<String>[] returnNonNullElements(Test[] array) {
+                // OK: the components agree on nullability
                 return array;
               }
               static Test<String>[] returnNullableElements(@Nullable Test[] array) {
                 // BUG: Diagnostic contains: incompatible types: @Nullable Test [] cannot be converted to Test<String> []
                 return array;
+              }
+              static void assignNonNullElements(Test[] array) {
+                // OK: the components agree on nullability
+                Test<String>[] assigned = array;
+              }
+              static void assignNullableElements(@Nullable Test[] array) {
+                // BUG: Diagnostic contains: incompatible types: @Nullable Test [] cannot be converted to Test<String> []
+                Test<String>[] assigned = array;
+              }
+              static void passNonNullElementsThroughTernary(boolean b, Test[] array) {
+                // OK: the components agree on nullability
+                takesParameterized(b ? array : array);
+              }
+              static void passNullableElementsThroughTernary(boolean b, @Nullable Test[] array) {
+                // BUG: Diagnostic contains: Conditional expression must have type Test<String> [] but the sub-expression has type @Nullable Test []
+                takesParameterized(b ? array : array);
               }
             }
             """)
@@ -354,8 +393,37 @@ public class JSpecifyArrayTests extends NullAwayTestsBase {
   }
 
   /**
-   * {@code Gen<String>} is not raw, so this pins the side of the rule that the allowance for raw
-   * array types must leave alone.
+   * An array with a raw component type reaches generic method inference, since {@code
+   * generateConstraintsForPseudoAssignment} bails out only on a null {@code getTreeType} result.
+   */
+  @Test
+  public void rawArrayAsGenericMethodArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            public class Test<E> {
+              static <T> void takesArray(T[] array) {}
+              static void nonNullElements(Test[] array) {
+                // OK: the components are @NonNull, so T is not constrained to be @Nullable
+                takesArray(array);
+              }
+              static void nullableElements(@Nullable Test[] array) {
+                // BUG: Diagnostic contains: inference failure: type variable T is constrained to be @Nullable, but its upper bound requires it to be @NonNull
+                takesArray(array);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  /**
+   * An array-element write follows the component nullability when the element type is a
+   * parameterized type, which no other test covers. {@code Gen<String>} is not raw, so this case
+   * cannot fail if the rule for raw array types regresses.
    */
   @Test
   public void nullableAssignmentParameterArrayWithParameterizedElementType() {


### PR DESCRIPTION
Fixes #1800 

`javac` treats an array type as raw if its component type is raw, but we can still use type annotations within the type to do useful checking.  So, preserve such raw array types when computing types of trees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of raw array types while preserving available type and nullability information.
  * Corrected nullable array assignment analysis for generic and non-generic array parameters.
  * Non-null element arrays now correctly report diagnostics when assigned null values.
  * Improved analysis of raw arrays in enhanced loops, conditional expressions, and generic method calls.

* **Tests**
  * Added regression coverage for nullable and non-null array assignments, enhanced loops, conditional expressions, generic inference, and raw-to-parameterized array conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->