### PR TITLE
Model Stream.takeWhile (+ reactive equivalents) like .filter

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagatorFactory.java
@@ -39,6 +39,7 @@ public class StreamNullabilityPropagatorFactory {
             // Names of all the methods of java.util.stream.Stream that behave like .filter(...)
             // (must take exactly 1 argument)
             .withFilterMethodFromSignature("filter(java.util.function.Predicate<? super T>)")
+            .withFilterMethodFromSignature("takeWhile(java.util.function.Predicate<? super T>)")
             // Names and relevant arguments of all the methods of java.util.stream.Stream that
             // behave
             // like .map(...) for the purposes of this checker (the listed arguments are those that
@@ -114,6 +115,7 @@ public class StreamNullabilityPropagatorFactory {
             // Names of all the methods of io.reactivex.Observable that behave like .filter(...)
             // (must take exactly 1 argument)
             .withFilterMethodFromSignature("filter(io.reactivex.functions.Predicate<? super T>)")
+            .withFilterMethodFromSignature("takeWhile(io.reactivex.functions.Predicate<? super T>)")
             // Names and relevant arguments of all the methods of io.reactivex.Observable that
             // behave
             // like .map(...) for the purposes of this checker (the listed arguments are those that
@@ -175,6 +177,7 @@ public class StreamNullabilityPropagatorFactory {
         StreamModelBuilder.start()
             .addStreamTypeFromName("reactor.core.publisher.Flux")
             .withFilterMethodFromSignature("filter(java.util.function.Predicate<? super T>)")
+            .withFilterMethodFromSignature("takeWhile(java.util.function.Predicate<? super T>)")
             .withMapMethodFromSignature(
                 "<V>map(java.util.function.Function<? super T,? extends V>)",
                 "apply",


### PR DESCRIPTION
Like `.filter`, `.takeWhile` returns a stream of only elements the predicate was found to be true on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for `takeWhile` operations on Java Streams, RxJava Observables, and Project Reactor Fluxes.
  * Nullability information now propagates through `takeWhile` consistently with filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->