### PR TITLE
Document PR squash merging and commit headline style in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,10 @@ Whenever you add a non-trivial method, add Javadoc, even if it's a private metho
 
 You do _not_ need to run `./gradlew spotlessJavaCheck` to check formatting.  We have a pre-commit hook that
 automatically formats code before it is committed.
+
+# Pull requests
+
+Pull requests are squash-merged: the description becomes the body of the single commit that lands on the target branch,
+so write it as the commit message for all the changes in the PR.  Headlines are imperative and in sentence case, with no
+Conventional Commits prefix and no trailing period, e.g. `Preserve nested nullness in enhanced for var types`; the squash
+merge appends the PR number.


### PR DESCRIPTION
## Why

AGENTS.md did not say how pull requests are merged, so a PR description could be written as a note to the reviewer rather than as the commit message that lands in the history, and picking up the headline style meant running `git log` in every session.

## What

A "Pull requests" section records both: the description becomes the body of the squashed commit, so it should read as the commit message for all the changes in the PR, and headlines are imperative and in sentence case, with no Conventional Commits prefix and no trailing period.

Documentation only; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for pull request squash-merge behavior.
  * Documented commit-message formatting requirements, including headline style and automatic pull request number suffixing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->