### PR TITLE
Require an `Assisted-by:` commit trailer for AI-assisted work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ Whenever you add a non-trivial method, add Javadoc, even if it's a private metho
 You do _not_ need to run `./gradlew spotlessJavaCheck` to check formatting.  We have a pre-commit hook that
 automatically formats code before it is committed.
 
+
+## Commit messages
+
+Always end commit messages, including drafts, with `Assisted-by: <tool> (<model-id>)`, never `Co-Authored-By:`.
+Keep existing trailers and add yours when amending someone else's commit.
+
 # Pull requests
 
 Pull requests are squash-merged: the description becomes the body of the single commit that lands on the target branch,


### PR DESCRIPTION
Adopt `Assisted-by:` for the disclosure the generative tooling guidance asks for, matching the Linux kernel, Fedora, Rocky Linux, Mesa, Zephyr, and OpenInfra, and keep the author fields for people.

The section is one sentence because every sentence in this file steers an agent. The wording is the one that passed the test matrix in the pull request; prose added around it changed what agents wrote, so the rationale lives in the pull request instead.

See also (PRs below include prompt used to optimize and test the exact phrase added in the PR):
* https://github.com/apache/jmeter/pull/6760
* https://github.com/apache/calcite/pull/5230
* https://issues.apache.org/jira/browse/CALCITE-7752