### PR TITLE
Instantiate unbound method reference receivers from the target type

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1690,6 +1690,26 @@ public final class GenericsChecks {
       MemberReferenceTree memberReferenceTree,
       Symbol.MethodSymbol overridingMethod,
       VisitorState state) {
+    return getMemberReferenceMethodType(memberReferenceTree, overridingMethod, state, null);
+  }
+
+  /**
+   * Gets the method type for a member reference handling generics, in JSpecify mode
+   *
+   * @param memberReferenceTree the member reference tree
+   * @param overridingMethod the method symbol for the method referenced by {@code
+   *     memberReferenceTree}
+   * @param state the visitor state
+   * @param unboundReceiverType for an unbound member reference, the receiver type computed by the
+   *     caller from the target functional interface type; {@code null} to compute it here
+   * @return the method type for the member reference, with generics handled, or null if not in
+   *     JSpecify mode
+   */
+  public Type.@Nullable MethodType getMemberReferenceMethodType(
+      MemberReferenceTree memberReferenceTree,
+      Symbol.MethodSymbol overridingMethod,
+      VisitorState state,
+      @Nullable Type unboundReceiverType) {
     if (!config.isJSpecifyMode()) {
       return null;
     }
@@ -1698,7 +1718,17 @@ public final class GenericsChecks {
       // This handles any generic type parameters of the qualifier of the member reference, e.g. for
       // x::m, where x is of type Foo<Integer>, it handles the type parameter Integer whereever it
       // appears in the signature of m.
-      Type qualifierType = ASTHelpers.getType(memberReferenceTree.getQualifierExpression());
+      Type qualifierType = null;
+      if (isUnboundMemberReference(memberReferenceTree)) {
+        qualifierType =
+            unboundReceiverType != null
+                ? unboundReceiverType
+                : getUnboundMemberReferenceReceiverType(
+                    memberReferenceTree, overridingMethod, null, state);
+      }
+      if (qualifierType == null) {
+        qualifierType = ASTHelpers.getType(memberReferenceTree.getQualifierExpression());
+      }
       if (qualifierType != null && !qualifierType.isRaw()) {
         result =
             TypeSubstitutionUtils.memberType(
@@ -1726,6 +1756,100 @@ public final class GenericsChecks {
     }
     // finally, run any handlers
     return handler.onOverrideMethodType(overridingMethod, result, state, null);
+  }
+
+  /**
+   * Checks whether a member reference is an unbound instance-method reference like {@code
+   * Foo::instanceMethod}, whose qualifier denotes a type rather than a value.
+   *
+   * @param memberReferenceTree the member reference tree
+   * @return true if the member reference is unbound
+   */
+  static boolean isUnboundMemberReference(MemberReferenceTree memberReferenceTree) {
+    return ((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound();
+  }
+
+  /**
+   * Computes the receiver type of an unbound member reference whose qualifier is a bare type name,
+   * like {@code Foo::instanceMethod}.
+   *
+   * <p>Such a qualifier writes no type arguments, so javac infers them from the first parameter of
+   * the functional interface method and the type of the qualifier expression is the generic
+   * declaration {@code Foo<T>}, which carries no nullability information. This method recovers the
+   * instantiation by viewing that first parameter type as the class declaring the referenced
+   * method. A qualifier that writes its own type arguments, like {@code Foo<@Nullable String>},
+   * gets no such treatment: the written arguments are authoritative, and callers fall back on the
+   * type of the qualifier expression.
+   *
+   * @param memberReferenceTree the member reference tree
+   * @param referencedMethod the method symbol for the referenced method
+   * @param groundTargetType the target functional interface type, already grounded; {@code null} to
+   *     derive it from {@code memberReferenceTree}
+   * @param state the visitor state
+   * @return the receiver type, or {@code null} if it cannot be computed
+   */
+  @Nullable Type getUnboundMemberReferenceReceiverType(
+      MemberReferenceTree memberReferenceTree,
+      Symbol.MethodSymbol referencedMethod,
+      @Nullable Type groundTargetType,
+      VisitorState state) {
+    if (!qualifierIsBareTypeName(memberReferenceTree.getQualifierExpression())) {
+      return null;
+    }
+    if (!(referencedMethod.owner instanceof Symbol.ClassSymbol ownerClass)) {
+      return null;
+    }
+    Type targetType = groundTargetType;
+    if (targetType == null) {
+      targetType = getInferredPolyExpressionType(memberReferenceTree);
+      if (targetType == null) {
+        targetType = ASTHelpers.getType(memberReferenceTree);
+      }
+      if (targetType == null) {
+        return null;
+      }
+      targetType = GenericsUtils.groundTargetType(targetType, state, config, handler);
+    }
+    if (targetType.isRaw()) {
+      return null;
+    }
+    Types types = state.getTypes();
+    Symbol.MethodSymbol fiMethod =
+        NullabilityUtil.getFunctionalInterfaceMethod(memberReferenceTree, types);
+    com.sun.tools.javac.util.List<Type> fiParamTypes =
+        TypeSubstitutionUtils.memberType(types, targetType, fiMethod, config)
+            .asMethodType()
+            .getParameterTypes();
+    if (fiParamTypes.isEmpty()) {
+      return null;
+    }
+    return TypeSubstitutionUtils.asSuper(types, fiParamTypes.get(0), ownerClass, config);
+  }
+
+  /**
+   * Checks whether the qualifier of a member reference is a bare type name, such as {@code Foo},
+   * {@code p.Outer.Foo}, or either of those under a type-use annotation.
+   *
+   * <p>The walk rejects on the first node that is neither an {@link AnnotatedTypeTree}, a {@link
+   * MemberSelectTree}, nor an {@link IdentifierTree}. That covers a qualifier writing its own type
+   * arguments ({@code Foo<@Nullable String>}, {@code Outer<@Nullable String>.Inner}) and an array
+   * type ({@code String[]}), including the case where an annotation sits above the type arguments,
+   * as in {@code @A Foo<String>}.
+   *
+   * @param qualifierExpression the qualifier expression of a member reference
+   * @return true if the qualifier is a bare type name
+   */
+  private static boolean qualifierIsBareTypeName(ExpressionTree qualifierExpression) {
+    Tree current = qualifierExpression;
+    while (true) {
+      if (current instanceof AnnotatedTypeTree annotatedType) {
+        current = annotatedType.getUnderlyingType();
+      } else if (current instanceof MemberSelectTree memberSelect) {
+        current = memberSelect.getExpression();
+      } else {
+        return current instanceof IdentifierTree;
+      }
+    }
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -280,18 +280,30 @@ public class GenericsUtils {
       //  https://github.com/uber/NullAway/issues/1468
       return;
     }
-    Type.MethodType referencedMethodType =
-        genericsChecks.getMemberReferenceMethodType(memberReferenceTree, referencedMethod, state);
-    if (referencedMethodType == null) {
-      return;
+    Type unboundReceiverType = null;
+    if (!referencedMethod.isStatic()
+        && GenericsChecks.isUnboundMemberReference(memberReferenceTree)) {
+      // where an unbound member reference writes no type arguments on its qualifier, javac infers
+      // them, so the qualifier expression's own type says nothing about their nullability; recover
+      // them from targetType instead.  Returns null for a qualifier that does write them, and the
+      // fallback below then reads the written type.
+      unboundReceiverType =
+          genericsChecks.getUnboundMemberReferenceReceiverType(
+              memberReferenceTree, referencedMethod, targetType, state);
     }
-    Type qualifierType = null;
-    if (!referencedMethod.isStatic()) {
+    Type qualifierType = unboundReceiverType;
+    if (qualifierType == null && !referencedMethod.isStatic()) {
       ExpressionTree qualifierExpression = memberReferenceTree.getQualifierExpression();
       qualifierType =
           genericsChecks.getTreeType(
               qualifierExpression,
               state.withPath(new TreePath(state.getPath(), qualifierExpression)));
+    }
+    Type.MethodType referencedMethodType =
+        genericsChecks.getMemberReferenceMethodType(
+            memberReferenceTree, referencedMethod, state, unboundReceiverType);
+    if (referencedMethodType == null) {
+      return;
     }
 
     // now, get the type of the corresponding functional interface method, as a member of targetType
@@ -315,7 +327,7 @@ public class GenericsUtils {
     com.sun.tools.javac.util.List<Type> referencedParamTypes =
         referencedMethodType.getParameterTypes();
     int fiStartIndex = 0;
-    if (((JCTree.JCMemberReference) memberReferenceTree).kind.isUnbound()) {
+    if (GenericsChecks.isUnboundMemberReference(memberReferenceTree)) {
       Verify.verify(
           !fiParamTypes.isEmpty(),
           "Expected receiver parameter for unbound method ref %s",

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodLambdaOrMethodRefArgTests.java
@@ -1296,6 +1296,217 @@ public class GenericMethodLambdaOrMethodRefArgTests extends NullAwayTestsBase {
         .doTest();
   }
 
+  @Test
+  public void unboundMethodRefReceiverTypeArgsFromTargetType() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import java.util.function.BiConsumer;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                T get() {
+                  throw new RuntimeException();
+                }
+                void put(T t) {}
+                List<T> list() {
+                  throw new RuntimeException();
+                }
+              }
+
+              static void takeGetter(Function<Box<@Nullable String>, @Nullable String> f) {}
+
+              static void takeNestedMatch(
+                  Function<Box<@Nullable String>, List<@Nullable String>> f) {}
+
+              static void takeNestedMismatch(Function<Box<@Nullable String>, List<String>> f) {}
+
+              static void test() {
+                takeGetter(Box::get);
+                takeNestedMatch(Box::list);
+                // BUG: Diagnostic contains: referenced method returns
+                takeNestedMismatch(Box::list);
+              }
+
+              static BiConsumer<Box<@Nullable String>, @Nullable String> nullableReceiverTypeArg() {
+                return Box::put;
+              }
+
+              static BiConsumer<Box<String>, @Nullable String> nonNullReceiverTypeArg() {
+                // BUG: Diagnostic contains: parameter t of referenced method is @NonNull
+                return Box::put;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unboundMethodRefArgToGenericMethod() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import java.util.Objects;
+            import java.util.concurrent.CompletableFuture;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static CompletableFuture<@Nullable Exception> chainSynchronous(
+                  List<CompletableFuture<@Nullable Exception>> futures) {
+                return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                    .thenApply(unused -> futures.stream()
+                        .map(CompletableFuture::join)
+                        .filter(Objects::nonNull)
+                        .reduce((e1, e2) -> {
+                          e1.addSuppressed(e2);
+                          return e1;
+                        }).orElse(null));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void explicitlyParameterizedUnboundMethodRefQualifier() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.function.BiConsumer;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                T get() {
+                  throw new RuntimeException();
+                }
+                void put(T t) {}
+              }
+
+              static class Outer<T extends @Nullable Object> {
+                class Inner {
+                  T get() {
+                    throw new RuntimeException();
+                  }
+                }
+              }
+
+              static void takeNullableGetter(Function<Box<@Nullable String>, @Nullable String> f) {}
+
+              static void takeNonNullGetter(Function<Box<String>, String> f) {}
+
+              static void takeInnerGetter(Function<Outer<String>.Inner, String> f) {}
+
+              static void test() {
+                takeNullableGetter(Box<@Nullable String>::get);
+                // BUG: Diagnostic contains: parameter type of referenced method is Box<@Nullable String>
+                takeNonNullGetter(Box<@Nullable String>::get);
+                // BUG: Diagnostic contains: parameter type of referenced method is Outer<@Nullable String>.Inner
+                takeInnerGetter(Outer<@Nullable String>.Inner::get);
+              }
+
+              static BiConsumer<Box<@Nullable String>, @Nullable String> writtenNonNullQualifier() {
+                // BUG: Diagnostic contains: parameter t of referenced method is @NonNull
+                return Box<String>::put;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotatedUnboundMethodRefQualifier() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            import java.util.List;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              @Target(ElementType.TYPE_USE)
+              @interface A {}
+
+              static class Box<T extends @Nullable Object> {
+                List<T> list() {
+                  throw new RuntimeException();
+                }
+              }
+
+              static void takeNullable(Function<Box<@Nullable String>, List<@Nullable String>> f) {}
+
+              static void takeNonNull(Function<Box<String>, List<String>> f) {}
+
+              static void test() {
+                takeNullable(@A Box::list);
+                takeNullable(@A com.uber.Test.Box::list);
+                // BUG: Diagnostic contains: referenced method returns List<@Nullable String>
+                takeNonNull(@A Box<@Nullable String>::list);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void unboundMethodRefInheritedReceiver() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.List;
+            import java.util.function.Function;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {
+                List<T> list() {
+                  throw new RuntimeException();
+                }
+              }
+
+              static class Sub extends Box<@Nullable String> {}
+
+              static void takeMatch(Function<Sub, List<@Nullable String>> f) {}
+
+              static void takeMismatch(Function<Sub, List<String>> f) {}
+
+              static void test() {
+                takeMatch(Box::list);
+                // BUG: Diagnostic contains: referenced method returns List<@Nullable String>
+                takeMismatch(Box::list);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   private CompilationTestHelper makeHelper() {
     return makeTestHelperWithArgs(
         JSpecifyJavacConfig.withJSpecifyModeArgs(


### PR DESCRIPTION
## Why

For an unbound method reference whose qualifier is a bare type name, such as the `CompletableFuture::join` in `stream.map(CompletableFuture::join)`, javac infers the qualifier's type arguments from the first parameter of the functional interface method. NullAway instead used the type of the qualifier expression, which for a generic class is that class's own declaration, `CompletableFuture<T>`, and carries no nullability annotations.

The mistake shows up in two ways. In JSpecify mode NullAway rejected any such reference on a generic class instantiated with a `@Nullable` type argument:

```text
parameter type of referenced method is CompletableFuture<T>, but parameter in functional
interface method has type CompletableFuture<@Nullable Exception>, which has mismatched type
parameter nullability
```

It also left the referenced method's own signature unsubstituted, so a genuine mismatch in a nested position went unreported: `Box::list` passed where `Function<Box<@Nullable String>, List<String>>` is expected drew no diagnostic at all.

The false positive came from real code — Caffeine's `EventDispatcher.chainSynchronous`, which works around it by replacing a lambda with an anonymous class.

## What

`GenericsChecks.getUnboundMemberReferenceReceiverType` recovers the receiver by viewing the functional interface's first parameter type as the class that declares the referenced method. Both the receiver check in `processMethodRefTypeRelations` and the substitution in `getMemberReferenceMethodType` use it.

A qualifier that writes its own type arguments is excluded, because javac infers nothing there and the written arguments are authoritative. Deriving the receiver from the target for `Box<@Nullable String>::get` or `Outer<@Nullable String>.Inner::get` would silence mismatches NullAway already reported. `qualifierIsBareTypeName` decides this by walking the qualifier, unwrapping type-use annotations and member selects, and accepting only an identifier at the end. It rejects on the first node that is none of those three, which is why `@A Box<String>::get` is excluded as well: javac nests that as `ANNOTATED_TYPE` over `PARAMETERIZED_TYPE`, so stripping annotations first and testing the remainder would be right only by accident.

Skipping the receiver check for unbound references would have silenced the false positive on its own, but the return and parameter checks read the substituted signature, so the missed nested mismatch would have remained.

## Verification

Five new tests in `GenericMethodLambdaOrMethodRefArgTests`. `unboundMethodRefReceiverTypeArgsFromTargetType` and `unboundMethodRefArgToGenericMethod` pin the bare-qualifier direction, the second on the Caffeine snippet; `explicitlyParameterizedUnboundMethodRefQualifier` and `annotatedUnboundMethodRefQualifier` pin the diagnostics a written qualifier must keep, across the plain, parameterized-outer and annotated spellings; `unboundMethodRefInheritedReceiver` reaches `TypeSubstitutionUtils.asSuper`'s annotation-restoring branch through `Sub extends Box<@Nullable String>`, which nothing in the suite exercised.

Each group was shown to have teeth by reverting the code it covers: removing the bare-name guard fails the two written-qualifier tests, removing the annotation arm of the walk fails the annotated one, and restoring both production files from `master` fails the three bare-qualifier tests. `:nullaway:test` and `:nullaway:buildWithNullAway` both pass.

## Scope

`String[]::clone` emits the same diagnostic before and after, measured; an array qualifier never reaches the derived receiver either way.

Two older gaps are left alone. The top-level nullness of a method reference's return is checked in `NullAway.checkOverriding`, which reads the method symbol's declared return type rather than the substituted one, so `Supplier<String> s = box::get` with `Box<@Nullable String>` is still missed in both the bound and unbound forms. And the generics-level member reference checks run for call arguments only, not for assignments or returns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability analysis for unbound method references, including generic receiver types inferred from functional-interface targets.
  * Added support for explicitly parameterized, annotated, and inherited receiver types in method references.
  * Improved diagnostics for nullability mismatches when method references are passed to generic methods.

* **Tests**
  * Added coverage for generic type inference and nullability checking across unbound method-reference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->