### PR TITLE
Stop repeating the check name in RequireExplicitNullMarking diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Add `JSpecifyUnrecognizedAnnotationLocation`, an opt-in check that reports nullness annotations in locations JSpecify does not recognize (#1787)
+* Fix `RequireExplicitNullMarking` diagnostics repeating the check name, so a report no longer begins with `[RequireExplicitNullMarking] [RequireExplicitNullMarking]` (#1815)
 
 Version 0.14.1
 --------------

--- a/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
+++ b/nullaway/src/main/java/com/uber/nullaway/JSpecifyUnrecognizedAnnotationLocation.java
@@ -110,8 +110,7 @@ import org.jspecify.annotations.Nullable;
 @BugPattern(
     severity = SeverityLevel.SUGGESTION,
     summary =
-        "[JSpecifyUnrecognizedAnnotationLocation] JSpecify gives no meaning to a nullness"
-            + " annotation in a location it does not recognize.")
+        "JSpecify gives no meaning to a nullness annotation in a location it does not recognize.")
 public final class JSpecifyUnrecognizedAnnotationLocation extends BugChecker
     implements BugChecker.AnnotatedTypeTreeMatcher,
         BugChecker.ClassTreeMatcher,

--- a/nullaway/src/main/java/com/uber/nullaway/RequireExplicitNullMarking.java
+++ b/nullaway/src/main/java/com/uber/nullaway/RequireExplicitNullMarking.java
@@ -40,7 +40,7 @@ import javax.lang.model.element.NestingKind;
 @BugPattern(
     severity = SeverityLevel.SUGGESTION,
     summary =
-        "[RequireExplicitNullMarking] Top-level classes must either be directly annotated with @NullMarked/@NullUnmarked,"
+        "Top-level classes must either be directly annotated with @NullMarked/@NullUnmarked,"
             + " be in a package that is explicitly @NullMarked/@NullUnmarked,"
             + " or be in a module that is explicitly @NullMarked.")
 public final class RequireExplicitNullMarking extends BugChecker

--- a/nullaway/src/test/java/com/uber/nullaway/RequireExplicitNullMarkingTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/RequireExplicitNullMarkingTest.java
@@ -37,6 +37,28 @@ public class RequireExplicitNullMarkingTest {
         .doTest();
   }
 
+  /**
+   * Error Prone prefixes every diagnostic with the check name, so the {@code @BugPattern} summary
+   * must not repeat it.
+   */
+  @Test
+  public void checkNameAppearsOnceInDiagnostic() {
+    compilationHelper
+        .expectErrorMessage(
+            "SINGLE_CHECK_NAME",
+            message ->
+                message.startsWith("[RequireExplicitNullMarking] Top-level classes must either be"))
+        .addSourceLines(
+            "test/MissingAnnotation.java",
+            """
+            package test;
+            // BUG: Diagnostic matches: SINGLE_CHECK_NAME
+            class MissingAnnotation {
+            }
+            """)
+        .doTest();
+  }
+
   @Test
   public void defaultURL() {
     compilationHelper


### PR DESCRIPTION
## Why

Every report from `RequireExplicitNullMarking` named the check twice. From a Spring Batch build, quoted in [a comment on #1364](https://github.com/uber/NullAway/issues/1364#issuecomment-3617031199):

```text
[ERROR] .../AfterChunk.java:[37,9] [RequireExplicitNullMarking] [RequireExplicitNullMarking] Top-level classes must either be directly annotated with @NullMarked/@NullUnmarked, be in a package that is explicitly @NullMarked/@NullUnmarked, or be in a module that is explicitly @NullMarked.
```

Error Prone formats a diagnostic as `[checkName] rawMessage` (`Description.getMessage()`). `matchClass` returns `describeMatch(classTree)` and never calls `setMessage`, so the `@BugPattern` summary is the raw message, and the summary itself opened with `[RequireExplicitNullMarking] `. The prefix arrived with #1366, which rewrote the sentence starting from the rendered diagnostic quoted in #1364 and kept that rendering's prefix. Released since 0.12.14.

## What

Drop the leading `[RequireExplicitNullMarking] ` from the summary. Nothing else about the wording changes, so the `RequireExplicitNullMarking` Checker section of the [JSpecify Support wiki page](https://github.com/uber/NullAway/wiki/JSpecify-Support), which quotes the sentence with no prefix, stays correct.

`JSpecifyUnrecognizedAnnotationLocation` embeds its own name the same way, and its summary never reaches a user: `report` is the only place that builds a `Description`, and it always calls `setMessage`. Dropped there too for consistency, with no change in behavior. `NullAway` itself, the third `@BugPattern` in the repository, carries no prefix.

## Verification

`checkNameAppearsOnceInDiagnostic` (new) pins the emitted message. It asserts through `expectErrorMessage` with a `startsWith` predicate rather than `// BUG: Diagnostic contains:`, because the obvious `contains` assertion does not discriminate: `DiagnosticTestHelper` matches on a substring, and `[RequireExplicitNullMarking] [RequireExplicitNullMarking] Top-level classes …` contains `[RequireExplicitNullMarking] Top-level classes …` starting at the second prefix. Put the prefix back in the summary and this test fails, alone.

`:nullaway:test` and `:nullaway:buildWithNullAway` pass.

## Scope

No issue tracks the doubling. It was reported in passing on #1364, which was filed for and closed on the misleading wording about `@NullUnmarked` on modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected diagnostic messages to prevent duplicated checker-name prefixes.
  - Improved the presentation of unrecognized nullness annotation diagnostics by removing redundant prefixes.
  - Diagnostic output now presents checker names consistently and only once.

- **Tests**
  - Added coverage verifying that checker names appear only once in diagnostic messages.

- **Documentation**
  - Added an entry to the unreleased changelog describing the diagnostic fixes and updated message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->