### PR TITLE
Set up zizmor-action

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3


### PR DESCRIPTION
Set up a dedicated zizmor workflow to audit the repository's GitHub Actions configuration on pushes to `master` and on all pull requests.

The workflow follows the upstream GitHub code scanning integration, grants only the required `security-events: write` permission, disables persisted checkout credentials, and pins both actions to full commit SHAs.

Validation:

- `actionlint v1.7.12` passes for all workflows.
- zizmor 1.30.0 reports no findings in both offline and authenticated online audits.
- `git diff --check` passes.

Repository configuration required:

- The initial zizmor run is blocked at startup by the current GitHub Actions allowlist. A repository, organization, or enterprise administrator must allow `zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99` before this workflow can run. See [GitHub's documentation for allowing selected actions](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run).

Fixes #1793.

> I used Codex to implement and validate the zizmor-action workflow. I manually reviewed the changes and understand all changes in this pull request.

Assisted-by: Codex (gpt-5)
