### PR TITLE
Tweak CI configuration to prepare for enabling merge queue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ on:
       - master
 # Cancel in-progress runs for pull requests, but not for master branch pushes or merge queue
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 permissions:
   contents: read

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,11 +1,13 @@
 name: Continuous integration
 on:
+  merge_group:
   pull_request:
   push:
     branches:
       - master
+# Cancel in-progress runs for pull requests, but not for master branch pushes or merge queue
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 permissions:
   contents: read


### PR DESCRIPTION
* Enable CI for merge queue jobs (the `merge_group` line)
* Tweak concurrency: cancel in-progress runs for pull requests when new commits pushed, but not for master branch pushes or merge queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Continuous integration now runs for merge queue events.
  - Improved workflow run handling to cancel outdated pull request runs while preserving master branch pushes and merge queue runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->