### PR TITLE
Fix crasher example from Caffeine

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
@@ -144,9 +144,13 @@ public class TypeSubstitutionUtils {
   /**
    * Returns a copy of an unbounded wildcard with its {@code bound} field set to a copy of {@code
    * typeVariable} with {@code upperBound} as its upper bound.
+   *
+   * <p>When javac has not recorded the corresponding formal type variable on a captured wildcard,
+   * callers can supply the capture itself as {@code typeVariable}.
    */
-  private static Type.WildcardType replaceUnboundedWildcardUpperBound(
+  public static Type.WildcardType replaceUnboundedWildcardUpperBound(
       Type.WildcardType wildcard, Type.TypeVar typeVariable, Type upperBound) {
+    Verify.verify(wildcard.kind == BoundKind.UNBOUND, "wildcard must be unbounded");
     // A metadata clone of a javac TypeVar delegates setUpperBound() to the original TypeVar. Build
     // a genuinely detached TypeVar with the desired bound instead of mutating an apparent clone.
     Type.TypeVar updatedFormalTypeVariable =

--- a/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
@@ -136,22 +136,30 @@ public final class AddAnnotationToNestedTypeVisitor extends Types.MapVisitor<Int
    */
   @Override
   public Type visitCapturedType(Type.CapturedType t, Integer pathIndex) {
+    Type.WildcardType wildcard = t.wildcard;
+    if (wildcard.kind == BoundKind.UNBOUND && wildcard.bound == null) {
+      // javac can omit the formal type variable on a captured wildcard. Use the capture's upper
+      // bound in that case, on a detached copy so neither path traversal nor annotation updates
+      // mutate compiler-owned types.
+      wildcard =
+          TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(wildcard, t, t.getUpperBound());
+    }
     Type.WildcardType updatedWildcard;
     if (pathIndex < typePath.size()) {
-      updatedWildcard = (Type.WildcardType) t.wildcard.accept(this, pathIndex);
+      updatedWildcard = (Type.WildcardType) wildcard.accept(this, pathIndex);
     } else {
       Verify.verify(pathIndex == typePath.size(), "path index out of bounds");
-      if (t.wildcard.kind == BoundKind.UNBOUND) {
+      if (wildcard.kind == BoundKind.UNBOUND) {
         Type.TypeVar formalTypeVariable =
             Verify.verifyNotNull(
-                t.wildcard.bound, "unbounded wildcard has no corresponding formal type variable");
+                wildcard.bound, "unbounded wildcard has no corresponding formal type variable");
         Type updatedUpperBound =
             TypeSubstitutionUtils.typeWithAnnot(formalTypeVariable.getUpperBound(), annotationType);
         updatedWildcard =
-            TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(t.wildcard, updatedUpperBound);
+            TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound(wildcard, updatedUpperBound);
       } else {
-        Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(t.wildcard.type, annotationType);
-        updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(t.wildcard, updatedBound);
+        Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(wildcard.type, annotationType);
+        updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(wildcard, updatedBound);
       }
     }
     if (updatedWildcard == t.wildcard) {

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/VarDeclaredLocalTests.java
@@ -9,6 +9,54 @@ import org.junit.Test;
 public class VarDeclaredLocalTests extends NullAwayTestsBase {
 
   @Test
+  public void wildcardCompletableFutureHandleWithVar() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.concurrent.CompletableFuture;
+            class Test {
+              private static CompletableFuture<?> supply() {
+                return CompletableFuture.completedFuture("x");
+              }
+
+              static void crash() {
+                var future = supply();
+                var ready = future.handle((result, error) -> "x");
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void wildcardCompletableFutureHandleWithVarChecksCallbackNullability() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.concurrent.CompletableFuture;
+            class Test {
+              private static CompletableFuture<?> supply() {
+                return CompletableFuture.completedFuture("x");
+              }
+
+              static void test() {
+                var future = supply();
+                var ready = future.handle((result, error) -> {
+                  // BUG: Diagnostic contains: dereferenced expression 'error' is @Nullable
+                  error.toString();
+                  return "x";
+                });
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void genericInferenceForVarLocal() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1819 

We had another place with a bad assumption that for an unbound wildcard, the `bound` field would be non-null.  Re-use the `TypeSubstitutionUtils.replaceUnboundedWildcardUpperBound` to fix.

Both the new tests would crash before this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analysis of wildcard types used with `var`-declared local variables, including wildcard `CompletableFuture` instances.
  - Prevented compiler crashes when handling captured, unbounded wildcard types.
  - Improved nullability checking for callback parameters, correctly identifying nullable error values and reporting unsafe dereferences.

- **API**
  - Made a wildcard type-handling utility available for integrations that need to process captured wildcard types without formal type-variable information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->