### PR TITLE
Do not treat type variables from caller as inference variables

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
@@ -12,7 +12,7 @@ import javax.lang.model.element.Element;
 public interface ConstraintSolver {
 
   /**
-   * Registers a type parameter whose nullability is being inferred by this solver. Must be called
+   * Registers a type variable whose nullability is being inferred by this solver. Must be called
    * before adding constraints involving that parameter; unregistered parameters are fixed types.
    */
   void registerInferenceVariable(Element typeVariable);

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolver.java
@@ -12,6 +12,12 @@ import javax.lang.model.element.Element;
 public interface ConstraintSolver {
 
   /**
+   * Registers a type parameter whose nullability is being inferred by this solver. Must be called
+   * before adding constraints involving that parameter; unregistered parameters are fixed types.
+   */
+  void registerInferenceVariable(Element typeVariable);
+
+  /**
    * Exception thrown when the constraints added to the solver are determined to be unsatisfiable.
    *
    * <p>This is an unchecked exception since in our current solver implementation it needs to be

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -36,7 +36,7 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   private final Handler handler;
   private final VisitorState state;
 
-  /** Type parameters belonging to the calls participating in this inference problem. */
+  /** Type variables belonging to the calls participating in this inference problem. */
   private final Set<Element> inferenceVariables = new LinkedHashSet<>();
 
   public ConstraintSolverImpl(Config config, VisitorState state, NullAway analysis) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/ConstraintSolverImpl.java
@@ -36,6 +36,9 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   private final Handler handler;
   private final VisitorState state;
 
+  /** Type parameters belonging to the calls participating in this inference problem. */
+  private final Set<Element> inferenceVariables = new LinkedHashSet<>();
+
   public ConstraintSolverImpl(Config config, VisitorState state, NullAway analysis) {
     this.config = config;
     this.handler = analysis.getHandler();
@@ -80,6 +83,11 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   private final Map<Element, VarState> vars = new LinkedHashMap<>();
 
   /* ───────────────────── public API ───────────────────── */
+
+  @Override
+  public void registerInferenceVariable(Element typeVariable) {
+    inferenceVariables.add(typeVariable);
+  }
 
   @Override
   public void addSubtypeConstraint(Type subtype, Type supertype, boolean localVariableType)
@@ -368,10 +376,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   /**
    * Records that {@code t} must be {@code @Nullable}.
    *
-   * <p>Only an inference variable takes a constraint, meaning a type-variable use with no explicit
-   * nullness annotation. Every other type already has a fixed nullness, including a class type and
-   * an explicitly annotated type-variable use. For those cases, this method does not introduce any
-   * constraint, and the normal type compatibility checks report any incompatibility.
+   * <p>Only a registered inference variable with no explicit nullness annotation takes a
+   * constraint. For other types, including enclosing type parameters and explicitly annotated
+   * type-variable uses, this method does not introduce any constraint, and the normal type
+   * compatibility checks report any incompatibility.
    *
    * @param t the type to constrain
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
@@ -385,10 +393,10 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
   /**
    * Records that {@code t} must be {@code @NonNull}.
    *
-   * <p>Only an inference variable takes a constraint, meaning a type-variable use with no explicit
-   * nullness annotation. Every other type already has a fixed nullness, including a class type and
-   * an explicitly annotated type-variable use. For those cases, this method does not introduce any
-   * constraint, and the normal type compatibility checks report any incompatibility.
+   * <p>Only a registered inference variable with no explicit nullness annotation takes a
+   * constraint. For other types, including enclosing type parameters and explicitly annotated
+   * type-variable uses, this method does not introduce any constraint, and the normal type
+   * compatibility checks report any incompatibility.
    *
    * @param t the type to constrain
    * @throws UnsatisfiableConstraintsException if the constraint leads to a contradiction
@@ -407,24 +415,40 @@ public final class ConstraintSolverImpl implements ConstraintSolver {
         v -> new VarState(GenericsUtils.upperBoundIsNullable(v, config, handler, state)));
   }
 
+  /** Returns whether this use denotes an inference variable without a nullness override. */
   private boolean treatAsTypeVariableForInference(Type t) {
     if (t instanceof TypeVar tv) {
       // Only treat as a type variable if it _doesn't_ have an explicit @Nullable or @NonNull
       // annotation.
-      return !Nullness.hasNullableAnnotation(tv.getAnnotationMirrors().stream(), config)
+      return inferenceVariables.contains(tv.asElement())
+          && !Nullness.hasNullableAnnotation(tv.getAnnotationMirrors().stream(), config)
           && !Nullness.hasNonNullAnnotation(tv.getAnnotationMirrors().stream(), config);
     } else {
       return false;
     }
   }
 
+  /** Returns whether a type is explicitly nullable or is the null type. */
   private boolean isKnownNullable(Type t) {
     return t instanceof NullType
         || Nullness.hasNullableAnnotation(t.getAnnotationMirrors().stream(), config);
   }
 
-  /** Everything non-nullable *and* non-variable counts as @NonNull. */
+  /**
+   * Returns whether a type is known non-null without solving inference constraints.
+   *
+   * <p>For the null type and types with an explicit {@code @Nullable} annotation, returns {@code
+   * false}. All other non-type-variable types are treated as non-null. Type-variable uses with an
+   * explicit {@code @NonNull} annotation are also known non-null; unannotated inference variables
+   * are not. For unannotated fixed type variables, a non-null upper bound establishes non-nullness,
+   * while a nullable upper bound alone establishes neither known-nullable nor known-non-null
+   * status.
+   */
   private boolean isKnownNonNull(Type t) {
-    return !isKnownNullable(t) && !treatAsTypeVariableForInference(t);
+    return !isKnownNullable(t)
+        && !treatAsTypeVariableForInference(t)
+        && (!(t instanceof TypeVar tv)
+            || Nullness.hasNonNullAnnotation(t.getAnnotationMirrors().stream(), config)
+            || !GenericsUtils.upperBoundIsNullable(tv.asElement(), config, handler, state));
   }
 }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1420,13 +1420,18 @@ public final class GenericsChecks {
   }
 
   /** Returns the type parameters whose nullability is inferred for {@code callTree}. */
-  private com.sun.tools.javac.util.List<Symbol.TypeVariableSymbol> getCallTypeParameters(
-      ExpressionTree callTree) {
+  private List<Symbol.TypeVariableSymbol> getCallTypeParameters(ExpressionTree callTree) {
     if (callTree instanceof MethodInvocationTree invocationTree) {
       return ASTHelpers.getSymbol(invocationTree).getTypeParameters();
     }
     Verify.verify(callTree instanceof NewClassTree);
-    return getConstructedTypeAtCallSite((NewClassTree) callTree).tsym.getTypeParameters();
+    NewClassTree newClassTree = (NewClassTree) callTree;
+    List<Symbol.TypeVariableSymbol> typeParameters =
+        new ArrayList<>(getConstructedTypeAtCallSite(newClassTree).tsym.getTypeParameters());
+    if (newClassTree.getTypeArguments().isEmpty()) {
+      typeParameters.addAll(getMethodSymbolForCall(newClassTree).getTypeParameters());
+    }
+    return typeParameters;
   }
 
   /**
@@ -1438,9 +1443,10 @@ public final class GenericsChecks {
    * receiver of type {@code Foo<@Nullable Object>}, the return type is {@code @Nullable Object}.
    *
    * <p>Type variables being inferred for this call remain unsubstituted so constraints can be
-   * generated for them. These are method type variables for a generic method invocation and class
-   * type variables for a diamond constructor. Unlike {@link #getInvokedMethodTypeAtCall}, this
-   * method does not resolve those variables using an already-computed inference result.
+   * generated for them. These are method type variables for a generic method invocation, and class
+   * and constructor type variables for a diamond constructor. Unlike {@link
+   * #getInvokedMethodTypeAtCall}, this method does not resolve those variables using an
+   * already-computed inference result.
    */
   private Type.MethodType getExecutableTypeForInference(
       ExpressionTree callTree,
@@ -1501,7 +1507,7 @@ public final class GenericsChecks {
       Set<Tree> allCalls,
       boolean calledFromDataflow)
       throws UnsatisfiableConstraintsException {
-    // register all the type variables for the generic method as inference variables
+    // Register all type variables whose nullability is inferred for this call.
     for (Symbol.TypeVariableSymbol typeVariable : getCallTypeParameters(callTree)) {
       solver.registerInferenceVariable(typeVariable);
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1501,6 +1501,7 @@ public final class GenericsChecks {
       Set<Tree> allCalls,
       boolean calledFromDataflow)
       throws UnsatisfiableConstraintsException {
+    // register all the type variables for the generic method as inference variables
     for (Symbol.TypeVariableSymbol typeVariable : getCallTypeParameters(callTree)) {
       solver.registerInferenceVariable(typeVariable);
     }
@@ -1676,6 +1677,8 @@ public final class GenericsChecks {
       ConstraintSolver solver,
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
+    // if we have a reference to a generic method, and the call site does not pass explicit type
+    // arguments, register the referenced method's type variables as inference variables
     Symbol.MethodSymbol referencedMethod = ASTHelpers.getSymbol(memberReferenceTree);
     List<? extends ExpressionTree> explicitTypeArguments = memberReferenceTree.getTypeArguments();
     if (referencedMethod != null

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -1501,6 +1501,9 @@ public final class GenericsChecks {
       Set<Tree> allCalls,
       boolean calledFromDataflow)
       throws UnsatisfiableConstraintsException {
+    for (Symbol.TypeVariableSymbol typeVariable : getCallTypeParameters(callTree)) {
+      solver.registerInferenceVariable(typeVariable);
+    }
     Type.MethodType methodType =
         getExecutableTypeForInference(callTree, path, state, calledFromDataflow);
     // first, handle the call result flow
@@ -1673,6 +1676,14 @@ public final class GenericsChecks {
       ConstraintSolver solver,
       Type lhsType,
       MemberReferenceTree memberReferenceTree) {
+    Symbol.MethodSymbol referencedMethod = ASTHelpers.getSymbol(memberReferenceTree);
+    List<? extends ExpressionTree> explicitTypeArguments = memberReferenceTree.getTypeArguments();
+    if (referencedMethod != null
+        && (explicitTypeArguments == null || explicitTypeArguments.isEmpty())) {
+      for (Symbol.TypeVariableSymbol typeVariable : referencedMethod.getTypeParameters()) {
+        solver.registerInferenceVariable(typeVariable);
+      }
+    }
     Type groundTargetType = GenericsUtils.groundTargetType(lhsType, state, config, handler);
     GenericsUtils.processMethodRefTypeRelations(
         this,

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
 
   @Test
-  public void arraysCopyOfWithRenamedEnclosingTypeVariable() {
+  public void issue1821DoNotTreatCallerTypeVariableAsAnInferenceVariable() {
     makeHelper()
         .addSourceLines(
             "Test.java",
@@ -37,11 +37,15 @@ public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
             import org.jspecify.annotations.Nullable;
             @NullMarked
             class Test {
-              public static <E> E @Nullable [] copyOf(E @Nullable [] original) {
+              public static <E> E @Nullable [] copyOfConditionalExpression(E @Nullable [] original) {
                 return original == null
                     ? null
                     // BUG: Diagnostic contains: Conditional expression must have type E @Nullable [] but the sub-expression has type @Nullable E []
                     : Arrays.copyOf(original, original.length);
+              }
+              public static <E> E @Nullable [] copyOfDirectReturn(E [] original) {
+                // BUG: Diagnostic contains: incompatible types: @Nullable E [] cannot be converted to E @Nullable []
+                return Arrays.copyOf(original, original.length);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericInferenceErrorReportingTests.java
@@ -26,6 +26,28 @@ import org.junit.Test;
  */
 public class GenericInferenceErrorReportingTests extends NullAwayTestsBase {
 
+  @Test
+  public void arraysCopyOfWithRenamedEnclosingTypeVariable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Arrays;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              public static <E> E @Nullable [] copyOf(E @Nullable [] original) {
+                return original == null
+                    ? null
+                    // BUG: Diagnostic contains: Conditional expression must have type E @Nullable [] but the sub-expression has type @Nullable E []
+                    : Arrays.copyOf(original, original.length);
+              }
+            }
+            """)
+        .doTest();
+  }
+
   /**
    * Source compiled before each call site, padded so a misattributed diagnostic lands on an
    * existing line and cannot be dropped by the test framework.

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -537,7 +537,15 @@ public class GenericMethodTests extends NullAwayTestsBase {
                 <U extends @Nullable Object> Box(Supplier<? super U> supplier) {}
               }
               void test() {
+                // no error: U should be inferred to be @Nullable
                 Box<String> box = new Box<>(() -> null);
+              }
+              static class Box2<T> {
+                <U extends Object> Box2(Supplier<? extends U> supplier) {}
+              }
+              void test2() {
+                // BUG: Diagnostic contains: inference failure: type variable U is constrained to be @Nullable
+                Box2<String> box = new Box2<>(() -> null);
               }
             }
             """)

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/GenericMethodTests.java
@@ -522,6 +522,29 @@ public class GenericMethodTests extends NullAwayTestsBase {
   }
 
   @Test
+  public void inferGenericConstructorTypeVariable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.util.function.Supplier;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T> {
+                <U extends @Nullable Object> Box(Supplier<? super U> supplier) {}
+              }
+              void test() {
+                Box<String> box = new Box<>(() -> null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void nullableAnnotOnMethodTypeVarUse() {
     makeHelper()
         .addSourceLines(


### PR DESCRIPTION
Fixes #1821 

#1821 exposed an important problem with our generic method inference.  We were not distinguishing between type variables of the generic method being called (for which nullability needs to be inferred) from other type variables from the caller's enclosing environment, whose nullability is not being inferred.  This is what led to the bad error message in that case, and in general could lead us to do excessive inference work (and potentially other problems).

We fix by requiring that inference variables be _registered_ with the constraint solver, and adding the appropriate calls to register variables in `GenericsChecks`.  We also correct the implementation of `getCallTypeParameters` to include type variables declared by generic constructors, to ensure these variables get registered as inference variables (add a test around this also).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generic type inference for constructor calls, including diamond-inference scenarios, method references, and generic method invocations.
  - Prevented caller-declared type variables from being incorrectly treated as inference variables.
  - Improved nullability handling for fixed type variables and their bounds, producing more accurate results and diagnostics.

- **Tests**
  - Added coverage for generic constructor inference and accurate diagnostics involving nullable generic arrays.
  - Added validation for nullable and non-nullable generic bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->