### PR TITLE
Set up Renovate and validate its config in CI

### DIFF
--- a/.github/workflows/renovate-config-lint.yml
+++ b/.github/workflows/renovate-config-lint.yml
@@ -1,0 +1,104 @@
+name: Validate Renovate config
+# There is deliberately no paths filter: a workflow that filters itself out reports no status, and
+# a status that is sometimes absent cannot be a required check. The job runs on every pull request,
+# every merge queue entry and every push to master, and skips the validation step on a pull request
+# or a queue entry that changed neither renovate.json nor this workflow.
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - master
+# Cancel in-progress runs for pull requests, but not for master branch pushes or merge queue
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  validate-renovate-config:
+    name: "Validate renovate.json"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out NullAway sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # The changes step diffs two commits, so both have to be in the clone.
+          fetch-depth: 0
+          persist-credentials: false
+      # This step carries no condition on purpose: the rename it guards against happens in
+      # gradle/libs.versions.toml, which the changes step does not watch.
+      - name: Check that the rules' catalog aliases exist
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            // Every rule that pins a version-catalog entry selects it by sharedVariableName, the
+            // alias Renovate reports for a dependency. A rename in libs.versions.toml would leave
+            // such a rule matching nothing while the config still validated.
+            const config = JSON.parse(fs.readFileSync('renovate.json', 'utf8'));
+            const pinned = new Set();
+            for (const rule of config.packageRules ?? []) {
+              for (const expression of rule.matchJsonata ?? []) {
+                if (!expression.includes('sharedVariableName')) continue;
+                for (const [, literal] of expression.matchAll(/'([^']*)'/g)) {
+                  const alias = literal.replace(/^libs\.versions\./, '');
+                  // A literal outside the alias character set belongs to some other field.
+                  if (/^[A-Za-z0-9_.-]+$/.test(alias)) pinned.add(alias);
+                }
+              }
+            }
+
+            // Renovate reports an alias with '-' and '_' replaced by '.', and that is the spelling
+            // a rule has to use, so normalize the declared names rather than the other way round.
+            const declared = new Set();
+            let inVersions = false;
+            for (const line of fs.readFileSync('gradle/libs.versions.toml', 'utf8').split('\n')) {
+              const header = line.match(/^\s*\[([^\]]+)\]/);
+              if (header) {
+                inVersions = header[1] === 'versions';
+                continue;
+              }
+              const entry = inVersions && line.match(/^\s*([A-Za-z0-9_.-]+)\s*=/);
+              if (entry) declared.add(entry[1].replace(/[-_]/g, '.'));
+            }
+
+            if (pinned.size === 0) {
+              core.setFailed(
+                'No rule in renovate.json selects a catalog alias. Either the pinning rules are ' +
+                  'gone, or their shape changed and this check no longer reads them.',
+              );
+              return;
+            }
+
+            const missing = [...pinned].filter((alias) => !declared.has(alias)).sort();
+            if (missing.length > 0) {
+              core.setFailed(
+                `renovate.json names version-catalog entries that gradle/libs.versions.toml does ` +
+                  `not declare: ${missing.join(', ')}. Renaming an entry disables the rule that ` +
+                  `pins it, and renovate-config-validator does not notice.`,
+              );
+            } else {
+              core.info(`Every catalog alias the rules select is declared: ${[...pinned].sort().join(', ')}`);
+            }
+      - name: Look for changes to the Renovate config
+        id: changes
+        if: github.event_name != 'push'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- renovate.json .github/workflows/renovate-config-lint.yml; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          fi
+      - name: Validate renovate.json
+        # An empty output means the changes step did not run, which leaves validation on.
+        if: steps.changes.outputs.changed != 'false'
+        # --no-global is required: without it the validator treats renovate.json as a self-hosted
+        # global config and accepts options a repository config may not carry, such as onboarding.
+        # The image tag stays unpinned so the config is validated against the newest Renovate
+        # release; a pinned validator would keep passing after that release changed an option.
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --no-global renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "minimumReleaseAge holds an update back until its release is seven days old, so that a broken or compromised publish has time to be found and pulled before it reaches a PR. internalChecksFilter defaults to strict, so such an update waits rather than opening a PR that is revised later. The Error Prone rule and the GitHub official actions rule set minimumReleaseAge to null; a security update bypasses it through Renovate's own vulnerabilityAlerts defaults.",
+  "extends": [
+    "config:best-practices"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "semanticCommits": "disabled",
+  "schedule": [
+    "every 2 weeks on Monday"
+  ],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "A major update lands on the dependency dashboard for manual review instead of opening a PR. The rule matches every manager, so a major GitHub Actions or Gradle plugin bump goes to the dashboard too.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "NullAway compiles against Error Prone internals such as ASTHelpers, so an Error Prone release can change what NullAway builds and runs against; testErrorProneLatestSnapshot exists to catch such a change before the release lands (#1555). Error Prone PRs open as soon as a release lands, rather than waiting for the next two-week window. Error Prone also skips the seven-day cooldown: a broken release breaks this build rather than reaching users, and testErrorProneLatestSnapshot has already exercised the change while it was a snapshot. A major Error Prone release still needs dependency dashboard approval, like every other major.",
+      "matchPackageNames": [
+        "com.google.errorprone{/,}**"
+      ],
+      "schedule": [
+        "at any time"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "The errorProne entry in gradle/libs.versions.toml is the Error Prone release NullAway builds and tests against, and it tracks the newest one. It needs a group of its own because group:monorepos, which config:best-practices pulls in through config:recommended, otherwise collects every com.google.errorprone dependency into one error-prone-monorepo PR, pinned catalog entries included.",
+      "matchJsonata": [
+        "sharedVariableName in ['errorProne', 'libs.versions.errorProne']"
+      ],
+      "groupName": "libs.versions.errorProne"
+    },
+    {
+      "description": "The errorProneOldest entry in gradle/libs.versions.toml is the oldest Error Prone release NullAway supports: README.md gives 2.36.0 as the minimum, and testErrorProneOldest runs the test suite against it. Raising that floor is a decision rather than maintenance, so this entry takes 2.36.x patch releases only. This rule and the errorProne, errorProneJdk17 and guava rules match on sharedVariableName, the version-catalog alias Renovate records for a dependency, because the three Error Prone entries resolve to the same com.google.errorprone artifacts and no other stable field distinguishes them. Each rule also accepts a libs.versions.-prefixed spelling as insurance. Renovate reports the bare alias for every entry here, because it strips that prefix while more than one dependency shares a catalog entry; an entry that build.gradle reads through an ext property would keep the prefix if a refactor left a single dependency on it. Renaming an alias would therefore drop its pin without failing the validator, so the lint workflow checks the names separately. Each bound is written as a Gradle range. Renovate's gradle versioning has no '<' range syntax, so a bound of '< 2.37' in either allowedVersions or matchCurrentVersion parses as nothing and holds nothing back.",
+      "matchJsonata": [
+        "sharedVariableName in ['errorProneOldest', 'libs.versions.errorProneOldest']"
+      ],
+      "groupName": "libs.versions.errorProneOldest",
+      "allowedVersions": "[,2.37)"
+    },
+    {
+      "description": "The errorProneJdk17 entry in gradle/libs.versions.toml holds the newest Error Prone that runs on JDK 17, because 2.43.0 and later require JDK 21 (#1401). The testJdk17 task puts its jars in front of the test classpath. This entry takes 2.42.x patch releases only.",
+      "matchJsonata": [
+        "sharedVariableName in ['errorProneJdk17', 'libs.versions.errorProneJdk17']"
+      ],
+      "groupName": "libs.versions.errorProneJdk17",
+      "allowedVersions": "[,2.43)"
+    },
+    {
+      "description": "The guava entry in gradle/libs.versions.toml is the Guava version NullAway itself depends on, so it stays on 31.x; guava-recent-unit-tests exists to test newer Guava without bumping it (#629). The guava-latest entry holds that newer Guava, resolves to the same com.google.guava:guava, and keeps the default schedule and the preset guava-monorepo group. The guava entry needs a group of its own, or group:monorepos would put both entries in one PR.",
+      "matchJsonata": [
+        "sharedVariableName in ['guava', 'libs.versions.guava']"
+      ],
+      "groupName": "libs.versions.guava",
+      "allowedVersions": "[,32)"
+    },
+    {
+      "description": "The errorProneLatestSnapshot configuration in nullaway/build.gradle asks for 1.0-HEAD-SNAPSHOT, the marker that resolves to the current Error Prone snapshot in the Sonatype snapshot repository. Renovate reads the marker as version 1.0 and offers every release above it, and replacing it would break testErrorProneLatestSnapshot.",
+      "matchCurrentValue": "1.0-HEAD-SNAPSHOT",
+      "enabled": false
+    },
+    {
+      "description": "jmh/build.gradle pins every version it names, so none of them takes an update. Most of them compile a released NullAway against the dependency versions that release was built with. The caffeine, autodispose and nullaway versions also appear as literal substrings in the classpath filters in that file, so a bump would leave a filter matching nothing and put the benchmark artifact back on its own classpath.",
+      "matchFileNames": [
+        "jmh/build.gradle"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "com.android.support is the legacy Android support library, superseded by AndroidX. sample-app is the only module that depends on it.",
+      "matchPackageNames": [
+        "com.android.support{/,}**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "actions/* and github/* are maintained by GitHub and can update together. GitHub publishes them, so they skip the seven-day cooldown; an action from any other publisher waits it out.",
+      "groupName": "github official actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "actions/**",
+        "github/**"
+      ],
+      "minimumReleaseAge": null
+    }
+  ]
+}


### PR DESCRIPTION
NullAway has no automated dependency updates. #1817 proposed Dependabot and was closed in favor of Renovate for its configuration options: grouping every GitHub Actions bump into one pull request, and custom regex managers for versions the standard managers do not reach.

Several versions in this build are pinned on purpose, and a bot that bumped every one of them would break the test matrix:

* `errorProneOldest` holds the minimum Error Prone that `README.md` documents, 2.36.0, and `testErrorProneOldest` runs the suite against it. Raising that floor is a decision rather than maintenance, so the entry takes 2.36.x only.
* `errorProneJdk17` holds the newest Error Prone that runs on JDK 17, since 2.43.0 and later require JDK 21 (#1401), and `testJdk17` puts its jars in front of the test classpath. The entry takes 2.42.x only.
* `guava` is the version NullAway itself depends on, and it reaches a user's annotation processor path, so it stays on 31.x. The separate `guava-latest` entry that `guava-recent-unit-tests` uses keeps taking updates (#629).
* `errorProneLatestSnapshot` asks for the literal `1.0-HEAD-SNAPSHOT` marker, which Renovate reads as version 1.0 and would replace with a release.
* `jmh/build.gradle` pins every version it names, and spells three of them as literal substrings in its classpath filters, so a bump would leave a filter matching nothing.
* `com.android.support` is the superseded Android support library, used only by `sample-app`.

The three Error Prone catalog entries resolve to the same `com.google.errorprone` artifacts, and `guava` and `guava-latest` both resolve to `com.google.guava:guava`, so `matchPackageNames` cannot tell them apart. Those rules match on `sharedVariableName`, the catalog alias Renovate reports for a dependency, under two spellings. Renovate reports the bare alias for every entry in this repository; the `libs.versions.` prefixed form is insurance, for an entry that `build.gradle` reads through an `ext` property and that a refactor leaves with a single dependency. Each bound is a Gradle range such as `[,2.37)`, because that versioning accepts `[a,b)`, `1.2.+` and `[1.0]` and has no `<` form, so a bound written as `< 2.37` would parse as nothing and hold nothing back. Each pinned entry also carries a `groupName`, because otherwise `group:monorepos`, which `config:best-practices` pulls in through `config:recommended`, would collect a pinned entry and an unpinned one into one monorepo pull request. Everything else is grouped the way Renovate already groups it, by version-catalog entry or by upstream monorepo.

The rest is policy. Updates arrive every two weeks, labeled `dependencies`, with no semantic-commit prefix, since this repository writes plain subjects. A major update goes to the dependency dashboard for manual approval instead of opening a pull request, Error Prone included; only the schedule and the cooldown below treat Error Prone differently. It is exempt from the schedule and opens as soon as a release is published: NullAway compiles against Error Prone internals such as `ASTHelpers`, and `testErrorProneLatestSnapshot` (#1555) runs the suite against Error Prone snapshots, so such a change shows up before the release does.

A release less than seven days old does not reach a pull request: `minimumReleaseAge` holds it back, so that a broken or compromised publish has time to be found and pulled. Where an older release above the current version is itself old enough, Renovate targets that one rather than waiting. Error Prone and the actions GitHub publishes are exempt, because a broken Error Prone release breaks this build rather than reaching users and `testErrorProneLatestSnapshot` has already exercised it as a snapshot, and because an action GitHub publishes is not the supply-chain risk a third-party one is. A security update bypasses the cooldown through Renovate's own `vulnerabilityAlerts` defaults.

`renovate-config-validator` checks the config's shape, not whether a rule still matches anything, so the workflow also checks that every alias a rule pins is still declared in `gradle/libs.versions.toml`; a rename there would leave the rule matching nothing while the config still validated. That step carries no `if:` condition, because the catalog is not one of the two files the workflow watches for changes. The workflow itself carries no `paths:` filter, so that its status is always reported and it can be made a required check; the validation step is skipped instead when neither `renovate.json` nor the workflow changed. The validator runs with `--no-global`, without which it accepts self-hosted global options such as `onboarding` that a repository config may not carry. The `merge_group` trigger and the `concurrency` group are the ones #1818 settled on for `continuous-integration.yml`.

This is configuration, so there are no unit tests. Checked with `renovate --platform=local --dry-run=full` over this worktree, which matched every rule against the real dependency set: each pinned entry is held, and widening a bound by hand produces the separate branch its rule names. Renaming a catalog entry by hand fails the alias check and names the entry. The cooldown was measured the same way: at seven days two updates are held as pending and three retarget to an older release that is old enough, and raising it to 365 days holds twenty while the exempt Error Prone update still comes through. No run covers GitHub Actions: a local Renovate has no token, so all 21 action dependencies come back `github-token-required`.

Left out, following the plan in #1792 to start with an initial version and tune the rules later. Automerge stays off and no custom regex manager is configured yet. The GitHub Actions grouping covers `actions/*` and `github/*`, not the other publishers this repository uses, so a `codecov`, `gradle/actions` or `zizmorcore` bump still arrives on its own. The older test fixtures in `gradle/libs.versions.toml` are not excluded either: nothing in the repository records which of them are held on purpose, so their majors need dashboard approval and their minors will open pull requests until someone names the ones to pin. `jmh/build.gradle` and `com.android.support` are disabled outright rather than bounded. Merging this file does not start Renovate; the app still has to be enabled for `uber/NullAway`.

Fixes #1792

Assisted-by: Claude Code (claude-opus-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated Renovate configuration to regularly identify and group dependency updates.
  - Dependency updates now follow release-age safeguards, version constraints, and approval requirements for major changes.
  - Added validation checks to ensure Renovate configuration remains consistent and valid across pull requests, merge queues, and pushes.
  - GitHub Actions updates are grouped together to simplify maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->