### PR TITLE
Prevent classloader closure from interrupting stubx reads

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -67,6 +67,8 @@ import com.uber.nullaway.librarymodel.AddAnnotationToNestedTypeVisitor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -1861,8 +1863,9 @@ public class LibraryModelsHandler implements Handler {
     if (isJarInferEnabled) {
       // hardcoded loading of stubx files from android-jarinfer-models-sdkXX artifacts
       try (InputStream androidStubxIS =
-          castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader())
-              .getResourceAsStream(ANDROID_ASTUBX_LOCATION)) {
+          openResourceWithoutCaching(
+              castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader()),
+              ANDROID_ASTUBX_LOCATION)) {
         if (androidStubxIS != null) {
           cacheUtil.parseStubStream(androidStubxIS, "android.jar: " + ANDROID_ASTUBX_LOCATION);
           astubxLoadLog("Loaded Android RT models.");
@@ -1878,8 +1881,9 @@ public class LibraryModelsHandler implements Handler {
 
     if (isJSpecifyJDKEnabled) {
       try (InputStream in =
-          castToNonNull(LibraryModelsHandler.class.getClassLoader())
-              .getResourceAsStream(JSPECIFY_JDK_ASTUBX_FILENAME)) {
+          openResourceWithoutCaching(
+              castToNonNull(LibraryModelsHandler.class.getClassLoader()),
+              JSPECIFY_JDK_ASTUBX_FILENAME)) {
         if (in == null) {
           throw new IllegalStateException(
               "JDK astubx model not found on classpath: %s"
@@ -1892,6 +1896,29 @@ public class LibraryModelsHandler implements Handler {
       }
     }
     return createImmutableStubxLibraryModels(cacheUtil);
+  }
+
+  /**
+   * Opens a classpath resource without sharing a cached JAR file with other classloaders.
+   *
+   * <p>A {@link java.net.URLClassLoader} tracks JAR files opened by {@code getResourceAsStream} and
+   * closes them when the classloader is closed. Since {@link java.net.JarURLConnection} caches JAR
+   * files across classloaders by default, closing one classloader can otherwise invalidate a stream
+   * that another classloader is still reading.
+   *
+   * @param classLoader classloader used to locate the resource
+   * @param resourceName name of the resource to open
+   * @return the resource stream, or {@code null} if the resource is not found
+   */
+  static @Nullable InputStream openResourceWithoutCaching(
+      ClassLoader classLoader, String resourceName) throws IOException {
+    URL resource = classLoader.getResource(resourceName);
+    if (resource == null) {
+      return null;
+    }
+    URLConnection connection = resource.openConnection();
+    connection.setUseCaches(false);
+    return connection.getInputStream();
   }
 
   /** Converts mutable parser caches into context-independent immutable library-model values. */

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/LibraryModelsHandler.java
@@ -1864,8 +1864,8 @@ public class LibraryModelsHandler implements Handler {
       // hardcoded loading of stubx files from android-jarinfer-models-sdkXX artifacts
       try (InputStream androidStubxIS =
           openResourceWithoutCaching(
-              castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader()),
-              ANDROID_ASTUBX_LOCATION)) {
+              castToNonNull(Class.forName(ANDROID_MODEL_CLASS).getClassLoader())
+                  .getResource(ANDROID_ASTUBX_LOCATION))) {
         if (androidStubxIS != null) {
           cacheUtil.parseStubStream(androidStubxIS, "android.jar: " + ANDROID_ASTUBX_LOCATION);
           astubxLoadLog("Loaded Android RT models.");
@@ -1882,8 +1882,8 @@ public class LibraryModelsHandler implements Handler {
     if (isJSpecifyJDKEnabled) {
       try (InputStream in =
           openResourceWithoutCaching(
-              castToNonNull(LibraryModelsHandler.class.getClassLoader()),
-              JSPECIFY_JDK_ASTUBX_FILENAME)) {
+              castToNonNull(LibraryModelsHandler.class.getClassLoader())
+                  .getResource(JSPECIFY_JDK_ASTUBX_FILENAME))) {
         if (in == null) {
           throw new IllegalStateException(
               "JDK astubx model not found on classpath: %s"
@@ -1906,13 +1906,11 @@ public class LibraryModelsHandler implements Handler {
    * files across classloaders by default, closing one classloader can otherwise invalidate a stream
    * that another classloader is still reading.
    *
-   * @param classLoader classloader used to locate the resource
-   * @param resourceName name of the resource to open
+   * @param resource URL of the resource to open, or {@code null} if it was not found
    * @return the resource stream, or {@code null} if the resource is not found
    */
-  static @Nullable InputStream openResourceWithoutCaching(
-      ClassLoader classLoader, String resourceName) throws IOException {
-    URL resource = classLoader.getResource(resourceName);
+  static @Nullable InputStream openResourceWithoutCaching(@Nullable URL resource)
+      throws IOException {
     if (resource == null) {
       return null;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StubxCacheUtil.java
@@ -129,7 +129,9 @@ public class StubxCacheUtil {
       for (String astubxPath : provider.pathsToStubxFiles()) {
         Class<? extends JarInferStubxProvider> providerClass = provider.getClass();
         String stubxLocation = providerClass + ":" + astubxPath;
-        try (InputStream stubxInputStream = providerClass.getResourceAsStream(astubxPath)) {
+        try (InputStream stubxInputStream =
+            LibraryModelsHandler.openResourceWithoutCaching(
+                providerClass.getResource(astubxPath))) {
           if (stubxInputStream == null) {
             throw new RuntimeException("could not get input stream for " + astubxPath);
           }

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/LibraryModelsHandlerTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/LibraryModelsHandlerTest.java
@@ -41,9 +41,8 @@ public class LibraryModelsHandlerTest {
 
   /**
    * Verifies that closing one classloader cannot invalidate a resource stream opened by a second
-   * classloader that uses {@link LibraryModelsHandler#openResourceWithoutCaching(ClassLoader,
-   * String)}. This models overlapping compilations whose classloaders read a model from the same
-   * JAR; see <a
+   * classloader that uses {@link LibraryModelsHandler#openResourceWithoutCaching(URL)}. This models
+   * overlapping compilations whose classloaders read a model from the same JAR; see <a
    * href="https://github.com/uber/NullAway/issues/1829">https://github.com/uber/NullAway/issues/1829</a>.
    */
   @Test
@@ -58,7 +57,8 @@ public class LibraryModelsHandlerTest {
         // Compilation B starts reading its model through an independently owned JAR handle.
         InputStream streamB =
             Objects.requireNonNull(
-                LibraryModelsHandler.openResourceWithoutCaching(loaderB, RESOURCE_NAME))) {
+                LibraryModelsHandler.openResourceWithoutCaching(
+                    loaderB.getResource(RESOURCE_NAME)))) {
       // Compilation A opens the same resource through URLClassLoader's shared JAR cache.
       try (InputStream streamA =
           Objects.requireNonNull(loaderA.getResourceAsStream(RESOURCE_NAME))) {

--- a/nullaway/src/test/java/com/uber/nullaway/handlers/LibraryModelsHandlerTest.java
+++ b/nullaway/src/test/java/com/uber/nullaway/handlers/LibraryModelsHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.nullaway.handlers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.io.ByteStreams;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LibraryModelsHandlerTest {
+
+  private static final String RESOURCE_NAME = "model.astubx";
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * Verifies that closing one classloader cannot invalidate a resource stream opened by a second
+   * classloader that uses {@link LibraryModelsHandler#openResourceWithoutCaching(ClassLoader,
+   * String)}. This models overlapping compilations whose classloaders read a model from the same
+   * JAR; see <a
+   * href="https://github.com/uber/NullAway/issues/1829">https://github.com/uber/NullAway/issues/1829</a>.
+   */
+  @Test
+  public void uncachedResourceStreamSurvivesClosingAnotherClassLoader() throws Exception {
+    byte[] expected = new byte[1_000_000];
+    Arrays.fill(expected, (byte) 42);
+    File jarFile = createJarContainingResource(expected);
+    URL[] urls = {jarFile.toURI().toURL()};
+
+    try (URLClassLoader loaderA = URLClassLoader.newInstance(urls, null);
+        URLClassLoader loaderB = URLClassLoader.newInstance(urls, null);
+        // Compilation B starts reading its model through an independently owned JAR handle.
+        InputStream streamB =
+            Objects.requireNonNull(
+                LibraryModelsHandler.openResourceWithoutCaching(loaderB, RESOURCE_NAME))) {
+      // Compilation A opens the same resource through URLClassLoader's shared JAR cache.
+      try (InputStream streamA =
+          Objects.requireNonNull(loaderA.getResourceAsStream(RESOURCE_NAME))) {
+        assertThat(streamA.read()).isNotEqualTo(-1);
+      }
+      // Finishing compilation A closes its classloader while compilation B is still reading.
+      loaderA.close();
+      // Check that the read from compilation B completes successfully
+      assertThat(ByteStreams.toByteArray(streamB)).isEqualTo(expected);
+    }
+  }
+
+  /** Creates a temporary JAR containing {@link #RESOURCE_NAME} with the supplied contents. */
+  private File createJarContainingResource(byte[] contents) throws IOException {
+    File jarFile = temporaryFolder.newFile("models.jar");
+    try (JarOutputStream output = new JarOutputStream(new FileOutputStream(jarFile))) {
+      output.putNextEntry(new ZipEntry(RESOURCE_NAME));
+      output.write(contents);
+      output.closeEntry();
+    }
+    return jarFile;
+  }
+}


### PR DESCRIPTION
Bazel multiplex workers can run compilations concurrently with separate processor classloaders over the same JARs. ClassLoader.getResourceAsStream uses the shared JarURLConnection cache, so closing the classloader for a completed compilation can close a JAR that another compilation is still reading and cause an IOException: Stream closed failure.

Load the bundled JSpecify JDK models and Android JarInfer models through explicit URLConnections with caching disabled. Each read therefore owns its JAR handle and remains valid when another compiler classloader is closed.

Add a deterministic regression test that opens the same temporary model JAR through two classloaders, closes one classloader, and verifies that the uncached stream from the other classloader can still be read completely.

Fixes #1829

Assisted-by: Codex (gpt-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of Android JarInfer, JSpecify, and provider library models when resources are shared across classloaders.
  * Prevented resource streams from being invalidated when another classloader using the same JAR is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->