### PR TITLE
Move compilation-unit cleanup out of class matching

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -1895,8 +1895,8 @@ public class NullAway extends BugChecker
   }
 
   /**
-   * Performs any state updates required before checking a new compilation unit. Does not report any
-   * warnings directly.
+   * Performs any state updates required before checking a new compilation unit. Also clears several
+   * per-compilation-unit caches. Does not report any warnings directly.
    *
    * @param tree the {@link CompilationUnitTree}
    * @param stateForNewCompilationUnit the {@link VisitorState} for the new compilation unit
@@ -1910,6 +1910,7 @@ public class NullAway extends BugChecker
     if (codeAnnotationInfo == null) {
       codeAnnotationInfo = CodeAnnotationInfo.instance(stateForNewCompilationUnit.context);
     }
+    // Checking for a valid javac config for JSpecify mode also requires access to the context
     if (!checkedJDKVersionForJSpecifyMode) {
       checkedJDKVersionForJSpecifyMode = true;
       if (config.isJSpecifyMode()) {
@@ -1920,9 +1921,10 @@ public class NullAway extends BugChecker
         }
       }
     }
-    getNullnessAnalysis(stateForNewCompilationUnit)
-        .updateForNewCompilationUnit(stateForNewCompilationUnit);
-    getNullnessAnalysis(stateForNewCompilationUnit).invalidateCaches();
+    AccessPathNullnessAnalysis nullnessAnalysis = getNullnessAnalysis(stateForNewCompilationUnit);
+    nullnessAnalysis.updateForNewCompilationUnit(stateForNewCompilationUnit);
+    // clear per-compilation-unit caches
+    nullnessAnalysis.invalidateCaches();
     initTree2PrevFieldInit.clear();
     class2Entities.clear();
     class2ConstructorUninit.clear();

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -226,10 +226,10 @@ public class NullAway extends BugChecker
 
   /**
    * We store the CodeAnnotationInfo object in a field for convenience; it is initialized in {@link
-   * #matchClass(ClassTree, VisitorState)}
+   * #matchCompilationUnit(CompilationUnitTree, VisitorState)}
    */
-  // suppress initialization warning rather than casting everywhere; we know matchClass() will
-  // always be called before the field gets dereferenced
+  // suppress initialization warning rather than casting everywhere; we know matchCompilationUnit()
+  // will always be called before the field gets dereferenced
   @SuppressWarnings("NullAway.Init")
   private CodeAnnotationInfo codeAnnotationInfo;
 
@@ -256,14 +256,14 @@ public class NullAway extends BugChecker
   }
 
   /**
-   * entities relevant to field initialization per class. cached for performance. nulled out in
-   * {@link #matchClass(ClassTree, VisitorState)}
+   * entities relevant to field initialization per class. cached for performance. cleared in {@link
+   * #matchCompilationUnit(CompilationUnitTree, VisitorState)}
    */
   private final Map<Symbol.ClassSymbol, FieldInitEntities> class2Entities = new LinkedHashMap<>();
 
   /**
-   * fields not initialized by constructors, per class. cached for performance. nulled out in {@link
-   * #matchClass(ClassTree, VisitorState)}
+   * fields not initialized by constructors, per class. cached for performance. cleared in {@link
+   * #matchCompilationUnit(CompilationUnitTree, VisitorState)}
    */
   private final SetMultimap<Symbol.ClassSymbol, Symbol> class2ConstructorUninit =
       LinkedHashMultimap.create();
@@ -272,7 +272,8 @@ public class NullAway extends BugChecker
    * maps each top-level initialization member (constructor, init block, field decl with initializer
    * expression) to the set of @NonNull fields known to be initialized before that member executes.
    *
-   * <p>cached for performance. nulled out in {@link #matchClass(ClassTree, VisitorState)}
+   * <p>cached for performance. cleared in {@link #matchCompilationUnit(CompilationUnitTree,
+   * VisitorState)}
    */
   private final Map<Symbol.ClassSymbol, Multimap<Tree, Element>> initTree2PrevFieldInit =
       new LinkedHashMap<>();
@@ -1904,28 +1905,36 @@ public class NullAway extends BugChecker
   @Override
   public Description matchCompilationUnit(
       CompilationUnitTree tree, VisitorState stateForNewCompilationUnit) {
-    getNullnessAnalysis(stateForNewCompilationUnit)
-        .updateForNewCompilationUnit(stateForNewCompilationUnit);
-    return Description.NO_MATCH;
-  }
-
-  @Override
-  public Description matchClass(ClassTree tree, VisitorState state) {
     // Ensure codeAnnotationInfo is initialized here since it requires access to the Context,
-    // which is not available in the constructor
+    // which is not available in the constructor.
     if (codeAnnotationInfo == null) {
-      codeAnnotationInfo = CodeAnnotationInfo.instance(state.context);
+      codeAnnotationInfo = CodeAnnotationInfo.instance(stateForNewCompilationUnit.context);
     }
     if (!checkedJDKVersionForJSpecifyMode) {
       checkedJDKVersionForJSpecifyMode = true;
       if (config.isJSpecifyMode()) {
         JSpecifyJavacConfig.JavacConfigValidityResult validity =
-            JSpecifyJavacConfig.isValidJavacConfigForJSpecifyMode(state);
+            JSpecifyJavacConfig.isValidJavacConfigForJSpecifyMode(stateForNewCompilationUnit);
         if (validity != JSpecifyJavacConfig.JavacConfigValidityResult.VALID) {
           throw new IllegalStateException(invalidJSpecifyJavacConfigErrorMessage(validity));
         }
       }
     }
+    getNullnessAnalysis(stateForNewCompilationUnit)
+        .updateForNewCompilationUnit(stateForNewCompilationUnit);
+    getNullnessAnalysis(stateForNewCompilationUnit).invalidateCaches();
+    initTree2PrevFieldInit.clear();
+    class2Entities.clear();
+    class2ConstructorUninit.clear();
+    computedNullnessMap.clear();
+    genericsChecks.clearCache();
+    EnclosingEnvironmentNullness.instance(stateForNewCompilationUnit.context).clear();
+    handler.onMatchCompilationUnit(this, tree, stateForNewCompilationUnit);
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
     // Check if the class is excluded according to the filter
     // if so, set the flag to match within the class to false
     // NOTE: for this mechanism to work, we rely on the enclosing ClassTree
@@ -1949,16 +1958,6 @@ public class NullAway extends BugChecker
       // class
       nullMarkingForTopLevelClass =
           isExcludedClass(classSymbol) ? NullMarking.FULLY_UNMARKED : NullMarking.FULLY_MARKED;
-      // since we are processing a new top-level class, invalidate any cached
-      // results for previous classes
-      handler.onMatchTopLevelClass(this, tree, state, classSymbol);
-      getNullnessAnalysis(state).invalidateCaches();
-      initTree2PrevFieldInit.clear();
-      class2Entities.clear();
-      class2ConstructorUninit.clear();
-      computedNullnessMap.clear();
-      genericsChecks.clearCache();
-      EnclosingEnvironmentNullness.instance(state.context).clear();
     } else if (classAnnotationIntroducesPartialMarking(classSymbol)) {
       // Handle the case where the top-class is unannotated, but there is a @NullMarked annotation
       // on a nested class, or, conversely the top-level is annotated but there is a @NullUnmarked

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/ApacheThriftIsSetHandler.java
@@ -26,7 +26,7 @@ import static com.google.errorprone.util.ASTHelpers.getEnclosedElements;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
@@ -56,13 +56,13 @@ public class ApacheThriftIsSetHandler implements Handler {
   private Optional<Type> tbaseType;
 
   /**
-   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
-   * processed, before any other handler methods
+   * This method is annotated {@code @Initializer} since it will be invoked when the first
+   * compilation unit is processed, before any other handler methods.
    */
   @Initializer
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     if (tbaseType == null) {
       tbaseType =
           Optional.ofNullable(TBASE_TYPE_SUPPLIER.get(state)).map(state.getTypes()::erasure);

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/CompositeHandler.java
@@ -28,7 +28,7 @@ import static com.uber.nullaway.handlers.AccessPathPredicates.TRUE_AP_PREDICATE;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
@@ -75,10 +75,10 @@ class CompositeHandler implements Handler {
   }
 
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     for (Handler h : handlers) {
-      h.onMatchTopLevelClass(analysis, tree, state, classSymbol);
+      h.onMatchCompilationUnit(analysis, tree, state);
     }
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/GrpcHandler.java
@@ -29,7 +29,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -65,13 +65,13 @@ public class GrpcHandler implements Handler {
   private Optional<Type> grpcKeyType;
 
   /**
-   * This method is annotated {@code @Initializer} since it will be invoked when the first class is
-   * processed, before any other handler methods
+   * This method is annotated {@code @Initializer} since it will be invoked when the first
+   * compilation unit is processed, before any other handler methods.
    */
   @Initializer
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     if (grpcMetadataType == null || grpcKeyType == null) {
       grpcMetadataType =
           Optional.ofNullable(GRPC_METADATA_TYPE_SUPPLIER.get(state))

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/Handler.java
@@ -24,7 +24,7 @@ package com.uber.nullaway.handlers;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
@@ -67,18 +67,14 @@ import org.jspecify.annotations.Nullable;
 public interface Handler {
 
   /**
-   * Called when NullAway matches a particular top level class.
-   *
-   * <p>This also means we are starting a new Compilation Unit, which allows us to clear CU-specific
-   * state.
+   * Called when NullAway matches a compilation unit.
    *
    * @param analysis A reference to the running NullAway analysis.
-   * @param tree The AST node for the class being matched.
+   * @param tree The compilation unit being matched.
    * @param state The current visitor state.
-   * @param classSymbol The class symbol for the class being matched.
    */
-  default void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  default void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     // NoOp
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/JakartaPersistenceHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/JakartaPersistenceHandler.java
@@ -3,7 +3,7 @@ package com.uber.nullaway.handlers;
 import static com.uber.nullaway.NullabilityUtil.hasAnyAnnotationMatching;
 
 import com.google.errorprone.VisitorState;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.tools.javac.code.Symbol;
 import com.uber.nullaway.NullAway;
 import com.uber.nullaway.NullabilityUtil;
@@ -123,8 +123,8 @@ public class JakartaPersistenceHandler implements Handler {
   private final Map<Symbol.ClassSymbol, JpaAccess> jpaAccessCache = new HashMap<>();
 
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     jpaAccessCache.clear();
   }
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/OptionalEmptinessHandler.java
@@ -25,7 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.util.TreePath;
@@ -98,8 +98,8 @@ public class OptionalEmptinessHandler implements Handler {
   }
 
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
 
     this.analysis = analysis;
 

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/StreamNullabilityPropagator.java
@@ -31,6 +31,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.LiteralTree;
@@ -202,8 +203,8 @@ class StreamNullabilityPropagator implements Handler {
   }
 
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     this.analysis = analysis;
     // Clear compilation unit specific state
     this.filterMethodOrLambdaSet.clear();
@@ -214,6 +215,7 @@ class StreamNullabilityPropagator implements Handler {
     this.filterToNSMap.clear();
     this.bodyToMethodOrLambda.clear();
     this.returnToEnclosingMethodOrLambda.clear();
+    this.expressionBodyToFilterLambda.clear();
   }
 
   @Override

--- a/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
+++ b/nullaway/src/main/java/com/uber/nullaway/handlers/contract/ContractHandler.java
@@ -29,7 +29,7 @@ import static com.uber.nullaway.handlers.contract.ContractUtils.getConsequent;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -92,8 +92,8 @@ public class ContractHandler implements Handler {
 
   private @Nullable NullAway analysis;
 
-  // Cached on visiting the top-level class and used for onCFGBuildPhase1AfterVisitMethodInvocation,
-  // where no VisitorState is otherwise available.
+  // Cached on visiting the compilation unit and used for
+  // onCFGBuildPhase1AfterVisitMethodInvocation, where no VisitorState is otherwise available.
   private @Nullable VisitorState storedVisitorState;
 
   private @Nullable TypeMirror runtimeExceptionType;
@@ -223,8 +223,8 @@ public class ContractHandler implements Handler {
   }
 
   @Override
-  public void onMatchTopLevelClass(
-      NullAway analysis, ClassTree tree, VisitorState state, Symbol.ClassSymbol classSymbol) {
+  public void onMatchCompilationUnit(
+      NullAway analysis, CompilationUnitTree tree, VisitorState state) {
     this.analysis = analysis;
     this.storedVisitorState = state;
   }


### PR DESCRIPTION
Cache cleanup and handler lifecycle work currently runs whenever NullAway encounters a top-level class. This conflates class and compilation-unit boundaries and repeats cleanup for source files containing multiple top-level types.

Perform checker cache invalidation from matchCompilationUnit. Replace Handler.onMatchTopLevelClass with onMatchCompilationUnit and migrate handlers that refresh visitor state, initialize context-dependent types, or clear compilation-unit data. Move CodeAnnotationInfo initialization and the one-time JSpecify JDK configuration validation to the same callback, while leaving per-top-level null-marking logic in matchClass.

Also clear expressionBodyToFilterLambda with the rest of the stream propagator's compilation-unit state so AST nodes are not retained across source files.

Fixes #1737

Assisted-by: Codex (gpt-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis consistency by initializing and clearing per-file state once per compilation unit.
  * Prevented cached analysis data from carrying over between source files.
  * Ensured supported analysis handlers process each compilation unit consistently.
  * Added validation for JSpecify compiler configuration, with clear failure reporting when invalid.
  * Improved handling of stream, persistence, contract, optional, gRPC, and Apache Thrift analysis across source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->