### PR TITLE
Store the nullness analysis in a NullAway field instead of the javac context

### DIFF
--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -3044,9 +3044,10 @@ public class NullAway extends BugChecker
    * @param state visitor state for the compilation
    * @return the analysis instance
    */
+  @SuppressWarnings("DoNotCall") // this is the one place a call to create() is allowed
   public AccessPathNullnessAnalysis getNullnessAnalysis(VisitorState state) {
     if (nullnessAnalysis == null) {
-      nullnessAnalysis = new AccessPathNullnessAnalysis(state, this);
+      nullnessAnalysis = AccessPathNullnessAnalysis.create(state, this);
     }
     return nullnessAnalysis;
   }

--- a/nullaway/src/main/java/com/uber/nullaway/NullAway.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullAway.java
@@ -235,6 +235,13 @@ public class NullAway extends BugChecker
 
   private boolean checkedJDKVersionForJSpecifyMode = false;
 
+  /**
+   * The dataflow analysis for this compilation; lazily created by {@link
+   * #getNullnessAnalysis(VisitorState)}, as its construction requires a {@link VisitorState}, which
+   * is not available in the constructor.
+   */
+  private @Nullable AccessPathNullnessAnalysis nullnessAnalysis;
+
   private final Config config;
 
   /** Returns the configuration being used for this analysis. */
@@ -3031,8 +3038,17 @@ public class NullAway extends BugChecker
     return NullabilityUtil.nullnessToBool(nullness);
   }
 
+  /**
+   * Returns the dataflow analysis for this compilation, creating it on the first call.
+   *
+   * @param state visitor state for the compilation
+   * @return the analysis instance
+   */
   public AccessPathNullnessAnalysis getNullnessAnalysis(VisitorState state) {
-    return AccessPathNullnessAnalysis.instance(state, this);
+    if (nullnessAnalysis == null) {
+      nullnessAnalysis = new AccessPathNullnessAnalysis(state, this);
+    }
+    return nullnessAnalysis;
   }
 
   private Description matchDereference(

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -56,9 +56,6 @@ import org.jspecify.annotations.Nullable;
  */
 public final class AccessPathNullnessAnalysis {
 
-  private static final Context.Key<AccessPathNullnessAnalysis> FIELD_NULLNESS_ANALYSIS_KEY =
-      new Context.Key<>();
-
   private final AccessPath.AccessPathContext apContext;
 
   private final AccessPathNullnessPropagation nullnessPropagation;
@@ -67,8 +64,15 @@ public final class AccessPathNullnessAnalysis {
 
   private @Nullable AccessPathNullnessPropagation contractNullnessPropagation;
 
-  // Use #instance to instantiate
-  private AccessPathNullnessAnalysis(VisitorState state, NullAway analysis) {
+  /**
+   * Creates an analysis instance. {@link NullAway} holds the single instance for a compilation and
+   * exposes it via {@link NullAway#getNullnessAnalysis(VisitorState)}; other code should go through
+   * that method rather than constructing an instance directly.
+   *
+   * @param state visitor state for the compilation
+   * @param analysis instance of NullAway analysis
+   */
+  public AccessPathNullnessAnalysis(VisitorState state, NullAway analysis) {
     Config config = analysis.getConfig();
     Handler handler = analysis.getHandler();
     apContext =
@@ -95,23 +99,6 @@ public final class AccessPathNullnessAnalysis {
               new ContractNullnessStoreInitializer(),
               /* trackUnreachableStores= */ true);
     }
-  }
-
-  /**
-   * Get the per-Javac instance of the analysis.
-   *
-   * @param state visitor state for the compilation
-   * @param analysis instance of NullAway analysis
-   * @return instance of the analysis
-   */
-  public static AccessPathNullnessAnalysis instance(VisitorState state, NullAway analysis) {
-    Context context = state.context;
-    AccessPathNullnessAnalysis instance = context.get(FIELD_NULLNESS_ANALYSIS_KEY);
-    if (instance == null) {
-      instance = new AccessPathNullnessAnalysis(state, analysis);
-      context.put(FIELD_NULLNESS_ANALYSIS_KEY, instance);
-    }
-    return instance;
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
+++ b/nullaway/src/main/java/com/uber/nullaway/dataflow/AccessPathNullnessAnalysis.java
@@ -23,6 +23,7 @@ import static com.uber.nullaway.NullabilityUtil.castToNonNull;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.dataflow.nullnesspropagation.NullnessAnalysis;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.LambdaExpressionTree;
@@ -67,12 +68,18 @@ public final class AccessPathNullnessAnalysis {
   /**
    * Creates an analysis instance. {@link NullAway} holds the single instance for a compilation and
    * exposes it via {@link NullAway#getNullnessAnalysis(VisitorState)}; other code should go through
-   * that method rather than constructing an instance directly.
+   * that method rather than constructing an instance directly (hence the {@code @DoNotCall}
+   * annotation).
    *
    * @param state visitor state for the compilation
    * @param analysis instance of NullAway analysis
    */
-  public AccessPathNullnessAnalysis(VisitorState state, NullAway analysis) {
+  @DoNotCall
+  public static AccessPathNullnessAnalysis create(VisitorState state, NullAway analysis) {
+    return new AccessPathNullnessAnalysis(state, analysis);
+  }
+
+  private AccessPathNullnessAnalysis(VisitorState state, NullAway analysis) {
     Config config = analysis.getConfig();
     Handler handler = analysis.getHandler();
     apContext =


### PR DESCRIPTION
`AccessPathNullnessAnalysis` was kept in the javac `Context` under its own key, but `NullAway.getNullnessAnalysis` is the only way anything reaches it, so the context entry served no purpose. It also meant the cached instance was built from whichever `NullAway` asked for it first, capturing that checker's `Config`, `Handler` and `GenericsChecks`.

This moves it to a field on `NullAway`, created on first use since the constructor has no `VisitorState`. That matches how the checker already holds its other per-compilation state (`codeAnnotationInfo`, `class2Entities`, `computedNullnessMap`, `genericsChecks`). The object still lives for the whole compilation, and `updateForNewCompilationUnit` from #1736 still refreshes its state per compilation unit.

Partially addresses #1738. The remaining part of that issue, building a fresh analysis per compilation unit so the propagation fields can be `final` again, is left alone since the issue notes it needs careful profiling first.

Tested with `./gradlew :nullaway:test` and `./gradlew :nullaway:buildWithNullAway`. `BytecodeGenericsTests.callMethodTakingJavaUtilFunction` fails on JDK 22.0.2 both with and without this change, so it is pre-existing.

Disclosure: I used AI tooling for the grunt and mechanical work here — boilerplate, test scaffolding, and running the test matrix. The approach and direction were mine, and I reviewed the result before submitting.

Assisted-by: Claude Code (claude-opus-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the internal lifecycle and reuse of nullness analysis during compilation.
  - Streamlined analysis initialization while preserving existing analysis behavior and results.
  - No changes to user-facing configuration, diagnostics, or supported functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->