### PR TITLE
Report diff coverage for the lines a branch changed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,6 +101,26 @@ jobs:
       - name: Run suppression remover regression tests
         working-directory: scripts/nullaway-suppression-remover
         run: python -m pytest
+  build-logic-tests:
+    name: "Build logic tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out NullAway sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: 'Set up JDKs'
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          check-latest: 'true'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      # Gradle builds buildSrc as an included build and asks it only for its plugins, so its own
+      # tests run only when something asks for them.
+      - name: Run buildSrc tests
+        run: ./gradlew -p buildSrc test
   test-with-error-prone-snapshot:
     name: "Test with Error Prone snapshot"
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,17 @@ Do _not_ try to run multiple Gradle build commands in parallel; it is not suppor
 Generally, whenever you run a test suite, it's best to also check that `./gradlew :nullaway:buildWithNullAway`
 also passes; that runs NullAway checking on itself.  You don't need to run this after every targeted test run.
 
+# Code coverage
+
+`./gradlew :nullaway:test` reports diff coverage for changed executable lines and branches; filtered test runs only
+reflect the tests actually executed, so run the module's full suite before treating uncovered code as a missing test.
+
+By default the diff is measured against the configured upstream/base; for stacked PRs, set `-PdiffCoverageBase=<ref>`
+to the parent PR or commit so only the current layer is measured.
+
+If an uncovered line is intentionally unreachable or not worth testing, acknowledge the reviewed exception with
+`// diff-coverage: ignore -- <reason>`; it remains counted as uncovered but is removed from the actionable list.
+
 # Changelog
 
 Our `CHANGELOG.md` file should be formatted as follows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
 
 * Add `JSpecifyUnrecognizedAnnotationLocation`, an opt-in check that reports nullness annotations in locations JSpecify does not recognize (#1787)
 * Fix `RequireExplicitNullMarking` diagnostics repeating the check name, so a report no longer begins with `[RequireExplicitNullMarking] [RequireExplicitNullMarking]` (#1815)
+* Maintenance
+  - Report diff coverage after each test run, quoting the changed lines the run did not execute and the branches it took one way, and writing the whole report to `<module>/build/reports/diff-coverage/test.txt`; a `// diff-coverage: ignore` comment moves a line out of that list without changing the counts by @vlsi (#1833)
 
 Version 0.14.1
 --------------

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,3 +17,34 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation gradleApi()
+    testImplementation platform("org.junit:junit-bom:5.14.0")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+}
+
+// Gradle builds buildSrc as an included build and asks it only for its plugins, so these tests run
+// when something asks for them: `./gradlew -p buildSrc test`, which is what CI runs.
+tasks.named("test") {
+    useJUnitPlatform()
+    // Random method order reports an order dependence rather than hiding it behind whatever order
+    // the compiler happened to emit; the seed is logged at CONFIG level and replays with
+    // -Djunit.jupiter.execution.order.random.seed=<seed>.
+    systemProperty "junit.jupiter.testmethod.order.default",
+            "org.junit.jupiter.api.MethodOrderer\$Random"
+    testLogging {
+        exceptionFormat = "full"
+    }
+}
+
+// Parameterized cases print each argument with its parameter name only where the names survive
+// compilation.
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << "-parameters"
+}

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -80,11 +80,17 @@ tasks.named("test") {
     finalizedBy(tasks.named("jacocoTestReport"))
 }
 
+// Every module asks git the same questions about the same repository, so one service answers them
+// once for the whole build.  The name is what the task's @ServiceReference binds to.
+gradle.sharedServices.registerIfAbsent(com.uber.nullaway.gradle.DiffCoverageTask.GIT_SERVICE,
+        com.uber.nullaway.gradle.GitService) {
+    parameters.repositoryRoot = rootProject.layout.projectDirectory
+}
+
 def diffCoverage = tasks.register("diffCoverage", com.uber.nullaway.gradle.DiffCoverageTask) {
     description = "Reports which of the lines this branch changed the last test run executed"
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     reportFiles.from(tasks.named("jacocoTestReport").map { it.reports.xml.outputLocation })
-    repositoryRoot = rootProject.layout.projectDirectory
     sourceRoots.set(providers.provider {
         sourceSets.main.java.srcDirs.collect { rootDir.toPath().relativize(it.toPath()).toString() }
     })

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -39,21 +39,94 @@ jacoco {
     toolVersion = "0.8.16-SNAPSHOT"
 }
 
-// Instrument test processes only when coverage is explicitly requested.  JaCoCo adds measurable
-// overhead to compilation-heavy tests, so ordinary local and CI test runs should not pay that cost.
-def enableJacoco = providers.gradleProperty("enableJacoco")
-        .map { it.toBoolean() }
-        .orElse(false)
+// -PenableJacoco decides instrumentation for every Test task.  Left unset, only the `test` task is
+// instrumented: it costs about 20% of that task's wall time, which buys the per-module XML report
+// the diffCoverage task reads.  The testJdk* tasks re-run the same suite under other JDKs,
+// so instrumenting them locally would multiply that cost over lines the `test` task already
+// reaches.  CI sets the property explicitly in both directions, and the aggregate report still
+// collects the JDK-specific execution data through coverageDataElementsForTest below.
+def enableJacoco = providers.gradleProperty("enableJacoco").map { it.toBoolean() }
 
-tasks.withType(Test).configureEach {
-    extensions.configure(JacocoTaskExtension) { jacocoExtension ->
-        jacocoExtension.enabled = enableJacoco.get()
+// -PdiffCoverageEnabled=false takes back everything the default turns on: the report, the XML it
+// reads, and the instrumentation that exists only to produce them, so that one flag buys back the
+// 20% for a run that is not about coverage.  -PenableJacoco still decides instrumentation wherever
+// it is set, since the aggregate report needs the execution data whether or not diffCoverage runs.
+def diffCoverageEnabled = providers.gradleProperty("diffCoverageEnabled")
+        .map { it.isEmpty() || Boolean.parseBoolean(it) }
+        .orElse(true)
+
+tasks.withType(Test).configureEach { testTask ->
+    def instrumented = enableJacoco
+            .orElse(diffCoverageEnabled.get() && testTask.name == "test")
+            .get()
+    testTask.extensions.configure(JacocoTaskExtension) { jacocoExtension ->
+        jacocoExtension.enabled = instrumented
     }
 }
 
-// Do not generate reports for individual projects
+// The aggregate report in :code-coverage-report covers the whole build.  This per-module XML covers
+// the `test` task alone, which is what a single-module run produces and all diffCoverage needs.
 tasks.named("jacocoTestReport") {
-    enabled = false
+    enabled = enableJacoco.orElse(diffCoverageEnabled).get()
+    reports {
+        xml.required = true
+        html.required = false
+    }
+}
+
+// Running the report as part of the test run keeps the XML in step with the execution data, so
+// diffCoverage cannot read line numbers left over from an earlier run.
+tasks.named("test") {
+    finalizedBy(tasks.named("jacocoTestReport"))
+}
+
+def diffCoverage = tasks.register("diffCoverage", com.uber.nullaway.gradle.DiffCoverageTask) {
+    description = "Reports which of the lines this branch changed the last test run executed"
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    reportFiles.from(tasks.named("jacocoTestReport").map { it.reports.xml.outputLocation })
+    repositoryRoot = rootProject.layout.projectDirectory
+    sourceRoots.set(providers.provider {
+        sourceSets.main.java.srcDirs.collect { rootDir.toPath().relativize(it.toPath()).toString() }
+    })
+    // A filtered run leaves the rest of the change looking unexecuted, so the scope is printed
+    // beside the counts rather than left for the reader to remember.
+    def testFilterPatterns = providers.provider {
+        def testTask = tasks.getByName("test")
+        def patterns = testTask.filter.includePatterns as List
+        if (testTask.filter.metaClass.respondsTo(testTask.filter, "getCommandLineIncludePatterns")) {
+            patterns += testTask.filter.commandLineIncludePatterns as List
+        }
+        patterns
+    }
+    scopeDescription = testFilterPatterns.map { patterns ->
+        patterns.isEmpty() ? "${project.path}:test" : "${project.path}:test --tests ${patterns.join(' --tests ')}"
+    }
+    filtered = testFilterPatterns.map { !it.isEmpty() }
+    // The console block is a summary of the work left; the file below holds the report whole.
+    maxFiles = providers.gradleProperty("diffCoverageMaxFiles").map { Integer.parseInt(it) }.orElse(10)
+    maxLinesPerFile = providers.gradleProperty("diffCoverageMaxLinesPerFile").map { Integer.parseInt(it) }.orElse(10)
+    maxLinesTotal = providers.gradleProperty("diffCoverageMaxLines").map { Integer.parseInt(it) }.orElse(50)
+    // -PdiffCoverageShowAll with no value reads as true, since nobody passing it means false.
+    showAll = providers.gradleProperty("diffCoverageShowAll")
+            .map { it.isEmpty() || Boolean.parseBoolean(it) }
+            .orElse(false)
+    outputFile = layout.buildDirectory.file("reports/diff-coverage/test.txt")
+    if (project.hasProperty("diffCoverageBase")) {
+        baseRef = project.property("diffCoverageBase").toString()
+    }
+    if (project.hasProperty("diffCoverageFailUnder")) {
+        failUnder = Double.parseDouble(project.property("diffCoverageFailUnder").toString())
+    }
+}
+
+// The automatic report is a local affordance, so it is wired only where nobody asked for a
+// particular JaCoCo setting.  Every CI job that reaches jacocoTestReport sets enableJacoco, and a
+// CI checkout fetches the pull request ref alone, so there the task would find no base ref and say
+// so once per module on every build.  `./gradlew :<module>:diffCoverage` still runs it on demand.
+if (!enableJacoco.isPresent() && diffCoverageEnabled.get()) {
+    tasks.named("jacocoTestReport") {
+        finalizedBy(diffCoverage)
+    }
 }
 
 configurations {

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -82,8 +82,7 @@ tasks.named("test") {
 
 // Every module asks git the same questions about the same repository, so one service answers them
 // once for the whole build.  The name is what the task's @ServiceReference binds to.
-gradle.sharedServices.registerIfAbsent(com.uber.nullaway.gradle.DiffCoverageTask.GIT_SERVICE,
-        com.uber.nullaway.gradle.GitService) {
+gradle.sharedServices.registerIfAbsent(com.uber.nullaway.gradle.DiffCoverageTask.GIT_SERVICE, com.uber.nullaway.gradle.GitService) {
     parameters.repositoryRoot = rootProject.layout.projectDirectory
 }
 

--- a/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/nullaway.java-test-conventions.gradle
@@ -120,9 +120,6 @@ def diffCoverage = tasks.register("diffCoverage", com.uber.nullaway.gradle.DiffC
     if (project.hasProperty("diffCoverageBase")) {
         baseRef = project.property("diffCoverageBase").toString()
     }
-    if (project.hasProperty("diffCoverageFailUnder")) {
-        failUnder = Double.parseDouble(project.property("diffCoverageFailUnder").toString())
-    }
 }
 
 // The automatic report is a local affordance, so it is wired only where nobody asked for a

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
@@ -43,21 +43,8 @@ final class DiffCoverageReport {
       Pattern.compile("(?://|/\\*|\\*)\\s*diff-coverage:\\s*ignore(?![\\w-])");
 
   /** One changed line the run left uncovered, with the source text the report quotes for it. */
-  static final class AffectedLine {
-    final int number;
-    final boolean executed;
-    final int coveredBranches;
-    final int totalBranches;
-    final String source;
-
-    AffectedLine(
-        int number, boolean executed, int coveredBranches, int totalBranches, String source) {
-      this.number = number;
-      this.executed = executed;
-      this.coveredBranches = coveredBranches;
-      this.totalBranches = totalBranches;
-      this.source = source;
-    }
+  record AffectedLine(
+      int number, boolean executed, int coveredBranches, int totalBranches, String source) {
 
     /** Returns how many branch outcomes of this line nothing took. */
     int missedBranches() {
@@ -119,7 +106,7 @@ final class DiffCoverageReport {
 
     /** Returns how many of the lines this file owes a test nothing ran. */
     int uncoveredChangedLines() {
-      return (int) affected.stream().filter(line -> !line.executed).count();
+      return (int) affected.stream().filter(line -> !line.executed()).count();
     }
 
     /**

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
@@ -285,11 +285,6 @@ final class DiffCoverageReport {
         : stripped.substring(0, QUOTE_WIDTH) + "...";
   }
 
-  /** Returns the changed files under a source root that no report read here mentions. */
-  List<String> unmeasuredPaths() {
-    return List.copyOf(notInAnyReport);
-  }
-
   /** Returns the paths whose changed lines the counts came from. */
   List<String> measuredPaths() {
     return measured.stream().map(file -> file.path).collect(Collectors.toList());

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageReport.java
@@ -1,0 +1,580 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** How much of a change a test run executed, file by file. */
+final class DiffCoverageReport {
+
+  /** Characters of a source line the report quotes, past which the line is cut. */
+  private static final int QUOTE_WIDTH = 100;
+
+  /**
+   * The comment that takes a line out of the list of work, such as {@code // diff-coverage: ignore
+   * -- defensive safeguard}.
+   *
+   * <p>The marker acknowledges the line it sits on, and has to follow a comment opener on it, so
+   * that the reason is readable where the uncovered line is. Nothing here parses Java, so a marker
+   * written with its opener inside a string literal counts as well.
+   */
+  private static final Pattern IGNORE_MARKER =
+      Pattern.compile("(?://|/\\*|\\*)\\s*diff-coverage:\\s*ignore(?![\\w-])");
+
+  /** One changed line the run left uncovered, with the source text the report quotes for it. */
+  static final class AffectedLine {
+    final int number;
+    final boolean executed;
+    final int coveredBranches;
+    final int totalBranches;
+    final String source;
+
+    AffectedLine(
+        int number, boolean executed, int coveredBranches, int totalBranches, String source) {
+      this.number = number;
+      this.executed = executed;
+      this.coveredBranches = coveredBranches;
+      this.totalBranches = totalBranches;
+      this.source = source;
+    }
+
+    /** Returns how many branch outcomes of this line nothing took. */
+    int missedBranches() {
+      return totalBranches - coveredBranches;
+    }
+
+    /**
+     * Returns the row the report prints, such as {@code 194: not executed; 0 of 2 branches
+     * covered: return null;}.
+     *
+     * <p>A line the run neither reached nor took a branch of is one line of work, so both counters
+     * share a row rather than repeating the line under two headings.
+     */
+    String describe() {
+      StringBuilder row = new StringBuilder().append(number).append(": ");
+      if (!executed) {
+        row.append("not executed");
+      }
+      if (missedBranches() > 0) {
+        if (!executed) {
+          row.append("; ");
+        }
+        row.append(coveredBranches).append(" of ").append(totalBranches).append(" branches covered");
+      }
+      if (!source.isEmpty()) {
+        row.append(": ").append(source);
+      }
+      return row.toString();
+    }
+  }
+
+  /** One file's changed lines, split by whether the run covered them. */
+  static final class FileCoverage {
+    final String path;
+
+    /** Changed lines of this file that emit bytecode, executed or not. */
+    int executableLines;
+
+    /** Changed lines of this file the run executed. */
+    int executedLines;
+
+    /** The uncovered lines this file still owes a test, in ascending order. */
+    final List<AffectedLine> affected = new ArrayList<>();
+
+    /** The uncovered lines a comment in the source acknowledges, in ascending order. */
+    final List<AffectedLine> acknowledged = new ArrayList<>();
+
+    int coveredBranches;
+    int totalBranches;
+
+    FileCoverage(String path) {
+      this.path = path;
+    }
+
+    /** Returns whether this file still owes a test, which is what makes it worth describing. */
+    boolean needsAttention() {
+      return !affected.isEmpty();
+    }
+
+    /** Returns how many of the lines this file owes a test nothing ran. */
+    int uncoveredChangedLines() {
+      return (int) affected.stream().filter(line -> !line.executed).count();
+    }
+
+    /**
+     * Returns how many branch outcomes of the lines this file owes a test nothing took.
+     *
+     * <p>Outcomes rather than lines, so that a line reported as {@code 0 of 4 branches covered}
+     * outweighs one reported as {@code 1 of 2}.
+     */
+    int missedChangedBranches() {
+      return affected.stream().mapToInt(AffectedLine::missedBranches).sum();
+    }
+  }
+
+  /** How much of the report to print, past which the reader is sent to the full report. */
+  static final class Limits {
+
+    /** Prints the report whole, as the file the task writes holds it. */
+    static final Limits NONE =
+        new Limits(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+    final int files;
+    final int linesPerFile;
+    final int lines;
+
+    /**
+     * @param files how many files to describe, over the block's lists together
+     * @param linesPerFile how many rows to spend on one file
+     * @param lines how many rows to spend over the block's lists together
+     * @throws IllegalArgumentException where a limit is negative, which a build property can
+     *     spell and which would otherwise surface as an index out of the rows it cuts
+     */
+    Limits(int files, int linesPerFile, int lines) {
+      if (files < 0 || linesPerFile < 0 || lines < 0) {
+        throw new IllegalArgumentException(
+            "a diff coverage limit cannot be negative: files="
+                + files
+                + ", linesPerFile="
+                + linesPerFile
+                + ", lines="
+                + lines);
+      }
+      this.files = files;
+      this.linesPerFile = linesPerFile;
+      this.lines = lines;
+    }
+  }
+
+  /**
+   * What one rendering has left to spend, which the lists take from in the order they are printed.
+   *
+   * <p>One budget over the whole block rather than one per list, so that the block a reader takes
+   * in at a glance is the limit they set, and the work is described before the lines somebody has
+   * already decided about.
+   */
+  private static final class Budget {
+    int files;
+    int rows;
+
+    Budget(Limits limits) {
+      this.files = limits.files;
+      this.rows = limits.lines;
+    }
+
+    boolean isSpent() {
+      return files == 0 || rows == 0;
+    }
+  }
+
+  /** The total printed where the change reached no line of this module that emits bytecode. */
+  static final String NO_EXECUTABLE_LINES =
+      "Total: no changed executable lines under this module's source roots.";
+
+  final List<FileCoverage> measured = new ArrayList<>();
+
+  /** Changed files under a source root that no report read here mentions. */
+  final List<String> notInAnyReport = new ArrayList<>();
+
+  /** Changed files whose changed lines emit no bytecode, such as comments and declarations. */
+  final List<String> nothingExecutable = new ArrayList<>();
+
+  /**
+   * Orders files by how much testing they still owe, most first.
+   *
+   * <p>An acknowledged line counts towards neither key: it is measured like any other line, and a
+   * file whose remaining work is acknowledged is not where the reader should start.
+   *
+   * <p>The keys stay separate rather than summing into one score, because a line and a branch
+   * outcome are different things and any coefficient joining them would be invented. A file with
+   * one uncovered line therefore outranks a file with nine untaken branches and no uncovered line.
+   *
+   * <p>The count is absolute rather than a share, because the question is where the most work is
+   * left, not which file reads worst: 90 of 100 lines executed leaves ten lines to test, and 1 of 2
+   * leaves one, however much worse the second looks as a percentage.
+   *
+   * <p>Each key is reversed on its own. Reversing a chain reverses every key before it as well, so
+   * {@code comparingInt(a).reversed().thenComparingInt(b).reversed()} orders by a ascending.
+   */
+  private static final Comparator<FileCoverage> BY_WORK_LEFT =
+      Comparator.comparingInt(FileCoverage::uncoveredChangedLines)
+          .reversed()
+          .thenComparing(Comparator.comparingInt(FileCoverage::missedChangedBranches).reversed())
+          .thenComparing(Comparator.comparingInt((FileCoverage file) -> file.executableLines)
+              .reversed())
+          .thenComparing(file -> file.path);
+
+  private DiffCoverageReport() {}
+
+  /**
+   * Measures the changed lines of the files that sit under one of the source roots.
+   *
+   * <p>A changed file outside every root belongs to another module and is left out entirely, so
+   * that a module's report says nothing about code it was never compiled from. A file under a root
+   * that no report mentions is reported, since the reader has to decide whether the module was part
+   * of the run or the file simply contributes no class.
+   *
+   * @param sourceRoots repository-relative source directories, such as {@code
+   *     nullaway/src/main/java}
+   * @param sources the working tree the uncovered lines are quoted from
+   */
+  static DiffCoverageReport measure(
+      Map<String, NavigableSet<Integer>> changed,
+      List<String> sourceRoots,
+      JacocoLines lines,
+      SourceLines sources) {
+    DiffCoverageReport report = new DiffCoverageReport();
+    for (Map.Entry<String, NavigableSet<Integer>> entry : new TreeMap<>(changed).entrySet()) {
+      String path = entry.getKey();
+      String key = sourceFileKey(path, sourceRoots);
+      if (key == null) {
+        continue;
+      }
+      if (!lines.covers(key)) {
+        report.notInAnyReport.add(path);
+        continue;
+      }
+      FileCoverage file = new FileCoverage(path);
+      for (int number : entry.getValue()) {
+        JacocoLines.Counters counters = lines.get(key, number);
+        if (counters == null) {
+          continue;
+        }
+        file.executableLines++;
+        if (counters.isExecuted()) {
+          file.executedLines++;
+        }
+        file.coveredBranches += counters.coveredBranches;
+        file.totalBranches += counters.totalBranches;
+        if (counters.isExecuted() && !counters.hasUntakenBranch()) {
+          continue;
+        }
+        String source = sources.get(path, number);
+        AffectedLine affected =
+            new AffectedLine(
+                number,
+                counters.isExecuted(),
+                counters.coveredBranches,
+                counters.totalBranches,
+                quote(source));
+        (IGNORE_MARKER.matcher(source).find() ? file.acknowledged : file.affected).add(affected);
+      }
+      if (file.executableLines > 0) {
+        report.measured.add(file);
+      } else {
+        report.nothingExecutable.add(path);
+      }
+    }
+    report.measured.sort(BY_WORK_LEFT);
+    return report;
+  }
+
+  /** Returns the source line as the report quotes it: stripped, and cut to a width that fits. */
+  private static String quote(String source) {
+    String stripped = source.strip();
+    return stripped.length() <= QUOTE_WIDTH
+        ? stripped
+        : stripped.substring(0, QUOTE_WIDTH) + "...";
+  }
+
+  /** Returns the changed files under a source root that no report read here mentions. */
+  List<String> unmeasuredPaths() {
+    return List.copyOf(notInAnyReport);
+  }
+
+  /** Returns the paths whose changed lines the counts came from. */
+  List<String> measuredPaths() {
+    return measured.stream().map(file -> file.path).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns whether the change reached none of this module's sources.
+   *
+   * <p>The conventions plugin gives every module the task, so a whole-build run would otherwise
+   * print a block per module saying that a change in one of them touched none of the others.
+   */
+  boolean isSilent() {
+    return measured.isEmpty() && notInAnyReport.isEmpty() && nothingExecutable.isEmpty();
+  }
+
+  int coveredBranches() {
+    return measured.stream().mapToInt(file -> file.coveredBranches).sum();
+  }
+
+  int totalBranches() {
+    return measured.stream().mapToInt(file -> file.totalBranches).sum();
+  }
+
+  int executedLines() {
+    return measured.stream().mapToInt(file -> file.executedLines).sum();
+  }
+
+  int executableLines() {
+    return measured.stream().mapToInt(file -> file.executableLines).sum();
+  }
+
+  /** Returns how many changed lines the run left unexecuted or took a branch of only one way. */
+  int uncoveredLines() {
+    return measured.stream()
+        .mapToInt(file -> file.affected.size() + file.acknowledged.size())
+        .sum();
+  }
+
+  /** Returns how many of the uncovered lines a comment in the source acknowledges. */
+  int acknowledgedLines() {
+    return measured.stream().mapToInt(file -> file.acknowledged.size()).sum();
+  }
+
+  /**
+   * Returns the report as the text the task prints.
+   *
+   * <p>Only the files that still owe a test are described, so that the block reads as the work
+   * left rather than as an inventory of the change. The fully covered ones are counted in one line,
+   * which is what tells the reader they were measured at all.
+   *
+   * <p>Every limit trades completeness for a block a reader takes in at a glance, and a truncated
+   * list states its own total so that the reader knows what was left out without counting what was
+   * shown. The task writes the same report under {@link Limits#NONE} to a file and names it.
+   *
+   * @param scope what the run covered, such as the test task and its filter
+   * @param filtered whether the run was narrowed to some of the tests
+   * @param staleSources measured files edited after the report was written, whose line numbers the
+   *     report therefore no longer names
+   * @param limits how much of the report to print
+   */
+  String render(String scope, boolean filtered, List<String> staleSources, Limits limits) {
+    if (isSilent()) {
+      return "";
+    }
+    StringBuilder out = new StringBuilder("Diff coverage ").append(scope);
+    if (filtered) {
+      // The header names the filter, and a reader still quotes the total as the branch's coverage.
+      out.append("\n  a filtered run leaves the rest of the change looking unexecuted");
+    }
+    List<FileCoverage> owing = measured.stream().filter(FileCoverage::needsAttention).toList();
+    if (!owing.isEmpty()) {
+      // Printed for one file too: a subheading that comes and goes between two runs reads as a
+      // different code path rather than as a list with nothing to order.
+      out.append("\n  ordered by uncovered changed lines, then uncovered branches");
+    }
+    if (!staleSources.isEmpty()) {
+      out.append("\n\n  WARNING: edited after the report was written, so its line numbers no ")
+          .append("longer match the source:");
+      for (String path : staleSources) {
+        out.append("\n    ").append(path);
+      }
+      out.append("\n  Re-run the tests before trusting the numbers below.");
+    }
+    Budget budget = new Budget(limits);
+    appendOwing(out, owing, budget, limits.linesPerFile);
+    appendFullyCovered(out);
+    appendAcknowledged(out, budget, limits.linesPerFile);
+    appendPaths(
+        out,
+        notInAnyReport,
+        "No report read here covers these files, so they were probably not part of the run:");
+    appendPaths(out, nothingExecutable, "Changed files with no executable changed lines:");
+    out.append("\n\n");
+    if (executableLines() == 0) {
+      out.append(NO_EXECUTABLE_LINES);
+      return out.toString();
+    }
+    out.append("Total: ")
+        .append(executedLines())
+        .append('/')
+        .append(executableLines())
+        .append(" changed lines executed");
+    appendBranches(out, coveredBranches(), totalBranches());
+    out.append('.');
+    // Every uncovered line counts here, printed or not: the executed share alone reports a line
+    // whose condition went one way as covered.
+    out.append("\nUncovered changed code: ")
+        .append(uncoveredLines())
+        .append(uncoveredLines() == 1 ? " line" : " lines");
+    if (acknowledgedLines() > 0) {
+      out.append(" (").append(acknowledgedLines()).append(" acknowledged)");
+    }
+    return out.toString();
+  }
+
+  /** Appends a block per file owing a test, until the budget stops the list. */
+  private void appendOwing(
+      StringBuilder out, List<FileCoverage> owing, Budget budget, int linesPerFile) {
+    int described = 0;
+    for (FileCoverage file : owing) {
+      if (budget.isSpent()) {
+        break;
+      }
+      out.append("\n\n  ").append(file.path);
+      out.append("\n    ")
+          .append(file.executedLines)
+          .append('/')
+          .append(file.executableLines)
+          .append(" changed lines executed");
+      appendBranches(out, file.coveredBranches, file.totalBranches);
+      out.append("\n    uncovered changed code:");
+      budget.rows -=
+          appendRows(
+              out, file.affected, Math.min(linesPerFile, budget.rows), " more affected lines");
+      budget.files--;
+      described++;
+    }
+    if (described < owing.size()) {
+      out.append("\n\n  ")
+          .append(owing.size())
+          .append(owing.size() == 1 ? " file owing" : " files owing")
+          .append(" a test in total");
+    }
+  }
+
+  /**
+   * Appends the count of the files with nothing left to test, and their line and branch totals.
+   *
+   * <p>A file with nothing left to test is not work, and describing it would push a file that is
+   * work out of the list. Counting it keeps "measured and fine" apart from "never measured", which
+   * is the distinction the whole report exists to make.
+   */
+  private void appendFullyCovered(StringBuilder out) {
+    List<FileCoverage> covered =
+        measured.stream()
+            .filter(file -> file.affected.isEmpty() && file.acknowledged.isEmpty())
+            .toList();
+    if (covered.isEmpty()) {
+      return;
+    }
+    int lines = covered.stream().mapToInt(file -> file.executableLines).sum();
+    int branches = covered.stream().mapToInt(file -> file.totalBranches).sum();
+    out.append("\n\n  ")
+        .append(covered.size())
+        .append(covered.size() == 1 ? " changed file is" : " changed files are")
+        .append(" fully covered (")
+        .append(lines)
+        .append(lines == 1 ? " line" : " lines");
+    if (branches > 0) {
+      out.append(", ").append(branches).append(branches == 1 ? " branch" : " branches");
+    }
+    out.append(')');
+  }
+
+  /**
+   * Appends the uncovered lines a comment in the source acknowledges, under their own heading.
+   *
+   * <p>They are listed away from the work so that a reader looking for the next test skips them,
+   * and listed at all so that an acknowledgement can be reviewed rather than only counted. What
+   * the work list left of the budget is what they are listed with, and the count in the total
+   * reports them whether or not any row here does.
+   */
+  private void appendAcknowledged(StringBuilder out, Budget budget, int linesPerFile) {
+    List<FileCoverage> files =
+        measured.stream().filter(file -> !file.acknowledged.isEmpty()).toList();
+    if (files.isEmpty() || budget.isSpent()) {
+      return;
+    }
+    out.append("\n\n  Acknowledged uncovered changed code:");
+    int described = 0;
+    for (FileCoverage file : files) {
+      if (budget.isSpent()) {
+        break;
+      }
+      out.append("\n    ").append(file.path);
+      budget.rows -=
+          appendRows(
+              out,
+              file.acknowledged,
+              Math.min(linesPerFile, budget.rows),
+              " more acknowledged lines");
+      budget.files--;
+      described++;
+    }
+    if (described < files.size()) {
+      out.append("\n    ").append(files.size()).append(" files in total");
+    }
+  }
+
+  /**
+   * Appends up to allowed rows, then a row stating how many were left out.
+   *
+   * @return how many rows were printed, which is what the caller takes off its budget
+   */
+  private static int appendRows(
+      StringBuilder out, List<AffectedLine> rows, int allowed, String more) {
+    int shown = Math.min(allowed, rows.size());
+    for (AffectedLine row : rows.subList(0, shown)) {
+      out.append("\n      ").append(row.describe());
+    }
+    if (shown < rows.size()) {
+      out.append("\n      ").append(rows.size() - shown).append(more);
+    }
+    return shown;
+  }
+
+  /**
+   * Appends the branch pair, or nothing where the changed lines branch nowhere.
+   *
+   * <p>Line counts alone report a line as executed once any path through it ran, so a changed
+   * condition tested one way reads as covered; the branch pair is what says otherwise.
+   */
+  private static void appendBranches(StringBuilder out, int covered, int total) {
+    if (total > 0) {
+      out.append(", ").append(covered).append('/').append(total).append(" branches covered");
+    }
+  }
+
+  private static void appendPaths(StringBuilder out, List<String> paths, String heading) {
+    if (paths.isEmpty()) {
+      return;
+    }
+    out.append("\n\n  ").append(heading);
+    for (String path : paths) {
+      out.append("\n    ").append(path);
+    }
+  }
+
+  /** Returns whether any of the paths sits under one of the source roots. */
+  static boolean reaches(List<String> sourceRoots, Collection<String> paths) {
+    return paths.stream().anyMatch(path -> sourceFileKey(path, sourceRoots) != null);
+  }
+
+  /**
+   * Returns the path with its source root stripped, or null where no root contains it.
+   *
+   * <p>The longest matching root wins, since a root nested inside another would otherwise leave the
+   * outer root's extra directories in the key and match no package JaCoCo reports.
+   *
+   * <p>A root's separators are normalised first. The paths come from a git diff and always use
+   * {@code /}, while a root built from a {@code java.nio.file.Path} uses the platform separator, so
+   * on Windows no root would match and every changed file would leave the report.
+   */
+  private static String sourceFileKey(String path, List<String> sourceRoots) {
+    String longest = null;
+    for (String sourceRoot : sourceRoots) {
+      String root = sourceRoot.replace('\\', '/');
+      String prefix = root.endsWith("/") ? root : root + "/";
+      if (path.startsWith(prefix) && (longest == null || prefix.length() > longest.length())) {
+        longest = prefix;
+      }
+    }
+    return longest == null ? null : path.substring(longest.length());
+  }
+}

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
@@ -15,33 +15,28 @@
  */
 package com.uber.nullaway.gradle;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
-import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
-import org.gradle.process.ExecOperations;
 
 /**
  * Prints which of the lines this branch changed the preceding test run executed.
@@ -77,10 +72,6 @@ public abstract class DiffCoverageTask extends DefaultTask {
   /** Source directories of the module, relative to the repository root. */
   @Internal
   public abstract ListProperty<String> getSourceRoots();
-
-  /** The repository the diff is taken in. */
-  @Internal
-  public abstract DirectoryProperty getRepositoryRoot();
 
   /**
    * The ref whose merge base with HEAD the diff is taken from.
@@ -131,8 +122,17 @@ public abstract class DiffCoverageTask extends DefaultTask {
   @Internal
   public abstract Property<Double> getFailUnder();
 
-  @Inject
-  protected abstract ExecOperations getExecOperations();
+  /**
+   * The name the build registers {@link GitService} under.
+   *
+   * <p>The registration and this reference share the constant because a reference that names an
+   * unregistered service fails only in a build that runs the task, which no test here does.
+   */
+  public static final String GIT_SERVICE = "nullaway.git";
+
+  /** Runs the git commands, and names the repository the diff and the sources are read from. */
+  @ServiceReference(GIT_SERVICE)
+  public abstract Property<GitService> getGit();
 
   @TaskAction
   public void report() throws IOException {
@@ -162,13 +162,14 @@ public abstract class DiffCoverageTask extends DefaultTask {
     if (Files.isRegularFile(output)) {
       Files.delete(output);
     }
-    File repository = getRepositoryRoot().get().getAsFile();
-    Base base = resolveBase(repository);
+    GitService git = getGit().get();
+    File repository = git.repositoryRoot();
+    Base base = resolveBase(git);
     if (base == null) {
       return giveUp(NO_BASE);
     }
     List<String> unreadable = new ArrayList<>();
-    Map<String, NavigableSet<Integer>> changed = changedLines(repository, base.commit, unreadable);
+    Map<String, NavigableSet<Integer>> changed = changedLines(git, base.commit, unreadable);
 
     // A module the change never reached has nothing to say, and saying it anyway would put a line
     // in every whole-build run for every module with no test and for every module the change
@@ -393,23 +394,22 @@ public abstract class DiffCoverageTask extends DefaultTask {
    * <p>The ref is carried back so that the report names the one that won, which {@code
    * @{upstream}} and {@code origin/master} otherwise leave the reader to guess between.
    */
-  private Base resolveBase(File repository) {
+  private Base resolveBase(GitService git) {
     String explicit = getBaseRef().getOrNull();
-    if (explicit != null && !resolves(repository, explicit)) {
+    if (explicit != null && !resolves(git, explicit)) {
       throw new GradleException(
           "diffCoverageBase " + explicit + " does not resolve to a commit");
     }
-    String upstream = gitOrNull(repository, new ByteArrayOutputStream(), UPSTREAM_NAME);
-    String branch = gitOrNull(repository, new ByteArrayOutputStream(), BRANCH_NAME);
+    String upstream = git.outputOrNull(UPSTREAM_NAME);
+    String branch = git.outputOrNull(BRANCH_NAME);
     for (String candidate : baseCandidates(explicit, upstream, branch)) {
-      if (!resolves(repository, candidate)) {
+      if (!resolves(git, candidate)) {
         continue;
       }
       // A ref can resolve and still share no commit with HEAD, as in a shallow clone or after an
       // orphan branch, and merge-base then fails. That is a base this run does not have, not a
       // reason to fail a build whose tests passed.
-      String mergeBase =
-          gitOrNull(repository, new ByteArrayOutputStream(), "merge-base", candidate, "HEAD");
+      String mergeBase = git.outputOrNull("merge-base", candidate, "HEAD");
       if (mergeBase != null) {
         return new Base(candidate, mergeBase);
       }
@@ -444,15 +444,8 @@ public abstract class DiffCoverageTask extends DefaultTask {
   }
 
   /** Returns whether the ref names a commit of this repository. */
-  private boolean resolves(File repository, String ref) {
-    return gitOrNull(
-            repository,
-            new ByteArrayOutputStream(),
-            "rev-parse",
-            "--verify",
-            "--quiet",
-            ref + "^{commit}")
-        != null;
+  private boolean resolves(GitService git, String ref) {
+    return git.outputOrNull("rev-parse", "--verify", "--quiet", ref + "^{commit}") != null;
   }
 
   /**
@@ -465,14 +458,13 @@ public abstract class DiffCoverageTask extends DefaultTask {
    * @param unreadable collects a line naming each untracked file this JVM cannot decode
    */
   private Map<String, NavigableSet<Integer>> changedLines(
-      File repository, String base, List<String> unreadable) {
-    String diff = git(repository, diffCommand(base).toArray(new String[0]));
+      GitService git, String base, List<String> unreadable) {
+    String diff = git.output(diffCommand(base).toArray(new String[0]));
     Map<String, NavigableSet<Integer>> changed = UnifiedDiff.parse(diff);
     // core.quotePath is off here for the reason diffCommand gives: a quoted path names no file
     // this JVM can open, and the file would be reported as unreadable rather than measured.
     String untracked =
-        git(
-            repository,
+        git.output(
             "-c",
             "core.quotePath=false",
             "ls-files",
@@ -490,7 +482,7 @@ public abstract class DiffCoverageTask extends DefaultTask {
       // An untracked file has no diff, so every line in it counts as changed.
       NavigableSet<Integer> lines = new TreeSet<>();
       try {
-        int count = Files.readAllLines(repository.toPath().resolve(path)).size();
+        int count = Files.readAllLines(git.repositoryRoot().toPath().resolve(path)).size();
         for (int number = 1; number <= count; number++) {
           lines.add(number);
         }
@@ -525,42 +517,4 @@ public abstract class DiffCoverageTask extends DefaultTask {
     return stale;
   }
 
-  /**
-   * Returns the trimmed output of a git command.
-   *
-   * @throws GradleException where git reported failure, since empty output means the command
-   *     succeeded and found nothing, and the two must not read alike
-   */
-  private String git(File repository, String... arguments) {
-    ByteArrayOutputStream error = new ByteArrayOutputStream();
-    String output = gitOrNull(repository, error, arguments);
-    if (output == null) {
-      throw new GradleException(
-          "git "
-              + String.join(" ", arguments)
-              + " failed: "
-              + new String(error.toByteArray(), StandardCharsets.UTF_8).trim());
-    }
-    return output;
-  }
-
-  /** Returns the trimmed output of a git command, or null where git reported failure. */
-  private String gitOrNull(File repository, ByteArrayOutputStream error, String... arguments) {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    List<String> command = new ArrayList<>();
-    command.add("git");
-    command.addAll(Arrays.asList(arguments));
-    int exitCode =
-        getExecOperations()
-            .exec(
-                spec -> {
-                  spec.setWorkingDir(repository);
-                  spec.setCommandLine(command);
-                  spec.setStandardOutput(output);
-                  spec.setErrorOutput(error);
-                  spec.setIgnoreExitValue(true);
-                })
-            .getExitValue();
-    return exitCode == 0 ? new String(output.toByteArray(), StandardCharsets.UTF_8).trim() : null;
-  }
 }

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.UntrackedTask;
+import org.gradle.process.ExecOperations;
+
+/**
+ * Prints which of the lines this branch changed the preceding test run executed.
+ *
+ * <p>The task intersects two sets: the lines a git diff marks as changed, and the lines a JaCoCo
+ * report records as executed. It reads no coverage data from the base commit, so nothing has to be
+ * recorded before the run or stored in the repository; the base is a git ref, used only to decide
+ * which lines count as changed.
+ *
+ * <p>The output goes to the {@code QUIET} log level, which {@code --quiet} still shows, because the
+ * point of the task is to reach whoever is reading the test output. What the printed block leaves
+ * out is in the file {@link #getOutputFile()} names, which the block ends by naming.
+ */
+@UntrackedTask(
+    because = "the working tree and the branch decide the result, and Gradle tracks neither")
+public abstract class DiffCoverageTask extends DefaultTask {
+
+  static final String NO_BASE =
+      "Diff coverage: no base ref resolved, so no line counts as changed. Pass -PdiffCoverageBase=<ref>, "
+          + "or set an upstream branch, or fetch origin/master.";
+
+  private static final String[] UPSTREAM_NAME = {"rev-parse", "--abbrev-ref", "@{upstream}"};
+
+  private static final String[] BRANCH_NAME = {"rev-parse", "--abbrev-ref", "HEAD"};
+
+  static final String NO_REPORT =
+      "Diff coverage: no JaCoCo report was produced, so no line counts as executed.";
+
+  /** The JaCoCo XML reports to read. */
+  @InputFiles
+  public abstract ConfigurableFileCollection getReportFiles();
+
+  /** Source directories of the module, relative to the repository root. */
+  @Internal
+  public abstract ListProperty<String> getSourceRoots();
+
+  /** The repository the diff is taken in. */
+  @Internal
+  public abstract DirectoryProperty getRepositoryRoot();
+
+  /**
+   * The ref whose merge base with HEAD the diff is taken from.
+   *
+   * <p>Taking the merge base rather than the ref itself keeps commits that landed on the ref since
+   * the branch point out of the diff, so the report covers this branch's own work. Unset, the
+   * upstream branch is tried, then {@code origin/master}. A ref that is set and does not resolve
+   * fails the task rather than falling through, because diffing against something else would
+   * report the wrong lines as executed.
+   */
+  @Internal
+  public abstract Property<String> getBaseRef();
+
+  /** What the run covered, printed so that a filtered run is not read as missing coverage. */
+  @Internal
+  public abstract Property<String> getScopeDescription();
+
+  /** How many uncovered lines to print for one file, past which the file states its total. */
+  @Internal
+  public abstract Property<Integer> getMaxLinesPerFile();
+
+  /** How many uncovered lines to print over the block's lists together. */
+  @Internal
+  public abstract Property<Integer> getMaxLinesTotal();
+
+  /** Whether the run was narrowed to some of the tests, which the report has to say. */
+  @Internal
+  public abstract Property<Boolean> getFiltered();
+
+  /** How many files to describe over the block's lists together, most work left first. */
+  @Internal
+  public abstract Property<Integer> getMaxFiles();
+
+  /** Whether to print the whole report, spending no limit on the console output. */
+  @Internal
+  public abstract Property<Boolean> getShowAll();
+
+  /**
+   * The file the whole report is written to, whatever the console limits leave out.
+   *
+   * <p>The task prints its path, so that a reader who needs the rest reads a report rather than
+   * the JaCoCo XML.
+   */
+  @OutputFile
+  public abstract RegularFileProperty getOutputFile();
+
+  /** Fails the task where fewer than this percentage of the changed lines ran; unset by default. */
+  @Internal
+  public abstract Property<Double> getFailUnder();
+
+  @Inject
+  protected abstract ExecOperations getExecOperations();
+
+  @TaskAction
+  public void report() throws IOException {
+    String text = describeRun();
+    if (!text.isEmpty()) {
+      getLogger().quiet(text);
+    }
+  }
+
+  /**
+   * Returns the text this run prints, which is empty where the change reached none of the module.
+   *
+   * <p>Returning the text rather than logging it is what lets a test read the report: the scope
+   * line naming the ref that resolved, the message of a run that measured nothing, and the note
+   * about a file that could not be read are all outcomes a caller can only otherwise infer.
+   *
+   * <p>The file {@link #getOutputFile()} names is rewritten here, and is deleted where this run
+   * measured nothing, so that it holds this run's report or no report at all.
+   *
+   * @throws GradleException where a threshold was asked for and this run cannot honour it
+   */
+  String describeRun() throws IOException {
+    // The file belongs to this task, so a run that measures nothing must not leave the last run's
+    // report where a reader would take it for this one. A path that names no regular file is left
+    // to the write below, which reports what is wrong with it.
+    Path output = getOutputFile().get().getAsFile().toPath();
+    if (Files.isRegularFile(output)) {
+      Files.delete(output);
+    }
+    File repository = getRepositoryRoot().get().getAsFile();
+    Base base = resolveBase(repository);
+    if (base == null) {
+      return giveUp(NO_BASE);
+    }
+    List<String> unreadable = new ArrayList<>();
+    Map<String, NavigableSet<Integer>> changed = changedLines(repository, base.commit, unreadable);
+
+    // A module the change never reached has nothing to say, and saying it anyway would put a line
+    // in every whole-build run for every module with no test and for every module the change
+    // missed. Decided before the report, since a module with no test produces none.
+    if (!DiffCoverageReport.reaches(getSourceRoots().get(), changed.keySet())) {
+      return String.join("\n", unreadable);
+    }
+    List<File> reports = new ArrayList<>(getReportFiles().getFiles());
+    reports.removeIf(file -> !file.isFile());
+    if (reports.isEmpty()) {
+      return giveUp(NO_REPORT);
+    }
+    DiffCoverageReport report =
+        DiffCoverageReport.measure(
+            changed,
+            getSourceRoots().get(),
+            JacocoLines.read(reports),
+            SourceLines.under(repository));
+    String scope =
+        "against "
+            + base.ref
+            + " ("
+            + base.commit.substring(0, Math.min(9, base.commit.length()))
+            + "), from "
+            + getScopeDescription().get();
+    List<String> stale = staleSources(repository, report.measuredPaths(), reports);
+    String full =
+        report.render(scope, getFiltered().get(), stale, DiffCoverageReport.Limits.NONE);
+    String console =
+        getShowAll().get()
+            ? full
+            : report.render(
+                scope,
+                getFiltered().get(),
+                stale,
+                new DiffCoverageReport.Limits(
+                    getMaxFiles().get(), getMaxLinesPerFile().get(), getMaxLinesTotal().get()));
+    String text = console.isEmpty() ? console : withReportPaths(repository, reports, console, full);
+    failIfBelowThreshold(report, fullReportPath(repository));
+    if (unreadable.isEmpty()) {
+      return text;
+    }
+    // The silence rule is for a module the change never reached. A file the task could not read is
+    // a change it did reach and could not measure, so it is said either way.
+    String notes = String.join("\n", unreadable);
+    return text.isEmpty() ? notes : notes + "\n" + text;
+  }
+
+  /**
+   * Writes the whole report to a file and returns the text to print, ending in the paths of both.
+   *
+   * <p>The console block is a summary of work, so the reader is left with somewhere to read the
+   * rest: the file holds every uncovered line, and the JaCoCo XML holds the run it was measured
+   * from. A file that cannot be written is reported in place of its path, since a path that names
+   * no file sends the reader to a stale report or to none.
+   */
+  private String withReportPaths(
+      File repository, List<File> reports, String console, String full) {
+    StringBuilder jacoco =
+        new StringBuilder(reports.size() == 1 ? "Full JaCoCo report:" : "Full JaCoCo reports:");
+    for (File report : reports) {
+      jacoco.append("\n  ").append(relativize(repository, report));
+    }
+    File output = getOutputFile().get().getAsFile();
+    String diffCoverage;
+    try {
+      Files.createDirectories(output.toPath().getParent());
+      Files.writeString(output.toPath(), full + "\n\n" + jacoco + "\n");
+      diffCoverage = "Full diff coverage report:\n  " + relativize(repository, output);
+    } catch (IOException e) {
+      diffCoverage =
+          "Full diff coverage report: cannot write " + relativize(repository, output) + ": " + e;
+    }
+    return console + "\n\n" + diffCoverage + "\n" + jacoco;
+  }
+
+  /** Returns the path as the reader would type it, which is relative to the repository. */
+  private static String relativize(File repository, File file) {
+    Path root = repository.toPath().toAbsolutePath().normalize();
+    Path target = file.toPath().toAbsolutePath().normalize();
+    return target.startsWith(root) ? root.relativize(target).toString() : target.toString();
+  }
+
+  /**
+   * Reports that no measurement was possible, and fails the task where a threshold was asked for.
+   *
+   * <p>A threshold is a gate, and a gate that passes because the measurement did not happen is
+   * worse than no gate. Without one the message is advice, and failing the build over it would
+   * stop a test run that otherwise succeeded.
+   */
+  private String giveUp(String reason) {
+    if (getFailUnder().isPresent()) {
+      throw new GradleException(reason);
+    }
+    return reason;
+  }
+
+  /**
+   * Fails the task where the run left a changed file unmeasured or below the threshold.
+   *
+   * @param reportPath the report this run wrote, or null where it wrote none. A failing task
+   *     prints its exception and not the block, so the message carries the one line of it a reader
+   *     needs to see which lines fell short
+   */
+  private void failIfBelowThreshold(DiffCoverageReport report, String reportPath) {
+    if (!getFailUnder().isPresent()) {
+      return;
+    }
+    String unmeasured = unmeasuredFilesFailure(report.unmeasuredPaths());
+    if (unmeasured != null) {
+      throw new GradleException(naming(unmeasured, reportPath));
+    }
+    String failure =
+        thresholdFailure(report.executedLines(), report.executableLines(), getFailUnder().get());
+    if (failure != null) {
+      throw new GradleException(naming(failure, reportPath));
+    }
+  }
+
+  /** Returns the path of the report this run wrote, or null where it wrote none. */
+  private String fullReportPath(File repository) {
+    File output = getOutputFile().get().getAsFile();
+    return output.isFile() ? relativize(repository, output) : null;
+  }
+
+  /** Returns the failure with the report named after it, where there is a report to name. */
+  private static String naming(String failure, String reportPath) {
+    return reportPath == null ? failure : failure + ". The full report is in " + reportPath;
+  }
+
+  /**
+   * Returns why a gate cannot be applied to the given files, or null where there are none.
+   *
+   * <p>A changed file no report mentions contributes nothing to either side of the share, so a
+   * change made entirely in such files would clear every threshold without being measured.
+   */
+  static String unmeasuredFilesFailure(List<String> unmeasuredPaths) {
+    if (unmeasuredPaths.isEmpty()) {
+      return null;
+    }
+    return "no JaCoCo report covers these changed files, so no threshold applies to them: "
+        + String.join(", ", unmeasuredPaths);
+  }
+
+  /**
+   * Returns why the executed share falls below required, or null where it does not.
+   *
+   * <p>A change with no executable line clears every threshold, since a gate on a share of nothing
+   * would fail a commit that touched only comments.
+   */
+  static String thresholdFailure(int executedLines, int executableLines, double required) {
+    if (executableLines == 0) {
+      return null;
+    }
+    double executed = 100.0 * executedLines / executableLines;
+    if (executed >= required) {
+      return null;
+    }
+    return String.format(
+        // The default locale would write 66,7% here, which no reader greps and no CI log spells
+        // the same way twice across runners.
+        Locale.ROOT,
+        "%.1f%% of the changed lines ran, below the required %.1f%%",
+        executed,
+        required);
+  }
+
+  /**
+   * Returns the refs to try as the base, in order.
+   *
+   * <p>An explicit ref stands alone: falling through from the ref the caller named to another one
+   * would report a different set of lines as changed, under a base the caller did not choose.
+   *
+   * <p>An upstream that is this branch's own pushed copy is left out. In a fork workflow the branch
+   * tracks the fork, so after the first push its upstream is the branch itself, every line it
+   * changed is already in the base, and the report says nothing was changed rather than that it
+   * could not find a base.
+   *
+   * @param explicit the ref the caller named, or null
+   * @param upstreamRef the upstream branch as git names it, such as {@code origin/develop}, or null
+   * @param currentBranch the checked-out branch, or null on a detached HEAD
+   */
+  static List<String> baseCandidates(String explicit, String upstreamRef, String currentBranch) {
+    if (explicit != null) {
+      return List.of(explicit);
+    }
+    if (upstreamRef == null || isOwnPushedBranch(upstreamRef, currentBranch)) {
+      return List.of("origin/master");
+    }
+    return List.of(upstreamRef, "origin/master");
+  }
+
+  /**
+   * Returns whether the upstream ref is the current branch pushed to a remote.
+   *
+   * <p>The comparison drops the remote name, which is the first segment, so that a branch of its
+   * own named after the tail of another one is not mistaken for it.
+   */
+  static boolean isOwnPushedBranch(String upstreamRef, String currentBranch) {
+    if (currentBranch == null) {
+      return false;
+    }
+    int remoteEnd = upstreamRef.indexOf('/');
+    String branch = remoteEnd < 0 ? upstreamRef : upstreamRef.substring(remoteEnd + 1);
+    return branch.equals(currentBranch);
+  }
+
+  /** The ref the diff is taken against, and the merge base with HEAD it resolved to. */
+  private static final class Base {
+    final String ref;
+    final String commit;
+
+    Base(String ref, String commit) {
+      this.ref = ref;
+      this.commit = commit;
+    }
+  }
+
+  /**
+   * Returns the first candidate ref that resolves with its merge base, or null where none does.
+   *
+   * <p>The ref is carried back so that the report names the one that won, which {@code
+   * @{upstream}} and {@code origin/master} otherwise leave the reader to guess between.
+   */
+  private Base resolveBase(File repository) {
+    String explicit = getBaseRef().getOrNull();
+    if (explicit != null && !resolves(repository, explicit)) {
+      throw new GradleException(
+          "diffCoverageBase " + explicit + " does not resolve to a commit");
+    }
+    String upstream = gitOrNull(repository, new ByteArrayOutputStream(), UPSTREAM_NAME);
+    String branch = gitOrNull(repository, new ByteArrayOutputStream(), BRANCH_NAME);
+    for (String candidate : baseCandidates(explicit, upstream, branch)) {
+      if (!resolves(repository, candidate)) {
+        continue;
+      }
+      // A ref can resolve and still share no commit with HEAD, as in a shallow clone or after an
+      // orphan branch, and merge-base then fails. That is a base this run does not have, not a
+      // reason to fail a build whose tests passed.
+      String mergeBase =
+          gitOrNull(repository, new ByteArrayOutputStream(), "merge-base", candidate, "HEAD");
+      if (mergeBase != null) {
+        return new Base(candidate, mergeBase);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the git arguments the diff is taken with.
+   *
+   * <p>{@code --unified=0} is what makes a hunk header name only changed lines, and the prefixes
+   * are pinned because {@code diff.noprefix} and {@code diff.mnemonicPrefix} are personal settings
+   * that would otherwise change the {@code a/} and {@code b/} that {@link UnifiedDiff} strips.
+   *
+   * <p>{@code core.quotePath} is off because it wraps a path holding a non-ASCII byte in quotes
+   * and escapes the byte, as in {@code "b/src/caf\303\251.java"}. Such a {@code +++} line starts
+   * with a quotation mark rather than with the prefix, so it is no file header, and every hunk of
+   * that file leaves the report with nothing to show that it happened.
+   */
+  static List<String> diffCommand(String base) {
+    return List.of(
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--unified=0",
+        "--no-color",
+        "--src-prefix=a/",
+        "--dst-prefix=b/",
+        base,
+        "--",
+        "*.java");
+  }
+
+  /** Returns whether the ref names a commit of this repository. */
+  private boolean resolves(File repository, String ref) {
+    return gitOrNull(
+            repository,
+            new ByteArrayOutputStream(),
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            ref + "^{commit}")
+        != null;
+  }
+
+  /**
+   * Returns the changed lines of every Java file, keyed by repository-relative path.
+   *
+   * <p>Two sources are merged: the post-image lines of the diff between base and the working tree,
+   * which covers committed, staged and unstaged changes alike, and every line of an untracked
+   * file, which no diff mentions at all.
+   *
+   * @param unreadable collects a line naming each untracked file this JVM cannot decode
+   */
+  private Map<String, NavigableSet<Integer>> changedLines(
+      File repository, String base, List<String> unreadable) {
+    String diff = git(repository, diffCommand(base).toArray(new String[0]));
+    Map<String, NavigableSet<Integer>> changed = UnifiedDiff.parse(diff);
+    // core.quotePath is off here for the reason diffCommand gives: a quoted path names no file
+    // this JVM can open, and the file would be reported as unreadable rather than measured.
+    String untracked =
+        git(
+            repository,
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.java");
+    if (untracked.isEmpty()) {
+      return changed;
+    }
+    for (String path : untracked.split("\n")) {
+      if (path.isEmpty()) {
+        continue;
+      }
+      // An untracked file has no diff, so every line in it counts as changed.
+      NavigableSet<Integer> lines = new TreeSet<>();
+      try {
+        int count = Files.readAllLines(repository.toPath().resolve(path)).size();
+        for (int number = 1; number <= count; number++) {
+          lines.add(number);
+        }
+      } catch (IOException e) {
+        // A broken symlink or a file this JVM cannot decode is not worth failing a build whose
+        // tests passed, so it is named and left out of the counts.
+        unreadable.add("Diff coverage: cannot read the untracked file " + path + ": " + e);
+        continue;
+      }
+      changed.put(path, lines);
+    }
+    return changed;
+  }
+
+  /**
+   * Returns the files among measuredPaths that were edited after the newest report was written.
+   *
+   * <p>JaCoCo numbers lines against the sources that were compiled, so an edit after the run shifts
+   * every line below it and the report stops naming the code it was recorded for. Only the files
+   * the counts came from are checked; an edit elsewhere moves no line number in this report.
+   */
+  static List<String> staleSources(
+      File repository, List<String> measuredPaths, List<File> reports) {
+    long newest = reports.stream().mapToLong(File::lastModified).max().orElse(Long.MAX_VALUE);
+    List<String> stale = new ArrayList<>();
+    for (String path : measuredPaths) {
+      File source = new File(repository, path);
+      if (source.isFile() && source.lastModified() > newest) {
+        stale.add(path);
+      }
+    }
+    return stale;
+  }
+
+  /**
+   * Returns the trimmed output of a git command.
+   *
+   * @throws GradleException where git reported failure, since empty output means the command
+   *     succeeded and found nothing, and the two must not read alike
+   */
+  private String git(File repository, String... arguments) {
+    ByteArrayOutputStream error = new ByteArrayOutputStream();
+    String output = gitOrNull(repository, error, arguments);
+    if (output == null) {
+      throw new GradleException(
+          "git "
+              + String.join(" ", arguments)
+              + " failed: "
+              + new String(error.toByteArray(), StandardCharsets.UTF_8).trim());
+    }
+    return output;
+  }
+
+  /** Returns the trimmed output of a git command, or null where git reported failure. */
+  private String gitOrNull(File repository, ByteArrayOutputStream error, String... arguments) {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    List<String> command = new ArrayList<>();
+    command.add("git");
+    command.addAll(Arrays.asList(arguments));
+    int exitCode =
+        getExecOperations()
+            .exec(
+                spec -> {
+                  spec.setWorkingDir(repository);
+                  spec.setCommandLine(command);
+                  spec.setStandardOutput(output);
+                  spec.setErrorOutput(error);
+                  spec.setIgnoreExitValue(true);
+                })
+            .getExitValue();
+    return exitCode == 0 ? new String(output.toByteArray(), StandardCharsets.UTF_8).trim() : null;
+  }
+}

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
@@ -169,7 +169,7 @@ public abstract class DiffCoverageTask extends DefaultTask {
       return giveUp(NO_BASE);
     }
     List<String> unreadable = new ArrayList<>();
-    Map<String, NavigableSet<Integer>> changed = changedLines(git, base.commit, unreadable);
+    Map<String, NavigableSet<Integer>> changed = changedLines(git, base.commit(), unreadable);
 
     // A module the change never reached has nothing to say, and saying it anyway would put a line
     // in every whole-build run for every module with no test and for every module the change
@@ -190,9 +190,9 @@ public abstract class DiffCoverageTask extends DefaultTask {
             SourceLines.under(repository));
     String scope =
         "against "
-            + base.ref
+            + base.ref()
             + " ("
-            + base.commit.substring(0, Math.min(9, base.commit.length()))
+            + base.commit().substring(0, Math.min(9, base.commit().length()))
             + "), from "
             + getScopeDescription().get();
     List<String> stale = staleSources(repository, report.measuredPaths(), reports);
@@ -378,15 +378,7 @@ public abstract class DiffCoverageTask extends DefaultTask {
   }
 
   /** The ref the diff is taken against, and the merge base with HEAD it resolved to. */
-  private static final class Base {
-    final String ref;
-    final String commit;
-
-    Base(String ref, String commit) {
-      this.ref = ref;
-      this.commit = commit;
-    }
-  }
+  private record Base(String ref, String commit) {}
 
   /**
    * Returns the first candidate ref that resolves with its merge base, or null where none does.

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/DiffCoverageTask.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -118,10 +117,6 @@ public abstract class DiffCoverageTask extends DefaultTask {
   @OutputFile
   public abstract RegularFileProperty getOutputFile();
 
-  /** Fails the task where fewer than this percentage of the changed lines ran; unset by default. */
-  @Internal
-  public abstract Property<Double> getFailUnder();
-
   /**
    * The name the build registers {@link GitService} under.
    *
@@ -151,8 +146,6 @@ public abstract class DiffCoverageTask extends DefaultTask {
    *
    * <p>The file {@link #getOutputFile()} names is rewritten here, and is deleted where this run
    * measured nothing, so that it holds this run's report or no report at all.
-   *
-   * @throws GradleException where a threshold was asked for and this run cannot honour it
    */
   String describeRun() throws IOException {
     // The file belongs to this task, so a run that measures nothing must not leave the last run's
@@ -166,7 +159,7 @@ public abstract class DiffCoverageTask extends DefaultTask {
     File repository = git.repositoryRoot();
     Base base = resolveBase(git);
     if (base == null) {
-      return giveUp(NO_BASE);
+      return NO_BASE;
     }
     List<String> unreadable = new ArrayList<>();
     Map<String, NavigableSet<Integer>> changed = changedLines(git, base.commit(), unreadable);
@@ -180,7 +173,7 @@ public abstract class DiffCoverageTask extends DefaultTask {
     List<File> reports = new ArrayList<>(getReportFiles().getFiles());
     reports.removeIf(file -> !file.isFile());
     if (reports.isEmpty()) {
-      return giveUp(NO_REPORT);
+      return NO_REPORT;
     }
     DiffCoverageReport report =
         DiffCoverageReport.measure(
@@ -208,7 +201,6 @@ public abstract class DiffCoverageTask extends DefaultTask {
                 new DiffCoverageReport.Limits(
                     getMaxFiles().get(), getMaxLinesPerFile().get(), getMaxLinesTotal().get()));
     String text = console.isEmpty() ? console : withReportPaths(repository, reports, console, full);
-    failIfBelowThreshold(report, fullReportPath(repository));
     if (unreadable.isEmpty()) {
       return text;
     }
@@ -251,90 +243,6 @@ public abstract class DiffCoverageTask extends DefaultTask {
     Path root = repository.toPath().toAbsolutePath().normalize();
     Path target = file.toPath().toAbsolutePath().normalize();
     return target.startsWith(root) ? root.relativize(target).toString() : target.toString();
-  }
-
-  /**
-   * Reports that no measurement was possible, and fails the task where a threshold was asked for.
-   *
-   * <p>A threshold is a gate, and a gate that passes because the measurement did not happen is
-   * worse than no gate. Without one the message is advice, and failing the build over it would
-   * stop a test run that otherwise succeeded.
-   */
-  private String giveUp(String reason) {
-    if (getFailUnder().isPresent()) {
-      throw new GradleException(reason);
-    }
-    return reason;
-  }
-
-  /**
-   * Fails the task where the run left a changed file unmeasured or below the threshold.
-   *
-   * @param reportPath the report this run wrote, or null where it wrote none. A failing task
-   *     prints its exception and not the block, so the message carries the one line of it a reader
-   *     needs to see which lines fell short
-   */
-  private void failIfBelowThreshold(DiffCoverageReport report, String reportPath) {
-    if (!getFailUnder().isPresent()) {
-      return;
-    }
-    String unmeasured = unmeasuredFilesFailure(report.unmeasuredPaths());
-    if (unmeasured != null) {
-      throw new GradleException(naming(unmeasured, reportPath));
-    }
-    String failure =
-        thresholdFailure(report.executedLines(), report.executableLines(), getFailUnder().get());
-    if (failure != null) {
-      throw new GradleException(naming(failure, reportPath));
-    }
-  }
-
-  /** Returns the path of the report this run wrote, or null where it wrote none. */
-  private String fullReportPath(File repository) {
-    File output = getOutputFile().get().getAsFile();
-    return output.isFile() ? relativize(repository, output) : null;
-  }
-
-  /** Returns the failure with the report named after it, where there is a report to name. */
-  private static String naming(String failure, String reportPath) {
-    return reportPath == null ? failure : failure + ". The full report is in " + reportPath;
-  }
-
-  /**
-   * Returns why a gate cannot be applied to the given files, or null where there are none.
-   *
-   * <p>A changed file no report mentions contributes nothing to either side of the share, so a
-   * change made entirely in such files would clear every threshold without being measured.
-   */
-  static String unmeasuredFilesFailure(List<String> unmeasuredPaths) {
-    if (unmeasuredPaths.isEmpty()) {
-      return null;
-    }
-    return "no JaCoCo report covers these changed files, so no threshold applies to them: "
-        + String.join(", ", unmeasuredPaths);
-  }
-
-  /**
-   * Returns why the executed share falls below required, or null where it does not.
-   *
-   * <p>A change with no executable line clears every threshold, since a gate on a share of nothing
-   * would fail a commit that touched only comments.
-   */
-  static String thresholdFailure(int executedLines, int executableLines, double required) {
-    if (executableLines == 0) {
-      return null;
-    }
-    double executed = 100.0 * executedLines / executableLines;
-    if (executed >= required) {
-      return null;
-    }
-    return String.format(
-        // The default locale would write 66,7% here, which no reader greps and no CI log spells
-        // the same way twice across runners.
-        Locale.ROOT,
-        "%.1f%% of the changed lines ran, below the required %.1f%%",
-        executed,
-        required);
   }
 
   /**

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/GitService.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/GitService.java
@@ -52,19 +52,13 @@ public abstract class GitService implements BuildService<GitService.Parameters> 
     DirectoryProperty getRepositoryRoot();
   }
 
-  /** What one git command printed, kept so that a repeat of it prints the same thing. */
-  private static final class Output {
-    /** The trimmed standard output, or null where git reported failure. */
-    final String value;
-
-    /** The trimmed standard error, which is what a failure has to report. */
-    final String error;
-
-    Output(String value, String error) {
-      this.value = value;
-      this.error = error;
-    }
-  }
+  /**
+   * What one git command printed, kept so that a repeat of it prints the same thing.
+   *
+   * @param value the trimmed standard output, or null where git reported failure
+   * @param error the trimmed standard error, which is what a failure has to report
+   */
+  private record Output(String value, String error) {}
 
   private final Map<List<String>, Output> outputs = new ConcurrentHashMap<>();
 
@@ -84,16 +78,16 @@ public abstract class GitService implements BuildService<GitService.Parameters> 
    */
   public String output(String... arguments) {
     Output result = run(arguments);
-    if (result.value == null) {
+    if (result.value() == null) {
       throw new GradleException(
-          "git " + String.join(" ", arguments) + " failed: " + result.error);
+          "git " + String.join(" ", arguments) + " failed: " + result.error());
     }
-    return result.value;
+    return result.value();
   }
 
   /** Returns the trimmed output of a git command, or null where git reported failure. */
   public String outputOrNull(String... arguments) {
-    return run(arguments).value;
+    return run(arguments).value();
   }
 
   private Output run(String... arguments) {

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/GitService.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/GitService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.process.ExecOperations;
+
+/**
+ * Runs git in one repository and remembers what each command printed.
+ *
+ * <p>Every module of a build asks the same questions of the same repository: which ref the diff is
+ * taken against, which lines it changed, which files are untracked. Running git once per module
+ * repeats work that cannot answer differently, and a build service is the one object a build has
+ * that outlives a task and is shared across projects, so the answers are cached here.
+ *
+ * <p>A command runs at most once per build. The working tree can change while a build runs, and a
+ * cached answer therefore describes the tree as it stood when the first module asked. That is the
+ * behavior this cache is for: a report that names different changed lines in two modules of one
+ * build would be read as a difference between the modules.
+ *
+ * <p>Instances are shared between tasks that may run in parallel, so the cache is concurrent and
+ * git may run on several threads at once.
+ */
+public abstract class GitService implements BuildService<GitService.Parameters> {
+
+  /** The repository every command of this service runs in. */
+  public interface Parameters extends BuildServiceParameters {
+    DirectoryProperty getRepositoryRoot();
+  }
+
+  /** What one git command printed, kept so that a repeat of it prints the same thing. */
+  private static final class Output {
+    /** The trimmed standard output, or null where git reported failure. */
+    final String value;
+
+    /** The trimmed standard error, which is what a failure has to report. */
+    final String error;
+
+    Output(String value, String error) {
+      this.value = value;
+      this.error = error;
+    }
+  }
+
+  private final Map<List<String>, Output> outputs = new ConcurrentHashMap<>();
+
+  @Inject
+  protected abstract ExecOperations getExecOperations();
+
+  /** Returns the repository the commands run in, which is also where its files are read from. */
+  public File repositoryRoot() {
+    return getParameters().getRepositoryRoot().get().getAsFile();
+  }
+
+  /**
+   * Returns the trimmed output of a git command.
+   *
+   * @throws GradleException where git reported failure, since empty output means the command
+   *     succeeded and found nothing, and the two must not read alike
+   */
+  public String output(String... arguments) {
+    Output result = run(arguments);
+    if (result.value == null) {
+      throw new GradleException(
+          "git " + String.join(" ", arguments) + " failed: " + result.error);
+    }
+    return result.value;
+  }
+
+  /** Returns the trimmed output of a git command, or null where git reported failure. */
+  public String outputOrNull(String... arguments) {
+    return run(arguments).value;
+  }
+
+  private Output run(String... arguments) {
+    return outputs.computeIfAbsent(List.of(arguments), this::execute);
+  }
+
+  private Output execute(List<String> arguments) {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    ByteArrayOutputStream error = new ByteArrayOutputStream();
+    List<String> command = new ArrayList<>();
+    command.add("git");
+    command.addAll(arguments);
+    int exitCode =
+        getExecOperations()
+            .exec(
+                spec -> {
+                  spec.setWorkingDir(repositoryRoot());
+                  spec.setCommandLine(command);
+                  spec.setStandardOutput(output);
+                  spec.setErrorOutput(error);
+                  spec.setIgnoreExitValue(true);
+                })
+            .getExitValue();
+    String text = new String(output.toByteArray(), StandardCharsets.UTF_8).trim();
+    return new Output(
+        exitCode == 0 ? text : null,
+        new String(error.toByteArray(), StandardCharsets.UTF_8).trim());
+  }
+}

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/JacocoLines.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/JacocoLines.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** The per-line counters a set of JaCoCo XML reports records, keyed by package-qualified path. */
+final class JacocoLines {
+
+  /** Instruction and branch counters of one source line. */
+  static final class Counters {
+    final int coveredInstructions;
+    final int coveredBranches;
+    final int totalBranches;
+
+    Counters(int coveredInstructions, int coveredBranches, int totalBranches) {
+      this.coveredInstructions = coveredInstructions;
+      this.coveredBranches = coveredBranches;
+      this.totalBranches = totalBranches;
+    }
+
+    boolean isExecuted() {
+      return coveredInstructions > 0;
+    }
+
+    boolean hasUntakenBranch() {
+      return totalBranches > 0 && coveredBranches < totalBranches;
+    }
+  }
+
+  private final Map<String, Map<Integer, Counters>> bySourceFile;
+
+  private JacocoLines(Map<String, Map<Integer, Counters>> bySourceFile) {
+    this.bySourceFile = bySourceFile;
+  }
+
+  /**
+   * Returns the counters the given reports record, merged by taking the larger of each counter.
+   *
+   * <p>JaCoCo numbers no branch, so two reports covering the same line give no way to tell one
+   * branch reached twice from two branches reached once. Taking the larger counter reports a branch
+   * one report reached and another did not as partly taken, which asks for a test that already
+   * exists rather than hiding one that is missing.
+   *
+   * @throws IOException if a report cannot be read or is not well-formed XML
+   */
+  static JacocoLines read(List<File> reports) throws IOException {
+    DocumentBuilder builder;
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      // A JaCoCo report declares report.dtd as a relative system id, and JaCoCo writes no such
+      // file beside it, so a parser that loads it fails with FileNotFoundException.
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      builder = factory.newDocumentBuilder();
+    } catch (ParserConfigurationException e) {
+      throw new IllegalStateException("the platform XML parser rejected its own configuration", e);
+    }
+    Map<String, Map<Integer, Counters>> merged = new HashMap<>();
+    for (File report : reports) {
+      NodeList packages;
+      try {
+        packages = builder.parse(report).getElementsByTagName("package");
+      } catch (SAXException e) {
+        throw new IOException("cannot parse the JaCoCo report at " + report, e);
+      }
+      for (int p = 0; p < packages.getLength(); p++) {
+        Element packageElement = (Element) packages.item(p);
+        String packageName = packageElement.getAttribute("name");
+        NodeList sourceFiles = packageElement.getElementsByTagName("sourcefile");
+        for (int s = 0; s < sourceFiles.getLength(); s++) {
+          Element sourceFile = (Element) sourceFiles.item(s);
+          Map<Integer, Counters> lines =
+              merged.computeIfAbsent(
+                  packageName + "/" + sourceFile.getAttribute("name"), unused -> new HashMap<>());
+          NodeList lineElements = sourceFile.getElementsByTagName("line");
+          for (int l = 0; l < lineElements.getLength(); l++) {
+            Element line = (Element) lineElements.item(l);
+            int number = attribute(line, "nr");
+            int coveredBranches = attribute(line, "cb");
+            Counters previous = lines.get(number);
+            Counters current =
+                new Counters(
+                    attribute(line, "ci"),
+                    coveredBranches,
+                    coveredBranches + attribute(line, "mb"));
+            lines.put(number, previous == null ? current : larger(previous, current));
+          }
+        }
+      }
+    }
+    return new JacocoLines(merged);
+  }
+
+  /** Returns the counters recorded for one line, or null where the report mentions no such line. */
+  Counters get(String sourceFileKey, int line) {
+    Map<Integer, Counters> lines = bySourceFile.get(sourceFileKey);
+    return lines == null ? null : lines.get(line);
+  }
+
+  /** Returns whether any report read here mentions the given package-qualified source path. */
+  boolean covers(String sourceFileKey) {
+    return bySourceFile.containsKey(sourceFileKey);
+  }
+
+  private static Counters larger(Counters first, Counters second) {
+    return new Counters(
+        Math.max(first.coveredInstructions, second.coveredInstructions),
+        Math.max(first.coveredBranches, second.coveredBranches),
+        Math.max(first.totalBranches, second.totalBranches));
+  }
+
+  private static int attribute(Element element, String name) {
+    String value = element.getAttribute(name);
+    return value.isEmpty() ? 0 : Integer.parseInt(value);
+  }
+}

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/SourceLines.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/SourceLines.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The text of the working tree's sources, read at most once per file.
+ *
+ * <p>The report quotes a line beside its counters, so that the reader sees the code to test without
+ * opening the file, and reads the same text to decide whether the line carries an ignore marker.
+ */
+final class SourceLines {
+
+  private final File repositoryRoot;
+
+  private final Map<String, List<String>> byPath = new HashMap<>();
+
+  private SourceLines(File repositoryRoot) {
+    this.repositoryRoot = repositoryRoot;
+  }
+
+  /** Returns the text of the files under the given repository, each read as it is asked for. */
+  static SourceLines under(File repositoryRoot) {
+    return new SourceLines(repositoryRoot);
+  }
+
+  /**
+   * Returns one line as the working tree holds it, or an empty string where there is no such line.
+   *
+   * <p>A file this JVM cannot read or decode, and a number past the end of the file, both give an
+   * empty string. The counters beside the quote are the report's subject, so a line that cannot be
+   * quoted is still reported, without its text.
+   *
+   * @param path repository-relative path, as a git diff spells it
+   * @param number 1-based line number, as JaCoCo numbers lines
+   */
+  String get(String path, int number) {
+    List<String> lines = byPath.computeIfAbsent(path, this::read);
+    return number >= 1 && number <= lines.size() ? lines.get(number - 1) : "";
+  }
+
+  private List<String> read(String path) {
+    try {
+      return Files.readAllLines(repositoryRoot.toPath().resolve(path));
+    } catch (IOException | InvalidPathException e) {
+      return List.of();
+    }
+  }
+}

--- a/buildSrc/src/main/java/com/uber/nullaway/gradle/UnifiedDiff.java
+++ b/buildSrc/src/main/java/com/uber/nullaway/gradle/UnifiedDiff.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Reads the post-image line numbers out of a unified diff. */
+final class UnifiedDiff {
+
+  private static final Pattern HUNK_HEADER =
+      Pattern.compile("^@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,(\\d+))? @@.*");
+
+  private UnifiedDiff() {}
+
+  /**
+   * Returns the lines each file gained or had rewritten, keyed by repository-relative path.
+   *
+   * <p>The diff has to be produced with {@code --unified=0} and the default {@code a/} and {@code
+   * b/} prefixes, which {@code diff.noprefix} and {@code diff.mnemonicPrefix} would otherwise
+   * change. A hunk that only deletes lines contributes none, since the deleted lines are in no file
+   * a coverage report can mention.
+   *
+   * <p>A file header counts as one only in the header section git opens with {@code diff --git},
+   * and only as the {@code +++} directly under its {@code ---}. Content carries the same shapes: an
+   * added line whose text starts with {@code ++} reaches the diff as {@code +++ …}, and a deleted
+   * line reading {@code -- a/x} beside an added {@code ++ b/y} reaches it as a header pair. Reading
+   * either as a header opens a file named after that text and takes every later hunk of the real
+   * file with it, which drops those lines from the report with nothing to show that it happened.
+   */
+  static Map<String, NavigableSet<Integer>> parse(String diff) {
+    Map<String, NavigableSet<Integer>> changed = new LinkedHashMap<>();
+    NavigableSet<Integer> current = null;
+    boolean inHeaderSection = false;
+    boolean afterSourceHeader = false;
+    for (String line : diff.split("\n", -1)) {
+      if (line.startsWith("diff --git ")) {
+        inHeaderSection = true;
+        afterSourceHeader = false;
+        current = null;
+      } else if (inHeaderSection && isHeader(line, "--- ", "a/")) {
+        afterSourceHeader = true;
+      } else if (afterSourceHeader && isHeader(line, "+++ ", "b/")) {
+        String target = line.substring(4).trim();
+        current =
+            target.equals("/dev/null")
+                ? null
+                : changed.computeIfAbsent(target.substring(2), unused -> new TreeSet<>());
+        inHeaderSection = false;
+        afterSourceHeader = false;
+      } else if (current != null && line.startsWith("@@")) {
+        Matcher matcher = HUNK_HEADER.matcher(line);
+        if (matcher.matches()) {
+          int start = Integer.parseInt(matcher.group(1));
+          int count = matcher.group(2) == null ? 1 : Integer.parseInt(matcher.group(2));
+          for (int number = start; number < start + count; number++) {
+            current.add(number);
+          }
+        }
+        inHeaderSection = false;
+        afterSourceHeader = false;
+      } else {
+        afterSourceHeader = false;
+      }
+    }
+    changed.values().removeIf(NavigableSet::isEmpty);
+    return changed;
+  }
+
+  /** Returns whether the line is a file header naming a path under prefix, or /dev/null. */
+  private static boolean isHeader(String line, String marker, String prefix) {
+    if (!line.startsWith(marker)) {
+      return false;
+    }
+    String target = line.substring(marker.length()).trim();
+    return target.equals("/dev/null") || target.startsWith(prefix);
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageReportTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageReportTest.java
@@ -230,22 +230,25 @@ class DiffCoverageReportTest {
   @Nested
   class FilesThatCannotBeMeasured {
 
-    /** A file no report covers is the one thing that fails a threshold whatever the coverage. */
+    /**
+     * A file no report covers was never measured, so counting it as covered would report a test
+     * that does not exist.
+     */
     @Test
     void aFileUnderARootThatNoReportMentionsIsNamedAsMissingFromTheReport() throws IOException {
       DiffCoverageReport result = measure(changed(OTHER, 10), ROOTS, report(""));
-      assertEquals(List.of(OTHER), result.unmeasuredPaths());
+      assertEquals(List.of(OTHER), result.notInAnyReport);
     }
 
     /**
      * A comment-only change contributes to neither side of the share, so it has to be named
-     * without joining the files that fail the threshold for want of a report.
+     * without joining the files that a report was expected to cover and did not.
      */
     @Test
     void aFileWhoseChangedLinesEmitNoBytecodeIsNamedSeparately() throws IOException {
       DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(99, 4, 0, 0)));
       assertAll(
-          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () -> assertEquals(List.of(), result.notInAnyReport, "unmeasuredPaths"),
           () ->
               assertLinesMatch(
                   List.of(
@@ -257,14 +260,14 @@ class DiffCoverageReportTest {
     }
 
     @Test
-    void aFileOfAnotherModuleIsMeasuredNowhereAndFailsNoThreshold() throws IOException {
+    void aFileOfAnotherModuleIsLeftOutOfTheReportEntirely() throws IOException {
       DiffCoverageReport result =
           measure(
               changed("other/src/main/java/com/uber/nullaway/Sample.java", 10),
               ROOTS,
               report(line(10, 0, 0, 0)));
       assertAll(
-          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () -> assertEquals(List.of(), result.notInAnyReport, "unmeasuredPaths"),
           () -> assertEquals(0, result.executableLines(), "executableLines"));
     }
 
@@ -308,14 +311,14 @@ class DiffCoverageReportTest {
 
     /** The test tree of this module shares its prefix and is still not a main source root. */
     @Test
-    void aTestSourceOfThisModuleIsMeasuredNowhereAndFailsNoThreshold() throws IOException {
+    void aTestSourceOfThisModuleIsLeftOutOfTheReportEntirely() throws IOException {
       DiffCoverageReport result =
           measure(
               changed("nullaway/src/test/java/com/uber/nullaway/SampleTest.java", 10),
               ROOTS,
               report(line(10, 0, 0, 0)));
       assertAll(
-          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () -> assertEquals(List.of(), result.notInAnyReport, "unmeasuredPaths"),
           () -> assertEquals(0, result.executableLines(), "executableLines"));
     }
   }

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageReportTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageReportTest.java
@@ -1,0 +1,1126 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.uber.nullaway.gradle.DiffCoverageReport.Limits;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The changed lines of a module's own sources are split by whether the run covered them, and
+ * rendered as the text the build prints.
+ *
+ * <p>A source root is repository-relative, so a path under it names a file of this module and a
+ * path outside every root belongs to another module.
+ */
+class DiffCoverageReportTest {
+
+  private static final String ROOT = "nullaway/src/main/java";
+  private static final String PACKAGE = ROOT + "/com/uber/nullaway/";
+  private static final String SAMPLE = PACKAGE + "Sample.java";
+  private static final String OTHER = PACKAGE + "Other.java";
+  private static final List<String> ROOTS = List.of(ROOT);
+  private static final String SCOPE = "against master (5c1f60370), from :nullaway:test";
+
+  /** The marker a source line carries to acknowledge that nothing covers it. */
+  private static final String IGNORE = "// diff-coverage: ignore -- defensive safeguard";
+
+  @TempDir Path directory;
+
+  /** Returns one changed file with the given line numbers, as {@code measure} takes them. */
+  private static Map<String, NavigableSet<Integer>> changed(String path, Integer... numbers) {
+    Map<String, NavigableSet<Integer>> changed = new LinkedHashMap<>();
+    changed.put(path, new TreeSet<>(Arrays.asList(numbers)));
+    return changed;
+  }
+
+  /**
+   * Returns a JaCoCo {@code <line>} element for Sample.java.
+   *
+   * @param coveredInstructions above zero the line counts as executed
+   * @param coveredBranches branches the run took
+   * @param missedBranches branches it did not
+   */
+  private static String line(
+      int number, int coveredInstructions, int coveredBranches, int missedBranches) {
+    return String.format(
+        "<line nr=\"%d\" mi=\"%d\" ci=\"%d\" mb=\"%d\" cb=\"%d\"/>",
+        number, coveredInstructions > 0 ? 0 : 4, coveredInstructions, missedBranches,
+        coveredBranches);
+  }
+
+  /** Reads a report holding the given {@code <line>} elements for Sample.java. */
+  private JacocoLines report(String lines) throws IOException {
+    Path file = directory.resolve("jacocoTestReport.xml");
+    Files.writeString(
+        file,
+        "<report name=\"test\"><package name=\"com/uber/nullaway\">"
+            + "<sourcefile name=\"Sample.java\">"
+            + lines
+            + "</sourcefile></package></report>");
+    return JacocoLines.read(List.of(file.toFile()));
+  }
+
+  /**
+   * Measures against the working tree written here, in which a file nobody wrote has no text.
+   *
+   * <p>A test that says nothing about the quoted source therefore gets rows of counters alone,
+   * which is also what a report of a file the task cannot read looks like.
+   */
+  private DiffCoverageReport measure(
+      Map<String, NavigableSet<Integer>> changed, List<String> sourceRoots, JacocoLines lines) {
+    return DiffCoverageReport.measure(
+        changed, sourceRoots, lines, SourceLines.under(directory.toFile()));
+  }
+
+  /** Writes one source file of this module, whose first line is line 1. */
+  private void writeSource(String name, String... lines) throws IOException {
+    Path file = directory.resolve(PACKAGE + name);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, String.join("\n", lines) + "\n");
+  }
+
+  /**
+   * Measures one changed line per named file, each with the given counters.
+   *
+   * @param counters per file, in the order the names are given: covered instructions, covered
+   *     branches, missed branches, repeated once per changed line
+   */
+  private DiffCoverageReport measureFiles(List<String> names, List<int[]> counters)
+      throws IOException {
+    StringBuilder xml = new StringBuilder("<report name=\"test\">");
+    Map<String, NavigableSet<Integer>> changed = new LinkedHashMap<>();
+    for (int index = 0; index < names.size(); index++) {
+      String name = names.get(index);
+      int[] file = counters.get(index);
+      xml.append("<package name=\"com/uber/nullaway\"><sourcefile name=\"")
+          .append(name)
+          .append("\">");
+      NavigableSet<Integer> numbers = new TreeSet<>();
+      for (int number = 1; number <= file.length / 3; number++) {
+        int at = (number - 1) * 3;
+        xml.append(line(number, file[at], file[at + 1], file[at + 2]));
+        numbers.add(number);
+      }
+      xml.append("</sourcefile></package>");
+      changed.put(PACKAGE + name, numbers);
+    }
+    xml.append("</report>");
+    Path report = directory.resolve("multi.xml");
+    Files.writeString(report, xml.toString());
+    return measure(changed, ROOTS, JacocoLines.read(List.of(report.toFile())));
+  }
+
+  /** Returns the counters of a file with executed lines followed by uncovered ones, no branches. */
+  private static int[] someExecuted(int executed, int uncovered) {
+    int[] counters = new int[(executed + uncovered) * 3];
+    for (int line = 0; line < executed; line++) {
+      counters[line * 3] = 4;
+    }
+    return counters;
+  }
+
+  /** Returns the file names of the measured paths, in the order the report puts them. */
+  private static List<String> names(DiffCoverageReport report) {
+    return report.measuredPaths().stream().map(path -> path.substring(path.lastIndexOf('/') + 1))
+        .toList();
+  }
+
+  /**
+   * Returns the one rendered line with the given prefix, failing where there is not exactly one.
+   */
+  private static String onlyLineStartingWith(String rendered, String prefix) {
+    List<String> matching = rendered.lines().filter(line -> line.startsWith(prefix)).toList();
+    assertEquals(
+        1, matching.size(), () -> "lines starting with \"" + prefix + "\" in:\n" + rendered);
+    return matching.get(0);
+  }
+
+  /** Returns the rows the block spends on uncovered lines, whichever file they belong to. */
+  private static List<String> rows(String rendered) {
+    return rendered.lines().filter(line -> line.startsWith("      ")).toList();
+  }
+
+  /** Returns the paths of the files the block describes under the main list. */
+  private static List<String> describedPaths(String rendered) {
+    return rendered.lines().filter(line -> line.startsWith("  " + ROOT)).map(String::strip)
+        .toList();
+  }
+
+  @Nested
+  class SplittingTheChangedLines {
+
+    @Test
+    void anExecutedLineCountsTowardsBothTheExecutedAndTheExecutableTotal() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 0, 0)));
+      assertAll(
+          () -> assertEquals(1, result.executedLines(), "executedLines"),
+          () -> assertEquals(1, result.executableLines(), "executableLines"),
+          () -> assertEquals(0, result.uncoveredLines(), "uncoveredLines"));
+    }
+
+    @Test
+    void anUnexecutedLineCountsTowardsTheExecutableTotalAlone() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 0, 0, 0)));
+      assertAll(
+          () -> assertEquals(0, result.executedLines(), "executedLines"),
+          () -> assertEquals(1, result.executableLines(), "executableLines"),
+          () -> assertEquals(1, result.uncoveredLines(), "uncoveredLines"));
+    }
+
+    @Test
+    void aChangedLineTheReportOmitsCountsTowardsNeitherTotal() throws IOException {
+      DiffCoverageReport result =
+          measure(changed(SAMPLE, 10, 11), ROOTS, report(line(10, 4, 0, 0)));
+      assertEquals(1, result.executableLines());
+    }
+
+    @Test
+    void aLineWithABranchTakenOneWayCountsAsUncoveredThoughItRan() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 1, 1)));
+      assertAll(
+          () -> assertEquals(1, result.executedLines(), "executedLines"),
+          () -> assertEquals(1, result.uncoveredLines(), "uncoveredLines"));
+    }
+
+    @Test
+    void aLineWithEveryBranchTakenIsNotCountedAsUncovered() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 2, 0)));
+      assertEquals(0, result.uncoveredLines());
+    }
+
+    @Test
+    void onlyTheFilesTheCountsCameFromAreNamedAsMeasured() throws IOException {
+      Map<String, NavigableSet<Integer>> changed = changed(SAMPLE, 10);
+      changed.put(OTHER, new TreeSet<>(List.of(10)));
+      DiffCoverageReport result = measure(changed, ROOTS, report(line(10, 0, 0, 0)));
+      assertEquals(List.of(SAMPLE), result.measuredPaths());
+    }
+  }
+
+  @Nested
+  class FilesThatCannotBeMeasured {
+
+    /** A file no report covers is the one thing that fails a threshold whatever the coverage. */
+    @Test
+    void aFileUnderARootThatNoReportMentionsIsNamedAsMissingFromTheReport() throws IOException {
+      DiffCoverageReport result = measure(changed(OTHER, 10), ROOTS, report(""));
+      assertEquals(List.of(OTHER), result.unmeasuredPaths());
+    }
+
+    /**
+     * A comment-only change contributes to neither side of the share, so it has to be named
+     * without joining the files that fail the threshold for want of a report.
+     */
+    @Test
+    void aFileWhoseChangedLinesEmitNoBytecodeIsNamedSeparately() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(99, 4, 0, 0)));
+      assertAll(
+          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () ->
+              assertLinesMatch(
+                  List.of(
+                      ">> the header >>",
+                      "  Changed files with no executable changed lines:",
+                      "    " + SAMPLE,
+                      ">> the total >>"),
+                  result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList()));
+    }
+
+    @Test
+    void aFileOfAnotherModuleIsMeasuredNowhereAndFailsNoThreshold() throws IOException {
+      DiffCoverageReport result =
+          measure(
+              changed("other/src/main/java/com/uber/nullaway/Sample.java", 10),
+              ROOTS,
+              report(line(10, 0, 0, 0)));
+      assertAll(
+          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () -> assertEquals(0, result.executableLines(), "executableLines"));
+    }
+
+    /**
+     * :nullaway compiles a second source root, the shared sources of
+     * library-model/library-model-generator, so a file of either root is a file of this module.
+     */
+    @Test
+    void aFileUnderASecondSourceRootIsMeasuredLikeOneUnderTheFirst() throws IOException {
+      String shared = "library-model/library-model-generator/src/shared/java";
+      DiffCoverageReport result =
+          measure(
+              changed(shared + "/com/uber/nullaway/Sample.java", 10),
+              List.of(ROOT, shared),
+              report(line(10, 4, 0, 0)));
+      assertEquals(List.of(shared + "/com/uber/nullaway/Sample.java"), result.measuredPaths());
+    }
+
+    /**
+     * Where one root is a prefix of another, the longer root has to win, or every file of the
+     * nested root is keyed with the extra directories still in its package path.
+     */
+    @Test
+    void aFileUnderTwoNestedRootsIsKeyedFromTheLongerOneWhicheverComesFirst() throws IOException {
+      DiffCoverageReport result =
+          measure(changed(SAMPLE, 10), List.of("nullaway/src", ROOT), report(line(10, 4, 0, 0)));
+      assertEquals(List.of(SAMPLE), result.measuredPaths());
+    }
+
+    /**
+     * A root built from a {@code java.nio.file.Path} carries the platform separator, while the
+     * changed paths come from a git diff and always use {@code /}.
+     */
+    @Test
+    void aRootSpelledWithBackslashesStillMatchesAGitPath() throws IOException {
+      DiffCoverageReport result =
+          measure(changed(SAMPLE, 10), List.of("nullaway\\src\\main\\java"),
+              report(line(10, 4, 0, 0)));
+      assertEquals(List.of(SAMPLE), result.measuredPaths());
+    }
+
+    /** The test tree of this module shares its prefix and is still not a main source root. */
+    @Test
+    void aTestSourceOfThisModuleIsMeasuredNowhereAndFailsNoThreshold() throws IOException {
+      DiffCoverageReport result =
+          measure(
+              changed("nullaway/src/test/java/com/uber/nullaway/SampleTest.java", 10),
+              ROOTS,
+              report(line(10, 0, 0, 0)));
+      assertAll(
+          () -> assertEquals(List.of(), result.unmeasuredPaths(), "unmeasuredPaths"),
+          () -> assertEquals(0, result.executableLines(), "executableLines"));
+    }
+  }
+
+  @Nested
+  class QuotingTheSource {
+
+    @Test
+    void anUncoveredLineIsQuotedFromTheWorkingTreeWithItsIndentationStripped() throws IOException {
+      writeSource("Sample.java", "class Sample {", "    return null;");
+      DiffCoverageReport result = measure(changed(SAMPLE, 2), ROOTS, report(line(2, 0, 0, 0)));
+      assertEquals(
+          "      2: not executed: return null;",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "      2: "));
+    }
+
+    /** A generated line can run to thousands of characters and would wrap the whole block. */
+    @Test
+    void aLineLongerThanTheQuoteWidthIsCutAndMarked() throws IOException {
+      writeSource("Sample.java", "x".repeat(130));
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      assertEquals(
+          "      1: not executed: " + "x".repeat(100) + "...",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "      1: "));
+    }
+
+    @Test
+    void aLineExactlyAtTheQuoteWidthIsQuotedWhole() throws IOException {
+      writeSource("Sample.java", "x".repeat(100));
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      assertEquals(
+          "      1: not executed: " + "x".repeat(100),
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "      1: "));
+    }
+
+    /**
+     * The counters are the report's subject, so a file that was deleted or that this JVM cannot
+     * decode is still measured; only the quote goes.
+     */
+    @Test
+    void aLineWithNoSourceToQuoteIsReportedWithItsCountersAlone() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 7), ROOTS, report(line(7, 0, 0, 0)));
+      assertEquals(
+          "      7: not executed",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "      7: "));
+    }
+  }
+
+  @Nested
+  class AcknowledgingAnUncoveredLine {
+
+    @Test
+    void aLineMarkedInACommentIsListedUnderTheAcknowledgedHeadingRatherThanAsWork()
+        throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); " + IGNORE);
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "",
+              "  Acknowledged uncovered changed code:",
+              "    " + SAMPLE,
+              "      1: not executed: throw new AssertionError(); " + IGNORE,
+              "",
+              "Total: 0/1 changed lines executed.",
+              "Uncovered changed code: 1 line (1 acknowledged)"),
+          result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList());
+    }
+
+    /** The marker takes the line out of the work, not out of the measurement. */
+    @Test
+    void anAcknowledgedLineStillCountsAsUnexecutedInTheTotal() throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); " + IGNORE, "return 1;");
+      DiffCoverageReport result =
+          measure(changed(SAMPLE, 1, 2), ROOTS, report(line(1, 0, 0, 0) + line(2, 4, 0, 0)));
+      assertAll(
+          () -> assertEquals(1, result.executedLines(), "executedLines"),
+          () -> assertEquals(2, result.executableLines(), "executableLines"),
+          () -> assertEquals(1, result.acknowledgedLines(), "acknowledgedLines"));
+    }
+
+    @Test
+    void aMarkerInABlockCommentAcknowledgesItsLineToo() throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); /* diff-coverage: ignore */");
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      assertEquals(1, result.acknowledgedLines());
+    }
+
+    /** The marker follows a comment opener, so a line that only names it acknowledges nothing. */
+    @Test
+    void aMarkerWithNoCommentOpenerLeavesTheLineInTheWork() throws IOException {
+      writeSource("Sample.java", "String marker = \"diff-coverage: ignore\";");
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      String rendered = result.render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () -> assertEquals(0, result.acknowledgedLines(), "acknowledgedLines"),
+          () ->
+              assertEquals(
+                  List.of("      1: not executed: String marker = \"diff-coverage: ignore\";"),
+                  rows(rendered),
+                  "rows"),
+          () -> assertFalse(rendered.contains("Acknowledged"), rendered));
+    }
+
+    /** A hyphenated word after the marker is another marker, not this one. */
+    @Test
+    void aMarkerWhoseWordOnlyStartsWithIgnoreDoesNotAcknowledge() throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); // diff-coverage: ignore-until-1.2");
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      assertEquals(0, result.acknowledgedLines());
+    }
+
+    @Test
+    void aCoveredLineCarryingTheMarkerIsNotCountedAsAcknowledged() throws IOException {
+      writeSource("Sample.java", "return 1; " + IGNORE);
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 4, 0, 0)));
+      assertAll(
+          () -> assertEquals(0, result.acknowledgedLines(), "acknowledgedLines"),
+          () -> assertEquals(0, result.uncoveredLines(), "uncoveredLines"));
+    }
+
+    /**
+     * Counted as fully covered, a file whose remaining work is only acknowledged would report that
+     * every changed line of it ran.
+     */
+    @Test
+    void aFileWhoseUncoveredLinesAreAllAcknowledgedIsNotCountedAsFullyCovered() throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); " + IGNORE);
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 0)));
+      String rendered = result.render(SCOPE, false, List.of(), Limits.NONE);
+      assertFalse(rendered.contains("fully covered"), rendered);
+    }
+
+    @Test
+    void aFileWithBothKindsOfUncoveredLineIsDescribedInBothLists() throws IOException {
+      writeSource("Sample.java", "throw new AssertionError(); " + IGNORE, "return 1;");
+      DiffCoverageReport result =
+          measure(changed(SAMPLE, 1, 2), ROOTS, report(line(1, 0, 0, 0) + line(2, 0, 0, 0)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "  ordered by uncovered changed lines, then uncovered branches",
+              "",
+              "  " + SAMPLE,
+              "    0/2 changed lines executed",
+              "    uncovered changed code:",
+              "      2: not executed: return 1;",
+              "",
+              "  Acknowledged uncovered changed code:",
+              "    " + SAMPLE,
+              "      1: not executed: throw new AssertionError(); " + IGNORE,
+              "",
+              "Total: 0/2 changed lines executed.",
+              "Uncovered changed code: 2 lines (1 acknowledged)"),
+          result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList());
+    }
+
+    /**
+     * The work is printed first, so a block whose budget the work spends says how many lines are
+     * acknowledged and lists none of them.
+     */
+    @Test
+    void theWorkListSpendsTheBudgetBeforeTheAcknowledgedListSeesIt() throws IOException {
+      writeSource("Sample.java", "a();", "b();", "c(); " + IGNORE);
+      DiffCoverageReport result =
+          measure(
+              changed(SAMPLE, 1, 2, 3),
+              ROOTS,
+              report(line(1, 0, 0, 0) + line(2, 0, 0, 0) + line(3, 0, 0, 0)));
+      String rendered = result.render(SCOPE, false, List.of(), new Limits(4, 10, 2));
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of("      1: not executed: a();", "      2: not executed: b();"),
+                  rows(rendered),
+                  "rows"),
+          () -> assertFalse(rendered.contains("Acknowledged"), rendered),
+          () ->
+              assertEquals(
+                  "Uncovered changed code: 3 lines (1 acknowledged)",
+                  onlyLineStartingWith(rendered, "Uncovered changed code: ")));
+    }
+
+    @Test
+    void theAcknowledgedFilesPastTheFileCapAreReplacedByTheirCount() throws IOException {
+      writeSource("First.java", "a(); " + IGNORE);
+      writeSource("Second.java", "b(); " + IGNORE);
+      String rendered =
+          measureFiles(
+                  List.of("First.java", "Second.java"),
+                  List.of(someExecuted(0, 1), someExecuted(0, 1)))
+              .render(SCOPE, false, List.of(), new Limits(1, 10, 50));
+      assertLinesMatch(
+          List.of(
+              ">> the header >>",
+              "  Acknowledged uncovered changed code:",
+              "    " + PACKAGE + "First.java",
+              "      1: not executed: a(); " + IGNORE,
+              "    2 files in total",
+              ">> the totals >>"),
+          rendered.lines().toList());
+    }
+
+    @Test
+    void theAcknowledgedListIsCutByThePerFileCapLikeTheWorkIs() throws IOException {
+      writeSource("Sample.java", "a(); " + IGNORE, "b(); " + IGNORE, "c(); " + IGNORE);
+      DiffCoverageReport result =
+          measure(
+              changed(SAMPLE, 1, 2, 3),
+              ROOTS,
+              report(line(1, 0, 0, 0) + line(2, 0, 0, 0) + line(3, 0, 0, 0)));
+      assertEquals(
+          List.of("      1: not executed: a(); " + IGNORE, "      2 more acknowledged lines"),
+          rows(result.render(SCOPE, false, List.of(), new Limits(4, 1, 50))));
+    }
+  }
+
+  @Nested
+  class Rendering {
+
+    @Test
+    void aMeasuredFileRendersItsCountsAndOneRowPerUncoveredLine() throws IOException {
+      writeSource("Sample.java", "if (a) {", "  return 1;", "if (b) {");
+      DiffCoverageReport result =
+          measure(
+              changed(SAMPLE, 1, 2, 3),
+              ROOTS,
+              report(line(1, 4, 1, 1) + line(2, 0, 0, 0) + line(3, 0, 0, 2)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "  ordered by uncovered changed lines, then uncovered branches",
+              "",
+              "  " + SAMPLE,
+              "    1/3 changed lines executed, 1/4 branches covered",
+              "    uncovered changed code:",
+              "      1: 1 of 2 branches covered: if (a) {",
+              "      2: not executed: return 1;",
+              "      3: not executed; 0 of 2 branches covered: if (b) {",
+              "",
+              "Total: 1/3 changed lines executed, 1/4 branches covered.",
+              "Uncovered changed code: 3 lines"),
+          result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList());
+    }
+
+    /**
+     * Reported once as unexecuted and again as partly taken, the line reads as two pieces of work,
+     * and every count that adds the rows up is inflated by it.
+     */
+    @Test
+    void aLineNeitherExecutedNorFullyBranchedTakesOneRowCarryingBothCounts() throws IOException {
+      writeSource("Sample.java", "if (sourceType == null) {");
+      DiffCoverageReport result = measure(changed(SAMPLE, 1), ROOTS, report(line(1, 0, 0, 2)));
+      String rendered = result.render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(
+                      "      1: not executed; 0 of 2 branches covered: if (sourceType == null) {"),
+                  rows(rendered),
+                  "rows"),
+          () ->
+              assertEquals(
+                  "Uncovered changed code: 1 line",
+                  onlyLineStartingWith(rendered, "Uncovered changed code: ")));
+    }
+
+    /**
+     * A comment-only change to this module's sources is still a change the reader may be checking
+     * on, so the block names the file and says the total is not a coverage figure.
+     */
+    @Test
+    void aChangeOfNonExecutableLinesRendersThatInsteadOfAZeroTotal() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(99, 4, 0, 0)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "",
+              "  Changed files with no executable changed lines:",
+              "    " + SAMPLE,
+              "",
+              "Total: no changed executable lines under this module's source roots."),
+          result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList());
+    }
+
+    /**
+     * The conventions plugin gives every module the task, so a whole-build run would otherwise
+     * print a block per module saying that a change in one of them touched none of the others.
+     */
+    @Test
+    void aChangeThatReachesNoneOfThisModulesSourcesRendersNothingAtAll() throws IOException {
+      DiffCoverageReport result = measure(Map.of(), ROOTS, report(""));
+      assertEquals("", result.render(SCOPE, false, List.of(), Limits.NONE));
+    }
+
+    @Test
+    void aChangeOfAnotherModuleAloneRendersNothingAtAll() throws IOException {
+      DiffCoverageReport result =
+          measure(
+              changed("other/src/main/java/com/uber/nullaway/Sample.java", 10),
+              ROOTS,
+              report(line(10, 0, 0, 0)));
+      assertEquals("", result.render(SCOPE, false, List.of(), Limits.NONE));
+    }
+
+    @Test
+    void anEditAfterTheRunIsAnnouncedBeforeTheCountsItInvalidates() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 0, 0, 0)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "  ordered by uncovered changed lines, then uncovered branches",
+              "",
+              ">> the warning >>",
+              "    " + SAMPLE,
+              "  Re-run the tests before trusting the numbers below.",
+              ">> the counts >>"),
+          result.render(SCOPE, false, List.of(SAMPLE), Limits.NONE).lines().toList());
+    }
+
+    @Test
+    void aFileNoReportMentionsAndOneWithNoBytecodeGetDifferentHeadings() throws IOException {
+      Map<String, NavigableSet<Integer>> changed = changed(SAMPLE, 10);
+      changed.put(OTHER, new TreeSet<>(List.of(10)));
+      DiffCoverageReport result = measure(changed, ROOTS, report(line(99, 4, 0, 0)));
+      assertLinesMatch(
+          List.of(
+              "Diff coverage " + SCOPE,
+              "",
+              "  No report read here covers these files, so they were probably not part of the"
+                  + " run:",
+              "    " + OTHER,
+              "",
+              "  Changed files with no executable changed lines:",
+              "    " + SAMPLE,
+              "",
+              "Total: no changed executable lines under this module's source roots."),
+          result.render(SCOPE, false, List.of(), Limits.NONE).lines().toList());
+    }
+
+    /** A change whose lines branch nowhere gets no branch pair, rather than a 0/0 one. */
+    @Test
+    void aChangeWithNoBranchAtAllReportsLinesAlone() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 0, 0)));
+      assertEquals(
+          "Total: 1/1 changed lines executed.",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "Total: "));
+    }
+
+    /**
+     * A branch nothing took on a line something ran is the case line counts cannot report: the
+     * line reads as executed, and only the branch pair says the condition was tested one way.
+     */
+    @Test
+    void everyLineExecutedWithABranchUntakenStillReportsTheBranchPair() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 1, 1)));
+      assertEquals(
+          "Total: 1/1 changed lines executed, 1/2 branches covered.",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "Total: "));
+    }
+
+    @Test
+    void aFullyTakenBranchCountsTowardsBothSidesOfThePair() throws IOException {
+      DiffCoverageReport result = measure(changed(SAMPLE, 10), ROOTS, report(line(10, 4, 2, 0)));
+      assertEquals(
+          "Total: 1/1 changed lines executed, 2/2 branches covered.",
+          onlyLineStartingWith(result.render(SCOPE, false, List.of(), Limits.NONE), "Total: "));
+    }
+
+    @Test
+    void theBranchPairOfTheTotalSumsTheFiles() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"), List.of(new int[] {4, 1, 1}, new int[] {4, 1, 3}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "Total: 2/2 changed lines executed, 2/6 branches covered.",
+          onlyLineStartingWith(rendered, "Total: "));
+    }
+
+    /**
+     * The executed share reports a line whose condition went one way as covered, so it is not the
+     * count of what is left to do.
+     */
+    @Test
+    void theUncoveredTotalCountsTheRowsRatherThanTheUnexecutedLines() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"), List.of(new int[] {4, 1, 1}, new int[] {0, 0, 0}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () ->
+              assertEquals(
+                  "Total: 1/2 changed lines executed, 1/2 branches covered.",
+                  onlyLineStartingWith(rendered, "Total: ")),
+          () ->
+              assertEquals(
+                  "Uncovered changed code: 2 lines",
+                  onlyLineStartingWith(rendered, "Uncovered changed code: ")));
+    }
+
+    @Test
+    void aChangeWithEveryLineCoveredReportsNoUncoveredCode() throws IOException {
+      String rendered =
+          measureFiles(List.of("A.java"), List.of(someExecuted(2, 0)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "Uncovered changed code: 0 lines",
+          onlyLineStartingWith(rendered, "Uncovered changed code: "));
+    }
+
+    @Test
+    void theOrderingNoteAppearsWhereMoreThanOneFileIsDescribed() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"), List.of(new int[] {0, 0, 0}, new int[] {0, 0, 0}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "  ordered by uncovered changed lines, then uncovered branches",
+          onlyLineStartingWith(rendered, "  ordered "));
+    }
+
+    /** A subheading that comes and goes between two runs reads as a different code path. */
+    @Test
+    void theOrderingNoteAppearsForASingleFileToo() throws IOException {
+      String rendered =
+          measureFiles(List.of("A.java"), List.of(new int[] {0, 0, 0}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "  ordered by uncovered changed lines, then uncovered branches",
+          onlyLineStartingWith(rendered, "  ordered "));
+    }
+
+    @Test
+    void theOrderingNoteIsLeftOutWhereNoFileOwesATest() throws IOException {
+      String rendered =
+          measureFiles(List.of("A.java"), List.of(someExecuted(1, 0)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertFalse(rendered.contains("ordered by"), rendered);
+    }
+
+    @Test
+    void aFilteredRunSaysWhatItsNumbersLeaveOut() throws IOException {
+      String rendered =
+          measureFiles(List.of("A.java"), List.of(new int[] {0, 0, 0}))
+              .render(SCOPE, true, List.of(), Limits.NONE);
+      assertEquals(
+          "  a filtered run leaves the rest of the change looking unexecuted",
+          onlyLineStartingWith(rendered, "  a filtered run"));
+    }
+
+    @Test
+    void anUnfilteredRunSaysNothingAboutAFilter() throws IOException {
+      String rendered =
+          measureFiles(List.of("A.java"), List.of(new int[] {0, 0, 0}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertFalse(rendered.contains("filtered run"), rendered);
+    }
+
+    @Test
+    void theFullyCoveredCountCarriesTheLinesAndBranchesBehindIt() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Owing.java", "Covered.java"),
+                  List.of(someExecuted(0, 1), new int[] {4, 2, 0, 4, 0, 0}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "  1 changed file is fully covered (2 lines, 2 branches)",
+          onlyLineStartingWith(rendered, "  1 changed file"));
+    }
+
+    /** A file whose lines branch nowhere gets no branch count, as elsewhere in the block. */
+    @Test
+    void theFullyCoveredCountLeavesOutBranchesWhereThereAreNone() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Owing.java", "Covered.java"),
+                  List.of(someExecuted(0, 1), someExecuted(2, 0)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "  1 changed file is fully covered (2 lines)",
+          onlyLineStartingWith(rendered, "  1 changed file"));
+    }
+  }
+
+  @Nested
+  class TheLineCaps {
+
+    /** Returns a file of count unexecuted lines numbered from one. */
+    private DiffCoverageReport unexecutedLines(int count) throws IOException {
+      StringBuilder xml = new StringBuilder();
+      NavigableSet<Integer> numbers = new TreeSet<>();
+      for (int number = 1; number <= count; number++) {
+        xml.append(line(number, 0, 0, 0));
+        numbers.add(number);
+      }
+      return measure(Map.of(SAMPLE, numbers), ROOTS, report(xml.toString()));
+    }
+
+    @Test
+    void linesUpToThePerFileCapAreAllListedWithNoTotal() throws IOException {
+      String rendered = unexecutedLines(3).render(SCOPE, false, List.of(), new Limits(4, 3, 50));
+      assertEquals(
+          List.of("      1: not executed", "      2: not executed", "      3: not executed"),
+          rows(rendered));
+    }
+
+    @Test
+    void theLinesPastThePerFileCapAreReplacedByTheirCount() throws IOException {
+      String rendered = unexecutedLines(5).render(SCOPE, false, List.of(), new Limits(4, 3, 50));
+      assertEquals(
+          List.of(
+              "      1: not executed",
+              "      2: not executed",
+              "      3: not executed",
+              "      2 more affected lines"),
+          rows(rendered));
+    }
+
+    /**
+     * Without a cap over the whole block, a change spread across many files spends one screen per
+     * file however small each file's list is.
+     */
+    @Test
+    void theTotalCapStopsTheRowsPartWayThroughASecondFile() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"),
+                  List.of(someExecuted(0, 3), someExecuted(0, 3)))
+              .render(SCOPE, false, List.of(), new Limits(4, 10, 4));
+      assertEquals(
+          List.of(
+              "      1: not executed",
+              "      2: not executed",
+              "      3: not executed",
+              "      1: not executed",
+              "      2 more affected lines"),
+          rows(rendered));
+    }
+
+    /** A file the budget leaves no row for is not worth its heading, so it joins the total. */
+    @Test
+    void aFileTheTotalCapLeavesNoRowForIsCountedRatherThanDescribed() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"),
+                  List.of(someExecuted(0, 2), someExecuted(0, 2)))
+              .render(SCOPE, false, List.of(), new Limits(4, 10, 2));
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(PACKAGE + "A.java"), describedPaths(rendered), "files described"),
+          () ->
+              assertEquals(
+                  "  2 files owing a test in total",
+                  onlyLineStartingWith(rendered, "  2 files")));
+    }
+
+    /** A limit of zero is a limit; only a negative one names no number of rows to print. */
+    @Test
+    void aLimitOfZeroPrintsTheFileAndNoneOfItsRows() throws IOException {
+      String rendered = unexecutedLines(3).render(SCOPE, false, List.of(), new Limits(4, 0, 50));
+      assertEquals(List.of("      3 more affected lines"), rows(rendered));
+    }
+
+    /**
+     * A build property can spell a negative limit, and cutting the rows to it would throw an index
+     * out of the list rather than saying what is wrong.
+     */
+    @Test
+    void aNegativeLimitIsRefusedWithAMessageNamingIt() {
+      IllegalArgumentException thrown =
+          assertThrows(IllegalArgumentException.class, () -> new Limits(4, -1, 50));
+      assertEquals(
+          "a diff coverage limit cannot be negative: files=4, linesPerFile=-1, lines=50",
+          thrown.getMessage());
+    }
+
+    @Test
+    void showingEverythingSpendsNoCapAtAll() throws IOException {
+      String rendered = unexecutedLines(40).render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () -> assertEquals(40, rows(rendered).size(), "rows"),
+          () -> assertFalse(rendered.contains("more affected lines"), rendered));
+    }
+  }
+
+  @Nested
+  class Ordering {
+
+    @Test
+    void theFileWithMoreUncoveredChangedLinesComesFirst() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("Few.java", "Many.java"),
+              List.of(new int[] {0, 0, 0}, new int[] {0, 0, 0, 0, 0, 0}));
+      assertEquals(List.of("Many.java", "Few.java"), names(result));
+    }
+
+    /**
+     * Ordering by share would put HalfCovered.java first at 50% against WellCovered.java's 80%,
+     * and send the reader to the file with one line left to test rather than the one with two.
+     */
+    @Test
+    void moreUncoveredLinesBeatAWorseShareOfThem() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("HalfCovered.java", "WellCovered.java"),
+              List.of(someExecuted(1, 1), someExecuted(8, 2)));
+      assertEquals(List.of("WellCovered.java", "HalfCovered.java"), names(result));
+    }
+
+    /**
+     * A single uncovered line outranks nine untaken branches, since the two are different things
+     * and any coefficient joining them into one score would be invented.
+     */
+    @Test
+    void oneUncoveredLineOutranksAnyNumberOfUntakenBranches() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("OneLine.java", "NineBranches.java"),
+              List.of(new int[] {0, 0, 0}, new int[] {4, 1, 9}));
+      assertEquals(List.of("OneLine.java", "NineBranches.java"), names(result));
+    }
+
+    @Test
+    void filesTyingOnUncoveredLinesGoByMissedBranchOutcomes() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("OneMissed.java", "ThreeMissed.java"),
+              List.of(new int[] {4, 1, 1}, new int[] {4, 1, 3}));
+      assertEquals(List.of("ThreeMissed.java", "OneMissed.java"), names(result));
+    }
+
+    /** A line reported as 0 of 4 branches covered owes more than one reported as 1 of 2. */
+    @Test
+    void missedBranchesCountOutcomesRatherThanLinesCarryingThem() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("TwoLinesOneMissedEach.java", "OneLineFourMissed.java"),
+              List.of(new int[] {4, 1, 1, 4, 1, 1}, new int[] {4, 0, 4}));
+      assertEquals(
+          List.of("OneLineFourMissed.java", "TwoLinesOneMissedEach.java"), names(result));
+    }
+
+    @Test
+    void aFullyCoveredFileComesAfterOneWithAnUntakenBranch() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("Covered.java", "Branch.java"),
+              List.of(new int[] {4, 2, 0}, new int[] {4, 1, 1}));
+      assertEquals(List.of("Branch.java", "Covered.java"), names(result));
+    }
+
+    /**
+     * Between files owing the same, the larger change is the one worth reading first. The names
+     * are chosen so that ordering by path alone would put them the other way round.
+     */
+    @Test
+    void filesOwingTheSameGoByHowMuchTheyChanged() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("Alpha.java", "Beta.java"),
+              List.of(someExecuted(1, 1), someExecuted(3, 1)));
+      assertEquals(List.of("Beta.java", "Alpha.java"), names(result));
+    }
+
+    /** Ordering by path keeps two runs of the same change printing the same block. */
+    @Test
+    void filesAlikeOnEveryCountGoByPath() throws IOException {
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("Beta.java", "Alpha.java"),
+              List.of(new int[] {0, 0, 0}, new int[] {0, 0, 0}));
+      assertEquals(List.of("Alpha.java", "Beta.java"), names(result));
+    }
+
+    /** Ordered by uncovered lines alone, the acknowledged file would be read first. */
+    @Test
+    void aFileWhoseUncoveredLinesAreAcknowledgedComesAfterOneOwingASingleTest()
+        throws IOException {
+      writeSource("Acknowledged.java", "a(); " + IGNORE, "b(); " + IGNORE);
+      DiffCoverageReport result =
+          measureFiles(
+              List.of("Acknowledged.java", "Owing.java"),
+              List.of(someExecuted(0, 2), someExecuted(0, 1)));
+      assertEquals(List.of("Owing.java", "Acknowledged.java"), names(result));
+    }
+  }
+
+  @Nested
+  class FilesOwingNothing {
+
+    /**
+     * Silence would leave a fully covered file looking like one the run never measured, which is
+     * the confusion the separate headings elsewhere in the block exist to prevent.
+     */
+    @Test
+    void aFullyCoveredFileIsCountedRatherThanDescribed() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Owing.java", "Covered.java"),
+                  List.of(someExecuted(0, 1), someExecuted(1, 0)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(PACKAGE + "Owing.java"), describedPaths(rendered), "files described"),
+          () ->
+              assertEquals(
+                  "  1 changed file is fully covered (1 line)",
+                  onlyLineStartingWith(rendered, "  1 changed file")));
+    }
+
+    @Test
+    void severalFullyCoveredFilesAreCountedInOneLine() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Owing.java", "First.java", "Second.java"),
+                  List.of(someExecuted(0, 1), someExecuted(1, 0), someExecuted(1, 0)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertEquals(
+          "  2 changed files are fully covered (2 lines)",
+          onlyLineStartingWith(rendered, "  2 changed files"));
+    }
+
+    /** A file whose lines all ran still owes a test where a branch went one way. */
+    @Test
+    void aFileOwingOnlyABranchIsStillDescribed() throws IOException {
+      String rendered =
+          measureFiles(List.of("Branch.java"), List.of(new int[] {4, 1, 1}))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(PACKAGE + "Branch.java"), describedPaths(rendered), "files described"),
+          () -> assertFalse(rendered.contains("fully covered"), rendered));
+    }
+
+    @Test
+    void aRunWithNoFullyCoveredFileSaysNothingAboutThem() throws IOException {
+      String rendered =
+          measureFiles(List.of("Owing.java"), List.of(someExecuted(0, 1)))
+              .render(SCOPE, false, List.of(), Limits.NONE);
+      assertFalse(rendered.contains("fully covered"), rendered);
+    }
+
+    /**
+     * The cap is a budget for the files worth reading, so a covered one must not spend any of it.
+     */
+    @Test
+    void aFullyCoveredFileDoesNotSpendTheFileCap() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Covered.java", "OwingA.java", "OwingB.java"),
+                  List.of(someExecuted(1, 0), someExecuted(0, 1), someExecuted(0, 1)))
+              .render(SCOPE, false, List.of(), new Limits(2, 10, 50));
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(PACKAGE + "OwingA.java", PACKAGE + "OwingB.java"),
+                  describedPaths(rendered),
+                  "files described"),
+          () -> assertFalse(rendered.contains("owing a test in total"), rendered));
+    }
+  }
+
+  @Nested
+  class TheFileCap {
+
+    @Test
+    void filesUpToTheCapAreAllDescribedWithNoTotal() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("A.java", "B.java"),
+                  List.of(new int[] {0, 0, 0}, new int[] {0, 0, 0}))
+              .render(SCOPE, false, List.of(), new Limits(2, 10, 50));
+      assertAll(
+          () -> assertEquals(2, describedPaths(rendered).size(), "files described"),
+          () -> assertFalse(rendered.contains("in total"), rendered));
+    }
+
+    /** The files dropped are the ones with least to say, since the list is ordered by work left. */
+    @Test
+    void onePastTheCapIsReplacedByTheFileTotalAndTheLeastNeedyFileGoes() throws IOException {
+      String rendered =
+          measureFiles(
+                  List.of("Small.java", "Large.java", "Medium.java"),
+                  List.of(new int[] {0, 0, 0}, new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0},
+                      new int[] {0, 0, 0, 0, 0, 0}))
+              .render(SCOPE, false, List.of(), new Limits(2, 10, 50));
+      assertAll(
+          () ->
+              assertEquals(
+                  List.of(PACKAGE + "Large.java", PACKAGE + "Medium.java"),
+                  describedPaths(rendered),
+                  "files described"),
+          () ->
+              assertEquals(
+                  "  3 files owing a test in total",
+                  onlyLineStartingWith(rendered, "  3 files")),
+          () ->
+              assertEquals(
+                  "Total: 0/6 changed lines executed.",
+                  onlyLineStartingWith(rendered, "Total: ")));
+    }
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
@@ -17,7 +17,6 @@ package com.uber.nullaway.gradle;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * A run that measures nothing says so, and fails where a threshold asked for a gate.
+ * A run that measures nothing says so rather than reporting a change as fully covered.
  *
  * <p>These are the two outcomes a caller cannot tell apart from the counts: a base ref that does
  * not resolve and a report that was never written both leave no line changed and no line executed,
@@ -55,7 +54,7 @@ class DiffCoverageTaskRunTest {
 
   @TempDir Path directory;
 
-  private DiffCoverageTask task(Double failUnder, Path... reports) {
+  private DiffCoverageTask task(Path... reports) {
     Project project = ProjectBuilder.builder().withProjectDir(directory.toFile()).build();
     DiffCoverageTask task =
         project.getTasks().register("diffCoverage", DiffCoverageTask.class).get();
@@ -77,9 +76,6 @@ class DiffCoverageTaskRunTest {
     task.getMaxFiles().set(4);
     task.getShowAll().set(false);
     task.getOutputFile().set(directory.resolve(FULL_REPORT).toFile());
-    if (failUnder != null) {
-      task.getFailUnder().set(failUnder);
-    }
     for (Path report : reports) {
       task.getReportFiles().from(report.toFile());
     }
@@ -151,16 +147,9 @@ class DiffCoverageTaskRunTest {
 
     /** A repository with no commit resolves neither an upstream branch nor origin/master. */
     @Test
-    void aRunWithNoThresholdOnlyAdvises() throws Exception {
+    void aRunThatResolvedNoBaseSaysSoRatherThanReportingNoChangedLine() throws Exception {
       emptyRepository();
-      assertDoesNotThrow(() -> task(null).describeRun());
-    }
-
-    @Test
-    void aRunWithAThresholdFailsRatherThanPassingOnAnUnmeasuredChange() throws Exception {
-      emptyRepository();
-      GradleException thrown = assertThrows(GradleException.class, () -> task(90.0).describeRun());
-      assertEquals(DiffCoverageTask.NO_BASE, thrown.getMessage());
+      assertEquals(DiffCoverageTask.NO_BASE, task().describeRun());
     }
   }
 
@@ -168,27 +157,16 @@ class DiffCoverageTaskRunTest {
   class WithNoReport {
 
     /** The module has to be one the change reached, or it would rightly say nothing at all. */
-    private DiffCoverageTask taskInARepository(Double failUnder) throws Exception {
+    @Test
+    void aRunThatFoundNoReportSaysSoRatherThanReportingNoExecutedLine() throws Exception {
       repositoryWithOneCommit();
       Path source = directory.resolve("src/main/java/A.java");
       Files.createDirectories(source.getParent());
       Files.writeString(source, "class A {}\n");
-      DiffCoverageTask task = task(failUnder, directory.resolve("absent.xml"));
+      DiffCoverageTask task = task(directory.resolve("absent.xml"));
       task.getBaseRef().set("master");
-      return task;
-    }
 
-    @Test
-    void aRunWithNoThresholdOnlyAdvises() throws Exception {
-      DiffCoverageTask task = taskInARepository(null);
-      assertDoesNotThrow(task::describeRun);
-    }
-
-    @Test
-    void aRunWithAThresholdFailsRatherThanPassingOnAnUnmeasuredChange() throws Exception {
-      DiffCoverageTask task = taskInARepository(90.0);
-      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
-      assertEquals(DiffCoverageTask.NO_REPORT, thrown.getMessage());
+      assertEquals(DiffCoverageTask.NO_REPORT, task.describeRun());
     }
   }
 
@@ -203,7 +181,7 @@ class DiffCoverageTaskRunTest {
     void aFileThisJvmCannotDecodeIsNamedInTheReport() throws Exception {
       repositoryWithOneCommit();
       undecodableSource();
-      DiffCoverageTask task = task(null, reportCovering("Other.java"));
+      DiffCoverageTask task = task(reportCovering("Other.java"));
       task.getBaseRef().set("master");
       assertEquals(
           "Diff coverage: cannot read the untracked file src/main/java/Bad.java: "
@@ -212,16 +190,21 @@ class DiffCoverageTaskRunTest {
     }
 
     /**
-     * Left in the counts, the file would be a changed file no report covers, which is the one
-     * thing that fails a gate whatever the coverage.
+     * Left in the counts, the file would be reported as changed code no report covers, which is a
+     * measurement it never received.
      */
     @Test
     void aFileThisJvmCannotDecodeIsLeftOutOfTheCounts() throws Exception {
       repositoryWithOneCommit();
       undecodableSource();
-      DiffCoverageTask task = task(90.0, reportCovering("Other.java"));
+      DiffCoverageTask task = task(reportCovering("Other.java"));
       task.getBaseRef().set("master");
-      assertDoesNotThrow(task::describeRun);
+
+      String printed = task.describeRun();
+
+      assertFalse(
+          printed.contains("covers these files"),
+          () -> "the block listing files no report covers: " + printed);
     }
 
     private void undecodableSource() throws IOException {
@@ -235,9 +218,9 @@ class DiffCoverageTaskRunTest {
   class WithABaseThatDoesNotResolve {
 
     @Test
-    void anExplicitRefThatDoesNotResolveFailsWhateverTheThreshold() throws Exception {
+    void anExplicitRefThatDoesNotResolveFailsTheTask() throws Exception {
       repositoryWithOneCommit();
-      DiffCoverageTask task = task(null);
+      DiffCoverageTask task = task();
       task.getBaseRef().set("no/such/ref");
       GradleException thrown = assertThrows(GradleException.class, task::describeRun);
       assertEquals(
@@ -249,11 +232,11 @@ class DiffCoverageTaskRunTest {
   class WithAChangedFileNoReportCovers {
 
     /**
-     * Such a file contributes nothing to either side of the share, so a threshold applied to the
-     * rest of the change would pass over it without having measured it.
+     * Such a file was never measured, and a report that left it out silently would read as one
+     * where every changed line of it ran.
      */
     @Test
-    void aThresholdFailsRatherThanPassingOverAFileTheReportNeverMentions() throws Exception {
+    void aFileTheReportNeverMentionsIsNamedRatherThanLeftOut() throws Exception {
       repositoryWithOneCommit();
       Path source = directory.resolve("src/main/java/A.java");
       Files.createDirectories(source.getParent());
@@ -263,14 +246,16 @@ class DiffCoverageTaskRunTest {
           report,
           "<report name=\"test\"><package name=\"\">"
               + "<sourcefile name=\"Other.java\"/></package></report>");
-      DiffCoverageTask task = task(90.0, report);
+      DiffCoverageTask task = task(report);
       task.getBaseRef().set("master");
-      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
-      assertEquals(
-          "no JaCoCo report covers these changed files, so no threshold applies to them: "
-              + "src/main/java/A.java. The full report is in "
-              + FULL_REPORT,
-          thrown.getMessage());
+
+      String printed = task.describeRun();
+
+      assertTrue(
+          printed.contains(
+              "No report read here covers these files, so they were probably not part of the "
+                  + "run:\n    src/main/java/A.java"),
+          () -> "the block naming the unmeasured file: " + printed);
     }
   }
 
@@ -287,7 +272,7 @@ class DiffCoverageTaskRunTest {
       Path elsewhere = directory.resolve("other/src/main/java/A.java");
       Files.createDirectories(elsewhere.getParent());
       Files.writeString(elsewhere, "class A {}\n");
-      DiffCoverageTask task = task(null, directory.resolve("absent.xml"));
+      DiffCoverageTask task = task(directory.resolve("absent.xml"));
       task.getBaseRef().set("master");
       assertEquals("", task.describeRun());
     }
@@ -299,7 +284,7 @@ class DiffCoverageTaskRunTest {
       Path source = directory.resolve("src/main/java/A.java");
       Files.createDirectories(source.getParent());
       Files.writeString(source, "class A {}\n");
-      DiffCoverageTask task = task(null, directory.resolve("absent.xml"));
+      DiffCoverageTask task = task(directory.resolve("absent.xml"));
       task.getBaseRef().set("master");
       assertEquals(DiffCoverageTask.NO_REPORT, task.describeRun());
     }
@@ -318,7 +303,7 @@ class DiffCoverageTaskRunTest {
       Path source = directory.resolve("src/main/java/A.java");
       Files.createDirectories(source.getParent());
       Files.writeString(source, "class A {}\n");
-      DiffCoverageTask task = task(null, reportCovering("A.java"));
+      DiffCoverageTask task = task(reportCovering("A.java"));
       task.getBaseRef().set("master");
       String head = revParse("HEAD").substring(0, 9);
       assertEquals(
@@ -343,10 +328,10 @@ class DiffCoverageTaskRunTest {
       Files.writeString(directory.resolve("OTHER.md"), "other\n");
       run("add", "-A");
       run("commit", "-m", "unrelated");
-      DiffCoverageTask task = task(90.0);
+      DiffCoverageTask task = task();
       task.getBaseRef().set("master");
-      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
-      assertEquals(DiffCoverageTask.NO_BASE, thrown.getMessage());
+
+      assertEquals(DiffCoverageTask.NO_BASE, task.describeRun());
     }
   }
 
@@ -376,7 +361,7 @@ class DiffCoverageTaskRunTest {
       Files.writeString(file, source.toString());
       Path report = directory.resolve("report.xml");
       Files.writeString(report, xml.toString());
-      DiffCoverageTask task = task(null, report);
+      DiffCoverageTask task = task(report);
       task.getBaseRef().set("master");
       return task;
     }
@@ -470,21 +455,6 @@ class DiffCoverageTaskRunTest {
       assertFalse(
           Files.exists(directory.resolve(FULL_REPORT)),
           () -> "the report of the earlier run is still at " + FULL_REPORT);
-    }
-
-    /**
-     * A failing task prints its exception and not the block, so the reader is left with a
-     * percentage and nowhere to see which lines produced it.
-     */
-    @Test
-    void aThresholdFailureNamesTheReportHoldingTheLinesThatFailedIt() throws Exception {
-      DiffCoverageTask task = taskWithUncoveredLines(2);
-      task.getFailUnder().set(90.0);
-      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
-      assertEquals(
-          "0.0% of the changed lines ran, below the required 90.0%. The full report is in "
-              + FULL_REPORT,
-          thrown.getMessage());
     }
 
     @Test

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A run that measures nothing says so, and fails where a threshold asked for a gate.
+ *
+ * <p>These are the two outcomes a caller cannot tell apart from the counts: a base ref that does
+ * not resolve and a report that was never written both leave no line changed and no line executed,
+ * which is what a fully covered change looks like. The task is driven through a synthetic Gradle
+ * project rather than a build, so the decision is exercised rather than asserted about.
+ *
+ * <p>Every git command runs against a repository built here, with the system and global
+ * configuration switched off, so that a setting on the machine running the tests decides nothing.
+ */
+class DiffCoverageTaskRunTest {
+
+  /** Where the task writes the report whole, relative to the repository built here. */
+  private static final Path FULL_REPORT = Path.of("build", "reports", "diff-coverage", "test.txt");
+
+  @TempDir Path directory;
+
+  private DiffCoverageTask task(Double failUnder, Path... reports) {
+    Project project = ProjectBuilder.builder().withProjectDir(directory.toFile()).build();
+    DiffCoverageTask task =
+        project.getTasks().register("diffCoverage", DiffCoverageTask.class).get();
+    task.getRepositoryRoot().set(directory.toFile());
+    task.getSourceRoots().set(List.of("src/main/java"));
+    task.getScopeDescription().set("a test");
+    task.getFiltered().set(false);
+    task.getMaxLinesPerFile().set(10);
+    task.getMaxLinesTotal().set(50);
+    task.getMaxFiles().set(4);
+    task.getShowAll().set(false);
+    task.getOutputFile().set(directory.resolve(FULL_REPORT).toFile());
+    if (failUnder != null) {
+      task.getFailUnder().set(failUnder);
+    }
+    for (Path report : reports) {
+      task.getReportFiles().from(report.toFile());
+    }
+    return task;
+  }
+
+  /** Creates a repository with no commit, so that no ref of any kind resolves in it. */
+  private void emptyRepository() throws Exception {
+    run("init", "--initial-branch=master", ".");
+    run("config", "user.email", "test@example.com");
+    run("config", "user.name", "Test");
+  }
+
+  /** Creates a repository whose only commit is on master. */
+  private void repositoryWithOneCommit() throws Exception {
+    emptyRepository();
+    Files.writeString(directory.resolve("README.md"), "seed\n");
+    run("add", "-A");
+    run("commit", "-m", "seed");
+  }
+
+  /** Writes a JaCoCo report that mentions one source file and nothing else. */
+  private Path reportCovering(String sourceFile) throws IOException {
+    Path report = directory.resolve("report.xml");
+    Files.writeString(
+        report,
+        "<report name=\"test\"><package name=\"\"><sourcefile name=\""
+            + sourceFile
+            + "\"><line nr=\"1\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>"
+            + "</sourcefile></package></report>");
+    return report;
+  }
+
+  private String revParse(String ref) throws Exception {
+    Process process =
+        new ProcessBuilder("git", "rev-parse", ref).directory(directory.toFile()).start();
+    String output = new String(process.getInputStream().readAllBytes(), UTF_8).trim();
+    assertEquals(0, process.waitFor(), () -> "git rev-parse " + ref);
+    return output;
+  }
+
+  private void run(String... arguments) throws IOException, InterruptedException {
+    List<String> command = new ArrayList<>(List.of("git"));
+    command.addAll(List.of(arguments));
+    ProcessBuilder builder =
+        new ProcessBuilder(command).directory(directory.toFile()).redirectErrorStream(true);
+    Map<String, String> environment = builder.environment();
+    // A path git can read and will not find, rather than /dev/null, which names a file of its own
+    // on Windows and would leave the configuration of the machine deciding what these tests see.
+    String noConfig = directory.resolve("no-git-config").toString();
+    environment.put("GIT_CONFIG_GLOBAL", noConfig);
+    environment.put("GIT_CONFIG_SYSTEM", noConfig);
+    environment.put("GIT_CONFIG_NOSYSTEM", "1");
+    Process process = builder.start();
+    // Read before waiting: nothing else drains the pipe, so a command that filled it would hang,
+    // and what git printed is the only account of why it failed.
+    String output;
+    try (InputStream stream = process.getInputStream()) {
+      output = new String(stream.readAllBytes(), UTF_8);
+    }
+    assertEquals(
+        0,
+        process.waitFor(),
+        () -> "git " + String.join(" ", arguments) + " printed " + output);
+  }
+
+  @Nested
+  class WithNoBaseRef {
+
+    /** A repository with no commit resolves neither an upstream branch nor origin/master. */
+    @Test
+    void aRunWithNoThresholdOnlyAdvises() throws Exception {
+      emptyRepository();
+      assertDoesNotThrow(() -> task(null).describeRun());
+    }
+
+    @Test
+    void aRunWithAThresholdFailsRatherThanPassingOnAnUnmeasuredChange() throws Exception {
+      emptyRepository();
+      GradleException thrown = assertThrows(GradleException.class, () -> task(90.0).describeRun());
+      assertEquals(DiffCoverageTask.NO_BASE, thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class WithNoReport {
+
+    /** The module has to be one the change reached, or it would rightly say nothing at all. */
+    private DiffCoverageTask taskInARepository(Double failUnder) throws Exception {
+      repositoryWithOneCommit();
+      Path source = directory.resolve("src/main/java/A.java");
+      Files.createDirectories(source.getParent());
+      Files.writeString(source, "class A {}\n");
+      DiffCoverageTask task = task(failUnder, directory.resolve("absent.xml"));
+      task.getBaseRef().set("master");
+      return task;
+    }
+
+    @Test
+    void aRunWithNoThresholdOnlyAdvises() throws Exception {
+      DiffCoverageTask task = taskInARepository(null);
+      assertDoesNotThrow(task::describeRun);
+    }
+
+    @Test
+    void aRunWithAThresholdFailsRatherThanPassingOnAnUnmeasuredChange() throws Exception {
+      DiffCoverageTask task = taskInARepository(90.0);
+      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
+      assertEquals(DiffCoverageTask.NO_REPORT, thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class WithAnUnreadableUntrackedFile {
+
+    /**
+     * An untracked file has no diff, so the task reads it whole. One this JVM cannot decode is not
+     * worth failing a build whose tests just passed, so it is named and left out of the counts.
+     */
+    @Test
+    void aFileThisJvmCannotDecodeIsNamedInTheReport() throws Exception {
+      repositoryWithOneCommit();
+      undecodableSource();
+      DiffCoverageTask task = task(null, reportCovering("Other.java"));
+      task.getBaseRef().set("master");
+      assertEquals(
+          "Diff coverage: cannot read the untracked file src/main/java/Bad.java: "
+              + "java.nio.charset.MalformedInputException: Input length = 1",
+          task.describeRun().lines().findFirst().orElseThrow());
+    }
+
+    /**
+     * Left in the counts, the file would be a changed file no report covers, which is the one
+     * thing that fails a gate whatever the coverage.
+     */
+    @Test
+    void aFileThisJvmCannotDecodeIsLeftOutOfTheCounts() throws Exception {
+      repositoryWithOneCommit();
+      undecodableSource();
+      DiffCoverageTask task = task(90.0, reportCovering("Other.java"));
+      task.getBaseRef().set("master");
+      assertDoesNotThrow(task::describeRun);
+    }
+
+    private void undecodableSource() throws IOException {
+      Path source = directory.resolve("src/main/java/Bad.java");
+      Files.createDirectories(source.getParent());
+      Files.write(source, new byte[] {(byte) 0xC3, (byte) 0x28, '\n'});
+    }
+  }
+
+  @Nested
+  class WithABaseThatDoesNotResolve {
+
+    @Test
+    void anExplicitRefThatDoesNotResolveFailsWhateverTheThreshold() throws Exception {
+      repositoryWithOneCommit();
+      DiffCoverageTask task = task(null);
+      task.getBaseRef().set("no/such/ref");
+      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
+      assertEquals(
+          "diffCoverageBase no/such/ref does not resolve to a commit", thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class WithAChangedFileNoReportCovers {
+
+    /**
+     * Such a file contributes nothing to either side of the share, so a threshold applied to the
+     * rest of the change would pass over it without having measured it.
+     */
+    @Test
+    void aThresholdFailsRatherThanPassingOverAFileTheReportNeverMentions() throws Exception {
+      repositoryWithOneCommit();
+      Path source = directory.resolve("src/main/java/A.java");
+      Files.createDirectories(source.getParent());
+      Files.writeString(source, "class A {}\n");
+      Path report = directory.resolve("report.xml");
+      Files.writeString(
+          report,
+          "<report name=\"test\"><package name=\"\">"
+              + "<sourcefile name=\"Other.java\"/></package></report>");
+      DiffCoverageTask task = task(90.0, report);
+      task.getBaseRef().set("master");
+      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
+      assertEquals(
+          "no JaCoCo report covers these changed files, so no threshold applies to them: "
+              + "src/main/java/A.java. The full report is in "
+              + FULL_REPORT,
+          thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class WithAModuleTheChangeNeverReached {
+
+    /**
+     * A module with no test produces no report at all, so without this every whole-build run would
+     * carry one give-up line per such module, and one more for every module the change missed.
+     */
+    @Test
+    void aModuleWithNoChangedSourceSaysNothingEvenWithNoReport() throws Exception {
+      repositoryWithOneCommit();
+      Path elsewhere = directory.resolve("other/src/main/java/A.java");
+      Files.createDirectories(elsewhere.getParent());
+      Files.writeString(elsewhere, "class A {}\n");
+      DiffCoverageTask task = task(null, directory.resolve("absent.xml"));
+      task.getBaseRef().set("master");
+      assertEquals("", task.describeRun());
+    }
+
+    /** A module the change did reach still reports that its coverage could not be read. */
+    @Test
+    void aModuleWithAChangedSourceStillReportsAMissingReport() throws Exception {
+      repositoryWithOneCommit();
+      Path source = directory.resolve("src/main/java/A.java");
+      Files.createDirectories(source.getParent());
+      Files.writeString(source, "class A {}\n");
+      DiffCoverageTask task = task(null, directory.resolve("absent.xml"));
+      task.getBaseRef().set("master");
+      assertEquals(DiffCoverageTask.NO_REPORT, task.describeRun());
+    }
+  }
+
+  @Nested
+  class TheScopeLine {
+
+    /**
+     * Between an upstream branch and origin/master the reader cannot otherwise tell which base the
+     * counts were taken against, which is the whole reason the resolved ref is carried back.
+     */
+    @Test
+    void theHeaderNamesTheRefThatResolvedAndItsMergeBase() throws Exception {
+      repositoryWithOneCommit();
+      Path source = directory.resolve("src/main/java/A.java");
+      Files.createDirectories(source.getParent());
+      Files.writeString(source, "class A {}\n");
+      DiffCoverageTask task = task(null, reportCovering("A.java"));
+      task.getBaseRef().set("master");
+      String head = revParse("HEAD").substring(0, 9);
+      assertEquals(
+          "Diff coverage against master (" + head + "), from a test",
+          task.describeRun().lines().findFirst().orElseThrow());
+    }
+  }
+
+  @Nested
+  class WithNoCommonHistory {
+
+    /**
+     * A ref can resolve and share no commit with HEAD, as in a shallow clone or after an orphan
+     * branch. That is a base this run does not have, not a reason to fail a build whose tests
+     * passed, so the message is the one for a base that could not be found.
+     */
+    @Test
+    void aBaseWithNoMergeBaseIsTreatedAsNoBaseAtAll() throws Exception {
+      repositoryWithOneCommit();
+      run("checkout", "-q", "--orphan", "unrelated");
+      run("rm", "-q", "-f", "README.md");
+      Files.writeString(directory.resolve("OTHER.md"), "other\n");
+      run("add", "-A");
+      run("commit", "-m", "unrelated");
+      DiffCoverageTask task = task(90.0);
+      task.getBaseRef().set("master");
+      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
+      assertEquals(DiffCoverageTask.NO_BASE, thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class TheFullReport {
+
+    /**
+     * Builds a task over a repository holding one untracked source of count uncovered lines, whose
+     * text is {@code line1();} downwards, and the report that measures it.
+     */
+    private DiffCoverageTask taskWithUncoveredLines(int count) throws Exception {
+      repositoryWithOneCommit();
+      StringBuilder source = new StringBuilder();
+      StringBuilder xml =
+          new StringBuilder(
+              "<report name=\"test\"><package name=\"com/uber\">"
+                  + "<sourcefile name=\"A.java\">");
+      for (int number = 1; number <= count; number++) {
+        source.append("line").append(number).append("();\n");
+        xml.append("<line nr=\"")
+            .append(number)
+            .append("\" mi=\"4\" ci=\"0\" mb=\"0\" cb=\"0\"/>");
+      }
+      xml.append("</sourcefile></package></report>");
+      Path file = directory.resolve("src/main/java/com/uber/A.java");
+      Files.createDirectories(file.getParent());
+      Files.writeString(file, source.toString());
+      Path report = directory.resolve("report.xml");
+      Files.writeString(report, xml.toString());
+      DiffCoverageTask task = task(null, report);
+      task.getBaseRef().set("master");
+      return task;
+    }
+
+    /**
+     * The console block is a summary, so it has to leave the reader somewhere to read the rest and
+     * somewhere to read the run it was measured from.
+     */
+    @Test
+    void theConsoleEndsWithThePathOfTheReportItWroteAndOfTheJacocoXml() throws Exception {
+      List<String> printed = taskWithUncoveredLines(2).describeRun().lines().toList();
+      int paths = printed.indexOf("Full diff coverage report:");
+      assertEquals(
+          List.of(
+              "Full diff coverage report:",
+              "  " + FULL_REPORT,
+              "Full JaCoCo report:",
+              "  report.xml"),
+          printed.subList(Math.max(paths, 0), printed.size()),
+          () -> "the paths at the end of:\n" + String.join("\n", printed));
+    }
+
+    @Test
+    void theFileHoldsTheLinesTheConsoleCapLeftOut() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(3);
+      task.getMaxLinesTotal().set(1);
+      String console = task.describeRun();
+      String written = Files.readString(directory.resolve(FULL_REPORT));
+      assertAll(
+          () -> assertFalse(console.contains("\n      3: not executed"), console),
+          () -> assertTrue(written.contains("\n      3: not executed: line3();"), written));
+    }
+
+    /** The file is the reader's copy of the report, so it names the run it was measured from. */
+    @Test
+    void theFileEndsWithThePathOfTheJacocoXml() throws Exception {
+      taskWithUncoveredLines(2).describeRun();
+      String written = Files.readString(directory.resolve(FULL_REPORT));
+      assertTrue(written.endsWith("Full JaCoCo report:\n  report.xml\n"), written);
+    }
+
+    /** Several reports are read where a module has more than one test task instrumented. */
+    @Test
+    void aSecondJacocoReportIsNamedUnderThePluralHeading() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(1);
+      Path second = directory.resolve("other.xml");
+      Files.writeString(second, "<report name=\"other\"/>");
+      task.getReportFiles().from(second.toFile());
+      List<String> printed = task.describeRun().lines().toList();
+      assertAll(
+          () ->
+              assertEquals(
+                  "Full JaCoCo reports:",
+                  printed.get(printed.size() - 3),
+                  () -> String.join("\n", printed)),
+          () ->
+              assertEquals(
+                  List.of("  other.xml", "  report.xml"),
+                  printed.subList(printed.size() - 2, printed.size()).stream().sorted().toList(),
+                  () -> String.join("\n", printed)));
+    }
+
+    /**
+     * A path that names no file sends the reader to a stale report or to none, so the console says
+     * what happened where it would otherwise carry the path.
+     */
+    @Test
+    void aReportThatCannotBeWrittenIsSaidInPlaceOfItsPath() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(1);
+      // The JaCoCo report is a regular file, so no directory of that name can hold the report.
+      task.getOutputFile().set(directory.resolve("report.xml").resolve("test.txt").toFile());
+      String printed = task.describeRun();
+      assertTrue(
+          printed.contains(
+              "Full diff coverage report: cannot write "
+                  + Path.of("report.xml", "test.txt")
+                  + ": "),
+          printed);
+    }
+
+    /**
+     * The path is printed only where the task wrote the file, and a reader who kept the path from
+     * an earlier run would otherwise read that run's report as this one's.
+     */
+    @Test
+    void aRunThatMeasuresNothingLeavesNoReportFromAnEarlierRunBehind() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(2);
+      task.describeRun();
+      Files.delete(directory.resolve("src/main/java/com/uber/A.java"));
+      task.describeRun();
+      assertFalse(
+          Files.exists(directory.resolve(FULL_REPORT)),
+          () -> "the report of the earlier run is still at " + FULL_REPORT);
+    }
+
+    /**
+     * A failing task prints its exception and not the block, so the reader is left with a
+     * percentage and nowhere to see which lines produced it.
+     */
+    @Test
+    void aThresholdFailureNamesTheReportHoldingTheLinesThatFailedIt() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(2);
+      task.getFailUnder().set(90.0);
+      GradleException thrown = assertThrows(GradleException.class, task::describeRun);
+      assertEquals(
+          "0.0% of the changed lines ran, below the required 90.0%. The full report is in "
+              + FULL_REPORT,
+          thrown.getMessage());
+    }
+
+    @Test
+    void showingEverythingPrintsTheRowsTheCapWouldHaveDropped() throws Exception {
+      DiffCoverageTask task = taskWithUncoveredLines(3);
+      task.getMaxLinesTotal().set(1);
+      task.getShowAll().set(true);
+      String console = task.describeRun();
+      assertTrue(console.contains("      3: not executed: line3();"), console);
+    }
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskRunTest.java
@@ -59,7 +59,16 @@ class DiffCoverageTaskRunTest {
     Project project = ProjectBuilder.builder().withProjectDir(directory.toFile()).build();
     DiffCoverageTask task =
         project.getTasks().register("diffCoverage", DiffCoverageTask.class).get();
-    task.getRepositoryRoot().set(directory.toFile());
+    task.getGit()
+        .set(
+            project
+                .getGradle()
+                .getSharedServices()
+                .registerIfAbsent(
+                    "git",
+                    GitService.class,
+                    service ->
+                        service.getParameters().getRepositoryRoot().set(directory.toFile())));
     task.getSourceRoots().set(List.of("src/main/java"));
     task.getScopeDescription().set("a test");
     task.getFiltered().set(false);

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The decisions the task makes before and after the counts: which ref the diff is taken against,
+ * which sources the counts can still be trusted for, and whether a threshold was met.
+ *
+ * <p>{@link DiffCoverageTaskRunTest} drives the task itself through a synthetic project; what is
+ * here is the logic those runs carry, tested on its own.
+ */
+class DiffCoverageTaskTest {
+
+  private static final String MEASURED = "nullaway/src/main/java/Sample.java";
+  private static final long EARLIER = 1_000_000_000L;
+  private static final long LATER = 2_000_000_000L;
+
+  @TempDir Path directory;
+
+  private File writeAt(String path, long modified) throws IOException {
+    Path file = directory.resolve(path);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, "x\n");
+    Files.setLastModifiedTime(file, FileTime.fromMillis(modified));
+    return file.toFile();
+  }
+
+  private List<String> staleAmong(String... measuredPaths) throws IOException {
+    return DiffCoverageTask.staleSources(
+        directory.toFile(), List.of(measuredPaths), List.of(writeAt("report.xml", EARLIER)));
+  }
+
+  @Nested
+  class AgainstOneReport {
+
+    @Test
+    void aSourceEditedAfterTheReportIsStale() throws IOException {
+      writeAt(MEASURED, LATER);
+      assertEquals(List.of(MEASURED), staleAmong(MEASURED));
+    }
+
+    @Test
+    void aSourceOlderThanTheReportIsNotStale() throws IOException {
+      writeAt(MEASURED, EARLIER - 1000);
+      assertEquals(List.of(), staleAmong(MEASURED));
+    }
+
+    /** A source written in the same run as the report is not an edit that moved a line. */
+    @Test
+    void aSourceAsOldAsTheReportIsNotStale() throws IOException {
+      writeAt(MEASURED, EARLIER);
+      assertEquals(List.of(), staleAmong(MEASURED));
+    }
+
+    @Test
+    void aFileTheCountsDidNotComeFromIsNotChecked() throws IOException {
+      writeAt("nullaway/src/test/java/SampleTest.java", LATER);
+      assertEquals(List.of(), staleAmong());
+    }
+
+    @Test
+    void aMeasuredPathThatNoLongerExistsIsNotStale() throws IOException {
+      assertEquals(List.of(), staleAmong("nullaway/src/main/java/Deleted.java"));
+    }
+  }
+
+  @Nested
+  class TheBaseRef {
+
+    @Test
+    void anIntegrationUpstreamIsTriedBeforeOriginMaster() {
+      assertEquals(
+          List.of("origin/develop", "origin/master"),
+          DiffCoverageTask.baseCandidates(null, "origin/develop", "feature/x"));
+    }
+
+    @Test
+    void aBranchWithNoUpstreamFallsBackToOriginMaster() {
+      assertEquals(
+          List.of("origin/master"), DiffCoverageTask.baseCandidates(null, null, "feature/x"));
+    }
+
+    /**
+     * In a fork workflow the branch tracks the fork, so after the first push its upstream holds
+     * every line the branch changed and diffing against it would report an empty change.
+     */
+    @Test
+    void anUpstreamThatIsThisBranchPushedToAForkIsLeftOut() {
+      assertEquals(
+          List.of("origin/master"),
+          DiffCoverageTask.baseCandidates(null, "vs/feature/x", "feature/x"));
+    }
+
+    /**
+     * Falling through from the ref the caller named to another one would report a different set of
+     * lines as changed, under a base the caller did not choose.
+     */
+    @Test
+    void anExplicitRefIsTheOnlyCandidate() {
+      assertEquals(
+          List.of("release-1.0"),
+          DiffCoverageTask.baseCandidates("release-1.0", "origin/develop", "feature/x"));
+    }
+  }
+
+  @Nested
+  class RecognisingThisBranchPushed {
+
+    @Test
+    void anUpstreamNamedAfterThisBranchOnARemoteIsThisBranch() {
+      assertTrue(DiffCoverageTask.isOwnPushedBranch("vs/feature/x", "feature/x"));
+    }
+
+    @Test
+    void anUpstreamNamingAnotherBranchIsNotThisBranch() {
+      assertFalse(DiffCoverageTask.isOwnPushedBranch("origin/develop", "feature/x"));
+    }
+
+    /** Only the remote is dropped, so a branch named after another one's tail stays its own. */
+    @Test
+    void anUpstreamWhoseTailMatchesButWhosePathDoesNotIsAnotherBranch() {
+      assertFalse(DiffCoverageTask.isOwnPushedBranch("vs/feature/x", "x"));
+    }
+
+    @Test
+    void aLocalUpstreamWithNoRemoteSegmentIsComparedWhole() {
+      assertTrue(DiffCoverageTask.isOwnPushedBranch("x", "x"));
+    }
+
+    @Test
+    void aDetachedHeadHasNoBranchToRecognise() {
+      assertFalse(DiffCoverageTask.isOwnPushedBranch("origin/master", null));
+    }
+  }
+
+  @Nested
+  class GivingUp {
+
+    /**
+     * A run that measured nothing has to say so. Reusing the total a measured run prints for an
+     * empty change would tell the reader that everything they changed was covered.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {DiffCoverageTask.NO_BASE, DiffCoverageTask.NO_REPORT})
+    void aMessageSayingNothingWasMeasuredIsNotTheTotalOfAMeasuredRun(String message) {
+      assertFalse(
+          message.contains(DiffCoverageReport.NO_EXECUTABLE_LINES),
+          () -> "message reads as a measured run: " + message);
+    }
+
+    @Test
+    void theTwoGiveUpMessagesNameDifferentCauses() {
+      assertNotEquals(DiffCoverageTask.NO_BASE, DiffCoverageTask.NO_REPORT);
+    }
+  }
+
+  @Nested
+  class FilesNoReportCovers {
+
+    /**
+     * Such a file contributes nothing to either side of the share, so a change made entirely in
+     * one would clear every threshold without having been measured.
+     */
+    @Test
+    void aChangedFileNoReportCoversNamesItselfRatherThanClearingTheGate() {
+      assertEquals(
+          "no JaCoCo report covers these changed files, so no threshold applies to them: "
+              + "a/A.java, b/B.java",
+          DiffCoverageTask.unmeasuredFilesFailure(List.of("a/A.java", "b/B.java")));
+    }
+
+    @Test
+    void aRunWithEveryChangedFileInTheReportAppliesTheThreshold() {
+      assertNull(DiffCoverageTask.unmeasuredFilesFailure(List.of()));
+    }
+  }
+
+  @Nested
+  class TheThreshold {
+
+    @Test
+    void anExecutedShareBelowTheThresholdIsReportedWithBothPercentages() {
+      assertEquals(
+          "66.7% of the changed lines ran, below the required 90.0%",
+          DiffCoverageTask.thresholdFailure(2, 3, 90.0));
+    }
+
+    @Test
+    void anExecutedShareAboveTheThresholdPasses() {
+      assertNull(DiffCoverageTask.thresholdFailure(3, 3, 90.0));
+    }
+
+    @Test
+    void anExecutedShareExactlyAtTheThresholdPasses() {
+      assertNull(DiffCoverageTask.thresholdFailure(9, 10, 90.0));
+    }
+
+    @Test
+    void anExecutedShareJustBelowTheThresholdFails() {
+      assertEquals(
+          "89.0% of the changed lines ran, below the required 90.0%",
+          DiffCoverageTask.thresholdFailure(89, 100, 90.0));
+    }
+
+    /** A commit that changed only comments clears every threshold. */
+    @Test
+    void aChangeWithNoExecutableLinePassesEveryThreshold() {
+      assertNull(DiffCoverageTask.thresholdFailure(0, 0, 100.0));
+    }
+
+    /**
+     * A locale that writes a decimal comma would print 66,7%, which nobody greps and which two CI
+     * runners spell differently.
+     */
+    @Test
+    void thePercentagesCarryADecimalPointUnderALocaleThatWritesAComma() {
+      Locale original = Locale.getDefault();
+      try {
+        Locale.setDefault(Locale.GERMANY);
+        assertEquals(
+            "66.7% of the changed lines ran, below the required 90.0%",
+            DiffCoverageTask.thresholdFailure(2, 3, 90.0));
+      } finally {
+        Locale.setDefault(original);
+      }
+    }
+  }
+
+  @Nested
+  class AgainstSeveralReports {
+
+    /** The newest report decides, since it is the one the counts were read from. */
+    @Test
+    void aSourceOlderThanTheNewestReportIsNotStale() throws IOException {
+      File older = writeAt("first.xml", EARLIER);
+      File newer = writeAt("second.xml", LATER);
+      writeAt(MEASURED, LATER - 1000);
+      assertEquals(
+          List.of(),
+          DiffCoverageTask.staleSources(
+              directory.toFile(), List.of(MEASURED), List.of(older, newer)));
+    }
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/DiffCoverageTaskTest.java
@@ -17,7 +17,6 @@ package com.uber.nullaway.gradle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,16 +26,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.List;
-import java.util.Locale;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * The decisions the task makes before and after the counts: which ref the diff is taken against,
- * which sources the counts can still be trusted for, and whether a threshold was met.
+ * and which sources the counts can still be trusted for.
  *
  * <p>{@link DiffCoverageTaskRunTest} drives the task itself through a synthetic project; what is
  * here is the logic those runs carry, tested on its own.
@@ -162,99 +158,6 @@ class DiffCoverageTaskTest {
     @Test
     void aDetachedHeadHasNoBranchToRecognise() {
       assertFalse(DiffCoverageTask.isOwnPushedBranch("origin/master", null));
-    }
-  }
-
-  @Nested
-  class GivingUp {
-
-    /**
-     * A run that measured nothing has to say so. Reusing the total a measured run prints for an
-     * empty change would tell the reader that everything they changed was covered.
-     */
-    @ParameterizedTest
-    @ValueSource(strings = {DiffCoverageTask.NO_BASE, DiffCoverageTask.NO_REPORT})
-    void aMessageSayingNothingWasMeasuredIsNotTheTotalOfAMeasuredRun(String message) {
-      assertFalse(
-          message.contains(DiffCoverageReport.NO_EXECUTABLE_LINES),
-          () -> "message reads as a measured run: " + message);
-    }
-
-    @Test
-    void theTwoGiveUpMessagesNameDifferentCauses() {
-      assertNotEquals(DiffCoverageTask.NO_BASE, DiffCoverageTask.NO_REPORT);
-    }
-  }
-
-  @Nested
-  class FilesNoReportCovers {
-
-    /**
-     * Such a file contributes nothing to either side of the share, so a change made entirely in
-     * one would clear every threshold without having been measured.
-     */
-    @Test
-    void aChangedFileNoReportCoversNamesItselfRatherThanClearingTheGate() {
-      assertEquals(
-          "no JaCoCo report covers these changed files, so no threshold applies to them: "
-              + "a/A.java, b/B.java",
-          DiffCoverageTask.unmeasuredFilesFailure(List.of("a/A.java", "b/B.java")));
-    }
-
-    @Test
-    void aRunWithEveryChangedFileInTheReportAppliesTheThreshold() {
-      assertNull(DiffCoverageTask.unmeasuredFilesFailure(List.of()));
-    }
-  }
-
-  @Nested
-  class TheThreshold {
-
-    @Test
-    void anExecutedShareBelowTheThresholdIsReportedWithBothPercentages() {
-      assertEquals(
-          "66.7% of the changed lines ran, below the required 90.0%",
-          DiffCoverageTask.thresholdFailure(2, 3, 90.0));
-    }
-
-    @Test
-    void anExecutedShareAboveTheThresholdPasses() {
-      assertNull(DiffCoverageTask.thresholdFailure(3, 3, 90.0));
-    }
-
-    @Test
-    void anExecutedShareExactlyAtTheThresholdPasses() {
-      assertNull(DiffCoverageTask.thresholdFailure(9, 10, 90.0));
-    }
-
-    @Test
-    void anExecutedShareJustBelowTheThresholdFails() {
-      assertEquals(
-          "89.0% of the changed lines ran, below the required 90.0%",
-          DiffCoverageTask.thresholdFailure(89, 100, 90.0));
-    }
-
-    /** A commit that changed only comments clears every threshold. */
-    @Test
-    void aChangeWithNoExecutableLinePassesEveryThreshold() {
-      assertNull(DiffCoverageTask.thresholdFailure(0, 0, 100.0));
-    }
-
-    /**
-     * A locale that writes a decimal comma would print 66,7%, which nobody greps and which two CI
-     * runners spell differently.
-     */
-    @Test
-    void thePercentagesCarryADecimalPointUnderALocaleThatWritesAComma() {
-      Locale original = Locale.getDefault();
-      try {
-        Locale.setDefault(Locale.GERMANY);
-        assertEquals(
-            "66.7% of the changed lines ran, below the required 90.0%",
-            DiffCoverageTask.thresholdFailure(2, 3, 90.0));
-      } finally {
-        Locale.setDefault(original);
-      }
     }
   }
 

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/GitServiceTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/GitServiceTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * One git command runs once a build, and a failing one is told apart from an empty result.
+ *
+ * <p>The cache is what makes the service worth registering: twelve modules ask the same questions
+ * of one repository, and a second run of a command can only repeat its answer. It is asserted by
+ * changing the repository between two identical calls, since a call that ran again would report the
+ * new state.
+ *
+ * <p>Every command runs against a repository built here. The fixture that builds it switches the
+ * system and global configuration off for its own processes, so that a setting on the machine
+ * running the tests decides nothing about what the repository holds.
+ */
+class GitServiceTest {
+
+  @TempDir Path directory;
+
+  private GitService service() {
+    Project project = ProjectBuilder.builder().withProjectDir(directory.toFile()).build();
+    return project
+        .getGradle()
+        .getSharedServices()
+        .registerIfAbsent(
+            "git",
+            GitService.class,
+            service -> service.getParameters().getRepositoryRoot().set(directory.toFile()))
+        .get();
+  }
+
+  @Test
+  void aRepeatedCommandKeepsTheAnswerOfItsFirstRun() throws Exception {
+    repositoryWithOneCommit();
+    GitService git = service();
+    String first = git.output("rev-parse", "HEAD");
+
+    commit("second");
+
+    assertEquals(first, git.output("rev-parse", "HEAD"), "rev-parse HEAD after a second commit");
+    assertNotEquals(first, head(), "the commit HEAD names after the second commit");
+  }
+
+  @Test
+  void aCommandIsKeyedByItsWholeArgumentList() throws Exception {
+    repositoryWithOneCommit();
+    GitService git = service();
+    git.output("rev-parse", "HEAD");
+
+    commit("second");
+
+    assertEquals(head(), git.output("rev-parse", "master"), "rev-parse master");
+  }
+
+  @Test
+  void aFailingCommandComesBackAsNullRatherThanAsEmptyOutput() throws Exception {
+    repositoryWithOneCommit();
+
+    assertNull(
+        service().outputOrNull("rev-parse", "--verify", "--quiet", "absent^{commit}"),
+        "a ref that does not resolve");
+  }
+
+  @Test
+  void aFailingCommandReportsWhatGitPrinted() throws Exception {
+    repositoryWithOneCommit();
+    GitService git = service();
+
+    GradleException thrown =
+        assertThrows(GradleException.class, () -> git.output("rev-parse", "absent"));
+
+    String prefix = "git rev-parse absent failed: ";
+    assertTrue(
+        thrown.getMessage().startsWith(prefix),
+        () -> "the command that failed: " + thrown.getMessage());
+    assertNotEquals(
+        "",
+        thrown.getMessage().substring(prefix.length()),
+        () -> "what git printed about the ref: " + thrown.getMessage());
+  }
+
+  @Test
+  void aFailedCommandKeepsFailingForTheRestOfTheBuild() throws Exception {
+    repositoryWithOneCommit();
+    GitService git = service();
+    String[] resolveAbsent = {"rev-parse", "--verify", "--quiet", "absent^{commit}"};
+    git.outputOrNull(resolveAbsent);
+
+    run("branch", "absent");
+
+    assertNull(git.outputOrNull(resolveAbsent), "the ref the branch now names");
+  }
+
+  @Test
+  void aCommandThatFoundNothingComesBackAsEmptyOutput() throws Exception {
+    repositoryWithOneCommit();
+
+    assertEquals(
+        "",
+        service().output("ls-files", "--others", "--exclude-standard", "--", "*.java"),
+        "an untracked Java file");
+  }
+
+  /** Creates a repository whose only commit is on master. */
+  private void repositoryWithOneCommit() throws Exception {
+    run("init", "--initial-branch=master", ".");
+    run("config", "user.email", "test@example.com");
+    run("config", "user.name", "Test");
+    commit("seed");
+  }
+
+  /** Adds a file named after the message and commits everything in the tree. */
+  private void commit(String message) throws Exception {
+    Files.writeString(directory.resolve(message + ".txt"), message + "\n");
+    run("add", "-A");
+    run("commit", "-m", message);
+  }
+
+  /** Returns the commit HEAD names now, read outside the service so no cache stands between. */
+  private String head() throws Exception {
+    return run("rev-parse", "HEAD").trim();
+  }
+
+  private String run(String... arguments) throws IOException, InterruptedException {
+    List<String> command = new ArrayList<>(List.of("git"));
+    command.addAll(List.of(arguments));
+    ProcessBuilder builder =
+        new ProcessBuilder(command).directory(directory.toFile()).redirectErrorStream(true);
+    Map<String, String> environment = builder.environment();
+    // A path git can read and will not find, rather than /dev/null, which names a file of its own
+    // on Windows and would leave the configuration of the machine deciding what these tests see.
+    String noConfig = directory.resolve("no-git-config").toString();
+    environment.put("GIT_CONFIG_GLOBAL", noConfig);
+    environment.put("GIT_CONFIG_SYSTEM", noConfig);
+    environment.put("GIT_CONFIG_NOSYSTEM", "1");
+    Process process = builder.start();
+    // Read before waiting: nothing else drains the pipe, so a command that filled it would hang,
+    // and what git printed is the only account of why it failed.
+    String output;
+    try (InputStream stream = process.getInputStream()) {
+      output = new String(stream.readAllBytes(), UTF_8);
+    }
+    assertEquals(0, process.waitFor(), () -> "git " + String.join(" ", arguments) + ": " + output);
+    return output;
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/JacocoLinesTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/JacocoLinesTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The counters of a JaCoCo XML report are read per source line, and several reports merge by taking
+ * the larger of each counter.
+ *
+ * <p>The attribute names are JaCoCo's: {@code ci} and {@code mi} count covered and missed
+ * instructions, {@code cb} and {@code mb} covered and missed branches.
+ */
+class JacocoLinesTest {
+
+  private static final String KEY = "com/uber/nullaway/Sample.java";
+
+  @TempDir Path directory;
+
+  /** Writes a report holding the given {@code <line>} elements for Sample.java. */
+  private File report(String name, String lines) throws IOException {
+    File file = directory.resolve(name).toFile();
+    Files.writeString(
+        file.toPath(),
+        "<report name=\"test\"><package name=\"com/uber/nullaway\">"
+            + "<sourcefile name=\"Sample.java\">"
+            + lines
+            + "</sourcefile></package></report>");
+    return file;
+  }
+
+  private JacocoLines read(String lines) throws IOException {
+    return JacocoLines.read(List.of(report("jacocoTestReport.xml", lines)));
+  }
+
+  /** Returns the counters of line 10, failing by name rather than by NPE where it is absent. */
+  private JacocoLines.Counters counters(String lines) throws IOException {
+    JacocoLines.Counters counters = read(lines).get(KEY, 10);
+    assertNotNull(counters, () -> "no counters for line 10 in " + lines);
+    return counters;
+  }
+
+  @Nested
+  class OneReport {
+
+    @Test
+    void aLineWithACoveredInstructionCountsAsExecuted() throws IOException {
+      assertTrue(
+          counters("<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>")
+              .isExecuted());
+    }
+
+    @Test
+    void aLineWithNoCoveredInstructionCountsAsNotExecuted() throws IOException {
+      assertFalse(
+          counters("<line nr=\"10\" mi=\"4\" ci=\"0\" mb=\"0\" cb=\"0\"/>")
+              .isExecuted());
+    }
+
+    @Test
+    void aLineWithAMissedBranchHasAnUntakenBranch() throws IOException {
+      assertTrue(
+          counters("<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"1\" cb=\"1\"/>")
+              .hasUntakenBranch());
+    }
+
+    @Test
+    void aLineWithNoMissedBranchHasNoUntakenBranch() throws IOException {
+      assertFalse(
+          counters("<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"2\"/>")
+              .hasUntakenBranch());
+    }
+
+    @Test
+    void aLineWithNoBranchAtAllHasNoUntakenBranch() throws IOException {
+      assertFalse(
+          counters("<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>")
+              .hasUntakenBranch());
+    }
+
+    @Test
+    void theBranchTotalIsTheCoveredAndMissedBranchesTogether() throws IOException {
+      JacocoLines.Counters counters =
+          counters("<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"3\" cb=\"1\"/>");
+      assertAll(
+          () -> assertEquals(1, counters.coveredBranches, "coveredBranches"),
+          () -> assertEquals(4, counters.totalBranches, "totalBranches"));
+    }
+
+    @Test
+    void anAbsentCounterAttributeReadsAsZero() throws IOException {
+      JacocoLines.Counters counters = counters("<line nr=\"10\" ci=\"4\"/>");
+      assertAll(
+          () -> assertEquals(0, counters.coveredBranches, "coveredBranches"),
+          () -> assertEquals(0, counters.totalBranches, "totalBranches"));
+    }
+
+    @Test
+    void aLineTheReportDoesNotMentionHasNoCounters() throws IOException {
+      assertNull(read("<line nr=\"10\" mi=\"0\" ci=\"4\"/>").get(KEY, 11));
+    }
+
+    @Test
+    void aSourceFileTheReportDoesNotMentionIsNotCovered() throws IOException {
+      assertFalse(read("").covers("com/uber/nullaway/Other.java"));
+    }
+
+    @Test
+    void aSourceFileTheReportMentionsIsCovered() throws IOException {
+      assertTrue(read("").covers(KEY));
+    }
+  }
+
+  @Nested
+  class SeveralReports {
+
+    @Test
+    void aLineExecutedByEitherReportCountsAsExecuted() throws IOException {
+      JacocoLines merged =
+          JacocoLines.read(
+              List.of(
+                  report("first.xml", "<line nr=\"10\" mi=\"4\" ci=\"0\" mb=\"0\" cb=\"0\"/>"),
+                  report("second.xml", "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>")));
+      assertTrue(merged.get(KEY, 10).isExecuted());
+    }
+
+    /**
+     * JaCoCo numbers no branch, so two reports each covering one of two branches cannot be told
+     * from two reports covering the same branch. Reporting the line as partly taken asks for a test
+     * that may already exist; adding the counters up would hide one that does not.
+     */
+    @Test
+    void aBranchOneReportMissedStaysMissedRatherThanAddingUpToTheTotal() throws IOException {
+      String line = "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"1\" cb=\"1\"/>";
+      JacocoLines merged =
+          JacocoLines.read(List.of(report("first.xml", line), report("second.xml", line)));
+      JacocoLines.Counters counters = merged.get(KEY, 10);
+      assertAll(
+          () -> assertEquals(1, counters.coveredBranches, "coveredBranches"),
+          () -> assertEquals(2, counters.totalBranches, "totalBranches"),
+          () -> assertTrue(counters.hasUntakenBranch(), "hasUntakenBranch"));
+    }
+
+    /** A report compiled from fewer branches must not shrink the total the other one saw. */
+    @Test
+    void theLargerBranchTotalOfTheTwoReportsWins() throws IOException {
+      JacocoLines merged =
+          JacocoLines.read(
+              List.of(
+                  report("first.xml", "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"1\" cb=\"1\"/>"),
+                  report("second.xml", "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"3\" cb=\"1\"/>")));
+      assertEquals(4, merged.get(KEY, 10).totalBranches);
+    }
+
+    @Test
+    void aLineOnlyOneReportMentionsKeepsThatReportsCounters() throws IOException {
+      JacocoLines merged =
+          JacocoLines.read(
+              List.of(
+                  report("first.xml", "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>"),
+                  report("second.xml", "<line nr=\"20\" mi=\"4\" ci=\"0\" mb=\"0\" cb=\"0\"/>")));
+      assertAll(
+          () -> assertTrue(merged.get(KEY, 10).isExecuted(), "line 10"),
+          () -> assertFalse(merged.get(KEY, 20).isExecuted(), "line 20"));
+    }
+  }
+
+  @Nested
+  class MalformedInput {
+
+    /**
+     * JaCoCo declares {@code report.dtd} as a relative system id and writes no such file beside the
+     * report, so a parser that resolves it fails on every report this build produces.
+     */
+    @Test
+    void aReportDeclaringTheJacocoDoctypeIsReadWithoutResolvingIt() throws IOException {
+      File file = directory.resolve("doctyped.xml").toFile();
+      Files.writeString(
+          file.toPath(),
+          "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+              + "<!DOCTYPE report PUBLIC \"-//JACOCO//DTD Report 1.1//EN\" \"report.dtd\">"
+              + "<report name=\"test\"><package name=\"com/uber/nullaway\">"
+              + "<sourcefile name=\"Sample.java\">"
+              + "<line nr=\"10\" mi=\"0\" ci=\"4\" mb=\"0\" cb=\"0\"/>"
+              + "</sourcefile></package></report>");
+      assertTrue(JacocoLines.read(List.of(file)).get(KEY, 10).isExecuted());
+    }
+
+    @Test
+    void aReportThatIsNotWellFormedNamesItsFile() throws IOException {
+      File file = directory.resolve("truncated.xml").toFile();
+      Files.writeString(file.toPath(), "<report><package name=\"p\">");
+      IOException thrown = assertThrows(IOException.class, () -> JacocoLines.read(List.of(file)));
+      assertTrue(
+          thrown.getMessage().contains(file.getName()),
+          () -> "message does not name the file: " + thrown.getMessage());
+    }
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/SourceLinesTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/SourceLinesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A line of the working tree comes back as the file holds it, and a line that is not there comes
+ * back empty.
+ *
+ * <p>The report quotes what this returns beside counters it has already taken from JaCoCo, so a
+ * file it cannot read costs the quote and not the measurement.
+ */
+class SourceLinesTest {
+
+  private static final String PATH = "src/main/java/A.java";
+
+  @TempDir Path directory;
+
+  /** Writes the sample file with the given lines, the first of which is line 1. */
+  private void write(String... lines) throws IOException {
+    Path file = directory.resolve(PATH);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, String.join("\n", lines) + "\n");
+  }
+
+  private SourceLines workingTree() {
+    return SourceLines.under(directory.toFile());
+  }
+
+  /** The report strips and cuts the text itself, so it arrives here as the file holds it. */
+  @Test
+  void aLineComesBackWithItsIndentation() throws IOException {
+    write("class A {", "    return null;");
+    assertEquals("    return null;", workingTree().get(PATH, 2));
+  }
+
+  /**
+   * An edit that shortens a file after the run leaves the report naming lines past its end, which
+   * is the case the stale-source warning is printed for.
+   */
+  @Test
+  void aNumberPastTheEndOfTheFileHasNoText() throws IOException {
+    write("class A {", "}");
+    assertEquals("", workingTree().get(PATH, 7));
+  }
+
+  @Test
+  void theLineBeforeTheFirstHasNoText() throws IOException {
+    write("class A {}");
+    assertEquals("", workingTree().get(PATH, 0));
+  }
+
+  @Test
+  void aFileThatIsNotThereHasNoText() {
+    assertEquals("", workingTree().get(PATH, 1));
+  }
+
+  @Test
+  void aFileThisJvmCannotDecodeHasNoText() throws IOException {
+    Path file = directory.resolve(PATH);
+    Files.createDirectories(file.getParent());
+    Files.write(file, new byte[] {(byte) 0xC3, (byte) 0x28, '\n'});
+    assertEquals("", workingTree().get(PATH, 1));
+  }
+
+  /**
+   * A report quotes many lines of the same file, and each read of a source file competes with the
+   * test run that produced the report for the same disk.
+   */
+  @Test
+  void aFileIsReadOnceHoweverManyOfItsLinesAreQuoted() throws IOException {
+    write("class A {", "    return null;");
+    SourceLines sources = workingTree();
+    sources.get(PATH, 1);
+    Files.delete(directory.resolve(PATH));
+    assertEquals("    return null;", sources.get(PATH, 2));
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/UnifiedDiffFromGitTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/UnifiedDiffFromGitTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Real git output, taken with the arguments {@link DiffCoverageTask#diffCommand}, parses to the
+ * lines the change touched.
+ *
+ * <p>{@link UnifiedDiffTest} pins the parser against diff text written by hand, which stays correct
+ * only while git keeps emitting that text. This test runs git, so a change in what git emits
+ * reaches the parser here rather than in a coverage report someone is reading.
+ *
+ * <p>A missing git fails these tests rather than skipping them. Every contributor and every CI job
+ * has git, so a skip here would hide a broken environment instead of reporting one. The system and
+ * global configuration are switched off for every command, so only what a test sets applies.
+ */
+class UnifiedDiffFromGitTest {
+
+  @TempDir Path repository;
+
+  private String base;
+
+  private static Set<Integer> lines(int... numbers) {
+    Set<Integer> set = new TreeSet<>();
+    for (int number : numbers) {
+      set.add(number);
+    }
+    return set;
+  }
+
+  @BeforeEach
+  void createRepositoryWithOneCommit() throws Exception {
+    run("init", "--initial-branch=master", ".");
+    run("config", "user.email", "test@example.com");
+    run("config", "user.name", "Test");
+    write("a/B.java", "one\ntwo\nthree\n");
+    commitAll();
+    base = run("rev-parse", "HEAD").trim();
+  }
+
+  @Test
+  void aRewrittenLineIsTheOnlyLineReported() throws Exception {
+    write("a/B.java", "one\nCHANGED\nthree\n");
+    assertEquals(Map.of("a/B.java", lines(2)), parseDiff());
+  }
+
+  @Test
+  void anInsertedLineIsReportedAtItsPositionInTheNewFile() throws Exception {
+    write("a/B.java", "one\ntwo\nINSERTED\nthree\n");
+    assertEquals(Map.of("a/B.java", lines(3)), parseDiff());
+  }
+
+  @Test
+  void aDeletionAloneReportsNoLine() throws Exception {
+    write("a/B.java", "one\nthree\n");
+    assertEquals(Map.of(), parseDiff());
+  }
+
+  @Test
+  void anAddedFileReportsEveryLineOfIt() throws Exception {
+    write("a/C.java", "one\ntwo\n");
+    commitAll();
+    assertEquals(Map.of("a/C.java", lines(1, 2)), parseDiff());
+  }
+
+  @Test
+  void aDeletedFileReportsNoLine() throws Exception {
+    Files.delete(repository.resolve("a/B.java"));
+    commitAll();
+    assertEquals(Map.of(), parseDiff());
+  }
+
+  /** See {@code UnifiedDiffTest.anAddedLineThatLooksLikeAFileHeaderStaysContentOfTheFileItIsIn}. */
+  @Test
+  void anAddedLineBeginningWithTwoPlusSignsDoesNotHideTheRestOfTheFile() throws Exception {
+    write("a/B.java", "++ tricky\ntwo\nthree\nFOUR\n");
+    assertEquals(Map.of("a/B.java", lines(1, 4)), parseDiff());
+  }
+
+  /** See {@code UnifiedDiffTest.aDeletedAndAnAddedLineFormingAHeaderPairDoNotOpenAFile}. */
+  @Test
+  void replacingAHeaderLookingLineWithAnotherDoesNotHideTheRestOfTheFile() throws Exception {
+    write("a/B.java", "-- a/x\ntwo\nthree\n");
+    commitAll();
+    write("a/B.java", "++ b/y\ntwo\nthree\nFOUR\n");
+    assertEquals(Map.of("a/B.java", lines(1, 4)), parseDiff());
+  }
+
+  /**
+   * See {@code UnifiedDiffTest.anAddedLineWhoseTextIsADiffGitHeaderStaysContentOfTheFileItIsIn}.
+   */
+  @Test
+  void anAddedLineReadingLikeADiffGitHeaderDoesNotHideTheRestOfTheFile() throws Exception {
+    write("a/B.java", "diff --git a/x b/x\ntwo\nthree\nFOUR\n");
+    assertEquals(Map.of("a/B.java", lines(1, 4)), parseDiff());
+  }
+
+  @Test
+  void theDiffPrefixesSurviveARepositoryConfiguredWithoutThem() throws Exception {
+    run("config", "diff.noprefix", "true");
+    write("a/B.java", "one\nCHANGED\nthree\n");
+    assertEquals(Map.of("a/B.java", lines(2)), parseDiff());
+  }
+
+  /**
+   * With {@code core.quotePath} left on, git wraps this path in quotes and escapes the byte, and
+   * the {@code +++} line then starts with a quotation mark rather than with the prefix. It is no
+   * file header, so every hunk of the file leaves the report with nothing to show that it
+   * happened.
+   *
+   * <p>The name is written and read back first, since a machine whose locale cannot hold it has
+   * nothing to say about git.
+   */
+  @Test
+  void aPathHoldingANonAsciiByteIsReadLikeAnyOther() throws Exception {
+    String path = "a/Caf\u00e9.java";
+    write(path, "one\ntwo\n");
+    assumeTrue(Files.exists(repository.resolve(path)), () -> "this file system holds " + path);
+    commitAll();
+    assertEquals(Map.of(path, lines(1, 2)), parseDiff());
+  }
+
+  @Test
+  void theDiffPrefixesSurviveMnemonicPrefixes() throws Exception {
+    run("config", "diff.mnemonicPrefix", "true");
+    write("a/B.java", "one\nCHANGED\nthree\n");
+    assertEquals(Map.of("a/B.java", lines(2)), parseDiff());
+  }
+
+  private Map<String, NavigableSet<Integer>> parseDiff() throws Exception {
+    List<String> arguments = new ArrayList<>(DiffCoverageTask.diffCommand(base));
+    return UnifiedDiff.parse(run(arguments.toArray(new String[0])));
+  }
+
+  private void write(String path, String content) throws IOException {
+    Path file = repository.resolve(path);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content);
+  }
+
+  private void commitAll() throws Exception {
+    run("add", "-A");
+    run("commit", "-m", "change");
+  }
+
+  private String run(String... arguments) throws Exception {
+    List<String> command = new ArrayList<>(List.of("git"));
+    command.addAll(List.of(arguments));
+    ProcessBuilder builder =
+        new ProcessBuilder(command).directory(repository.toFile()).redirectErrorStream(true);
+    // The tests set diff.noprefix and diff.mnemonicPrefix on the repository on purpose, so the
+    // configuration of the machine running them must not decide anything else.
+    Map<String, String> environment = builder.environment();
+    // A path git can read and will not find, rather than /dev/null, which names a file of its own
+    // on Windows and would leave the configuration of the machine deciding what these tests see.
+    String noConfig = repository.resolve("no-git-config").toString();
+    environment.put("GIT_CONFIG_GLOBAL", noConfig);
+    environment.put("GIT_CONFIG_SYSTEM", noConfig);
+    environment.put("GIT_CONFIG_NOSYSTEM", "1");
+    Process process = builder.start();
+    String output;
+    try (InputStream stream = process.getInputStream()) {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      stream.transferTo(buffer);
+      output = buffer.toString(StandardCharsets.UTF_8);
+    }
+    int exitCode = process.waitFor();
+    assertEquals(0, exitCode, () -> "git " + String.join(" ", arguments) + " printed " + output);
+    return output;
+  }
+}

--- a/buildSrc/src/test/java/com/uber/nullaway/gradle/UnifiedDiffTest.java
+++ b/buildSrc/src/test/java/com/uber/nullaway/gradle/UnifiedDiffTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.nullaway.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A diff produced with {@code --unified=0} and the {@code a/} and {@code b/} prefixes yields the
+ * post-image line numbers of every file it adds to or rewrites.
+ *
+ * <p>Each test spells the diff out rather than running git, so that the input the parser sees is
+ * the input the reader sees. The shapes come from real git output; {@code UnifiedDiffFromGitTest}
+ * checks that git still produces them.
+ */
+class UnifiedDiffTest {
+
+  private static final String HEADERS = "diff --git a/a/B.java b/a/B.java\n--- a/a/B.java\n";
+
+  private static Set<Integer> lines(Integer... numbers) {
+    return new TreeSet<>(Arrays.asList(numbers));
+  }
+
+  @Nested
+  class HunkHeaders {
+
+    @Test
+    void aHunkWithNoCountCoversTheOneLineItNames() {
+      assertEquals(
+          Map.of("a/B.java", lines(7)),
+          UnifiedDiff.parse(HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@\n+x\n"));
+    }
+
+    @Test
+    void aHunkWithACountCoversThatManyLinesFromItsStart() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 8, 9)),
+          UnifiedDiff.parse(HEADERS + "+++ b/a/B.java\n@@ -3,0 +7,3 @@\n+x\n+y\n+z\n"));
+    }
+
+    @Test
+    void aHunkOfCountZeroDeletesAndSoCoversNoLine() {
+      assertEquals(
+          Map.of(), UnifiedDiff.parse(HEADERS + "+++ b/a/B.java\n@@ -3,2 +2,0 @@\n-x\n-y\n"));
+    }
+
+    @Test
+    void aHunkHeaderCarryingAFunctionNameIsStillRead() {
+      assertEquals(
+          Map.of("a/B.java", lines(7)),
+          UnifiedDiff.parse(HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@ void probe() {\n+x\n"));
+    }
+
+    @Test
+    void twoHunksOfOneFileCollectIntoOneLineSet() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20, 21)),
+          UnifiedDiff.parse(
+              HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@\n+x\n@@ -18,0 +20,2 @@\n+y\n+z\n"));
+    }
+  }
+
+  @Nested
+  class FileHeaders {
+
+    @Test
+    void hunksOfTwoFilesStayApart() {
+      assertEquals(
+          Map.of("a/B.java", lines(1), "a/C.java", lines(4)),
+          UnifiedDiff.parse(
+              HEADERS
+                  + "+++ b/a/B.java\n@@ -1 +1 @@\n+x\n"
+                  + "diff --git a/a/C.java b/a/C.java\n--- a/a/C.java\n"
+                  + "+++ b/a/C.java\n@@ -1 +4 @@\n+y\n"));
+    }
+
+    @Test
+    void aDeletedFileContributesNoLine() {
+      assertEquals(
+          Map.of(),
+          UnifiedDiff.parse(HEADERS + "+++ /dev/null\n@@ -1,2 +0,0 @@\n-x\n-y\n"));
+    }
+
+    @Test
+    void anAddedFileIsReadThroughTheDevNullSourceHeader() {
+      assertEquals(
+          Map.of("a/B.java", lines(1, 2)),
+          UnifiedDiff.parse(
+              "diff --git a/a/B.java b/a/B.java\n--- /dev/null\n"
+                  + "+++ b/a/B.java\n@@ -0,0 +1,2 @@\n+x\n+y\n"));
+    }
+
+    /**
+     * An added line reading {@code ++ x} arrives as {@code +++ x}, and reading that as a file
+     * header used to key the rest of the file's hunks under the path {@code + x}, where no source
+     * root claims them and they leave the report silently.
+     */
+    @Test
+    void anAddedLineThatLooksLikeAFileHeaderStaysContentOfTheFileItIsIn() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20)),
+          UnifiedDiff.parse(
+              HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@\n+++ tricky\n@@ -18 +20 @@\n+y\n"));
+    }
+
+    /**
+     * {@code ++ b/x.java} is the one added line the prefix check alone does not tell from a header,
+     * so this is what the pairing with the {@code ---} line above it is for.
+     */
+    @Test
+    void anAddedLineCarryingATargetPrefixStaysContentOfTheFileItIsIn() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20)),
+          UnifiedDiff.parse(
+              HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@\n+++ b/fake.java\n@@ -18 +20 @@\n+y\n"));
+    }
+
+    @Test
+    void aDeletedLineThatLooksLikeASourceHeaderDoesNotOpenAFile() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20)),
+          UnifiedDiff.parse(
+              HEADERS + "+++ b/a/B.java\n@@ -3 +7 @@\n--- a/decoy\n@@ -18 +20 @@\n+y\n"));
+    }
+
+    /**
+     * Replacing a line {@code -- a/x} with a line {@code ++ b/y} puts a whole well-formed header
+     * pair inside a hunk, which the pairing rule alone cannot tell from a real one; only the
+     * {@code diff --git} line git opens a real header section with can.
+     */
+    @Test
+    void aDeletedAndAnAddedLineFormingAHeaderPairDoNotOpenAFile() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20)),
+          UnifiedDiff.parse(
+              HEADERS
+                  + "+++ b/a/B.java\n@@ -3 +7 @@\n--- a/x\n+++ b/y\n@@ -18 +20 @@\n+y\n"));
+    }
+
+    /**
+     * git prefixes content with {@code +}, {@code -}, or a space, and {@code diff} starts with
+     * none of those, so a line whose own text is a {@code diff --git} header cannot arrive looking
+     * like one. This is what the {@code ---} and {@code +++} shapes do not have.
+     */
+    @Test
+    void anAddedLineWhoseTextIsADiffGitHeaderStaysContentOfTheFileItIsIn() {
+      assertEquals(
+          Map.of("a/B.java", lines(7, 20)),
+          UnifiedDiff.parse(
+              HEADERS
+                  + "+++ b/a/B.java\n@@ -3 +7 @@\n+diff --git a/x b/x\n@@ -18 +20 @@\n+y\n"));
+    }
+
+    @Test
+    void aHeaderPairWithNoDiffGitLineAboveItOpensNoFile() {
+      assertEquals(
+          Map.of(), UnifiedDiff.parse("--- a/a/B.java\n+++ b/a/B.java\n@@ -3 +7 @@\n+x\n"));
+    }
+  }
+
+  @Nested
+  class EmptyInput {
+
+    @Test
+    void anEmptyDiffNamesNoFile() {
+      assertEquals(Map.of(), UnifiedDiff.parse(""));
+    }
+
+    @Test
+    void aFileWithNoHunkIsNotNamed() {
+      assertEquals(Map.of(), UnifiedDiff.parse(HEADERS + "+++ b/a/B.java\n"));
+    }
+  }
+}


### PR DESCRIPTION
The build collects JaCoCo data only under -PenableJacoco, generates no per-module report, and aggregates through :code-coverage-report, whose coverageDataElementsForTest wiring pulls in testJdk17, testJdk21, testJdk26 and testJdk28. Coverage was therefore reachable only by re-running the suite on five JDKs, which is too expensive to consult while writing a test, so nobody consulted it and a test that never reached the code it was written for looked the same as one that did.

Instrument the `test` task by default and write its XML report as a finalizer of that task. Measured on :nullaway:test, 1098 tests: instrumentation takes the run from 16.4 s to 20.0 s and the report adds about 1 s. -PdiffCoverageEnabled=false takes back everything the default turns on, the report, the XML it reads and the instrumentation that exists only to produce them, so that one flag buys the 20% back for a run that is not about coverage. -PenableJacoco still decides instrumentation wherever it is set, off or extended to the testJdk* tasks for the aggregate report; CI already sets the property explicitly on every platform, so the new default does not change what CI runs.

The diffCoverage task intersects that report with the lines git diff marks as changed under the module's main source roots, and prints the ones the run did not execute and the branches it took one way. It compares no stored coverage data: the base is a git ref whose merge base with HEAD decides which lines count as changed, so nothing has to be recorded on the base commit or committed to the repository. A ratchet against a stored baseline was rejected because it needs a second instrumented run of the base tree and answers a worse question, reporting that coverage fell by 0.1% rather than naming a line. The task prints at the QUIET log level, so --quiet still shows it, and it names the ref that resolved and the test filter the counts came from, since a filtered run leaves the rest of the change looking unexecuted.

The report is advisory and fails no build. Failing to resolve the base ref or to find a report prints a message saying so, rather than the "no changed executable lines" that would read as "everything is covered". A changed file no report covers is named in a block of its own for the same reason: it counts towards neither side of the total, so a change made entirely in such files would otherwise print as fully covered without having been measured. An untracked file this JVM cannot decode is named and left out instead, since failing a build whose tests passed over an advisory report is the trade the other way round.

Every git command the task runs asks about the repository rather than about the module: the base ref, the diff of every Java file, the untracked files. A shared build service runs them, keyed by the whole argument list, so twelve modules produce one run of each command rather than twelve, and a working tree edited while the build runs cannot make two modules print different changed lines for one change. A command that git rejected is cached with its standard error, since a failure and a command that succeeded and found nothing must not read alike.

The finalizer is wired only where nobody set -PenableJacoco and nobody turned the report off: every CI job that reaches jacocoTestReport sets the property, and a CI checkout fetches the pull request ref alone, so there the task would find no base ref and say so once per module on every build. The conventions plugin gives all twelve modules the task, so a whole-build run prints a block for each module the change touched and nothing for the others. Whether the change reached the module is settled before the report is looked for, because a module with no test of its own produces no report, and :annotations would otherwise report a missing one on every whole-build run.

Measured on a full `./gradlew build --rerun-tasks --no-build-cache`, twelve modules with the JDK matrix: 167 s with -PenableJacoco=false, about 180 s on the new default, and 216 s with -PenableJacoco=true, which instruments the testJdk17, testJdk21, testJdk26 and testJdk28 runs as well. The default therefore costs around 8% of a full build and the aggregate configuration around 30%.

The base is the first ref that resolves of `-PdiffCoverageBase`, the upstream branch, and `origin/master`, and the diff is taken from its merge base with HEAD. A ref that resolves and shares no commit with HEAD, as in a shallow clone or after an orphan branch, gives no merge base and counts as no base at all, rather than failing a build whose tests passed. An upstream that is this branch's own pushed copy is left out: in a fork workflow the branch tracks the fork, so after the first push its upstream holds every line the branch changed, and the report would say nothing was changed rather than that it could not find a base. The remote name is dropped before that comparison, so a branch named after the tail of another one keeps its own upstream.

A diff line counts as a file header only inside the header section git opens with `diff --git`, and only as the `+++` directly under its `---`. Content carries both shapes: an added line reading `++ x` arrives as `+++ x`, and replacing a line `-- a/x` with a line `++ b/y` arrives as a whole well-formed header pair. Reading either as a header keys the rest of that file's hunks under a path no source root claims, which drops those lines from the report with nothing to show that it happened. Where two source roots are nested, the longer one keys the file, since the shorter one would leave its extra directories in the package path and match no JaCoCo entry. Both git commands run with core.quotePath off, since a path holding a non-ASCII byte otherwise arrives quoted and escaped, as `"b/src/café.java"`: such a `+++` line starts with a quotation mark rather than with the prefix, so it is no file header and every hunk of that file leaves the report silently, and the same path from ls-files names no file this JVM can open.

Only the files that still owe a test are described, so that the block reads as the work left rather than as an inventory of the change; the fully covered ones are counted in one line, which is what keeps "measured and fine" apart from "never measured". They are ordered by uncovered changed lines, then by uncovered branch outcomes, then by how much the file changed, then by path. The keys stay separate rather than summing into a score, because a line and a branch outcome are different things and any coefficient joining them would be invented, and the counts are absolute rather than shares, because the question is where the most work is left: 90 of 100 lines executed leaves ten lines to test and 1 of 2 leaves one, however much worse the second reads as a percentage. A filtered run says that the rest of the change looks unexecuted, because the scope alone has not stopped anyone quoting its total as the branch's.

Each file gets one row per uncovered line, carrying the line number, why the line counts as uncovered, and the source stripped and cut to 100 characters. The quote is what makes a row actionable with no editor open beside it. A line the run neither reached nor took a branch of is one line of work, so `194: not executed; 0 of 2 branches covered` is one row rather than an entry in each of two lists: reported twice, the line inflates every count that adds the rows up, and the branch list was a subset of the pair above it that a reader who added them up found inconsistent.

The block describes at most 10 files, at most 10 rows per file and at most 50 rows over its lists together, and -PdiffCoverageMaxFiles, -PdiffCoverageMaxLinesPerFile and -PdiffCoverageMaxLines move those limits. One budget covers the whole block rather than one per list, so that a block capped at 50 rows is 50 rows; the work is printed first, and the acknowledged lines below get what it leaves. A truncated list states its own total, and -PdiffCoverageShowAll prints the report whole.

What the limits leave out is in <module>/build/reports/diff-coverage/test.txt, whose path the block prints beside the JaCoCo XML's, so that reading the rest costs a file read rather than a parse of the XML. A run that measures nothing deletes that file, since a reader holding the path from an earlier run would otherwise read that run's report as this one's.

A comment acknowledges a line nothing covers: `throw new AssertionError(); // diff-coverage: ignore -- defensive safeguard` moves the line into a list of its own, so that the next reader does not weigh a line somebody has already decided about. It changes no count: the line still counts as unexecuted in the total, and `Uncovered changed code: 27 lines (1 acknowledged)` names how many of them carry a marker. The marker has to follow a comment opener on the line it acknowledges; nothing here parses Java, so a marker whose opener sits inside a string literal counts as well.

Each file's counts, and the total, carry branches beside lines. A line counts as executed once any path through it ran, so a changed condition tested one way reads as fully covered by line counts alone; the branch pair is what reports it. A change whose lines branch nowhere gets no branch pair rather than a 0/0 one.

Running the module's suite with -PdiffCoverageBase=ebd9b822~1, which makes the lines of the four commits since then count as changed, prints:

    Diff coverage against ebd9b822~1 (e97f8ff91), from :nullaway:test
      ordered by uncovered changed lines, then uncovered branches

      nullaway/src/main/java/com/uber/nullaway/librarymodel/AddAnnotationToNestedTypeVisitor.java
        6/9 changed lines executed, 4/6 branches covered
        uncovered changed code:
          140: 3 of 4 branches covered: if (wildcard.kind == BoundKind.UNBOUND && wildcard.bound == null) {
          149: not executed: updatedWildcard = (Type.WildcardType) wildcard.accept(this, pathIndex);
          152: 1 of 2 branches covered: if (wildcard.kind == BoundKind.UNBOUND) {
          161: not executed: Type updatedBound = TypeSubstitutionUtils.typeWithAnnot(wildcard.type, annotationType);
          162: not executed: updatedWildcard = TYPE_METADATA_BUILDER.createWildcardType(wildcard, updatedBound);

      nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
        39/40 changed lines executed, 22/28 branches covered
        uncovered changed code:
          888: 5 of 6 branches covered: if (type != null && type.isRaw() && !(type instanceof Type.ArrayType)) {
          1087: not executed: return typeOrNullIfRawNonArray(symbol.type);
          1705: 5 of 6 branches covered: if (!config.isJSpecifyMode() || targetType.isRaw() || referencedMethod.isConstructor()) {
          1720: 3 of 4 branches covered: if (qualifierType == null || qualifierType.isRaw()) {
          1725: 1 of 2 branches covered: if (qualifierType instanceof Type.ClassType qualifierClassType) {
          1734: 1 of 2 branches covered: !fiParamTypes.isEmpty(),
          1745: 1 of 2 branches covered: return methodType == null ? null : new ResolvedMethodReference(methodType, qualifierType);

      [GenericsUtils.java and NullAway.java, abridged here]

      nullaway/src/main/java/com/uber/nullaway/generics/TypeSubstitutionUtils.java
        1/1 changed lines executed, 1/2 branches covered
        uncovered changed code:
          153: 1 of 2 branches covered: Verify.verify(wildcard.kind == BoundKind.UNBOUND, "wildcard must be unbounded");

    Total: 78/82 changed lines executed, 47/60 branches covered.
    Uncovered changed code: 17 lines

    Full diff coverage report:
      nullaway/build/reports/diff-coverage/test.txt
    Full JaCoCo report:
      nullaway/build/reports/jacoco/test/jacocoTestReport.xml

The changed line of TypeSubstitutionUtils.java runs, so line counts alone report that file as covered; its branch row is what says the condition is exercised one way by the entire module suite. Running only GenericsTests against the same base reports 19/82 lines, and says under the header that a filtered run leaves the rest of the change looking unexecuted, which is the reading the scope line exists to prevent.

The buildSrc suite covers the format: the three row shapes, the quote at and past its width, each limit at and past its boundary, the one budget the two lists share, the marker and the four ways it does not fire, and the report file holding the rows the console left out. It takes a real diff of a path holding a non-ASCII byte, which reaches the parser as no file at all with core.quotePath left on. Removing the acknowledgement fails eight of those tests, giving the acknowledged list a budget of its own fails one, and cutting the quote a character early fails the boundary case. GitServiceTest covers the cache from both sides: a repeated command keeps the answer of its first run across a commit made between the two, and a command with different arguments does not.

Assisted-by: Claude Code (claude-opus-5)
