### PR TITLE
Report a type argument whose bound admits null where a non-null wildcard is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+* JSpecify: report a type argument whose declared upper bound admits null where a wildcard requires a non-null one, an assignment that was accepted silently before; for example a `Box<T>` with `T extends @Nullable Object` passed to a `Box<? extends Object>` parameter, a `Box<? extends T>` with the same `T` passed to the same parameter, or a `Box<S>` with `S extends @Nullable T` passed to a `Box<? extends T>` whose `T` cannot be null, by @vlsi (#1834)
+  - This also reaches override checks: an override returning `List<V>` where the overridden method returns `List<? extends @NonNull V>` now reports `mismatched type parameter nullability`, since `V` may be null and `@NonNull V` may not. Code that compiled clean can need a narrower return type or a suppression
 * Add `JSpecifyUnrecognizedAnnotationLocation`, an opt-in check that reports nullness annotations in locations JSpecify does not recognize (#1787)
 * Fix `RequireExplicitNullMarking` diagnostics repeating the check name, so a report no longer begins with `[RequireExplicitNullMarking] [RequireExplicitNullMarking]` (#1815)
 

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -8,6 +8,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.uber.nullaway.Config;
+import com.uber.nullaway.Nullness;
 import com.uber.nullaway.handlers.Handler;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -248,7 +249,12 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   /**
    * Returns whether a formal {@code ? extends S} contains the actual type argument on the right.
    * For concrete actuals {@code T}, wildcard actuals {@code ? extends T}, and non-extends wildcard
-   * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}.
+   * actuals whose effective upper bound is {@code T}, containment holds when {@code T <: S}. An
+   * actual that is a type variable with no annotation at the use site is judged by its own declared
+   * upper bound, for the same reason a wildcard is, unless {@code S} is itself a type variable.
+   * {@code S} then states a parametric requirement, admitting whatever it is instantiated as, so
+   * the two are compared as written; and an actual that may be null is contained only if {@code S}
+   * may be null too.
    *
    * @param lhsBound the effective upper bound {@code S} of the formal wildcard on the left
    * @param rhsTypeArgument the actual type argument on the right whose containment is checked
@@ -262,13 +268,70 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
   private boolean extendsBoundContains(
       Type lhsBound, Type rhsTypeArgument, Type.TypeVar correspondingTypeVariable) {
     Type.WildcardType rhsWildcard = GenericsUtils.asWildcard(rhsTypeArgument);
-    if (rhsWildcard != null) {
-      Type rhsUpperBound =
-          GenericsUtils.wildcardUpperBound(
-              rhsWildcard, correspondingTypeVariable, state, config, handler);
-      return typeArgumentSubtype(lhsBound, rhsUpperBound);
+    Type rhsUpperBound =
+        rhsWildcard == null
+            ? rhsTypeArgument
+            : GenericsUtils.wildcardUpperBound(
+                rhsWildcard, correspondingTypeVariable, state, config, handler);
+    if (lhsBound instanceof Type.TypeVar) {
+      return typeArgumentSubtype(lhsBound, rhsUpperBound)
+          // capture conversion drops type-use annotations, so a captured actual carries no
+          // nullness of its own to compare
+          && (rhsTypeArgument instanceof Type.CapturedType
+              || admitsNull(lhsBound)
+              || !admitsNull(rhsUpperBound));
     }
-    return typeArgumentSubtype(lhsBound, rhsTypeArgument);
+    return typeArgumentSubtype(lhsBound, typeComparedForNullness(rhsUpperBound));
+  }
+
+  /**
+   * Returns whether a value of {@code type} may be null: the use site says so, or it says nothing
+   * and the declared upper bound admits null.
+   *
+   * <p>This is the one question a parametric requirement still answers. {@code ? extends T} admits
+   * whatever {@code T} is instantiated as, so the actual is compared to {@code T} as written; but
+   * an actual that may be null where {@code T} may not is holding a null the requirement rejects,
+   * however the two names relate.
+   */
+  private boolean admitsNull(Type type) {
+    if (type instanceof Type.TypeVar typeVar && !hasNullnessAnnotation(type)) {
+      // the same answer as isNullableAnnotated(typeVariableUpperBound(typeVar)), without building
+      // the annotated bound to read one bit off it: that method annotates exactly when
+      // upperBoundIsNullable holds, which is itself true whenever the declared bound carries
+      // @Nullable
+      return GenericsUtils.upperBoundIsNullable(typeVar.asElement(), config, handler, state);
+    }
+    return genericsChecks.isNullableAnnotated(type);
+  }
+
+  /**
+   * Returns the type whose nullness stands for {@code type} in a containment comparison. A type
+   * variable carrying no nullness annotation at the use site admits null exactly when its declared
+   * upper bound does, so it is compared as that bound; every other type is compared as written.
+   *
+   * <p>A {@code Box<T>} declared with {@code T extends @Nullable Object} holds a null where a
+   * {@code Box<? extends Object>} may not, whatever the use site writes. A {@code @Nullable T} and
+   * a {@code @NonNull T} each carry their own nullness and are left alone.
+   *
+   * <p>This answers for an actual type argument compared against a concrete requirement. Where the
+   * requirement names a type variable, no bound stands in for it and the two types are compared as
+   * written; {@link #admitsNull(Type)} answers the nullness question there.
+   */
+  private Type typeComparedForNullness(Type type) {
+    if (type instanceof Type.TypeVar typeVar && !hasNullnessAnnotation(type)) {
+      return GenericsUtils.typeVariableUpperBound(typeVar, state, config, handler);
+    }
+    return type;
+  }
+
+  /**
+   * Returns whether {@code type} carries a {@code @Nullable} or a {@code @NonNull} annotation of
+   * its own. This asks about the type as written, not about whether the code around it is
+   * null-annotated, which is what {@link com.uber.nullaway.CodeAnnotationInfo} answers.
+   */
+  private boolean hasNullnessAnnotation(Type type) {
+    return genericsChecks.isNullableAnnotated(type)
+        || Nullness.hasNonNullAnnotation(type.getAnnotationMirrors().stream(), config);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -89,22 +89,37 @@ public class GenericsUtils {
       upperBound =
           formalTypeVar == null
               ? Symtab.instance(state.context).objectType
-              : formalTypeVar.getUpperBound();
-      // check if the upper bound should be treated as @Nullable, e.g., due to a library model or a
-      // type variable in @NullUnmarked code
-      if (formalTypeVar != null
-          && upperBoundIsNullable(formalTypeVar.asElement(), config, handler, state)
-          && !Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
-        upperBound =
-            TypeSubstitutionUtils.typeWithAnnot(
-                upperBound, GenericsChecks.getSyntheticNullableAnnotType(state));
-      }
+              : typeVariableUpperBound(formalTypeVar, state, config, handler);
     }
     if (upperBound instanceof WildcardType nestedWildcard) {
       return wildcardUpperBound(nestedWildcard, state, config, handler);
     }
     if (upperBound instanceof CapturedType capturedType && capturedType.wildcard != null) {
       return wildcardUpperBound(capturedType.wildcard, state, config, handler);
+    }
+    return upperBound;
+  }
+
+  /**
+   * Returns the upper bound of {@code typeVariable}, carrying {@code @Nullable} where that bound
+   * admits null.
+   *
+   * <p>The declared bound does not always say so itself: a library model may override it, and a
+   * type variable declared in unannotated code admits null whatever its bound reads. Where that
+   * holds, the returned type carries the annotation, so that one comparison serves a bound written
+   * as {@code @Nullable Object} and a bound that only behaves like one.
+   *
+   * <p>This describes the declaration and not a use of it. A {@code @Nullable T} carries its own
+   * nullness where it is written, and a caller that replaced it with this bound would discard what
+   * the reader wrote.
+   */
+  static Type typeVariableUpperBound(
+      Type.TypeVar typeVariable, VisitorState state, Config config, Handler handler) {
+    Type upperBound = typeVariable.getUpperBound();
+    if (upperBoundIsNullable(typeVariable.asElement(), config, handler, state)
+        && !Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+      return TypeSubstitutionUtils.typeWithAnnot(
+          upperBound, GenericsChecks.getSyntheticNullableAnnotType(state));
     }
     return upperBound;
   }

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/WildcardTests.java
@@ -1447,4 +1447,439 @@ public class WildcardTests extends NullAwayTestsBase {
         JSpecifyJavacConfig.withJSpecifyModeArgs(
             Arrays.asList("-XepOpt:NullAway:OnlyNullMarked=true")));
   }
+
+  @Test
+  public void aTypeVariableWhoseBoundAdmitsNullFailsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T extends @Nullable Object> void test(Box<T> b) {
+                // BUG: Diagnostic contains: incompatible types: Box<T> cannot be converted to Box<? extends Object>
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableWithANonNullBoundMeetsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T> void test(Box<T> b) {
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableWhoseBoundAdmitsNullMeetsANullableWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNullable(Box<? extends @Nullable Object> b) {}
+              static <T extends @Nullable Object> void test(Box<T> b) {
+                takeNullable(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNullableWrittenOnATypeVariableUseFailsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T> void test(Box<@Nullable T> b) {
+                // BUG: Diagnostic contains: incompatible types: Box<@Nullable T> cannot be converted to Box<? extends Object>
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNullableWrittenOnATypeVariableUseMeetsANullableWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNullable(Box<? extends @Nullable Object> b) {}
+              static <T> void test(Box<@Nullable T> b) {
+                takeNullable(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableMeetsAWildcardBoundedByThatSameTypeVariable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static <T extends @Nullable Object> Box<? extends T> test(Box<T> b) {
+                return b;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableMeetsAWildcardBoundedByThatSameTypeVariableUnderInference() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.concurrent.CompletableFuture;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            interface Test<V extends @Nullable Object> {
+              V load();
+              default CompletableFuture<? extends V> asyncLoad() {
+                return CompletableFuture.supplyAsync(() -> load());
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableWhoseBoundAdmitsNullMeetsAnUnboundedWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeAny(Box<?> b) {}
+              static <T extends @Nullable Object> void test(Box<T> b) {
+                takeAny(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableDeclaredInUnannotatedCodeFailsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NullUnmarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              @NullUnmarked
+              static class Holder<T> {
+                @NullMarked
+                void test(Box<T> b) {
+                  // BUG: Diagnostic contains: incompatible types: Box<T> cannot be converted to Box<? extends Object>
+                  takeNonNull(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableBoundedByAnotherWhoseBoundAdmitsNullFailsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T extends @Nullable Object, S extends T> void test(Box<S> b) {
+                // BUG: Diagnostic contains: incompatible types: Box<S> cannot be converted to Box<? extends Object>
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableMeetsAWildcardBoundedByTheVariableItExtends() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static class Holder<T extends @Nullable Object> {
+                void takeExtendsT(Box<? extends T> b) {}
+                <S extends T> void test(Box<S> b) {
+                  takeExtendsT(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNonNullWrittenOnATypeVariableUseMeetsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<T extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T extends @Nullable Object> void test(Box<@NonNull T> b) {
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aNullableWrittenOnATypeVariableUseFailsAWildcardBoundedByThatVariable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static class Holder<T extends @Nullable Object> {
+                void takeExtendsT(Box<? extends T> b) {}
+                void test(Box<@Nullable T> b) {
+                  // BUG: Diagnostic contains: incompatible types: Box<@Nullable T> cannot be converted to Box<? extends T>
+                  takeExtendsT(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableThatAdmitsNullFailsAWildcardBoundedByOneThatDoesNot() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static class Holder<T> {
+                void takeExtendsT(Box<? extends T> b) {}
+                <S extends @Nullable T> void test(Box<S> b) {
+                  // BUG: Diagnostic contains: incompatible types: Box<S> cannot be converted to Box<? extends T>
+                  takeExtendsT(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableThatAdmitsNoNullMeetsAWildcardBoundedByOneThatDoesNot() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static class Holder<T> {
+                void takeExtendsT(Box<? extends T> b) {}
+                <S extends T> void test(Box<S> b) {
+                  takeExtendsT(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aCapturedTypeArgumentMeetsANullnessAnnotatedTypeVariableRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Map;
+            import java.util.Set;
+            import java.util.concurrent.CompletableFuture;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            interface Test<K, V extends @Nullable Object> {
+              Map<? extends K, ? extends @NonNull V> loadAll(Set<? extends K> keys);
+              default CompletableFuture<? extends Map<? extends K, ? extends @NonNull V>> asyncLoadAll(
+                  Set<? extends K> keys) {
+                return CompletableFuture.supplyAsync(() -> loadAll(keys));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aCapturedTypeArgumentMeetsABareTypeVariableRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Map;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            interface Test<K, V extends @Nullable Object> {
+              Map<? extends K, ? extends V> loadAll();
+              default Map<? extends K, ? extends V> pass() {
+                return loadAll();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void aTypeVariableThatMayBeNullFailsANonNullAnnotatedWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static class Holder<T extends @Nullable Object> {
+                void takeExtendsNonNullT(Box<? extends @NonNull T> b) {}
+                void test(Box<T> b) {
+                  // BUG: Diagnostic contains: incompatible types: Box<T> cannot be converted to Box<? extends T>
+                  takeExtendsNonNullT(b);
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void anOverrideThatWidensANonNullProjectionInItsReturnTypeIsReported() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            interface Test<V extends @Nullable Object> {
+              List<? extends @NonNull V> get();
+              static <V extends @Nullable Object> Test<V> make() {
+                return new Test<>() {
+                  // BUG: Diagnostic contains: mismatched type parameter nullability
+                  @Override public List<V> get() {
+                    throw new UnsupportedOperationException();
+                  }
+                };
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void
+      aWildcardActualBoundedByATypeVariableThatAdmitsNullFailsANonNullWildcardRequirement() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              static class Box<E extends @Nullable Object> {}
+              static void takeNonNull(Box<? extends Object> b) {}
+              static <T extends @Nullable Object> void test(Box<? extends T> b) {
+                // BUG: Diagnostic contains: incompatible types: Box<? extends T> cannot be converted to Box<? extends Object>
+                takeNonNull(b);
+              }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
## Why

A `Box<T>` declared with `T extends @Nullable Object` was accepted where a `Box<? extends Object>` was required, so a null could reach a position that rejects one. A wildcard in that position is judged by its effective upper bound; a type variable was judged by the use site, which carries no nullness of its own, and every such call passed.

The defect has no diagnostic a reader could grep for: the symptom is the silence, and the code compiles clean today.

## What

`CheckIdenticalNullabilityVisitor` runs the actual type argument of an extends-bound containment through `typeComparedForNullness`, which takes a type variable carrying no nullness annotation as its declared upper bound and every other type as written. A `@Nullable T` and a `@NonNull T` are each compared as written, since either says what the declaration alone does not.

**A requirement that names a type variable is not read the same way.** `? extends T` admits whatever `T` is instantiated as, which is not what `T`'s declared bound admits, so no bound stands in for it and the two types are compared as written, exactly as on `master`.

That distinction is measured rather than assumed. Substituting the bound on both sides keeps `Box<T>` and `Box<S extends T>` assignable to a `Box<? extends T>`, and the Caffeine report below goes away either way — but it also silences the report that `Box<@Nullable T>` into `Box<? extends T>` draws on `master`, which `aNullableWrittenOnATypeVariableUseFailsAWildcardBoundedByThatVariable` pins.

**A parametric requirement is not a hole.** Whether either side may be null is decided separately, by `admitsNull`: a `Box<S>` declared with `S extends @Nullable T` holds a null where a `Box<? extends T>` may not when `T` itself cannot be null, however the two names relate, and that is reported. So the check keeps the report the substitution would have silenced and covers the shape the substitution was wanted for.

**A captured actual is the exception, and capture conversion is the reason.** javac's capture of `? extends @NonNull V` prints as `capture of ? extends V`, so the actual carries no nullness of its own and is taken as written. This is what Caffeine's `CacheLoader.asyncLoadAll` needs: a `Map<? extends K, ? extends @NonNull V>` returned into a `CompletableFuture<? extends Map<? extends K, ? extends @NonNull V>>` reaches the check as `Map<capture of ? extends K, capture of ? extends V>`. Scoping the exception to the annotation on the requirement instead would have been wider and would have kept `Box<T>` assignable to a `Box<? extends @NonNull T>`, which is now reported.

Resolving the requirement was what produced this, in Caffeine's `CacheLoader.asyncReload`, where `CompletableFuture.supplyAsync` infers `CompletableFuture<V>` against a `CompletableFuture<? extends V>`:

```text
CacheLoader.java:196: error: [NullAway] incompatible types: CompletableFuture<V> cannot be converted to CompletableFuture<? extends V>
```

`GenericsUtils.typeVariableUpperBound` holds the rule that decides whether a bound admits null: an explicit `@Nullable`, a library model that overrides the bound, or a declaration in unannotated code. It is factored out of `wildcardUpperBound`, so the two cannot drift apart.

This reports code that compiled clean before. Nothing in the test suite and nothing in NullAway's own sources was relying on the silence.

## Verification

Twenty new tests in `WildcardTests` establish which type arguments a wildcard formal contains once a type variable is the actual: the use site annotated `@Nullable`, `@NonNull`, or neither, against a requirement that is `? extends Object`, `? extends @Nullable Object`, `?`, or `? extends T`; a bound that admits null because the variable is declared in unannotated code rather than by an explicit `@Nullable`; a variable bounded by another such variable, on both sides of the decision; the reflexive `Box<T>` into `Box<? extends T>`, written directly and through the inference that produced the report above; both halves of the null-admittance decision under a parametric requirement, an actual that may be null where the requirement may not, and one that may not; a captured type argument against a requirement that names a type variable, bare and nullness-annotated; a bare actual against a requirement annotated `@NonNull`; and the same mismatch reached through the override reporter rather than an assignment; and a wildcard actual, rather than a bare type variable, whose bound admits null. They sit beside `unboundedWildcardFormalWithNullableTypeParameterBound`, which asks the same question with concrete actuals.

Every test is pinned to a production change that turns it red, each run under `--rerun --no-watch-fs`. Ten mutations were run in all; a nineteenth test survived every one of them and was deleted rather than kept as coverage it did not provide.

| Reverted | Turns red |
| --- | --- |
| The whole change | `aTypeVariableWhoseBoundAdmitsNullFailsANonNullWildcardRequirement`, `aTypeVariableBoundedByAnotherWhoseBoundAdmitsNullFailsANonNullWildcardRequirement`, `aTypeVariableDeclaredInUnannotatedCodeFailsANonNullWildcardRequirement` |
| `isParametricRequirement` | `aTypeVariableMeetsAWildcardBoundedByThatSameTypeVariable`, `aTypeVariableMeetsAWildcardBoundedByTheVariableItExtends` |
| The `@NonNull` clause of `hasNullnessAnnotation` | `aNonNullWrittenOnATypeVariableUseMeetsANonNullWildcardRequirement` |
| The `@Nullable` guard | `aNullableWrittenOnATypeVariableUseFailsANonNullWildcardRequirement` |
| The `admitsNull` conjunct | `aTypeVariableThatAdmitsNullFailsAWildcardBoundedByOneThatDoesNot`, `aTypeVariableThatAdmitsNoNullMeetsAWildcardBoundedByOneThatDoesNot` |
| Its requirement-side disjunct alone | `aTypeVariableMeetsAWildcardBoundedByThatSameTypeVariable`, `aTypeVariableMeetsAWildcardBoundedByTheVariableItExtends`, `aCapturedTypeArgumentMeetsABareTypeVariableRequirement` |
| The exemption for a captured actual | `aCapturedTypeArgumentMeetsANullnessAnnotatedTypeVariableRequirement` |
| The whole change, on the wildcard-actual shape | `aWildcardActualBoundedByATypeVariableThatAdmitsNullFailsANonNullWildcardRequirement` |
| The `@NonNull` clause, second site | `aTypeVariableThatMayBeNullFailsANonNullAnnotatedWildcardRequirement`, `anOverrideThatWidensANonNullProjectionInItsReturnTypeIsReported` |
| The feature written naively, rejecting every nullable-bounded actual | `aTypeVariableWhoseBoundAdmitsNullMeetsANullableWildcardRequirement`, `aNullableWrittenOnATypeVariableUseMeetsANullableWildcardRequirement`, `aTypeVariableWhoseBoundAdmitsNullMeetsAnUnboundedWildcardRequirement` |
| The bound taken as nullable unconditionally | `aTypeVariableWithANonNullBoundMeetsANonNullWildcardRequirement` |

`aTypeVariableMeetsAWildcardBoundedByThatSameTypeVariableUnderInference` fails against none of these; it fails against the commit that first introduced the check, together with the Caffeine source verbatim, and is kept as the regression test for that report. `:nullaway:test` is 1118 green; `:nullaway:buildWithNullAway` and `spotlessCheck` pass.

## What this newly reports

The check is shared with the override reporter, so a `@NonNull` projection in an overridden return type is now enforced. Caffeine's `AsyncCacheLoader.bulk` is the case found in the wild:

```java
static <K, V extends @Nullable Object> AsyncCacheLoader<K, V> bulk(...) {
  return new AsyncCacheLoader<>() {
    @Override public CompletableFuture<Map<K, V>> asyncLoadAll(Set<? extends K> keys, Executor executor) { ... }
  };
}
```

The interface declares `CompletableFuture<? extends Map<? extends K, ? extends @NonNull V>>`. The override's `Map<K, V>` has a value type that may be null where the contract says it may not, so a caller holding an `AsyncCacheLoader<K, @Nullable String>` is promised non-null values and can be handed nulls. `GenericInheritanceTests.nonnullInExtends` and `annotOnTypeVarStillWins` already fix the project's reading of `@NonNull T` as a strict non-null projection, which is what makes this a report rather than a false positive. The body already carries `@SuppressWarnings("unchecked")` on the cast that produces the wider type.

Code that compiled clean can need a narrower return type or a suppression. The changelog says so.

## Scope

`ConstraintSolverImpl` builds its own constraints from wildcard upper bounds and never routes a bare type variable through `typeComparedForNullness`, so a nullable-bounded type variable inferred into a non-null `? extends` position may still go unreported. `superWildcardContains` does not resolve a type-variable operand either; `? super S` containment holds only for an actual equal to `S` or a `? super` wildcard, so reaching it with a bare type variable whose bound admits null needs javac to accept a `Box<T>` for a `Box<? super Object>`, which it does not.

`GenericsChecks` re-derives "does this bound admit null" by hand in three places that the extraction did not unify. That is a follow-up.

Two partitions of the new arm are unclaimed for want of an input: a requirement whose effective upper bound is itself a captured type, and a `? super` actual against a requirement that names a type variable.

The library-model rule in `typeVariableUpperBound` has no test through the new caller, and the reason is that no input was found that reaches it. A library model keys a nullable upper bound to a class and a type-parameter index, so it applies to that class's own type variable; by the time checked code presents a type argument, the variable has been substituted. Instrumenting the rule across `:nullaway:test` produced 39 hits, every one of them through `wildcardUpperBound` or the override check and none through `admitsNull` or `typeComparedForNullness`. The rule is exercised on its existing callers, which the extraction left behaving as before.

This is the first commit of #1828 as a standalone change, plus the fix for the Caffeine report. #1828 rewrites the message text of the same diagnostic and touches `CheckIdenticalNullabilityVisitor`, `GenericsChecks` and `WildcardTests`; it carries the false positive above, so it wants this one first.
