### PR TITLE
Print the failure message and stack trace for a failing test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,19 @@ subprojects { project ->
 
     tasks.withType(Test).configureEach {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        // A failed test has to be diagnosable from the console alone: CI runs `./gradlew build`
+        // and publishes no test report, so the log is all a reader gets.  Gradle's default logging
+        // names the exception class and the line of the test method and drops the message, which
+        // for a NullAway compilation test throws away the entire diagnosis.
+        testLogging {
+            exceptionFormat = 'full'
+            // The top-level settings above configure the lifecycle log level only, so a run under
+            // --quiet, as agents make, would otherwise report a failure count and nothing else.
+            quiet {
+                events 'failed'
+                exceptionFormat = 'full'
+            }
+        }
     }
 
     repositories {


### PR DESCRIPTION
## Why

Gradle's default test logging prints the exception class and the line of the test method and drops the message, so a failing test in CI showed only:

```
ArrayTests > arrayDeclarationAnnotation FAILED
    com.google.common.truth.AssertionErrorWithFacts at ArrayTests.java:49
```

`continuous-integration.yml` runs `./gradlew build` and no step uploads a test report, so that line is everything a reader gets. For a NullAway compilation test the entire diagnosis is the `Did not see an error on line N matching ...` message and the diagnostics that were emitted instead, none of which appears. Under `--quiet` there was no per-test output at all, only `3 tests completed, 3 failed`.

## What

`exceptionFormat = 'full'` on every `Test` task, which restores both the message and the stack:

```
ZzDemoFailureTest > compilationExpectationMismatch FAILED
    Did not see an error on line 7 matching this text will never match. All errors:
    /Test.java:7: warning: [NullAway] dereferenced expression 's' is @Nullable
          s.length();
           ^
        at com.google.errorprone.DiagnosticTestHelper.assertHasDiagnosticOnAllMatchingLines(...)
        at com.uber.nullaway.ZzDemoFailureTest.compilationExpectationMismatch(...)
```

`testLogging`'s top-level settings configure the lifecycle log level alone, so `--quiet` needs a block of its own, and that block has to name `events 'failed'` because the quiet level logs no test events at all.

The block goes in the `subprojects` closure of the root build rather than in `nullaway.java-test-conventions`: `sample` has tests and does not apply that plugin.

Nothing sets `showCauses` or `stackTraceFilters`. Both defaults were checked against the alternative: nested causes are already printed with indented `Caused by:` blocks, and the default `TRUNCATE` filter keeps every frame between the test method and the throw site while dropping the JUnit and Gradle runner frames. Clearing the filter list turned an 8-line trace into 52 lines of `jdk.internal.reflect` and `org.gradle.api.internal.tasks.testing` frames and revealed nothing extra; `ENTRY_POINT` collapses the trace to the single test-method frame and hides the throw site.

## Verification

Checked by hand against a temporary test class, not committed, covering a JUnit comparison failure, an exception with two nested causes, a `CompilationTestHelper` expectation mismatch, and an exception thrown three calls deep inside a lambda. Each was run under `--console=plain` and under `--quiet`, and the last one under each of `stackTraceFilters` unset, `'ENTRY_POINT'`, and `= []` to settle the paragraph above. The `sample` gap was confirmed the same way, with a failing test in `sample/src/test`. `./gradlew :nullaway:test` passes.

## Scope

Build configuration only, so no changelog entry. Test output on a *passing* run is unchanged: no `events` are added at the lifecycle level, so a green build logs nothing new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test failure output by displaying complete exception details, including in quiet-mode test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->