### PR TITLE
Require every element of an intersection bound to be @Nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 
 * Add `JSpecifyUnrecognizedAnnotationLocation`, an opt-in check that reports nullness annotations in locations JSpecify does not recognize (#1787)
 * Fix `RequireExplicitNullMarking` diagnostics repeating the check name, so a report no longer begins with `[RequireExplicitNullMarking] [RequireExplicitNullMarking]` (#1815)
+* Fix handling of type variables whose upper bound is an intersection: such a bound includes `null` only when every one of its elements is annotated `@Nullable` (#1836)
 
 Version 0.14.1
 --------------

--- a/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
+++ b/nullaway/src/main/java/com/uber/nullaway/NullabilityUtil.java
@@ -465,6 +465,19 @@ public class NullabilityUtil {
    *     type, false otherwise
    */
   private static boolean isDirectTypeUseAnnotation(Attribute.TypeCompound t, Symbol symbol) {
+    return isDirectTypeUseAnnotation(t, symbol.type);
+  }
+
+  /**
+   * Check whether a type-use annotation should be treated as applying directly to {@code type}
+   * rather than to something nested inside it.
+   *
+   * @param t the annotation and its position in the type
+   * @param type the annotated type
+   * @return {@code true} if the annotation should be treated as applying directly to the top-level
+   *     type, false otherwise
+   */
+  public static boolean isDirectTypeUseAnnotation(Attribute.TypeCompound t, Type type) {
     // location is a list of TypePathEntry objects, indicating whether the annotation is
     // on an array, inner type, wildcard, or type argument. If it's empty, then the
     // annotation is directly on the type.
@@ -487,11 +500,11 @@ public class NullabilityUtil {
       }
     }
     // For non-nested classes annotations apply to the innermost type.
-    if (!isTypeOfNestedClass(symbol.type)) {
+    if (!isTypeOfNestedClass(type)) {
       return true;
     }
     // For nested classes the annotation is only valid if it is on the innermost type.
-    return innerTypeCount == getNestingDepth(symbol.type) - 1;
+    return innerTypeCount == getNestingDepth(type) - 1;
   }
 
   private static int getNestingDepth(Type type) {

--- a/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/CheckIdenticalNullabilityVisitor.java
@@ -191,8 +191,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * nullability.
    */
   private boolean haveIdenticalNullability(Type lhsType, Type rhsType) {
-    boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsType);
-    boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsType);
+    boolean isLHSNullableAnnotated = GenericsUtils.isNullableAnnotated(lhsType, config);
+    boolean isRHSNullableAnnotated = GenericsUtils.isNullableAnnotated(rhsType, config);
     if (isLHSNullableAnnotated != isRHSNullableAnnotated) {
       return false;
     }
@@ -302,8 +302,8 @@ public class CheckIdenticalNullabilityVisitor extends Types.DefaultTypeVisitor<B
    * checks.
    */
   private boolean typeArgumentSubtype(Type lhsType, Type rhsType) {
-    boolean isLHSNullableAnnotated = genericsChecks.isNullableAnnotated(lhsType);
-    boolean isRHSNullableAnnotated = genericsChecks.isNullableAnnotated(rhsType);
+    boolean isLHSNullableAnnotated = GenericsUtils.isNullableAnnotated(lhsType, config);
+    boolean isRHSNullableAnnotated = GenericsUtils.isNullableAnnotated(rhsType, config);
     if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
       return false;
     }

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsChecks.java
@@ -304,9 +304,7 @@ public final class GenericsChecks {
     for (int i = 0; i < baseTypeArgs.size(); i++) {
       Type typeVariable = baseTypeArgs.get(i);
       Type upperBound = typeVariable.getUpperBound();
-      com.sun.tools.javac.util.List<Attribute.TypeCompound> annotationMirrors =
-          upperBound.getAnnotationMirrors();
-      if (Nullness.hasNullableAnnotation(annotationMirrors.stream(), config)
+      if (GenericsUtils.isNullableAnnotated(upperBound, config)
           || handler.onOverrideClassTypeVariableUpperBound(type.tsym.toString(), i)) {
         result[i] = true;
       }
@@ -318,16 +316,67 @@ public final class GenericsChecks {
     com.sun.tools.javac.util.List<Attribute.TypeCompound> rawTypeAttributes =
         tsym.getRawTypeAttributes();
     if (rawTypeAttributes != null) {
+      Map<Integer, Set<Integer>> nullableBoundsPerTypeParam = new LinkedHashMap<>();
       for (Attribute.TypeCompound typeCompound : rawTypeAttributes) {
-        if (typeCompound.position.type.equals(TargetType.CLASS_TYPE_PARAMETER_BOUND)
-            && Nullness.isNullableAnnotation(
+        if (!typeCompound.position.type.equals(TargetType.CLASS_TYPE_PARAMETER_BOUND)
+            || !Nullness.isNullableAnnotation(
                 typeCompound.type.tsym.getQualifiedName().toString(), config)) {
-          int index = typeCompound.position.parameter_index;
-          result[index] = true;
+          continue;
+        }
+        int typeParamIndex = typeCompound.position.parameter_index;
+        Type bound =
+            boundAt(
+                baseTypeArgs.get(typeParamIndex).getUpperBound(),
+                typeCompound.position.bound_index);
+        // The annotation may sit on a type argument nested inside the bound, or on an enclosing
+        // type of a nested-class bound, rather than on the bound itself.
+        if (bound != null && NullabilityUtil.isDirectTypeUseAnnotation(typeCompound, bound)) {
+          nullableBoundsPerTypeParam
+              .computeIfAbsent(typeParamIndex, k -> new LinkedHashSet<>())
+              .add(typeCompound.position.bound_index);
         }
       }
+      nullableBoundsPerTypeParam.forEach(
+          (index, nullableBounds) ->
+              result[index] |=
+                  nullableBounds.size() == boundCount(baseTypeArgs.get(index).getUpperBound()));
     }
     return result;
+  }
+
+  /**
+   * Returns the bound that {@code boundIndex} names in a {@code CLASS_TYPE_PARAMETER_BOUND}
+   * type-annotation position, or {@code null} if the index names no bound of an intersection. The
+   * type path of such an annotation is relative to that one bound, so it cannot be read against the
+   * intersection. A type variable with a single bound has only that bound, which is returned for
+   * any index.
+   *
+   * <p>javac numbers the bounds of an intersection in declaration order, giving index 0 to the
+   * class bound. Where the declaration has none, index 0 goes to the implicit {@code Object}
+   * supertype and the declared bounds start at 1.
+   */
+  private static @Nullable Type boundAt(Type upperBound, int boundIndex) {
+    if (!(upperBound instanceof Type.IntersectionClassType intersectionType)) {
+      return upperBound;
+    }
+    com.sun.tools.javac.util.List<Type> bounds = intersectionType.getExplicitComponents();
+    int position = boundIndex - (intersectionType.allInterfaces ? 1 : 0);
+    return position >= 0 && position < bounds.size() ? bounds.get(position) : null;
+  }
+
+  /**
+   * Returns the number of bounds declared for a type variable with the given upper bound. An
+   * intersection bound includes {@code null} only when every one of these bounds is annotated
+   * {@code @Nullable}.
+   *
+   * <p>An intersection whose bounds are all interfaces carries an implicit {@code Object} supertype
+   * that the declaration did not write, hence {@code getExplicitComponents()}. It occupies {@code
+   * bound_index} 0 but never carries an annotation; see {@link #boundAt}.
+   */
+  private static int boundCount(Type upperBound) {
+    return upperBound instanceof Type.IntersectionClassType intersectionType
+        ? intersectionType.getExplicitComponents().size()
+        : 1;
   }
 
   /**
@@ -373,10 +422,8 @@ public final class GenericsChecks {
       if (nullableTypeArguments.containsKey(i)) {
         Type typeVariable = baseTypeVariables.get(i);
         Type upperBound = typeVariable.getUpperBound();
-        com.sun.tools.javac.util.List<Attribute.TypeCompound> annotationMirrors =
-            upperBound.getAnnotationMirrors();
         boolean hasNullableAnnotation =
-            Nullness.hasNullableAnnotation(annotationMirrors.stream(), config)
+            GenericsUtils.isNullableAnnotated(upperBound, config)
                 || handler.onOverrideClassTypeVariableUpperBound(baseType.tsym.toString(), i);
         // if type variable's upper bound does not have @Nullable annotation then the instantiation
         // is invalid
@@ -1988,16 +2035,21 @@ public final class GenericsChecks {
 
   private Type updateTypeWithNullness(
       VisitorState state, Type argumentType, Nullness refinedNullness) {
+    // Both branches act on the top-level annotation of argumentType, so they read the mirrors
+    // rather than going through GenericsUtils#isNullableAnnotated: removeNullableAnnotation
+    // requires a top-level annotation to be present, which an intersection never has.
+    boolean hasNullableAnnotation =
+        Nullness.hasNullableAnnotation(argumentType.getAnnotationMirrors().stream(), config);
     if (NullabilityUtil.nullnessToBool(refinedNullness)) {
       // refine to @Nullable
-      if (isNullableAnnotated(argumentType)) {
+      if (hasNullableAnnotation) {
         return argumentType;
       }
       return TypeSubstitutionUtils.typeWithAnnot(
           argumentType, getSyntheticNullableAnnotType(state));
     } else {
       // refine to @NonNull, by removing the top-level @Nullable annotation if present.
-      if (!isNullableAnnotated(argumentType)) {
+      if (!hasNullableAnnotation) {
         return argumentType;
       }
       return TypeSubstitutionUtils.removeNullableAnnotation(argumentType, config);
@@ -2131,8 +2183,8 @@ public final class GenericsChecks {
       Type.ArrayType rhsArrayType = (Type.ArrayType) rhsType;
       Type lhsComponentType = lhsArrayType.getComponentType();
       Type rhsComponentType = rhsArrayType.getComponentType();
-      boolean isLHSNullableAnnotated = isNullableAnnotated(lhsComponentType);
-      boolean isRHSNullableAnnotated = isNullableAnnotated(rhsComponentType);
+      boolean isLHSNullableAnnotated = GenericsUtils.isNullableAnnotated(lhsComponentType, config);
+      boolean isRHSNullableAnnotated = GenericsUtils.isNullableAnnotated(rhsComponentType, config);
       // an array of @Nullable references is _not_ a subtype of an array of @NonNull references
       if (isRHSNullableAnnotated && !isLHSNullableAnnotated) {
         return false;
@@ -2758,7 +2810,7 @@ public final class GenericsChecks {
       return true;
     }
     Type upperBound = substitutedTypeVar.getUpperBound();
-    if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+    if (GenericsUtils.isNullableAnnotated(upperBound, config)) {
       return true;
     }
     if (Nullness.hasNonNullAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
@@ -2775,7 +2827,7 @@ public final class GenericsChecks {
     List<Symbol.TypeVariableSymbol> originalTypeParams = overriddenMethod.getTypeParameters();
     Type originalBound =
         (Type) ((TypeVariable) originalTypeParams.get(typeVarIndex).asType()).getUpperBound();
-    if (Nullness.hasNullableAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
+    if (GenericsUtils.isNullableAnnotated(originalBound, config)) {
       return true;
     }
     if (Nullness.hasNonNullAnnotation(originalBound.getAnnotationMirrors().stream(), config)) {
@@ -3587,12 +3639,7 @@ public final class GenericsChecks {
    * @return Returns the Nullness of the type based on the Nullability annotation.
    */
   private Nullness getTypeNullness(Type type) {
-    boolean hasNullableAnnotation =
-        Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
-    if (hasNullableAnnotation) {
-      return Nullness.NULLABLE;
-    }
-    return Nullness.NONNULL;
+    return GenericsUtils.isNullableAnnotated(type, config) ? Nullness.NULLABLE : Nullness.NONNULL;
   }
 
   /**
@@ -3724,10 +3771,6 @@ public final class GenericsChecks {
     inferredVarLocalTypes.clear();
     varLocalDeclarations.clear();
     nestedNullabilityRepairInProgress.clear();
-  }
-
-  public boolean isNullableAnnotated(Type type) {
-    return Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
   }
 
   /**

--- a/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
+++ b/nullaway/src/main/java/com/uber/nullaway/generics/GenericsUtils.java
@@ -94,7 +94,7 @@ public class GenericsUtils {
       // type variable in @NullUnmarked code
       if (formalTypeVar != null
           && upperBoundIsNullable(formalTypeVar.asElement(), config, handler, state)
-          && !Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+          && !isNullableAnnotated(upperBound, config)) {
         upperBound =
             TypeSubstitutionUtils.typeWithAnnot(
                 upperBound, GenericsChecks.getSyntheticNullableAnnotType(state));
@@ -116,7 +116,8 @@ public class GenericsUtils {
    * library model overrides the bound nullability for the type variable, or when the declared upper
    * bound has an explicit {@code @Nullable} annotation. An explicit {@code @NonNull} annotation on
    * a type-variable bound takes precedence over nullability inherited from that type variable's
-   * upper bound.
+   * upper bound. An intersection bound is nullable only when every one of its elements is; see
+   * {@link #isNullableAnnotated}.
    */
   static boolean upperBoundIsNullable(
       Element typeVarElement, Config config, Handler handler, VisitorState state) {
@@ -144,7 +145,7 @@ public class GenericsUtils {
       }
     }
     Type upperBound = (Type) ((TypeVariable) typeVarElement.asType()).getUpperBound();
-    if (Nullness.hasNullableAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
+    if (isNullableAnnotated(upperBound, config)) {
       return true;
     }
     if (Nullness.hasNonNullAnnotation(upperBound.getAnnotationMirrors().stream(), config)) {
@@ -154,6 +155,27 @@ public class GenericsUtils {
       return upperBoundIsNullable(upperBound.asElement(), config, handler, state);
     }
     return false;
+  }
+
+  /**
+   * Returns true if {@code type} carries a {@code @Nullable} annotation, treating an intersection
+   * type as {@code @Nullable} only when every one of its elements is.
+   *
+   * <p>JSpecify assigns a nullness operator to each element of an intersection type separately, and
+   * fixes the operator of the intersection as a whole to {@code NO_CHANGE}; javac stores type
+   * annotations on the elements, and an {@code IntersectionClassType} cannot carry one at all. A
+   * type variable is null-exclusive as soon as one element of its bound is, since that element
+   * still establishes a nullness-subtyping edge. See the <a
+   * href="https://jspecify.dev/docs/spec/#intersection-types">JSpecify specification</a>.
+   */
+  static boolean isNullableAnnotated(Type type, Config config) {
+    if (type instanceof Type.IntersectionClassType intersectionType) {
+      return intersectionType.getExplicitComponents().stream()
+          .allMatch(
+              element ->
+                  Nullness.hasNullableAnnotation(element.getAnnotationMirrors().stream(), config));
+    }
+    return Nullness.hasNullableAnnotation(type.getAnnotationMirrors().stream(), config);
   }
 
   private static boolean fromUnannotatedMethodOrClass(

--- a/nullaway/src/test/java/com/uber/nullaway/jspecify/IntersectionBoundTests.java
+++ b/nullaway/src/test/java/com/uber/nullaway/jspecify/IntersectionBoundTests.java
@@ -1,0 +1,434 @@
+package com.uber.nullaway.jspecify;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.uber.nullaway.NullAwayTestsBase;
+import com.uber.nullaway.generics.JSpecifyJavacConfig;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * A type variable whose upper bound is an intersection type includes {@code null} only when every
+ * element of the intersection is annotated {@code @Nullable}. JSpecify assigns a nullness operator
+ * to each element separately, so one non-null element makes the whole bound null-exclusive.
+ *
+ * <p>The bounds these tests read from bytecode are declared in {@code
+ * com.uber.lib.generics.IntersectionTypeParam}, {@code com.uber.lib.generics.InnerClassBound}, and
+ * {@code com.uber.lib.generics.NestedNullableInBound}. Before JDK 22, javac drops the annotations
+ * on such a bound (<a href="https://bugs.openjdk.org/browse/JDK-8225377">JDK-8225377</a>), and
+ * NullAway falls back on the raw type attributes of the class file, which number the bounds of an
+ * intersection separately.
+ *
+ * <p>These tests never run without that bug's workaround: {@code JSpecifyJavacConfig} passes {@code
+ * -XDaddTypeAnnotationsToSymbol=true}, so the annotation mirrors answer on every JDK the suite runs
+ * on. The fallback can only turn a non-null verdict into a nullable one, so what the bytecode tests
+ * pin is that it adds nothing it should not; a fallback that stopped supplying nullability
+ * altogether fails none of them.
+ */
+public class IntersectionBoundTests extends NullAwayTestsBase {
+
+  @Test
+  public void allNullableIntersectionBoundAcceptsNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends @Nullable Object & @Nullable Serializable> {}
+              static void test(Box<@Nullable String> b) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nonNullFirstElementRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends Object & @Nullable Serializable> {}
+              // BUG: Diagnostic contains: type variable T of type com.uber.Test.Box does not have a @Nullable upper bound
+              static void test(Box<@Nullable String> b) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nonNullLaterElementRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends @Nullable Object & Serializable> {}
+              // BUG: Diagnostic contains: type variable T of type com.uber.Test.Box does not have a @Nullable upper bound
+              static void test(Box<@Nullable String> b) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void intersectionBoundWithNoNullableElementRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends Serializable & CharSequence> {}
+              // BUG: Diagnostic contains: type variable T of type com.uber.Test.Box does not have a @Nullable upper bound
+              static void test(Box<@Nullable String> b) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void allNullableIntersectionBoundAcceptsNullableTypeArgumentOnGenericMethodCall() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static <T extends @Nullable Object & @Nullable Serializable> void box(T t) {}
+              static void test() {
+                Test.<@Nullable String>box(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void intersectionBoundWithNonNullElementRefusesNullableTypeArgumentOnGenericMethodCall() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static <T extends @Nullable Object & Serializable> void box(T t) {}
+              static void test() {
+                // BUG: Diagnostic contains: method <T>box(T)'s type variable T is not @Nullable
+                Test.<@Nullable String>box(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void allNullableInterfaceOnlyBoundAcceptsNullableTypeArgumentOnGenericMethodCall() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static <T extends @Nullable Serializable & @Nullable CharSequence> void box(T t) {}
+              static void test() {
+                Test.<@Nullable String>box(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void interfaceOnlyBoundWithNonNullElementRefusesNullableTypeArgumentOnGenericMethodCall() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static <T extends @Nullable Serializable & CharSequence> void box(T t) {}
+              static void test() {
+                // BUG: Diagnostic contains: method <T>box(T)'s type variable T is not @Nullable
+                Test.<@Nullable String>box(null);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void readThroughWildcardWithAllNullableIntersectionBoundIsNullable() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends @Nullable Object & @Nullable Serializable> {
+                T get() { throw new RuntimeException(); }
+              }
+              static void test(Box<?> b) {
+                // BUG: Diagnostic contains: dereferenced expression 'b.get()' is @Nullable
+                b.get().toString();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void readThroughWildcardWithNonNullElementInBoundIsNonNull() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static class Box<T extends @Nullable Object & Serializable> {
+                T get() { throw new RuntimeException(); }
+              }
+              static void test(Box<?> b) {
+                b.get().toString();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideNarrowingIntersectionBoundIsRefused() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo {
+                <T extends @Nullable Object & @Nullable Serializable> void bar(T arg);
+              }
+              static class Baz implements Foo {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a non-null upper bound
+                public <T extends @Nullable Object & Serializable> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideWideningIntersectionBoundIsRefused() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo {
+                <T extends @Nullable Object & Serializable> void bar(T arg);
+              }
+              static class Baz implements Foo {
+                @Override
+                // BUG: Diagnostic contains: Method type variable T has a @Nullable upper bound
+                public <T extends @Nullable Object & @Nullable Serializable> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void overrideRepeatingIntersectionBoundIsAccepted() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import java.io.Serializable;
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            @NullMarked
+            class Test {
+              interface Foo {
+                <T extends @Nullable Object & @Nullable Serializable> void bar(T arg);
+              }
+              static class Baz implements Foo {
+                @Override
+                public <T extends @Nullable Object & @Nullable Serializable> void bar(T arg) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void allNullableIntersectionBoundFromBytecodeAcceptsNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.IntersectionTypeParam;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static void test(
+                  IntersectionTypeParam<
+                      // E1's class bound and interface bound are both @Nullable.
+                      @Nullable String,
+                      String,
+                      String,
+                      // E4 has no class bound, and both of its interface bounds are @Nullable.
+                      @Nullable String,
+                      String,
+                      // E6 has three elements, all @Nullable.
+                      @Nullable String,
+                      String,
+                      String> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void intersectionBoundFromBytecodeWithNonNullElementRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.IntersectionTypeParam;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static void test(
+                  IntersectionTypeParam<
+                      String,
+                      // E2's class bound is @Nullable and its interface bound is not.
+                      // BUG: Diagnostic contains: type variable E2 of type com.uber.lib.generics.IntersectionTypeParam
+                      @Nullable String,
+                      // E3's interface bound is @Nullable and its class bound is not.
+                      // BUG: Diagnostic contains: type variable E3 of type com.uber.lib.generics.IntersectionTypeParam
+                      @Nullable String,
+                      String,
+                      // E5 has no class bound, and one of its interface bounds is not @Nullable.
+                      // BUG: Diagnostic contains: type variable E5 of type com.uber.lib.generics.IntersectionTypeParam
+                      @Nullable String,
+                      String,
+                      // E7 has no @Nullable element at all.
+                      // BUG: Diagnostic contains: type variable E7 of type com.uber.lib.generics.IntersectionTypeParam
+                      @Nullable String,
+                      // E8 has three elements, and one of them is not @Nullable.
+                      // BUG: Diagnostic contains: type variable E8 of type com.uber.lib.generics.IntersectionTypeParam
+                      @Nullable String> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void innerClassBoundFromBytecodeAcceptsNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.InnerClassBound;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              static void test(InnerClassBound.Box<InnerClassBound.@Nullable Inner> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void annotationOnEnclosingTypeOfBoundFromBytecodeRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.InnerClassBound;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              // BUG: Diagnostic contains: type variable T of type com.uber.lib.generics.InnerClassBound.OuterAnnotatedBox
+              static void test(InnerClassBound.OuterAnnotatedBox<InnerClassBound.@Nullable Inner> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void
+      annotationOnEnclosingTypeOfIntersectionElementFromBytecodeRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.InnerClassBound;
+            import com.uber.lib.generics.InnerClassBound.OuterAnnotatedIntersectionBox;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              // BUG: Diagnostic contains: type variable T of type com.uber.lib.generics.InnerClassBound.OuterAnnotatedIntersectionBox
+              static void test(OuterAnnotatedIntersectionBox<InnerClassBound.@Nullable Inner> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void boundWithNullableTypeArgumentFromBytecodeRefusesNullableTypeArgument() {
+    makeHelper()
+        .addSourceLines(
+            "Test.java",
+            """
+            package com.uber;
+            import com.uber.lib.generics.NestedNullableInBound;
+            import java.util.List;
+            import org.jspecify.annotations.Nullable;
+            class Test {
+              interface Strings extends List<@Nullable String> {}
+              // BUG: Diagnostic contains: type variable T of type com.uber.lib.generics.NestedNullableInBound
+              static void test(NestedNullableInBound<@Nullable Strings> p) {}
+            }
+            """)
+        .doTest();
+  }
+
+  private CompilationTestHelper makeHelper() {
+    return makeTestHelperWithArgs(
+        JSpecifyJavacConfig.withJSpecifyModeArgs(
+            List.of("-XepOpt:NullAway:AnnotatedPackages=com.uber")));
+  }
+}

--- a/test-java-lib/src/main/java/com/uber/lib/generics/InnerClassBound.java
+++ b/test-java-lib/src/main/java/com/uber/lib/generics/InnerClassBound.java
@@ -1,0 +1,37 @@
+package com.uber.lib.generics;
+
+import java.io.Serializable;
+import org.jspecify.annotations.Nullable;
+
+/** Holder for the inner class {@link Inner} that the type parameters below are bounded by. */
+public class InnerClassBound {
+
+  // Deliberately an inner class: only an inner class puts INNER_TYPE on the bound's type path.
+  @SuppressWarnings("ClassCanBeStatic")
+  public class Inner implements Serializable {}
+
+  /**
+   * A type parameter bounded by an inner class, used to test bounds read from bytecode. javac
+   * records such an annotation at a type path of {@code INNER_TYPE}, which still applies to the
+   * bound itself, so {@code T} includes {@code null}.
+   */
+  public static class Box<T extends InnerClassBound.@Nullable Inner> {}
+
+  /**
+   * A type parameter whose annotation qualifies the enclosing type rather than the bound, so {@code
+   * T} excludes {@code null}. javac records it with an empty type path, the shape the annotation on
+   * a top-level bound has, which is what a check that reads the type path against the whole
+   * intersection cannot tell apart.
+   */
+  @SuppressWarnings({"NullableOnContainingClass", "NullAway"}) // the misplacement is the fixture
+  public static class OuterAnnotatedBox<T extends @Nullable InnerClassBound.Inner> {}
+
+  /**
+   * The intersection form of {@link OuterAnnotatedBox}. Both bounds are annotated, but only the
+   * annotation on {@code Serializable} reaches the bound it is written on, so {@code T} excludes
+   * {@code null}.
+   */
+  @SuppressWarnings({"NullableOnContainingClass", "NullAway"}) // the misplacement is the fixture
+  public static class OuterAnnotatedIntersectionBox<
+      T extends @Nullable InnerClassBound.Inner & @Nullable Serializable> {}
+}

--- a/test-java-lib/src/main/java/com/uber/lib/generics/IntersectionTypeParam.java
+++ b/test-java-lib/src/main/java/com/uber/lib/generics/IntersectionTypeParam.java
@@ -1,0 +1,21 @@
+package com.uber.lib.generics;
+
+import java.io.Serializable;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Type parameters whose bounds are intersections, used to test bounds read from bytecode. Only
+ * {@code E1}, {@code E4}, and {@code E6} include {@code null}: an intersection bound is nullable
+ * only when every one of its elements is.
+ */
+// The explicit Object bound of E3 is the point of the test case, not an oversight.
+@SuppressWarnings("ExtendsObject")
+public class IntersectionTypeParam<
+    E1 extends @Nullable Object & @Nullable Serializable,
+    E2 extends @Nullable Object & Serializable,
+    E3 extends Object & @Nullable Serializable,
+    E4 extends @Nullable Serializable & @Nullable CharSequence,
+    E5 extends @Nullable Serializable & CharSequence,
+    E6 extends @Nullable Serializable & @Nullable CharSequence & @Nullable Comparable<String>,
+    E7 extends Serializable & CharSequence,
+    E8 extends @Nullable Serializable & @Nullable CharSequence & Comparable<String>> {}

--- a/test-java-lib/src/main/java/com/uber/lib/generics/NestedNullableInBound.java
+++ b/test-java-lib/src/main/java/com/uber/lib/generics/NestedNullableInBound.java
@@ -1,0 +1,10 @@
+package com.uber.lib.generics;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A type parameter whose bound holds a {@code @Nullable} type argument, used to test that such an
+ * annotation is not mistaken for an annotation on the bound itself when read from bytecode.
+ */
+public class NestedNullableInBound<T extends List<@Nullable String>> {}


### PR DESCRIPTION
A type variable whose upper bound is an intersection, such as `<T extends @Nullable Object & @Nullable Serializable>`, was read through `upperBound.getAnnotationMirrors()`. javac stores type annotations on the elements of an intersection, and an `IntersectionClassType` cannot carry one at all — `cloneWithMetadata` throws — so that read answered "not `@Nullable`" for every intersection, whatever its elements said.

Both directions were wrong. An all-`@Nullable` bound came out null-exclusive, so NullAway stayed silent where it should report: a value read through `Box<?>` for such a `Box`, and an override that narrows or widens the bound. At a generic method call the same read produced a false positive instead, rejecting a legal type argument with

    Type argument cannot be @Nullable, as method <T>box(T)'s type variable T is not @Nullable

A bound read from a class file went the other way. Before JDK 22 javac drops these annotations from the symbol ([JDK-8225377](https://bugs.openjdk.org/browse/JDK-8225377)), and NullAway falls back on `Symbol.getRawTypeAttributes()`. That fallback ignored `bound_index` and marked the whole type parameter `@Nullable` when any one bound carried the annotation, so `<T extends @Nullable Object & Serializable>` accepted a `@Nullable` type argument it should refuse.

## What

JSpecify assigns a nullness operator to each element of an intersection separately and fixes the operator of the whole to `NO_CHANGE`; a type variable has nullness-subtype-establishing edges to all the elements, so one non-null element makes the bound null-exclusive. `GenericsUtils.isNullableAnnotated` states that rule once, and the sites that decide a bound's nullability call it: `upperBoundIsNullable`, the class and generic-method type-argument checks, the override comparison, and `getTypeNullness`.

It reads `getExplicitComponents()` rather than `getComponents()`: an intersection whose bounds are all interfaces carries an implicit `Object` supertype the declaration did not write, and counting that one would make every such bound non-null.

The raw-attributes fallback now collects the annotated bounds per type parameter and requires all of them. An annotation's type path is relative to the one bound its `bound_index` names, so the index is resolved to that element before `NullabilityUtil.isDirectTypeUseAnnotation` reads the path — otherwise an annotation on a type argument inside the bound, or on the enclosing type of a nested-class bound (`@Nullable Outer.Inner` rather than `Outer.@Nullable Inner`), counts as annotating the bound. That helper gained an overload taking the annotated `Type`; the existing `Symbol` form delegates to it.

`GenericsChecks.isNullableAnnotated(Type)`, which had the same name and the old intersection-blind body, is gone; its eight call sites use the shared helper.

## Verification

`IntersectionBoundTests` is new: 19 tests over one rule, split so that each name carries its outcome. They cover an all-`@Nullable` bound, a non-null first element, a non-null later element, and no `@Nullable` element at all, at each site that reads a bound — the class and generic-method type-argument checks, a read through a wildcard, and an override in both directions plus one that preserves the bound. Bytecode bounds come from three new `test-java-lib` fixtures and add the shapes only a class file has: an interface-only intersection, where `bound_index` starts at 1; a three-element bound; a `@Nullable` type argument nested inside a bound; and an annotation on the enclosing type of a nested-class bound.

Seventeen of the nineteen were observed failing against a change that breaks the rule they guard: eleven with the four main-source files reverted to `master`, and six more under one of three mutations — `allMatch` to `anyMatch` over the intersection's elements, an intersection reported nullable unconditionally, and the annotation-mirror and raw-attributes paths disabled together. Two are guarded only against a compound regression, because the mirror path and the fallback cover each other: `innerClassBoundFromBytecodeAcceptsNullableTypeArgument` needs both broken at once, and `overrideRepeatingIntersectionBoundIsAccepted` is the equality control for the override check, which no single-site mutation makes disagree with itself.

Two narrower mutations were cut for the parts of the fix the broad ones do not reach: neutering the `bound_index` resolution reddens `annotationOnEnclosingTypeOfIntersectionElementFromBytecodeRefusesNullableTypeArgument` and nothing else, and replacing `getExplicitComponents()` with `getComponents()` reddens `allNullableInterfaceOnlyBoundAcceptsNullableTypeArgumentOnGenericMethodCall` and nothing else.

`:nullaway:test` is green (1117 tests) and so is `:nullaway:buildWithNullAway`; `IntersectionBoundTests` is also green under `:nullaway:testErrorProneOldest` on JDK 17.

One converted site is not distinguished by any test: in `substitutedMethodTypeVarUpperBoundIsNullable`, reverting the read of the substituted bound to the plain mirror read changes no verdict, because the method falls through to the original declaration's bound, which the same helper reads. The two reads would have to be reverted together to show a difference.

One limit is worth stating, because it is not visible from the test names. These tests always pass `-XDaddTypeAnnotationsToSymbol=true`, which is JDK-8225377's own workaround, so the annotation mirrors answer on every JDK the suite runs on and the raw-attributes fallback can only add to their verdict. What the bytecode tests pin is that the fallback adds nothing it should not; removing the fallback entirely fails no test in the suite, on either JDK.

## Scope

Two pre-existing gaps are untouched:

* There is no raw-attributes fallback for **method** type parameters, so a generic method declared in bytecode still depends on the mirrors for its bound.
* `GenericsUtils.wildcardUpperBound` stamps a synthetic `@Nullable` on a formal type variable's bound when a library model or unannotated code makes it nullable, and `typeWithAnnot` throws on an intersection. This change narrows the reachable set — an all-`@Nullable` intersection is no longer stamped — but does not close it. I could not construct an input that reaches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed nullability handling for generic type parameters with intersection bounds.
  - A bound is now considered nullable only when every component of the intersection is annotated `@Nullable`.
  - Improved handling of nullable annotations in generic method calls, wildcard bounds, inheritance, nested types, and compiled libraries.
  - Added coverage for intersection bounds involving inner classes and nested nullable type arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->