### PR TITLE
Add Assisted-by text to PR template and CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,10 +13,11 @@ Before pressing the "Create Pull Request" button, please provide the following:
 **Note on AI usage**
 
 We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
-all the changes.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
-please disclose in the PR description which AI tools were used and how they were used, and also attest
-that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
-[JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
+all the changes.  Always end PR descriptions for AI-assisted changes, including drafts, with
+`Assisted-by: <tool> (<model-id>)` (not `Co-Authored-By:`).  If you are a first-time contributor, and you used
+AI tools as part of generating your PR, please also disclose in the PR description which AI tools were used and
+how they were used, and attest that you have read and understood all the changes in your PR.  Here are two example
+disclosures (taken from the [JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
 
 <!-- first example -->
 > I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,11 @@ AI usage
 --------
 
 We allow for AI-generated code in PRs, but, we require that contributors have manually reviewed and understood
-all the changes.  If you are a first-time contributor, and you used AI tools as part of generating your PR,
-please disclose in the PR description which AI tools were used and how they were used, and also attest
-that you have read and understood all the changes in your PR.  Here are two example disclosures (taken from the
-[JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
+all the changes.  Always end PR descriptions for AI-assisted changes, including drafts, with
+`Assisted-by: <tool> (<model-id>)` (not `Co-Authored-By:`).  If you are a first-time contributor, and you used
+AI tools as part of generating your PR, please also disclose in the PR description which AI tools were used and
+how they were used, and attest that you have read and understood all the changes in your PR.  Here are two example
+disclosures (taken from the [JabRef policy](https://github.com/JabRef/jabref/blob/main/AI_USAGE_POLICY.md)):
 
 <!-- first example -->
 > I used Claude to help debug a test failure. I reviewed the suggested fix, tested it locally, and verified it solves the issue without side effects.


### PR DESCRIPTION
Now it's consistent with AGENTS.md.

Fixes #1812 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance and pull request templates to require `Assisted-by: <tool> (<model-id>)` for AI-assisted changes, including drafts.
  - Clarified existing disclosure and attestation requirements for first-time contributors using AI tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->